### PR TITLE
fix(pci-billing): guide link

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/billing/billing.html
+++ b/packages/manager/modules/pci/src/projects/project/billing/billing.html
@@ -16,7 +16,7 @@
     </oui-header-tabs>
     <oui-guide-menu data-text="{{:: 'pci_project_guides_header' | translate }}">
         <oui-guide-menu-item
-            href="{{ $ctrl.guideUrl }}"
+            href="{{ BillingCtrl.guideUrl }}"
             data-external>
             <span data-translate="pci_project_guides_header_all_guides"></span>
         </oui-guide-menu-item>


### PR DESCRIPTION
The guide link in the billing page was not working. This has been fixed by correcting the controller name in the html

MANAGER-3867