### PR TITLE
fix(pci-streams-add): popover position

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/streams/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/streams/add/add.html
@@ -27,7 +27,8 @@
                 <button
                     type="button"
                     class="oui-popover-button"
-                    data-oui-popover="{{:: 'pci_projects_project_streams_add_stream_type_' + kind.toLowerCase() + '_popover' | translate }}"></button>
+                    data-oui-popover="{{:: 'pci_projects_project_streams_add_stream_type_' + kind.toLowerCase() + '_popover' | translate }}"
+                    data-oui-popover-placement="auto"></button>
             </oui-radio>
         </oui-step-form>
 


### PR DESCRIPTION
The pop-over in the create stream page goes outside the box, making it partially invisible. This has been fixed by setting the placement to `auto`.

MANAGER-3496