### PR TITLE
fix(telecom): restore ovhPabx sounds part

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/huntings-sounds.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/huntings-sounds.controller.js
@@ -1,0 +1,101 @@
+import endsWith from 'lodash/endsWith';
+import remove from 'lodash/remove';
+import set from 'lodash/set';
+import some from 'lodash/some';
+
+export default /* @ngInject */ function TelecomTelephonyAliasHuntingSoundsCtrl(
+  $stateParams,
+  $uibModalInstance,
+  $timeout,
+  $q,
+  $translate,
+  params,
+  OvhApiMe,
+  TucToastError,
+  tucVoipServiceTask,
+) {
+  const self = this;
+
+  function init() {
+    self.sounds = params.sounds;
+    self.apiEndpoint = params.apiEndpoint;
+  }
+
+  self.close = function close() {
+    $uibModalInstance.dismiss();
+  };
+
+  self.checkValidAudioExtention = function checkValidAudioExtention(file) {
+    const validExtensions = ['aiff', 'au', 'flac', 'ogg', 'mp3', 'wav', 'wma'];
+    const fileName = file ? file.name : '';
+    const found = some(validExtensions, ext => endsWith(fileName.toLowerCase(), ext));
+    if (!found) {
+      TucToastError($translate.instant('telephony_alias_hunting_sounds_invalid'));
+    }
+    return found;
+  };
+
+  self.uploadFile = function uploadFile() {
+    // api does not handle space characters in filenames
+    const name = (self.toUpload.name || '').replace(/\s/g, '_');
+    self.isUploading = true;
+
+    // first, upload document to get a file url
+    return OvhApiMe.Document().v6().upload(
+      name,
+      self.toUpload,
+    ).then(doc => self.apiEndpoint.v6().soundUpload({
+      billingAccount: $stateParams.billingAccount,
+      serviceName: $stateParams.serviceName,
+    }, {
+      name,
+      url: doc.getUrl,
+    }).$promise.then(result => tucVoipServiceTask.startPolling(
+      $stateParams.billingAccount,
+      $stateParams.serviceName,
+      result.taskId,
+      {
+        namespace: `soundUploadTask_${$stateParams.serviceName}`,
+        interval: 1000,
+        retryMaxAttempts: 0,
+      },
+    ).catch((err) => {
+      // When the task does not exist anymore it is considered done (T_T)
+      if (err.status === 404) {
+        // add some delay to ensure we get the sound from api when refreshing
+        return $timeout(() => $q.when(true), 2000);
+      }
+      return $q.reject(err);
+    })))
+      .then(() => {
+        self.toUpload = null;
+        params.refreshSounds();
+      })
+      .catch(err => new TucToastError(err))
+      .finally(() => {
+        self.isUploading = false;
+      });
+  };
+
+  self.chooseSound = function chooseSound(sound) {
+    $uibModalInstance.close(sound);
+  };
+
+  self.deleteSound = function deleteSound(sound) {
+    set(sound, 'isDeleting', true);
+    return $q.all([
+      $timeout(angular.noop, 500),
+      self.apiEndpoint.Sound().v6().remove({
+        billingAccount: $stateParams.billingAccount,
+        serviceName: $stateParams.serviceName,
+        soundId: sound.soundId,
+      }).$promise.then(() => {
+        remove(self.sounds, { soundId: sound.soundId });
+      }).catch(err => new TucToastError(err)).finally(() => {
+        set(sound, 'isDeleting', false);
+      }),
+    ]);
+  };
+
+  init();
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/huntings-sounds.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/huntings-sounds.html
@@ -1,0 +1,69 @@
+<form name="easyHuntingSoundsHelper"
+      data-ng-submit="$ctrl.uploadFile()"
+      novalidate>
+
+    <div class="modal-header">
+        <button type="button"
+                class="close float-right"
+                aria-label="{{ ::'cancel' | translate }}"
+                data-ng-click="$ctrl.close()">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="modal-body clearfix">
+        <h3 class="modal-title"
+            data-translate="telephony_alias_hunting_sounds_manager">
+        </h3>
+
+        <div class="form-group">
+            <tuc-input-file data-ng-model="$ctrl.toUpload"
+                        data-ng-accept="audio/*"
+                        data-ng-accept-filter="$ctrl.checkValidAudioExtention(file)">
+                <span class="fa fa-upload mr-1"></span>
+                <span data-translate="telephony_alias_hunting_sounds_upload"></span>
+            </tuc-input-file>
+
+            <button type="submit"
+                    class="btn btn-default mt-2 float-right no-transition"
+                    data-ng-disabled="$ctrl.isUploading"
+                    data-ng-if="$ctrl.toUpload">
+                <oui-spinner class="mr-2"
+                             data-ng-if="$ctrl.isUploading"
+                             data-size="s">
+                </oui-spinner>
+                <span data-translate="submit"></span>
+            </button>
+        </div>
+
+        <div class="form-group"
+             data-ng-if="$ctrl.sounds.length">
+             <label class="control-label"
+                    data-translate="telephony_alias_hunting_sounds_list">
+             </label>
+             <div class="btn-group d-block clearfix mb-4"
+                  role="group"
+                  data-ng-repeat="sound in $ctrl.sounds track by sound.soundId">
+                 <button type="button"
+                         class="btn btn-default w-75"
+                         data-ng-click="$ctrl.chooseSound(sound)"
+                         data-ng-bind=":: sound.name">
+                 </button>
+                 <button type="button"
+                         class="btn btn-default w-25"
+                         data-title="{{:: 'telephony_alias_hunting_sounds_delete' | translate }}"
+                         data-ng-disabled="sound.isDeleting"
+                         data-ng-click="$ctrl.deleteSound(sound)">
+                     <oui-spinner data-ng-if="sound.isDeleting"
+                                  data-size="s">
+                     </oui-spinner>
+                     <span class="ovh-font ovh-font-wrong"
+                           data-ng-if="!sound.isDeleting">
+                     </span>
+                 </button>
+             </div>
+        </div>
+
+    </div>
+
+</form>

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/hunting-sounds/translations/Messages_fr_FR.json
@@ -1,0 +1,7 @@
+{
+  "telephony_alias_hunting_sounds_invalid": "Format de fichier invalide.",
+  "telephony_alias_hunting_sounds_manager": "Gestion des fichiers",
+  "telephony_alias_hunting_sounds_upload": "Ajouter un fichier",
+  "telephony_alias_hunting_sounds_list": "Sélectionner un fichier existant :",
+  "telephony_alias_hunting_sounds_delete": "Supprimer le fichier"
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
@@ -15,6 +15,9 @@ import sortBy from 'lodash/sortBy';
 import { NUMBER_EXTERNAL_TYPE } from './telecom-telephony-alias-configuration-queues-ovhPabx.constants';
 import modalTemplate from './telecom-telephony-alias-configuration-queues-ovhPabx-modal.html';
 
+import huntingSoundsController from './hunting-sounds/huntings-sounds.controller';
+import huntingSoundsTemplate from './hunting-sounds/huntings-sounds.html';
+
 angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueuesOvhPabxCtrl', function TelecomTelephonyAliasConfigurationQueuesOvhPabxCtrl($stateParams, $q, $translate, $timeout, $uibModal, OvhApiTelephony, TucToast, TucToastError) {
   const self = this;
 
@@ -331,8 +334,8 @@ angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueue
     self.managingSounds = true;
     const modal = $uibModal.open({
       animation: true,
-      templateUrl: 'components/telecom/alias/hunting/sounds/telecom-telephony-alias-hunting-sounds.html',
-      controller: 'TelecomTelephonyAliasHuntingSoundsCtrl',
+      template: huntingSoundsTemplate,
+      controller: huntingSoundsController,
       controllerAs: '$ctrl',
       resolve: {
         params() {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.js
@@ -8,6 +8,6 @@ angular.module('managerApp').config(($stateProvider) => {
         controllerAs: 'QueuesOvhPabxCtrl',
       },
     },
-    translations: { value: ['..'], format: 'json' },
+    translations: { value: ['..', './hunting-sounds'], format: 'json' },
   });
 });


### PR DESCRIPTION
## fix(telecom): restore ovhPabx sounds part

### Description of the Change

* add missing controller, template and translations

ref: DTRSD-6140

968fe0acb4 — fix(telecom): restore ovhPabx sounds part

Restored from https://github.com/ovh-ux/ovh-manager-telecom/tree/390b7a1f99b3741795dd34a50c37c039834c62a7/client/components/telecom/alias/hunting/sounds

