### PR TITLE
fix(telephony.line.contact): send siret instead of siren to API

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/telecom-telephony-service-contact.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/telecom-telephony-service-contact.controller.js
@@ -239,8 +239,7 @@ angular.module('managerApp').controller('TelecomTelephonyServiceContactCtrl', fu
           });
         };
 
-        // we take only first 10 chars which is SIREN code
-        fetchInfos(self.directoryForm.siret.substring(0, 9)).then((infos) => {
+        fetchInfos(self.directoryForm.siret).then((infos) => {
           if (infos.informations.isValid) {
             self.directoryForm.ape = infos.informations.ape;
             self.directoryForm.socialNomination = infos.informations.name;


### PR DESCRIPTION
## fix(telephony.line.contact): send siret instead of siren to API

### Description of the Change

ref: DTRSD-6146

53699b8288 — fix(telephony.line.contact): send siret instead of siren to API

