### PR TITLE
build: set modules as private

### DIFF
--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-banner",
   "version": "1.1.3",
+  "private": true,
   "description": "OVH control panel banner",
   "keywords": [
     "angularjs",

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-cloud-styles",
   "version": "0.3.1",
+  "private": true,
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/cloud-styles#readme",
   "bugs": {
     "url": "https://github.com/ovh/manager/issues"

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/ng-ovh-cloud-universe-components",
   "version": "1.5.0",
+  "private": true,
   "description": "Cloud Universe Components",
   "keywords": [
     "cloud",

--- a/packages/manager/modules/config/package.json
+++ b/packages/manager/modules/config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-config",
   "version": "0.4.0",
+  "private": true,
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/config#readme",
   "bugs": {
     "url": "https://github.com/ovh/manager/issues"

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-core",
   "version": "7.6.2",
+  "private": true,
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/core#readme",
   "bugs": {
     "url": "https://github.com/ovh/manager/issues"

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-enterprise-cloud-database",
   "version": "0.1.10",
+  "private": true,
   "description": "OVH Enterprise Cloud Database product control panel",
   "keywords": [
     "control",

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-navbar",
   "version": "2.2.0",
+  "private": true,
   "description": "OVH control panel navbar",
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/navbar#readme",
   "bugs": {

--- a/packages/manager/modules/request-tagger/package.json
+++ b/packages/manager/modules/request-tagger/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/ng-ovh-request-tagger",
   "version": "1.1.0",
+  "private": true,
   "description": "Request tagger",
   "keywords": [
     "angular",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-server-sidebar",
   "version": "1.0.1",
+  "private": true,
   "description": "OVH control panel sidebar",
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/server-sidebar#readme",
   "bugs": {

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-vrack",
   "version": "0.4.0",
+  "private": true,
   "description": "OVH vRack product control panel",
   "keywords": [
     "control",

--- a/packages/manager/modules/welcome/package.json
+++ b/packages/manager/modules/welcome/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ovh-ux/manager-welcome",
   "version": "2.1.1",
+  "private": true,
   "homepage": "https://github.com/ovh/manager/tree/master/packages/manager/modules/welcome#readme",
   "bugs": {
     "url": "https://github.com/ovh/manager/issues"


### PR DESCRIPTION
## build: set modules as private

### Description of the Change

b0c03910f8 — build: set modules as private

* @ovh-ux/manager-banner
* @ovh-ux/manager-cloud-styles
* @ovh-ux/manager-cloud-universe-components
* @ovh-ux/manager-config
* @ovh-ux/manager-core
* @ovh-ux/manager-enterprise-cloud-database
* @ovh-ux/manager-navbar
* @ovh-ux/manager-request-tagger
* @ovh-ux/manager-server-sidebar
* @ovh-ux/manager-vrack
* @ovh-ux/manager-welcome



