### PR TITLE
fix(pci): update title against the container type

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cloud-archives/add/add.routing.js
@@ -18,7 +18,7 @@ export default /* @ngInject */ ($stateProvider) => {
         cancelLink: /* @ngInject */ ($state, projectId) => $state.href('pci.projects.project.storages.archives', {
           projectId,
         }),
-        breadcrumb: /* @ngInject */ $translate => $translate.instant('pci_projects_project_storages_containers_add_title'),
+        breadcrumb: /* @ngInject */ $translate => $translate.instant('pci_projects_project_storages_containers_add_archive_title'),
       },
     });
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
@@ -1,4 +1,7 @@
-<h1 data-translate="pci_projects_project_storages_containers_add_title"></h1>
+<h1 data-translate="pci_projects_project_storages_containers_add_title"
+    data-ng-if="!$ctrl.archive"></h1>
+<h1 data-translate="pci_projects_project_storages_containers_add_archive_title"
+    data-ng-if="$ctrl.archive"></h1>
 
 <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_storages_containers_add_title": "Créer un conteneur d'objets",
+  "pci_projects_project_storages_containers_add_archive_title": "Créer un conteneur d'archive",
   "pci_projects_project_storages_containers_add_region_title": "Sélectionnez une localisation",
   "pci_projects_project_storages_containers_add_type_title": "Sélectionnez un type de conteneur",
   "pci_projects_project_storages_containers_add_type_static_label": "Hébergement statique",


### PR DESCRIPTION
## fix(pci): update title against the container type

### Description of the Change

`pciProjectStorageContainersAdd` component is hared between _Object Storage_ and _Cloud Archive_. 

Currently: 
- When the user click on "Create an **object container**" in _Object Storage_ section, he is redirected one the object storage creation form with title "Create an **object container**".
- When the user click on "Create an **archive container**" in  _Cloud Archive_ section, he is redirected one the cloud archive creation form with title "Create an **object container**".

In that case, the title should be "Create an **archive container**".

18764e8c82 — fix(pci): update title against the container type

