### PR TITLE
Feat/miaw cdn order (2/2 API)

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.component.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.component.js
@@ -5,13 +5,15 @@ export default {
   controller,
   template,
   bindings: {
+    autoPayWithPreferredPaymentMethod: '<',
+    catalogAddon: '<',
+    checkoutOrderCart: '<',
+    defaultPaymentMean: '<',
     goBack: '<',
-
-    availableOffers: '<',
-    hosting: '<',
-
     isOptionFree: '<',
-    isOrderable: '<',
-    isPerfOffer: '<',
+    prepareOrderCart: '<',
+    serviceName: '<',
+    serviceOption: '<',
+    user: '<',
   },
 };

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
@@ -1,6 +1,7 @@
 export default class {
   /* @ngInject */
-  constructor($timeout) {
+  constructor($filter, $timeout) {
+    this.$filter = $filter;
     this.$timeout = $timeout;
   }
 
@@ -45,5 +46,12 @@ export default class {
       this.isOptionFree ? this.isOptionFree : this.autoPayWithPreferredPaymentMethod,
       this.cartId,
     );
+  }
+
+  getDuration(_interval_) {
+    const interval = _interval_.toString();
+    const duration = this.$filter('wucDuration')(interval, 'longDate');
+
+    return duration;
   }
 }

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
@@ -8,58 +8,61 @@
 </div>
 
 <div data-ng-if="!$ctrl.loading">
-    <oui-message
-        data-ng-if="!$ctrl.isOrderable"
-        data-type="error">
-        <p class="m-0" data-translate="hosting_dashboard_cdn_order_not_available"></p>
-    </oui-message>
+    <p data-translate="hosting_cdn_order_description"></p>
 
-    <form novalidate
-        name="cdnOrder"
-        data-ng-if="$ctrl.isOrderable"
-        data-ng-submit="$ctrl.makeOrder()">
-        <p data-translate="hosting_cdn_order_text"></p>
+    <oui-stepper
+        data-current-index="$ctrl.currentIndex"
+        data-on-finish="$ctrl.checkout()">
+        <oui-step-form
+            data-header="{{:: 'hosting_cdn_order_step_header_duration' | translate }}"
+            data-editable="$ctrl.isEditable && !$ctrl.checkoutLoading"
+            data-on-focus="$ctrl.resetCart()">
 
-        <oui-field
-            data-label="{{:: 'hosting_cdn_order_duration' | translate }}"
-            data-size="xl">
-            <oui-radio
-                name="duration"
-                data-ng-repeat="duration in $ctrl.durations track by $index"
-                data-model="$ctrl.model.duration"
-                data-value="duration"
-                data-required>
-                <span data-ng-bind="duration | wucDuration:'longDate'"></span>&nbsp;:&nbsp;
-                <span data-ng-bind-html="$ctrl.details[duration].prices | price:$ctrl.user.ovhSubsidiary"></span>
-                <oui-spinner data-size="s" data-ng-if="!$ctrl.details[duration]"></oui-spinner>
-            </oui-radio>
-        </oui-field>
-
-        <p>
-            <oui-checkbox
-                name="contracts"
-                data-ng-if="$ctrl.details[$ctrl.model.duration].contracts"
-                data-model="$ctrl.model.contract"
-                data-required>
-                <span data-translate="hosting_cdn_order_contracts"></span>
-                <span data-ng-repeat="contract in $ctrl.details[$ctrl.model.duration].contracts track by $index">
-                    <span data-ng-if="!$first"
-                        data-translate="hosting_cdn_order_contracts_and">
-                    </span>
-                    <span data-translate="hosting_cdn_order_contracts_of"></span>
-                    <a target="_blank"
-                        data-ng-attr-title="{{contract.name}} ({{ 'common_newtab' | translate }})"
-                        data-ng-href="{{contract.url}}"
-                        data-ng-bind="contract.name"></a><span data-ng-if="!$last">, </span><span data-ng-if="$last">.</span>
-                </span>
-            </oui-checkbox>
-        </p>
-
-        <oui-form-actions
-            data-disabled="cdnOrder.$invalid"
-            data-submit-text="{{:: $ctrl.submitText }}"
+            <!-- Durations -->
+            <oui-field>
+                <oui-radio
+                    name="interval"
+                    data-ng-repeat="pricing in ::$ctrl.catalogAddon.pricings track by $index"
+                    data-model="$ctrl.interval"
+                    data-value="pricing.interval"
+                    data-required>
+                    <span data-ng-bind=":: '' + pricing.interval | wucDuration:'longDate'"></span>&nbsp;:&nbsp;
+                    <ovh-manager-order-catalog-price
+                        data-price="pricing.price"
+                        data-tax="pricing.tax"
+                        data-user="$ctrl.user">
+                    </ovh-manager-order-catalog-price>
+                </oui-radio>
+            </oui-field>
+        </oui-step-form>
+        <oui-step-form
+            name="checkout"
+            data-header="{{:: ($ctrl.isOptionFree ? 'hosting_cdn_order_step_header_activation' : 'hosting_cdn_order_step_header_payment') | translate }}"
+            data-description="{{:: ($ctrl.isOptionFree ? 'hosting_cdn_order_step_description_activation' : 'hosting_cdn_order_step_description_payment') | translate }}"
+            data-submit-text="{{:: ($ctrl.isOptionFree ? 'hosting_cdn_order_submit_activate' : 'hosting_cdn_order_submit_pay') | translate }}"
             data-cancel-text="{{:: 'hosting_cdn_order_cancel' | translate }}"
-            data-on-cancel="$ctrl.goBack()">
-        </oui-form-actions>
-    </form>
+            data-editable="::false"
+            data-loading="$ctrl.checkoutLoading"
+            data-valid="$ctrl.agreeContracts"
+            data-on-focus="$ctrl.prepareCheckout()"
+            data-on-cancel="$ctrl.goBack()"
+            data-prevent-next>
+
+            <!-- Payment Means -->
+            <ovh-manager-order-payment-means
+                name="paymentMean"
+                data-ng-if="::!$ctrl.isOptionFree"
+                data-default-payment-mean="$ctrl.defaultPaymentMean"
+                data-model="$ctrl.autoPayWithPreferredPaymentMethod">
+            </ovh-manager-order-payment-means>
+
+            <!-- Contracts -->
+            <ovh-manager-order-contracts
+                name="agreeContracts"
+                data-ng-if="$ctrl.cart"
+                data-items="$ctrl.cart.contracts"
+                data-model="$ctrl.agreeContracts">
+            </ovh-manager-order-contracts>
+        </oui-step-form>
+    </oui-stepper>
 </div>

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
@@ -26,7 +26,12 @@
                     data-model="$ctrl.interval"
                     data-value="pricing.interval"
                     data-required>
-                    <span data-ng-bind=":: '' + pricing.interval | wucDuration:'longDate'"></span>&nbsp;:&nbsp;
+                    <span
+                        data-translate="hosting_cdn_order_duration_label"
+                        data-translate-values="{
+                            duration: $ctrl.getDuration(pricing.interval)
+                        }">
+                    </span>
                     <ovh-manager-order-catalog-price
                         data-price="pricing.price"
                         data-tax="pricing.tax"

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.module.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.module.js
@@ -1,11 +1,13 @@
 import component from './hosting-cdn-order.component';
 import routing from './hosting-cdn-order.routing';
+import service from './hosting-cdn-order.service';
 
 const moduleName = 'ovhManagerHostingCdnOrder';
 
 angular
   .module(moduleName, [])
   .component('hostingCdnOrder', component)
+  .service('HostingCdnOrderService', service)
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);
 

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
@@ -23,6 +23,7 @@ export default /* @ngInject */ ($stateProvider) => {
 
       checkoutOrderCart: /* @ngInject */ (
         goBack,
+        isOptionFree,
         $translate,
         $window,
         HostingCdnOrderService,
@@ -34,10 +35,16 @@ export default /* @ngInject */ ($stateProvider) => {
           const order = await HostingCdnOrderService
             .checkoutOrderCart(autoPayWithPreferredPaymentMethod, cartId);
 
-          $window.open(order.url, '_blank');
-          goBack(
-            $translate.instant('hosting_dashboard_cdn_order_success', { t0: order.url }),
-          );
+          if (isOptionFree) {
+            goBack(
+              $translate.instant('hosting_dashboard_cdn_order_success_activation'),
+            );
+          } else {
+            $window.open(order.url, '_blank');
+            goBack(
+              $translate.instant('hosting_dashboard_cdn_order_success', { t0: order.url }),
+            );
+          }
         } catch (error) {
           goBack(
             $translate.instant('hosting_dashboard_cdn_order_error', { message: get(error, 'data.message', error) }),

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.service.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.service.js
@@ -1,0 +1,75 @@
+import find from 'lodash/find';
+
+export default class HostingCdnOrderService {
+  /* @ngInject */
+  constructor(OrderService) {
+    this.OrderService = OrderService;
+  }
+
+  async getCatalogAddon(
+    ovhSubsidiary,
+    serviceOption,
+  ) {
+    const { addons } = await this.OrderService
+      .getProductPublicCatalog(ovhSubsidiary, 'webHosting');
+
+    const addon = find(addons, { planCode: serviceOption.planCode });
+
+    if (!addon) {
+      throw new Error('No addon found');
+    } else {
+      return addon;
+    }
+  }
+
+  async getServiceOption(serviceName) {
+    const serviceOptions = await this.OrderService
+      .getProductServiceOptions('webHosting', serviceName);
+
+    const serviceOption = find(serviceOptions, { family: 'cdn' });
+
+    if (!serviceOption) {
+      throw new Error('No serviceOption found');
+    } else {
+      return serviceOption;
+    }
+  }
+
+  async prepareOrderCart(ovhSubsidiary) {
+    const { cartId } = await this.OrderService
+      .createNewCart(ovhSubsidiary);
+
+    await this.OrderService
+      .assignCart(cartId);
+
+    return cartId;
+  }
+
+  async addItemToCart(
+    cartId,
+    serviceName,
+    serviceOption,
+  ) {
+    const [price] = serviceOption.prices; // Will only have one price option
+    const { itemId } = await this.OrderService
+      .addProductServiceOptionToCart(cartId, 'webHosting', serviceName, {
+        duration: price.duration,
+        planCode: serviceOption.planCode,
+        pricingMode: price.pricingMode,
+        quantity: price.minimumQuantity,
+      });
+
+    await this.OrderService.addConfigurationItem(cartId, itemId, 'legacy_domain', serviceName);
+
+    return this.OrderService.getCheckoutInformations(cartId);
+  }
+
+  checkoutOrderCart(
+    autoPayWithPreferredPaymentMethod,
+    cartId,
+  ) {
+    return this.OrderService.checkoutCart(cartId, {
+      autoPayWithPreferredPaymentMethod,
+    });
+  }
+}

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/translations/Messages_fr_FR.json
@@ -1,11 +1,11 @@
 {
   "hosting_cdn_order_title": "Commander un CDN",
-  "hosting_cdn_order_text": "L'option CDN active un réseau de serveurs de cache pour vos fichiers statiques (HTML, CSS, JavaScript). Il vous permet d'accélérer le chargement de vos pages web et d'utiliser les ressources de votre hébergement uniquement pour vos pages dynamiques.",
-  "hosting_cdn_order_duration": "Votre durée",
-  "hosting_cdn_order_duration_tooltip": "Regardless of where your new hosting package is set up, your domain name will continue to point to the current records. You will need to make the changes in your DNS zone when your new website is ready. This is an ideal choice if you do not want your current website to go down.",
-  "hosting_cdn_order_contracts": "Je reconnais avoir bien pris connaissance",
-  "hosting_cdn_order_contracts_of": "des",
-  "hosting_cdn_order_contracts_and": "et",
+  "hosting_cdn_order_description": "L'option CDN active un réseau de serveurs de cache pour vos fichiers statiques (HTML, CSS, JavaScript). Il vous permet d'accélérer le chargement de vos pages web et d'utiliser les ressources de votre hébergement uniquement pour vos pages dynamiques.",
+  "hosting_cdn_order_step_header_duration": "Choisissez votre durée",
+  "hosting_cdn_order_step_header_activation": "Activation",
+  "hosting_cdn_order_step_header_payment": "Paiement",
+  "hosting_cdn_order_step_description_activation": "Afin de confirmer votre demande, veuillez accepter les conditions d'utilisation.",
+  "hosting_cdn_order_step_description_payment": "Afin de confirmer votre demande, veuillez choisir votre moyen de paiement, et accepter les conditions d'utilisation.",
   "hosting_cdn_order_submit_activate": "Activer",
   "hosting_cdn_order_submit_pay": "Payer",
   "hosting_cdn_order_cancel": "Annuler"

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/translations/Messages_fr_FR.json
@@ -1,6 +1,7 @@
 {
   "hosting_cdn_order_title": "Commander un CDN",
   "hosting_cdn_order_description": "L'option CDN active un réseau de serveurs de cache pour vos fichiers statiques (HTML, CSS, JavaScript). Il vous permet d'accélérer le chargement de vos pages web et d'utiliser les ressources de votre hébergement uniquement pour vos pages dynamiques.",
+  "hosting_cdn_order_duration_label": "{{duration}} :",
   "hosting_cdn_order_step_header_duration": "Choisissez votre durée",
   "hosting_cdn_order_step_header_activation": "Activation",
   "hosting_cdn_order_step_header_payment": "Paiement",

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
@@ -5,6 +5,7 @@ import isObject from 'lodash/isObject';
 import { QUOTA_DECIMAL_PRECISION } from './general-informations.constants';
 
 export default class HostingGeneralInformationsCtrl {
+  /* @ngInject */
   constructor(
     $q,
     $scope,

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -228,7 +228,7 @@
                         <oui-action-menu data-compact data-align="end" data-ng-if="flushCdnState === 'ok' && !hosting.hasCdn && hosting.offer!== 'START_10_M' || hosting.hasCdn && flushCdnState === 'ok' || hosting.hasCdn">
                             <oui-action-menu-item
                                 data-ng-if="flushCdnState === 'ok' && !hosting.hasCdn && hosting.offer!== 'START_10_M'"
-                                data-text="{{ ::'hosting_dashboard_service_order_cdn' | translate }}"
+                                data-text="{{ :: (isCdnFree ? 'hosting_dashboard_service_activate_cdn' : 'hosting_dashboard_service_order_cdn') | translate }}"
                                 data-href="{{:: $ctrl.$state.href('app.hosting.cdn.order') }}"></oui-action-menu-item>
                             <oui-action-menu-item
                                 data-ng-if="hosting.hasCdn && flushCdnState === 'ok'"

--- a/packages/manager/apps/web/client/app/hosting/hosting.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.controller.js
@@ -659,6 +659,8 @@ export default class {
         this.$scope.ftpUrl = `ftp://${hostingProxy.serviceManagementAccess.ftp.url}:${hostingProxy.serviceManagementAccess.ftp.port}/`;
         this.$scope.http = hostingProxy.serviceManagementAccess.http;
         this.$scope.httpUrl = `http://${hostingProxy.serviceManagementAccess.http.url}:${hostingProxy.serviceManagementAccess.http.port}/`;
+        this.$scope.isCdnFree = this.Hosting.constructor.isPerfOffer(hostingProxy.offer)
+          || this.$scope.hosting.isCloudWeb;
         this.$scope.ssh = hostingProxy.serviceManagementAccess.ssh;
         this.$scope.sshUrl = `ssh://${hostingProxy.serviceManagementAccess.ssh.url}:${hostingProxy.serviceManagementAccess.ssh.port}/`;
         this.$scope.urls.hosting = hostingUrl;

--- a/packages/manager/apps/web/client/app/hosting/hosting.routes.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.routes.js
@@ -13,13 +13,10 @@ export default /* @ngInject */ ($stateProvider) => {
     },
     resolve: {
       goToHosting: /* @ngInject */ ($state, $timeout, Alerter) => (message = false, type = 'success') => {
-        const reload = message && type === 'success';
-        const promise = $state.go('app.hosting', {}, {
-          reload,
-        });
+        const promise = $state.go('app.hosting', {});
 
         if (message) {
-          promise.then(() => $timeout(() => Alerter.set(`alert-${type}`, message, null, 'app.alerts.tabs')));
+          promise.then(() => $timeout(() => Alerter.set(`alert-${type}`, message, null, 'app.alerts.main')));
         }
 
         return promise;

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
@@ -165,6 +165,7 @@
   "hosting_dashboard_service_change_offer_explanation_db": "Une base de données commençant à 100 Mo",
   "hosting_dashboard_service_change_offer_now": "Changer d'offre maintenant",
   "hosting_dashboard_service_order_ssl": "Commander un certificat SSL",
+  "hosting_dashboard_service_activate_cdn": "Activer un CDN",
   "hosting_dashboard_service_order_cdn": "Commander un CDN",
   "hosting_dashboard_service_flush_cdn": "Vider le cache",
   "hosting_dashboard_service_flush_cdn_basic": "Vider le cache du CDN de base",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
@@ -213,6 +213,7 @@
   "hosting_dashboard_cdn_order_choose_duration": "Choisissez une durée :",
   "hosting_dashboard_cdn_order_validation": "Cliquez sur \"Valider\" pour créer votre bon de commande.",
   "hosting_dashboard_cdn_order_success": "Votre <a href=\"{{t0}}\" traget=\"_blank\">bon de commande</a> à été généré avec succès. Votre produit sera activé lorsque vous l'aurez validé.",
+  "hosting_dashboard_cdn_order_success_activation": "Votre activation à été faites avec succès. Votre produit sera activé dans quelques instants.",
   "hosting_dashboard_cdn_order_error": "Une erreur est survenue lors de la commande d'un CDN.",
   "hosting_dashboard_cdn_order_select_pack_offer": "Sélectionnez l'offre CDN que vous souhaitez :",
   "hosting_dashboard_cdn_order_CDN_BUSINESS": "CDN 17 PoP",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11792,7 +11792,7 @@ ovh-angular-user-pref@^0.3.1:
   resolved "https://registry.yarnpkg.com/ovh-angular-user-pref/-/ovh-angular-user-pref-0.3.1.tgz#07f5792513651f3262ae4879c174423649b08307"
   integrity sha1-B/V5JRNlHzJirkh5wXRCNkmwgwc=
 
-ovh-api-services@^9.26.0:
+ovh-api-services@^9.23.2, ovh-api-services@^9.26.0:
   version "9.26.0"
   resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.26.0.tgz#b88059896ac0865f874b12d4657c24729e5582f1"
   integrity sha512-JBD2xleitoKj5tz2W3oH2LKLGj04hH9lmZaKmLD5Vy+f+UlrO346YVSKTe/Q+C5Bv/p6AtQdu8k8ubxWFCot5A==


### PR DESCRIPTION
ref: MANAGER-3459

This is the second part that follows https://github.com/ovh/manager/pull/1488

- Update `hosting.cdn.order` to use only calls from `OrderService`.
- Update page layout to a stepper with 2 steps.
- Update translations to use `translate namespace`
- If the option is free, `pay` is replaced by `activate`. On the Dashboard, to avoid adding an umpteenth API call on the existing stack, I prefer using the existing informations from `Hosting`.