### PR TITLE
build(deps): upgrade ovh-ui-angular to v3.9.8

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -50,7 +50,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.22.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "punycode": "^1.4.1",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -119,7 +119,7 @@
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "~2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "popper.js": "^1.16.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -121,7 +121,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-api-services": "^9.22.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "punycode": "^1.4.1",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -34,7 +34,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.22.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "zxcvbn": "^4.4.2"
   },

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -45,7 +45,7 @@
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-api-services": "^9.22.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -47,7 +47,7 @@
     "ovh-api-services": "^9.22.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0"
   },

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -66,7 +66,7 @@
     "ovh-api-services": "^9.22.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "tweetnacl-util": "^0.15.0"

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -26,7 +26,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.15",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2"
   },
   "devDependencies": {

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -36,7 +36,7 @@
     "ovh-api-services": "^9.22.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -135,7 +135,7 @@
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "popper.js": "^1.16.0",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -36,7 +36,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.22.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2"
   },
   "devDependencies": {

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -112,7 +112,7 @@
     "office-ui-fabric-react": "^4.35.2",
     "ovh-api-services": "^9.22.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "properties": "latest",

--- a/packages/manager/modules/carrier-sip/package.json
+++ b/packages/manager/modules/carrier-sip/package.json
@@ -17,7 +17,7 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "ovh-api-services": "^9.18.0",
-    "ovh-ui-angular": "^3.8.2",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.34.3",
     "ovh-ui-kit-bs": "^2.1.2"
   }

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -53,6 +53,6 @@
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -50,6 +50,6 @@
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -28,6 +28,6 @@
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -59,7 +59,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.18.2",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.8.2",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^3.6.0",
     "ovh-ui-kit-bs": "^3.0.2"
   }

--- a/packages/manager/modules/error-page/package.json
+++ b/packages/manager/modules/error-page/package.json
@@ -16,6 +16,6 @@
     "angular-i18n": "~1.5.x",
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -29,6 +29,6 @@
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -24,7 +24,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"
   }

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -47,7 +47,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.3"
   }
 }

--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -26,6 +26,6 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
-    "ovh-ui-angular": "^3.8.0"
+    "ovh-ui-angular": "^3.9.8"
   }
 }

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -59,7 +59,7 @@
     "ovh-api-services": "^9.19.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.1.0",
-    "ovh-ui-angular": "^3.8.2",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"
   }

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -21,7 +21,7 @@
     "@ovh-ux/web-universe-components": "^7.0.0",
     "angular": "^1.7.5",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.3"
   }
 }

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -32,7 +32,7 @@
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.1"
   }
 }

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -23,7 +23,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.17.0",
     "ovh-manager-webfont": "^1.0.2",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"
   }

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -30,7 +30,7 @@
     "ng-csv": "^0.3.6",
     "ovh-api-services": "^9.17.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "punycode": "^1.4.1",
     "validator": "^11.1.0",
     "validator-js": "^0.2.1"

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -43,7 +43,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.16.0",
     "ovh-api-services": "^9.17.0",
-    "ovh-ui-angular": "^3.8.0",
+    "ovh-ui-angular": "^3.9.8",
     "punycode": "^1.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,7 +2169,7 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-translate-async-loader/-/ng-translate-async-loader-2.0.2.tgz#9eac55552bccbc08c5847c42a74d42fbb5dc04ea"
   integrity sha512-uvPAidjPxmC3AimrXuKMCquqpGvAAWZcSIvsOklBy5Y3VF6+1TXz8RNKe2I19vH7Xvp+4L7vDW4tAlBhbHfazw==
 
-"@ovh-ux/ng-ui-router-layout@^2.0.0", "@ovh-ux/ng-ui-router-layout@^2.1.1":
+"@ovh-ux/ng-ui-router-layout@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ui-router-layout/-/ng-ui-router-layout-2.1.1.tgz#cef3eba596735de2434947a7aaaa89c6be90a3f8"
   integrity sha512-2idvmsXwHmxIv0IfDfzJTYhUbYoZjGCo79UuAokbbdfW/4ULQY94md5Xj6x0vmoGnNMSD4CDgfszYtk9AAYHNQ==
@@ -7350,11 +7350,6 @@ flat@^4.1.0:
   dependencies:
     is-buffer "~2.0.3"
 
-flatpickr@^4.5.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.2.tgz#50e1b4fc84fbf67c5b0919ba3ddc330221f126da"
-  integrity sha512-bRfBPyxohUQWgCTg6jPALUO1t/x+sRJ/S/RVti/NzYvHqGRpCAesKSWKLzOuLmpu+vGHfXBld4SXvOCLFgYb+g==
-
 flatpickr@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
@@ -11879,15 +11874,14 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
-ovh-ui-angular@^3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.9.5.tgz#0e70ca612951c57b4102628c69e7206ccd39902f"
-  integrity sha512-X//tOvSkSv6DVxe3MKEm3hjOP8i1eKFPIkqBRj654pkUZAEGzJMrj8zC3mxdpUlVklIdXumYy/TwFs2OnHTSjw==
+ovh-ui-angular@^3.9.8:
+  version "3.9.8"
+  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.9.8.tgz#60c9a4440445c9f9f9d01838631239926442fe27"
+  integrity sha512-aCTYEDQdN5BaucJS+a86Lh8QXt8ac0wgIkX7kWJIU49OGYQUY5fPPUk5W20DwAEqXVw6Qz/Q0WVIjymv4kZeXw==
   dependencies:
     bloodhound-js "^1.2.3"
     clipboard "^2.0.1"
     escape-string-regexp "^1.0.5"
-    flatpickr "^4.5.2"
     popper.js "^1.14.4"
     ui-select "^0.19.8"
 


### PR DESCRIPTION
# Upgrade ovh-ui-angular to v3.9.8

## :arrow_up: Upgrade

b9f668f - build(deps): upgrade ovh-ui-angular to v3.9.8

uses: yarn upgrade-interactive --latest ovh-ui-angular
- ovh-ui-angular@3.9.8

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>