### PR TITLE
fix(dedicated-server): general information link to status tasks

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/ovh-tasks/dedicated-server-ovh-tasks.routes.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/ovh-tasks/dedicated-server-ovh-tasks.routes.js
@@ -3,7 +3,11 @@ angular
   .config(/* @ngInject */($stateProvider) => {
     $stateProvider.state('app.dedicated.server.dashboard.ovh-tasks', {
       url: '/ovh-tasks',
-      component: 'dedicatedServerOVHTasks',
+      views: {
+        'tabView@app.dedicated.server': {
+          component: 'dedicatedServerOVHTasks',
+        },
+      },
       translations: { value: ['../ovh-tasks'], format: 'json' },
     });
   });


### PR DESCRIPTION
The link to the status tasks was broken in the `Service Status` tile.

MANAGER-3755