### PR TITLE
fix(exchange): renew translations & duplicate component declaration

### DIFF
--- a/packages/manager/modules/exchange/src/billing/account-renew/renew.module.js
+++ b/packages/manager/modules/exchange/src/billing/account-renew/renew.module.js
@@ -8,6 +8,6 @@ angular.module(moduleName, [
 ])
   .component('exchangeAccountRenew', component)
   .controller('ExchangeUpdateRenewCtrl', controller)
-  .run(/* @ngTranslationsInject ./translations */);
+  .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/exchange/src/exchangeComponents.module.js
+++ b/packages/manager/modules/exchange/src/exchangeComponents.module.js
@@ -4,7 +4,7 @@ import exchangeAccountAdd from './account/add/account-add.component';
 import exchangeAccountAlias from './account/alias/account-alias.component';
 import exchangeAccountHome from './account/home/account-home.component';
 import exchangeHeader from './header/header.component';
-import exchangeAccountRenew from './billing/account-renew/renew.component';
+import exchangeAccountRenew from './billing/account-renew/renew.module';
 import exchangeWizardHostedCreationDomainConfiguration from './wizard-hosted-creation/first-step/domain-configuration/domain-configuration.component';
 import exchangeWizardHostedCreationEmailCreation from './wizard-hosted-creation/first-step/email-creation/email-creation.component';
 import exchangeWizardHostedCreationFirstStep from './wizard-hosted-creation/first-step/first-step.component';
@@ -15,12 +15,13 @@ import exchangeWizardHostedCreation from './wizard-hosted-creation/wizard-hosted
 const moduleName = 'Module.exchange.components';
 
 angular
-  .module(moduleName, [])
+  .module(moduleName, [
+    exchangeAccountRenew,
+  ])
   .component('exchangeAccountAdd', exchangeAccountAdd)
   .component('exchangeAccountAlias', exchangeAccountAlias)
   .component('exchangeAccountHome', exchangeAccountHome)
   .component('exchangeHeader', exchangeHeader)
-  .component('exchangeAccountRenew', exchangeAccountRenew)
   .component('exchangeWizardHostedCreationDomainConfiguration', exchangeWizardHostedCreationDomainConfiguration)
   .component('exchangeWizardHostedCreationEmailCreation', exchangeWizardHostedCreationEmailCreation)
   .component('exchangeWizardHostedCreationFirstStep', exchangeWizardHostedCreationFirstStep)


### PR DESCRIPTION
exchange account renew is totally broken in prod
(component was declared twice => white page, translations were not loaded)

see : DTRSD-4852