### PR TITLE
fix(dedicated): set charts granularity

### DIFF
--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.controller.js
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/manage/statistics/cdn-dedicated-manage-statistics.controller.js
@@ -18,6 +18,12 @@ angular.module('App').controller('CdnStatisticsCtrl', ($scope, $stateParams, $tr
           labelString: $translate.instant('unit_size_GB'),
         },
       }],
+      xAxes: [{
+        ticks: {
+          // This is default value according to doc but needs to dig why it's not applied
+          maxTicksLimit: 11,
+        },
+      }],
     },
   };
 
@@ -30,6 +36,12 @@ angular.module('App').controller('CdnStatisticsCtrl', ($scope, $stateParams, $tr
         scaleLabel: {
           display: true,
           labelString: $translate.instant('cdn_statistics_requests_per_second'),
+        },
+      }],
+      xAxes: [{
+        ticks: {
+          // This is default value according to doc but needs to dig why it's not applied
+          maxTicksLimit: 11,
         },
       }],
     },

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/statistics/dedicated-server-statistics.controller.js
@@ -104,6 +104,10 @@ angular.module('controllers').controller('controllers.Server.Stats', (
             display: true,
             labelString: $translate.instant('server_usage_chart_xaxis_label'),
           },
+          ticks: {
+            // This is default value according to doc but needs to dig why it's not applied
+            maxTicksLimit: 11,
+          },
         }],
       },
     };

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/statistics/rtm/load-avg/dedicated-server-statistics-rtm-load-avg.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/statistics/rtm/load-avg/dedicated-server-statistics-rtm-load-avg.controller.js
@@ -31,6 +31,14 @@ angular.module('controllers').controller('controllers.Server.Stats.Loadavg', ($s
         display: true,
         position: 'top',
       },
+      scales: {
+        xAxes: [{
+          ticks: {
+            // This is default value according to doc but needs to dig why it's not applied
+            maxTicksLimit: 11,
+          },
+        }],
+      },
     };
   }
 

--- a/packages/manager/apps/dedicated/client/app/ip/ip/mitigation/statistics/ip-ip-mitigation-statistics.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/mitigation/statistics/ip-ip-mitigation-statistics.controller.js
@@ -49,6 +49,12 @@ angular.module('Module.ip.controllers').controller('IpMitigationStatisticsCtrl',
             suggestedMin: 0,
           },
         }],
+        xAxes: [{
+          ticks: {
+            // This is default value according to doc but needs to dig why it's not applied
+            maxTicksLimit: 11,
+          },
+        }],
       },
     };
   };


### PR DESCRIPTION
### Description of the change 
* Set chart granularity with default value indicated by documentation : https://www.chartjs.org/docs/master/axes/cartesian/linear.html

ref: MANAGER-3748

### Additional information 
* Issue came with bumping Chart.js to `2.8.0`
 