### PR TITLE
fix(domain.redirection.delete): translate correctly the checkbox field

### DIFF
--- a/packages/manager/apps/web/client/app/domain/redirection/delete/domain-redirection-delete.html
+++ b/packages/manager/apps/web/client/app/domain/redirection/delete/domain-redirection-delete.html
@@ -20,8 +20,14 @@
 
             <oui-checkbox class="mt-4" id="removeWWW" name="removeWWW"
                 data-ng-if="ctrl.wwwDomainToDelete.data"
-                data-model="ctrl.wwwDomainToDelete.removeWWW"
-                data-text="{{ 'domain_tab_REDIRECTION_delete_www_confirm' | translate: { t0: ctrl.constructor.getDomainName(ctrl.wwwDomainToDelete.data), t1: ctrl.wwwDomainToDelete.data.targetDisplayName } }}">
+                data-model="ctrl.wwwDomainToDelete.removeWWW">
+                <span
+                    data-translate="domain_tab_REDIRECTION_delete_www_confirm"
+                    data-translate-values="{
+                        t0: ctrl.constructor.getDomainName(ctrl.wwwDomainToDelete.data),
+                        t1: ctrl.wwwDomainToDelete.data.targetDisplayName
+                    }">
+                </span>
             </oui-checkbox>
         </div>
     </div>


### PR DESCRIPTION
# Translate correctly the checkbox field

Since the `text` attribute is now deprecated on the [`<oui-checkbox>`](https://ovh-ux.github.io/ovh-ui-kit-documentation/#!/oui-angular/checkbox#deprecated) component, then I use
a transclude slot.

## :bug: Bugfix

d523330 - fix(domain.redirection.delete): translate correctly the checkbox field

## :link: Related

fix #1827

## :camera_flash: Screenshot

**Before**:

![web-domain-redirection-before](https://user-images.githubusercontent.com/428384/69342047-039ee380-0c6b-11ea-8a2c-852c596f6180.png)

**After**:

![web-domain-redirection-after](https://user-images.githubusercontent.com/428384/69342053-07326a80-0c6b-11ea-96ff-6847ee542ab9.png)

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>