### PR TITLE
build: support the REGION parameter for standalone applications

### DIFF
--- a/packages/manager/tools/sao-ovh-manager-app/lib/update-pkg.js
+++ b/packages/manager/tools/sao-ovh-manager-app/lib/update-pkg.js
@@ -9,7 +9,10 @@ module.exports = (
   license: 'BSD-3-Clause',
   author: 'OVH SAS',
   scripts: {
-    build: 'webpack --env.production',
+    build: 'yarn build:eu && yarn build:ca && yarn build:us',
+    'build:ca': 'webpack --env.production --env.region=\'CA\' && mv dist dist-CA',
+    'build:eu': 'webpack --env.production && mv dist dist-EU',
+    'build:us': 'webpack --env.production --env.region=\'US\' && mv dist dist-US',
     dev: 'webpack-dev-server',
     'dev:watch': 'yarn run dev',
     start: `lerna exec --stream --scope='@ovh-ux/manager-${name}-app' --include-filtered-dependencies -- npm run build --if-present`,
@@ -43,6 +46,7 @@ module.exports = (
   },
   devDependencies: {
     '@ovh-ux/manager-webpack-config': '^3.3.0',
+    lodash: '^4.17.15',
     'webpack-merge': '^4.2.2',
   },
 });

--- a/packages/manager/tools/sao-ovh-manager-app/saofile.js
+++ b/packages/manager/tools/sao-ovh-manager-app/saofile.js
@@ -28,6 +28,7 @@ module.exports = {
       {
         type: 'move',
         patterns: {
+          '_eslintrc.json': '.eslintrc.json',
           '_package.json': 'package.json',
         },
       },

--- a/packages/manager/tools/sao-ovh-manager-app/template/_eslintrc.json
+++ b/packages/manager/tools/sao-ovh-manager-app/template/_eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "__WEBPACK_REGION__": true
+  }
+}

--- a/packages/manager/tools/sao-ovh-manager-app/template/src/index.js
+++ b/packages/manager/tools/sao-ovh-manager-app/template/src/index.js
@@ -1,9 +1,11 @@
 <% const pascalcasedName = this.camelcase(name, { pascalCase: true }) -%>import 'script-loader!jquery'; // eslint-disable-line
 import '@ovh-ux/manager-<%= name %>';
-
+import { Environment } from '@ovh-ux/manager-config';
 import angular from 'angular';
 
+Environment.setRegion(__WEBPACK_REGION__);
+
 angular
-  .module('<%= pascalcasedName %>App', [
+  .module('<%= this.camelcase(name) %>App', [
     'ovhManager<%= pascalcasedName %>',
   ]);

--- a/packages/manager/tools/sao-ovh-manager-app/template/webpack.config.js
+++ b/packages/manager/tools/sao-ovh-manager-app/template/webpack.config.js
@@ -1,13 +1,20 @@
-const webpackConfig = require('@ovh-ux/manager-webpack-config');
+const _ = require('lodash');
 const path = require('path');
+const webpack = require('webpack'); // eslint-disable-line
 const merge = require('webpack-merge');
+const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
+  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+
   const { config } = webpackConfig({
     template: './src/index.html',
     basePath: './src',
+    lessPath: [
+      './node_modules',
+    ],
     root: path.resolve(__dirname, './src'),
-  }, env);
+  }, REGION ? Object.assign(env, { region: REGION }) : env);
 
   return merge(config, {
     entry: path.resolve('./src/index.js'),
@@ -19,5 +26,10 @@ module.exports = (env = {}) => {
       ],
       mainFields: ['module', 'browser', 'main'],
     },
+    plugins: [
+      new webpack.DefinePlugin({
+        __WEBPACK_REGION__: `'${REGION}'`,
+      }),
+    ],
   });
 };


### PR DESCRIPTION
# Support the `REGION` parameter for standalone applications

## 👷 Build

ab9b858 - build: support the REGION parameter for standalone applications

## 🔗 Related

fix #1761

## 🏠 Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>