### PR TITLE
fix: fix Analytics Data Platform order pipeline

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/analytics-data-platform/analytics-data-platform.service.js
+++ b/packages/manager/modules/pci/src/projects/project/analytics-data-platform/analytics-data-platform.service.js
@@ -232,7 +232,7 @@ export default class AnalyticsDataPlatformService {
         {
           method: 'get',
           namespace: `analytics-data-platform.order.${orderId}`,
-          successRule: orderDetail => orderDetail.domain !== '*',
+          successRule: orderDetail => orderDetail.domain !== '*001',
         },
       ))
       .then(orderDetail => orderDetail.domain);


### PR DESCRIPTION
Current implementation of Analytics Data Platform pipeline wrongly implements service name check when ordering through Agora. We use a Poller to wait for Agora to return updated service name but check for a default of `*` instead of `*001`. Asynchronous process can lead to Manager progressing too fast compared to Agora updates and failing to deploy cluster.