### PR TITLE
fix(telecom.telephony): hotfix to bypass API error when loading groups

### DIFF
--- a/packages/manager/apps/telecom/src/components/telecom/telephony/telephony-voip-service.service.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/telephony-voip-service.service.js
@@ -13,7 +13,7 @@ angular.module('managerApp').service('TelephonyVoipService', function TelephonyV
     // fetch all billing accounts
     return OvhApiTelephony.v7().query().expand().execute().$promise.then((result) => {
       forEach(result, (item) => {
-        if (!item.error) { // how should we handle errors ?
+        if (!item.error && item.value.billingAccount) { // how should we handle errors ?
           const telephonyGroup = new TelephonyGroup(item.value);
           groups[telephonyGroup.billingAccount] = telephonyGroup;
         }
@@ -29,6 +29,9 @@ angular.module('managerApp').service('TelephonyVoipService', function TelephonyV
             const pathParts = item.path.split('/');
             if (pathParts.length >= 2) {
               const billingAccount = pathParts[2].toLowerCase();
+              if (groups[billingAccount] === undefined) {
+                return;
+              }
               const service = item.value;
               service.billingAccount = billingAccount;
               if (has(item, 'value.serviceName')) {

--- a/packages/manager/modules/telecom-universe-components/src/telecom/voip/billingAccount/voip-billing-account.service.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/voip/billingAccount/voip-billing-account.service.js
@@ -46,7 +46,7 @@ export default class {
           res => has(res, 'value') || (withError && has(res, 'error')),
         ),
         (res) => {
-          if (res.value) {
+          if (res.value && res.value.billingAccount) {
             return new this.TucVoipBillingAccount(res.value);
           }
           return new this.TucVoipBillingAccount({


### PR DESCRIPTION
Hotfix against master to prevent loading error on groups when API fails

Call from manager: https://www.ovhtelecom.fr/engine/apiv7/telephony?$expand=1
Response, for some groups:
```{"1":{"key":"ovhtel-xxxxxxxxx-1","value":{"message":"Failed to bootstrap api"},"error":null}}```
the needed ```billingAccount``` property is not set and breaks the Javascript

Api error incident reported here: http://travaux.ovh.com/?do=details&id=41617