### PR TITLE
fix(sharepoint): use sharepoint icon for sidebar entry

### DIFF
--- a/packages/manager/modules/server-sidebar/src/web.constants.js
+++ b/packages/manager/modules/server-sidebar/src/web.constants.js
@@ -221,7 +221,7 @@ export const MICROSOFT_CONFIG = {
         },
       ],
       loadOnState: 'app.microsoft.sharepoint',
-      icon: 'ms-Icon ms-Icon--ExchangeLogo',
+      icon: 'ms-Icon ms-Icon--SharepointLogo',
       app: [WEB],
     },
   ],


### PR DESCRIPTION
## fix(sharepoint): use sharepoint icon for sidebar entry

### Description of the Change



c87d0b3e21 — fix(sharepoint): use sharepoint icon for sidebar entry

## :camera_flash: Screenshot

**Before**:
![Capture d’écran 2019-11-25 à 14 39 03](https://user-images.githubusercontent.com/56223/69545170-8d172400-0f91-11ea-9e36-e5ede3c4dd63.png)

**After**:
![Capture d’écran 2019-11-25 à 14 38 38](https://user-images.githubusercontent.com/56223/69545217-a3bd7b00-0f91-11ea-80f5-4dfc72aa421d.png)


