### PR TITLE
feat(config): use config settings to set some environment variables

### DIFF
--- a/packages/manager/tools/webpack-dev-server/package.json
+++ b/packages/manager/tools/webpack-dev-server/package.json
@@ -32,7 +32,8 @@
     "friendly-errors-webpack-plugin": "^1.7.0",
     "lodash": "^4.17.15",
     "request": "^2.88.0",
-    "webpack-dev-server": "^3.8.2"
+    "webpack-dev-server": "^3.8.2",
+    "yn": "^3.1.1"
   },
   "devDependencies": {
     "eslint": "^5.15.1",

--- a/packages/manager/tools/webpack-dev-server/src/config.ts
+++ b/packages/manager/tools/webpack-dev-server/src/config.ts
@@ -1,15 +1,17 @@
 import DuplicatePackageCheckerPlugin from 'duplicate-package-checker-webpack-plugin';
 import FriendlyErrorsWebpackPlugin from 'friendly-errors-webpack-plugin';
+import yn from 'yn';
 
 import Sso from './sso';
 import serverProxy from './proxy';
 
 export = (env) => {
-  const region = (env.region || 'eu').toLowerCase();
+  const region = (env.region || process.env.npm_package_config_region || 'eu')
+    .toLowerCase();
   const proxy = [serverProxy.v6(region)];
   const sso = new Sso(region);
 
-  if (env.local2API) {
+  if (yn(env.local2API) || yn(process.env.npm_package_config_local2API)) {
     proxy.unshift(serverProxy.aapi);
   }
   if (env.dev) {
@@ -30,10 +32,10 @@ export = (env) => {
       },
       clientLogLevel: 'none',
       logLevel: 'silent',
-      host: env.host || 'localhost',
-      https: env.https || false,
+      host: env.host || process.env.npm_package_config_host || 'localhost',
+      https: env.https || yn(process.env.npm_package_config_https) || false,
       overlay: true,
-      port: env.port || 9000,
+      port: env.port || Number.parseInt(process.env.npm_package_config_port, 10) || 9000,
       proxy,
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16630,6 +16630,11 @@ yeast@0.1.2:
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
+yn@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
 zxcvbn@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"


### PR DESCRIPTION
# Use config settings to set some environment variables

## :sparkles: Feature

Configuration can be made per package by adding a `config` entry in the
`package.json` file.

### Usage

Assuming you want to start the Public Cloud Control Panel UI in the US region,
you now have two options:

#### 1) Using `export`

```sh
$ cd packages/manager/apps/public-cloud
$ export REGION=US
$ yarn run start:dev
```

OR

#### 2) Update the `package.json`

```json
{
  "config": {
    "region": "US" // default: "EU"
  }
}
```

It could be extend to `local2API`, `host`, `https` and `port` options.

549b5e2 - feat(config): use config settings to set some environment variables

## :link: Related 

- [`yn`](https://www.npmjs.com/package/yn) - Parse yes/no like values

Installed by running:

```sh
$ yarn workspace @ovh-ux/manager-webpack-dev-server add yn
```

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>