### PR TITLE
fix(telephony-livecalls): sort calls and agents for consistent display

### DIFF
--- a/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
@@ -67,8 +67,8 @@ angular.module('managerApp').component('telecomTelephonyAliasLiveCalls', {
         agentsStatus: self.fetchAgentsLiveStatus(queueId),
       }).then((result) => {
         self.stats = result.stats;
-        self.calls = result.calls;
-        self.agentsStatus = result.agentsStatus;
+        self.calls = result.calls.sort((a, b) => (a.begin > b.begin ? 1 : -1));
+        self.agentsStatus = result.agentsStatus.sort((a, b) => (a.agentId > b.agentId ? 1 : -1));
       });
     };
 


### PR DESCRIPTION
Signed-off-by: Julien Issler <julien@issler.net>

Sorting the data will prevent flickering every second (BTW I think a refresh every 5 seconds is way enough and will save resources)