### PR TITLE
build: add postinstall hook

### DIFF
--- a/packages/manager/tools/component-rollup-config/package.json
+++ b/packages/manager/tools/component-rollup-config/package.json
@@ -24,6 +24,7 @@
     "build": "tsc",
     "dev": "yarn run build",
     "dev:watch": "tsc -w",
+    "postinstall": "yarn run build",
     "lint": "run-p lint:ts lint:md",
     "lint:md": "eslint --quiet --fix --format=pretty --ext .md .",
     "lint:ts": "eslint --quiet --fix --format=pretty ./src/**/*.ts",


### PR DESCRIPTION
# Add `postinstall` hook

## 👷 Build

fae6f90 - build: add postinstall hook

## 🔗 Related

fix #1755

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>