### PR TITLE
fix(vps): move cui-grid styles to cuc

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.less
+++ b/packages/manager/apps/cloud/client/app/app.less
@@ -353,7 +353,6 @@ html {
 @import "ui-components/advanced-options/advanced-options.less";
 @import "ui-components/dual-list/dual-list.less";
 @import "ui-components/form/form.less";
-@import "ui-components/grid/grid.less";
 @import "ui-components/icons/button-action.less";
 @import "ui-components/inline-adder/inline-adder.less";
 @import "ui-components/input/key-value.less";

--- a/packages/manager/modules/cloud-universe-components/src/cui/grid.less
+++ b/packages/manager/modules/cloud-universe-components/src/cui/grid.less
@@ -1,4 +1,5 @@
 @cui-grid-margin: 0.9375rem;
+@screen-sm-min: 801px;
 
 .cui-grid-cell  {
   padding: @cui-grid-margin / 2;

--- a/packages/manager/modules/cloud-universe-components/src/cui/index.js
+++ b/packages/manager/modules/cloud-universe-components/src/cui/index.js
@@ -7,6 +7,8 @@ import modal from './modal';
 import page from './page';
 import tabs from './tabs';
 
+import './grid.less';
+
 const moduleName = 'ngOvhCloudUniverseComponentsCui';
 
 angular


### PR DESCRIPTION
## fix(vps): move cui-grid styles to cuc

### Description of the Change

As `cui-grid` is used in `@ovh-ux/manager-vps`, styles from `cui-grid` should be in `@ovh-ux/ng-ovh-cloud-universe-components`

ce5ce69c34 — fix(vps): move cui-grid styles to cuc

