### PR TITLE
fix(pci): remove billing for non admin and billing nics

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/billing/billing.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/billing/billing.routing.js
@@ -6,6 +6,19 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/billing',
     controller,
     controllerAs: 'BillingCtrl',
+    redirectTo: (transition) => {
+      // Redirect back to project page if the current NIC
+      // is not an admin or a billing contact
+      const serviceName = transition.params().projectId;
+      const $q = transition.injector().get('$q');
+      return $q.all([
+        transition.injector().get('OvhApiMe').v6().get().$promise,
+        transition.injector().get('OvhApiCloudProjectServiceInfos').v6().get({
+          serviceName,
+        }).$promise,
+      ]).then(([me, serviceInfo]) => (((me.nichandle !== serviceInfo.contactAdmin)
+          && (me.nichandle !== serviceInfo.contactBilling)) ? 'pci.projects.project' : false));
+    },
     template,
     resolve: {
       breadcrumb: /* @ngInject */ $translate => $translate.instant('cpbc_billing_control'),

--- a/packages/manager/modules/pci/src/projects/project/project.html
+++ b/packages/manager/modules/pci/src/projects/project/project.html
@@ -6,6 +6,7 @@
                 'cloud-sidebar_hidden': !$ctrl.isSidebarOpen,
                 'cloud-sidebar_open': $ctrl.isSidebarOpen
             }"
+            data-user="$ctrl.user"
             data-is-open="$ctrl.isSidebarOpen"
             data-on-click="$ctrl.closeSidebar()">
         </cloud-sidebar>

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.component.js
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.component.js
@@ -4,6 +4,7 @@ import controller from './sidebar.controller';
 export default {
   bindings: {
     isOpen: '<',
+    user: '<',
     onClick: '&',
   },
   controller,

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
@@ -175,6 +175,7 @@ export const MENU = [
           state: 'pci.projects.project.billing',
         },
         regions: ['EU', 'CA'],
+        users: ['admin', 'billing'],
         title: 'Billing Control',
       },
       {
@@ -207,8 +208,15 @@ export const MENU = [
 
 export const UNIVERSE = 'Public Cloud';
 
+export const USER_TYPES_MAP = {
+  admin: 'contactAdmin',
+  billing: 'contactBilling',
+  tech: 'contactTech',
+};
+
 export default {
   HORIZON,
   MENU,
   UNIVERSE,
+  USER_TYPES_MAP,
 };

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.html
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.html
@@ -46,7 +46,8 @@
                         <div class="oui-sidebar-menu oui-sidebar-menu_fixed menu-sub-items">
                             <ul class="oui-sidebar-list">
                                 <li class="oui-sidebar-list__item"
-                                    data-ng-repeat="subitem in item.subitems">
+                                    data-ng-repeat="subitem in item.subitems track by $index"
+                                    data-ng-if="::$ctrl.isAvailableToUser(subitem)">
                                     <a
                                         data-ng-if="subitem.options.state"
                                         data-ng-click="$ctrl.onMenuItemClick(subitem)"


### PR DESCRIPTION
The `Billing` link in the side bar is now not visible to users/NICs who are not billing or admin contacts. The user is redirected to the project page, if he/she tries to access the `/billing` route directly by entering the url

MANAGER-4020