### PR TITLE
fix(telephony.fax.campaign): disable native validation on creation form

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/fax/campaigns/add/telecom-telephony-service-fax-campaigns-add.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/fax/campaigns/add/telecom-telephony-service-fax-campaigns-add.html
@@ -1,6 +1,7 @@
 <form name="addTelephonyFaxCampaignForm"
       id="addTelephonyFaxCampaignForm"
-      data-ng-submit="CampaignsAddCtrl.add()">
+      data-ng-submit="CampaignsAddCtrl.add()"
+      novalidate>
 
     <div class="modal-header">
         <button


### PR DESCRIPTION
## fix(telephony.fax.campaign): disable native validation on creation form

### Description of the Change

Fix console error : `An invalid form control with name='' is not focusable.`

ref: DTRSD-6488

5058ad2ea8 — fix(telephony.fax.campaign): disable native validation on creation form

