### PR TITLE
Upgrade ovh-api-services to v9.27.1 

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -49,7 +49,7 @@
     "moment": "^2.15.2",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -102,7 +102,7 @@
     "ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
     "ovh-angular-responsive-page-switcher": "^1.1.1",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -114,7 +114,7 @@
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-browser-alert": "ovh-ux/ovh-angular-browser-alert#^1.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -43,7 +43,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -28,7 +28,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "angular-ui-bootstrap": "^1.3.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -45,7 +45,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -64,7 +64,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.22.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -42,7 +42,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -26,7 +26,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -36,7 +36,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -33,7 +33,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.10.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -116,7 +116,7 @@
     "ovh-angular-timeline": "^1.5.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
     "ovh-angular-user-pref": "^0.3.1",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -38,7 +38,7 @@
     "d3": "~3.5.13",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.9",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -47,7 +47,7 @@
     "jquery": "^2.1.3",
     "jsurl": "0.1.5",
     "moment": "^2.19",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.9",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -97,7 +97,7 @@
     "ng-ckeditor": "^2.0.5",
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -45,6 +45,6 @@
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.26.1"
+    "ovh-api-services": "^9.27.1"
   }
 }

--- a/packages/manager/modules/carrier-sip/package.json
+++ b/packages/manager/modules/carrier-sip/package.json
@@ -15,7 +15,7 @@
     "@ovh-ux/ng-ovh-telecom-universe-components": "^3.0.9",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.34.3",
     "ovh-ui-kit-bs": "^2.1.2"

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -53,7 +53,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.10"
   }
 }

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -49,7 +49,7 @@
     "angular-sanitize": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-translate-loader-pluggable": "^1.3.1",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^^3.9.10"
   }
 }

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -22,7 +22,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.10"
   }
 }

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -57,7 +57,7 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^3.6.0",

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -22,7 +22,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "ng-ckeditor": "^2.0.5",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.10"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -23,7 +23,7 @@
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -46,7 +46,7 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.33.3"
   }

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -49,7 +49,7 @@
     "font-awesome": "^4.0.0",
     "jquery-ui": "components/jqueryui#~1.11.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^3.10.0",

--- a/packages/manager/modules/pci/src/components/project/labs/labs.service.js
+++ b/packages/manager/modules/pci/src/components/project/labs/labs.service.js
@@ -103,7 +103,7 @@ export default class PciProjectLabsService {
         .activate({
           serviceName: projectId,
           labId: lab.id,
-        }, {})
+        })
         .$promise);
   }
 }

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -44,6 +44,6 @@
     "@ovh-ux/ng-translate-async-loader": "^2.0.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.26.1"
+    "ovh-api-services": "^9.27.1"
   }
 }

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -15,7 +15,7 @@
     "@ovh-ux/ng-ovh-utils": "^14.0.3",
     "@ovh-ux/web-universe-components": "^7.0.0",
     "angular": "^1.7.5",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.33.3"
   }

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -31,7 +31,7 @@
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/support/package.json
+++ b/packages/manager/modules/support/package.json
@@ -20,7 +20,7 @@
     "angular-translate": "^2.18.1",
     "font-awesome": "~4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -21,7 +21,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.14",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -21,7 +21,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-angular": "^3.10.0",
     "ovh-ui-kit": "^2.33.3",

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -27,7 +27,7 @@
     "jsplumb": "^2.11.2",
     "moment": "^2.15.2",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.10.0",
     "punycode": "^1.4.1",

--- a/packages/manager/modules/veeam-enterprise/package.json
+++ b/packages/manager/modules/veeam-enterprise/package.json
@@ -20,7 +20,7 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.9",
     "ovh-ui-kit": "~2.35.2",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/modules/vps/package.json
+++ b/packages/manager/modules/vps/package.json
@@ -28,7 +28,7 @@
     "bootstrap": "~3.3.0",
     "chart.js": "chartjs/Chart.js#^2.0",
     "jsurl": "0.1.5",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.9.9",
     "ovh-ui-kit": "~2.35.2",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -53,7 +53,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -31,7 +31,7 @@
     "ipaddr.js": "^1.9.1",
     "jquery": "^2.1.3",
     "moment": "^2.16.0",
-    "ovh-api-services": "^9.26.1",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-angular": "^3.10.0",
     "punycode": "^1.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11792,10 +11792,10 @@ ovh-angular-user-pref@^0.3.1:
   resolved "https://registry.yarnpkg.com/ovh-angular-user-pref/-/ovh-angular-user-pref-0.3.1.tgz#07f5792513651f3262ae4879c174423649b08307"
   integrity sha1-B/V5JRNlHzJirkh5wXRCNkmwgwc=
 
-ovh-api-services@^9.26.1:
-  version "9.26.1"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.26.1.tgz#d583f97e4a80803bf51e90113c677beb16318149"
-  integrity sha512-tLR+s/sxKnD8/YAZfWbf6VQ5CZHg7tcndTratBUiJKwKiVMcdTqewKpbtYFpmO3J8D7KM5jZovGHzy10S1S6zA==
+ovh-api-services@^9.27.1:
+  version "9.27.1"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.27.1.tgz#f4211a1b9a3d64ed70c6fc4301480b3625c951f0"
+  integrity sha512-A+6h82iaiAxrSxVjhj2iyxtgvZa0sgAH5kS/Iv2Cd6EEgeCOelU1dllqZfoMzouMbEAz45uWx9QhYwfWIYQ5uw==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
# Upgrade ovh-api-services to v9.27.1 

## :ambulance: Hotfix

15cf5d9 - fix(deps): upgrade ovh-api-services to v9.27.1
53a1126 - fix(pci.components.project.labs): fix activateLab method

## :link: Related

- https://github.com/ovh-ux/ovh-api-services/pull/264

## :house: Internal

- DTRSD-5803
