### PR TITLE
fix(deps): downgrade ovh-ui-angular to v3.9.0

### DIFF
--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -135,7 +135,7 @@
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.9.5",
+    "ovh-ui-angular": "3.9.0",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0",
     "popper.js": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11879,6 +11879,18 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
+ovh-ui-angular@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.9.0.tgz#4786d8d00027ce56572c3773894611cd54f08614"
+  integrity sha512-aoFSv2eZ0T/6ajnH8ioKFULGm5c6ZlxirohPVasRA8II8aO0h4nV4JbBAc2015Ee8qTeE3l8JMIygrywyMnGcQ==
+  dependencies:
+    bloodhound-js "^1.2.3"
+    clipboard "^2.0.1"
+    escape-string-regexp "^1.0.5"
+    flatpickr "^4.5.2"
+    popper.js "^1.14.4"
+    ui-select "^0.19.8"
+
 ovh-ui-angular@^3.9.5:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.9.5.tgz#0e70ca612951c57b4102628c69e7206ccd39902f"


### PR DESCRIPTION
# Downgrade ovh-ui-angular to v3.9.0

## :ambulance: Hotfix

user can now scroll across header tabs items on small devices

c71751f - fix(deps): downgrade ovh-ui-angular to v3.9.0

## :link: Related

- ovh-ux/ovh-ui-angular#438

## :house: Internal

ref: MANAGER-3889

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>