### PR TITLE
fix(wuc.expiration): fix translate values

### DIFF
--- a/packages/manager/modules/web-universe-components/src/expiration/service-expiration-date.component.html
+++ b/packages/manager/modules/web-universe-components/src/expiration/service-expiration-date.component.html
@@ -4,7 +4,7 @@
         <div data-ng-if="!$ctrl.isExpired() && $ctrl.isInAutoRenew()">
             <div data-ng-if="$ctrl.shouldDeleteAtExpiration()">
                 <span data-translate="expiration_resiliation_date"
-                      data-translate-values="{ t0: ($ctrl.serviceInfos.expiration | date:'mediumDate')">
+                      data-translate-values="{ t0: ($ctrl.serviceInfos.expiration | date:'mediumDate') }">
                 </span>
                 <a class="oui-link"
                    data-ng-if="::$ctrl.getCancelTerminationUrl()"


### PR DESCRIPTION
## fix(wuc.expiration): fix translate values

### Description of the Change

Fix error `Error: [$parse:ueoe] Unexpected end of expression: { t0: ($ctrl.serviceInfos.expiration | date:'mediumDate')`

f461f685b — fix(wuc.expiration): fix translate values