### PR TITLE
fix(server-sidebar): clear action menu before creating order menu

### DIFF
--- a/packages/manager/modules/server-sidebar/src/controller.js
+++ b/packages/manager/modules/server-sidebar/src/controller.js
@@ -105,6 +105,7 @@ export default class OvhManagerServerSidebarController {
   }
 
   buildOrderMenu() {
+    this.SidebarMenu.actionsMenuOptions = [];
     return this.SessionService.getUser()
       .then(({ ovhSubsidiary }) => {
         const actionsMenuOptions = map(


### PR DESCRIPTION
## fix(server-sidebar): clear action menu before creating order menu

### Description of the Change

ref: DTRSD-6091

b94ef21ddb — fix(server-sidebar): clear action menu before creating order menu

