### PR TITLE
feat(cloud.logs): prepare network bulk management

### DIFF
--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/inputs/logs-inputs.service.js
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/inputs/logs-inputs.service.js
@@ -460,6 +460,7 @@ class LogsInputsService {
       description: input.info.description,
       engineId: input.info.engineId,
       optionId: input.info.optionId ? input.info.optionId : undefined,
+      allowedNetworks : input.info.allowedNetworks ? input.info.allowedNetworks : [],
       streamId: input.info.streamId,
       singleInstanceEnabled: input.info.singleInstanceEnabled,
       exposedPort: input.info.exposedPort.toString(),


### PR DESCRIPTION
Hello,

We will very soon allow LDP users to handle allowed networks on Input object directly, making the user experience more smooth than the actual strict restfull way.
This first PR will permit both endpoints to live the time we deploy all related code.

Thanks for your review, merge & prod time.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>