### PR TITLE
fix(order.constant): remove enterprise cloud database in CA region

### DIFF
--- a/packages/manager/modules/server-sidebar/src/order.constants.js
+++ b/packages/manager/modules/server-sidebar/src/order.constants.js
@@ -561,7 +561,7 @@ export const SIDEBAR_ORDER_CONFIG = [
     linkId: 'enterprise_cloud_database',
     linkPart: '#/enterprise-cloud-database/create',
     app: [DEDICATED],
-    regions: ['EU', 'CA'],
+    regions: ['EU'],
   },
 ];
 


### PR DESCRIPTION
# Remove enterprise cloud database in CA region

## :bug: Bug Fix

81766f4 - fix(order.constant): remove enterprise cloud database in CA region

## :link: Related

- MANAGER-3855

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>