### PR TITLE
fix(pci-projects-new): redirect to payment page on credit

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/new.controller.js
+++ b/packages/manager/modules/pci/src/projects/new/new.controller.js
@@ -209,6 +209,7 @@ export default class PciProjectNewCtrl {
       paymentType: {
         value: 'CREDIT_CARD',
       },
+      integration: 'REDIRECT',
     };
 
     return this.ovhPaymentMethod


### PR DESCRIPTION
While creating a new project using credit method, the user is not redirected to the payment page. This has been fixed by passing the integration flag as `REDIRECT` to the `addPaymentMethod` method

closes MANAGER-3801