### PR TITLE
fix(sidebar.menu.account): add missing menu support translation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/translations/Messages_en_GB.json
@@ -30,5 +30,6 @@
   "menu_users_management": "User management",
   "menu_emails": "Emails received",
   "menu_contacts": "My contacts",
-  "menu_agreements": "My contracts"
+  "menu_agreements": "My contracts",
+  "menu_support": "My support tickets"
 }


### PR DESCRIPTION
# Add missing menu support translation

## :ambulance: Hotfix

0637f83 - fix(sidebar.menu.account): add missing menu support translation

## :link: Related

Will be fixed later by following commit on `develop` branch:
- https://github.com/ovh/manager/commit/3b7c5a5529a3e3c911e56ec29359e914d800ba91

## :house: Internal

- DTRSD-4906

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>