### PR TITLE
fix(template): set module name in camelcase

### DIFF
--- a/packages/manager/tools/sao-ovh-manager-app/template/src/index.js
+++ b/packages/manager/tools/sao-ovh-manager-app/template/src/index.js
@@ -4,6 +4,6 @@ import '@ovh-ux/manager-<%= name %>';
 import angular from 'angular';
 
 angular
-  .module('<%= name %>App', [
+  .module('<%= pascalcasedName %>App', [
     'ovhManager<%= pascalcasedName %>',
   ]);


### PR DESCRIPTION
# Add missing data-ng-strict-di directive

## :bug: Fix

b51c08b - fix(template): set module name in camelcase

## :link: Related

fix #1674

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>

cc @cbourgois 