### PR TITLE
style: apply stylelint rules across all styles files

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch.css
+packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch-2.css

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,17 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+  "plugins": [
+    "stylelint-scss"
+  ],
+  "rules": {
+    "at-rule-no-unknown": null,
+    "function-calc-no-invalid": null,
+    "scss/at-rule-no-unknown": true,
+    "selector-type-no-unknown": [
+      true,
+      {
+        "ignore": ["custom-elements"]
+      }
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generate:app": "sao ./packages/manager/tools/sao-ovh-manager-app",
     "generate:module": "sao ./packages/manager/tools/sao-ovh-manager-module",
     "lint": "run-p lint:css lint:html lint:js lint:md",
-    "lint:css": "stylelint 'packages/**/*.less' --fix",
+    "lint:css": "stylelint 'packages/**/*.{css,less,scss}' --fix",
     "lint:html": "htmlhint --ignore \"**/dist/**,**/dist-EU/**,**/dist-CA/**,**/dist-US/**\" \"packages/**/*.html\"",
     "lint:js": "eslint --fix --quiet --format=pretty packages scripts",
     "lint:md": "remark -qf .",
@@ -66,6 +66,7 @@
     "semver": "^5.6.0",
     "stylelint": "^12.0.0",
     "stylelint-config-standard": "^19.0.0",
+    "stylelint-scss": "^3.13.0",
     "tcp-port-used": "^1.0.1"
   },
   "engines": {

--- a/packages/components/ng-ovh-contracts/src/full/index.less
+++ b/packages/components/ng-ovh-contracts/src/full/index.less
@@ -1,5 +1,4 @@
 // stylelint-disable no-descending-specificity
-// stylelint-disable-next-line selector-type-no-unknown
 ovh-contracts,
 [ovh-contracts],
 [data-ovh-contracts] {

--- a/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.less
+++ b/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.less
@@ -1,4 +1,4 @@
-ui-router-breadcrumb { /* stylelint-disable-line selector-type-no-unknown */
+ui-router-breadcrumb {
   ul {
     margin: 0;
     padding: 0;

--- a/packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch-2.css
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch-2.css
@@ -13,14 +13,15 @@
  * ============================================================ */
 .has-switch,
 .has-switch *,
-.has-switch:before,
-.has-switch *:before,
-.has-switch:after,
-.has-switch *:after {
+.has-switch::before,
+.has-switch *::before,
+.has-switch::after,
+.has-switch *::after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
+
 .has-switch {
   display: inline-block;
   cursor: pointer;
@@ -41,11 +42,13 @@
   vertical-align: middle;
   min-width: 100px;
 }
+
 .has-switch.switch-mini {
   min-width: 72px;
 }
+
 .has-switch.switch-mini i.switch-mini-icons {
-  height: 1.20em;
+  height: 1.2em;
   line-height: 9px;
   vertical-align: text-top;
   text-align: center;
@@ -53,43 +56,53 @@
   margin-top: -1px;
   margin-bottom: -1px;
 }
+
 .has-switch.switch-small {
   min-width: 80px;
 }
+
 .has-switch.switch-large {
   min-width: 120px;
 }
+
 .has-switch.deactivate {
   opacity: 0.5;
   filter: alpha(opacity=50);
   cursor: default !important;
 }
+
 .has-switch.deactivate label,
 .has-switch.deactivate span {
   cursor: default !important;
 }
+
 .has-switch > div {
   display: inline-block;
   width: 150%;
   position: relative;
   top: 0;
 }
+
 .has-switch > div.switch-animate {
   -webkit-transition: left 0.5s;
   -moz-transition: left 0.5s;
   -o-transition: left 0.5s;
   transition: left 0.5s;
 }
+
 .has-switch > div.switch-off {
   left: -50%;
 }
+
 .has-switch > div.switch-on {
   left: 0%;
 }
+
 .has-switch input[type=radio],
 .has-switch input[type=checkbox] {
   display: none;
 }
+
 .has-switch span,
 .has-switch label {
   -webkit-box-sizing: border-box;
@@ -104,6 +117,7 @@
   font-size: 14px;
   line-height: 20px;
 }
+
 .has-switch span.switch-mini,
 .has-switch label.switch-mini {
   padding-bottom: 4px;
@@ -111,6 +125,7 @@
   font-size: 10px;
   line-height: 9px;
 }
+
 .has-switch span.switch-small,
 .has-switch label.switch-small {
   padding-bottom: 3px;
@@ -118,6 +133,7 @@
   font-size: 12px;
   line-height: 18px;
 }
+
 .has-switch span.switch-large,
 .has-switch label.switch-large {
   padding-bottom: 9px;
@@ -125,56 +141,63 @@
   font-size: 16px;
   line-height: normal;
 }
+
 .has-switch label {
   text-align: center;
   margin-top: -1px;
   margin-bottom: -1px;
   z-index: 100;
   width: 34%;
-  border-left: 1px solid #cccccc;
-  border-right: 1px solid #cccccc;
-  color: #333333;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  color: #333;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #f5f5f5;
-  background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
-  background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
-  background-image: linear-gradient(to bottom, #ffffff, #e6e6e6);
+  background-image: -moz-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#e6e6e6));
+  background-image: -webkit-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -o-linear-gradient(top, #fff, #e6e6e6);
+  background-image: linear-gradient(to bottom, #fff, #e6e6e6);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
   border-color: #e6e6e6 #e6e6e6 #bfbfbf;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   *background-color: #e6e6e6;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch label:hover,
 .has-switch label:focus,
 .has-switch label:active,
 .has-switch label.active,
 .has-switch label.disabled,
 .has-switch label[disabled] {
-  color: #333333;
+  color: #333;
   background-color: #e6e6e6;
   *background-color: #d9d9d9;
 }
+
 .has-switch label:active,
 .has-switch label.active {
-  background-color: #cccccc \9;
+  background-color: #ccc \9;
 }
+
 .has-switch label i {
   color: #000;
   text-shadow: 0 1px 0 #fff;
   line-height: 18px;
   pointer-events: none;
 }
+
 .has-switch span {
   text-align: center;
   z-index: 1;
   width: 33%;
 }
+
 .has-switch span.switch-left {
   -webkit-border-top-left-radius: 4px;
   -moz-border-radius-topleft: 4px;
@@ -183,57 +206,64 @@
   -moz-border-radius-bottomleft: 4px;
   border-bottom-left-radius: 4px;
 }
+
 .has-switch span.switch-right {
-  color: #333333;
+  color: #333;
   text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
   background-color: #f0f0f0;
-  background-image: -moz-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#e6e6e6), to(#ffffff));
-  background-image: -webkit-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: -o-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: linear-gradient(to bottom, #e6e6e6, #ffffff);
+  background-image: -moz-linear-gradient(top, #e6e6e6, #fff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#e6e6e6), to(#fff));
+  background-image: -webkit-linear-gradient(top, #e6e6e6, #fff);
+  background-image: -o-linear-gradient(top, #e6e6e6, #fff);
+  background-image: linear-gradient(to bottom, #e6e6e6, #fff);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe6e6e6', endColorstr='#ffffffff', GradientType=0);
-  border-color: #ffffff #ffffff #d9d9d9;
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffe6e6e6', endColorstr='#ffffffff', GradientType=0);
+  border-color: #fff #fff #d9d9d9;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #ffffff;
+  *background-color: #fff;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-right:hover,
 .has-switch span.switch-right:focus,
 .has-switch span.switch-right:active,
 .has-switch span.switch-right.active,
 .has-switch span.switch-right.disabled,
 .has-switch span.switch-right[disabled] {
-  color: #333333;
-  background-color: #ffffff;
+  color: #333;
+  background-color: #fff;
   *background-color: #f2f2f2;
 }
+
 .has-switch span.switch-right:active,
 .has-switch span.switch-right.active {
   background-color: #e6e6e6 \9;
 }
+
 .has-switch span.switch-primary,
 .has-switch span.switch-left {
-  color: #ffffff;
+  color: #fff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #005fcc;
-  background-image: -moz-linear-gradient(top, #0044cc, #0088cc);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0044cc), to(#0088cc));
-  background-image: -webkit-linear-gradient(top, #0044cc, #0088cc);
-  background-image: -o-linear-gradient(top, #0044cc, #0088cc);
-  background-image: linear-gradient(to bottom, #0044cc, #0088cc);
+  background-image: -moz-linear-gradient(top, #04c, #08c);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#04c), to(#08c));
+  background-image: -webkit-linear-gradient(top, #04c, #08c);
+  background-image: -o-linear-gradient(top, #04c, #08c);
+  background-image: linear-gradient(to bottom, #04c, #08c);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0044cc', endColorstr='#ff0088cc', GradientType=0);
-  border-color: #0088cc #0088cc #005580;
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff0044cc', endColorstr='#ff0088cc', GradientType=0);
+  border-color: #08c #08c #005580;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #0088cc;
+  *background-color: #08c;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-primary:hover,
 .has-switch span.switch-left:hover,
 .has-switch span.switch-primary:focus,
@@ -246,18 +276,20 @@
 .has-switch span.switch-left.disabled,
 .has-switch span.switch-primary[disabled],
 .has-switch span.switch-left[disabled] {
-  color: #ffffff;
-  background-color: #0088cc;
+  color: #fff;
+  background-color: #08c;
   *background-color: #0077b3;
 }
+
 .has-switch span.switch-primary:active,
 .has-switch span.switch-left:active,
 .has-switch span.switch-primary.active,
 .has-switch span.switch-left.active {
-  background-color: #006699 \9;
+  background-color: #069 \9;
 }
+
 .has-switch span.switch-info {
-  color: #ffffff;
+  color: #fff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #41a7c5;
   background-image: -moz-linear-gradient(top, #2f96b4, #5bc0de);
@@ -266,30 +298,34 @@
   background-image: -o-linear-gradient(top, #2f96b4, #5bc0de);
   background-image: linear-gradient(to bottom, #2f96b4, #5bc0de);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff2f96b4', endColorstr='#ff5bc0de', GradientType=0);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff2f96b4', endColorstr='#ff5bc0de', GradientType=0);
   border-color: #5bc0de #5bc0de #28a1c5;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   *background-color: #5bc0de;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-info:hover,
 .has-switch span.switch-info:focus,
 .has-switch span.switch-info:active,
 .has-switch span.switch-info.active,
 .has-switch span.switch-info.disabled,
 .has-switch span.switch-info[disabled] {
-  color: #ffffff;
+  color: #fff;
   background-color: #5bc0de;
   *background-color: #46b8da;
 }
+
 .has-switch span.switch-info:active,
 .has-switch span.switch-info.active {
   background-color: #31b0d5 \9;
 }
+
 .has-switch span.switch-success {
-  color: #ffffff;
+  color: #fff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #58b058;
   background-image: -moz-linear-gradient(top, #51a351, #62c462);
@@ -298,30 +334,34 @@
   background-image: -o-linear-gradient(top, #51a351, #62c462);
   background-image: linear-gradient(to bottom, #51a351, #62c462);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff51a351', endColorstr='#ff62c462', GradientType=0);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ff51a351', endColorstr='#ff62c462', GradientType=0);
   border-color: #62c462 #62c462 #3b9e3b;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   *background-color: #62c462;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-success:hover,
 .has-switch span.switch-success:focus,
 .has-switch span.switch-success:active,
 .has-switch span.switch-success.active,
 .has-switch span.switch-success.disabled,
 .has-switch span.switch-success[disabled] {
-  color: #ffffff;
+  color: #fff;
   background-color: #62c462;
   *background-color: #4fbd4f;
 }
+
 .has-switch span.switch-success:active,
 .has-switch span.switch-success.active {
   background-color: #42b142 \9;
 }
+
 .has-switch span.switch-warning {
-  color: #ffffff;
+  color: #fff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #f9a123;
   background-image: -moz-linear-gradient(top, #f89406, #fbb450);
@@ -330,30 +370,34 @@
   background-image: -o-linear-gradient(top, #f89406, #fbb450);
   background-image: linear-gradient(to bottom, #f89406, #fbb450);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff89406', endColorstr='#fffbb450', GradientType=0);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#fff89406', endColorstr='#fffbb450', GradientType=0);
   border-color: #fbb450 #fbb450 #f89406;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   *background-color: #fbb450;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-warning:hover,
 .has-switch span.switch-warning:focus,
 .has-switch span.switch-warning:active,
 .has-switch span.switch-warning.active,
 .has-switch span.switch-warning.disabled,
 .has-switch span.switch-warning[disabled] {
-  color: #ffffff;
+  color: #fff;
   background-color: #fbb450;
   *background-color: #faa937;
 }
+
 .has-switch span.switch-warning:active,
 .has-switch span.switch-warning.active {
   background-color: #fa9f1e \9;
 }
+
 .has-switch span.switch-danger {
-  color: #ffffff;
+  color: #fff;
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
   background-color: #d14641;
   background-image: -moz-linear-gradient(top, #bd362f, #ee5f5b);
@@ -362,56 +406,63 @@
   background-image: -o-linear-gradient(top, #bd362f, #ee5f5b);
   background-image: linear-gradient(to bottom, #bd362f, #ee5f5b);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffbd362f', endColorstr='#ffee5f5b', GradientType=0);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffbd362f', endColorstr='#ffee5f5b', GradientType=0);
   border-color: #ee5f5b #ee5f5b #e51d18;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
   *background-color: #ee5f5b;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-danger:hover,
 .has-switch span.switch-danger:focus,
 .has-switch span.switch-danger:active,
 .has-switch span.switch-danger.active,
 .has-switch span.switch-danger.disabled,
 .has-switch span.switch-danger[disabled] {
-  color: #ffffff;
+  color: #fff;
   background-color: #ee5f5b;
   *background-color: #ec4844;
 }
+
 .has-switch span.switch-danger:active,
 .has-switch span.switch-danger.active {
   background-color: #e9322d \9;
 }
+
 .has-switch span.switch-default {
-  color: #333333;
+  color: #333;
   text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
   background-color: #f0f0f0;
-  background-image: -moz-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#e6e6e6), to(#ffffff));
-  background-image: -webkit-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: -o-linear-gradient(top, #e6e6e6, #ffffff);
-  background-image: linear-gradient(to bottom, #e6e6e6, #ffffff);
+  background-image: -moz-linear-gradient(top, #e6e6e6, #fff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#e6e6e6), to(#fff));
+  background-image: -webkit-linear-gradient(top, #e6e6e6, #fff);
+  background-image: -o-linear-gradient(top, #e6e6e6, #fff);
+  background-image: linear-gradient(to bottom, #e6e6e6, #fff);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe6e6e6', endColorstr='#ffffffff', GradientType=0);
-  border-color: #ffffff #ffffff #d9d9d9;
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffe6e6e6', endColorstr='#ffffffff', GradientType=0);
+  border-color: #fff #fff #d9d9d9;
   border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #ffffff;
+  *background-color: #fff;
+
   /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: progid:dximagetransform.microsoft.gradient(enabled = false);
 }
+
 .has-switch span.switch-default:hover,
 .has-switch span.switch-default:focus,
 .has-switch span.switch-default:active,
 .has-switch span.switch-default.active,
 .has-switch span.switch-default.disabled,
 .has-switch span.switch-default[disabled] {
-  color: #333333;
-  background-color: #ffffff;
+  color: #333;
+  background-color: #fff;
   *background-color: #f2f2f2;
 }
+
 .has-switch span.switch-default:active,
 .has-switch span.switch-default.active {
   background-color: #e6e6e6 \9;

--- a/packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch.css
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/directives/checkboxSwitch/checkboxSwitch.css
@@ -13,14 +13,15 @@
  * ============================================================ */
 .has-switch,
 .has-switch *,
-.has-switch:before,
-.has-switch *:before,
-.has-switch:after,
-.has-switch *:after {
+.has-switch::before,
+.has-switch *::before,
+.has-switch::after,
+.has-switch *::after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
+
 .has-switch {
   border-radius: 30px;
   display: inline-block;
@@ -38,20 +39,24 @@
   -o-user-select: none;
   user-select: none;
 }
+
 .has-switch.deactivate {
   opacity: 0.5;
   filter: alpha(opacity=50);
   cursor: default !important;
 }
+
 .has-switch.deactivate label,
 .has-switch.deactivate span {
   cursor: default !important;
 }
+
 .has-switch > div {
   width: 130px;
   position: relative;
   top: 0;
 }
+
 .has-switch > div.switch-animate {
   -webkit-transition: left 0.25s ease-out;
   -moz-transition: left 0.25s ease-out;
@@ -59,35 +64,41 @@
   transition: left 0.25s ease-out;
   -webkit-backface-visibility: hidden;
 }
+
 .has-switch > div.switch-off {
   left: -50px;
 }
+
 .has-switch > div.switch-off label {
   background: #4d4d55;
-  background: -moz-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -webkit-gradient(linear,left top,left bottom,color-stop(0,#4d4d55),color-stop(100%,#37373c));
-  background: -webkit-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -o-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -ms-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: linear-gradient(to bottom,#4d4d55 0,#37373c 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#4d4d55', endColorstr='#37373c', GradientType=0);
+  background: -moz-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #4d4d55), color-stop(100%, #37373c));
+  background: -webkit-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -o-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -ms-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: linear-gradient(to bottom, #4d4d55 0, #37373c 100%);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#4d4d55', endColorstr='#37373c', GradientType=0);
 }
+
 .has-switch > div.switch-on {
   left: 0;
 }
+
 .has-switch > div.switch-on label {
   background: #4d4d55;
-  background: -moz-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -webkit-gradient(linear,left top,left bottom,color-stop(0,#4d4d55),color-stop(100%,#37373c));
-  background: -webkit-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -o-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: -ms-linear-gradient(top,#4d4d55 0,#37373c 100%);
-  background: linear-gradient(to bottom,#4d4d55 0,#37373c 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#4d4d55', endColorstr='#37373c', GradientType=0);
+  background: -moz-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #4d4d55), color-stop(100%, #37373c));
+  background: -webkit-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -o-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: -ms-linear-gradient(top, #4d4d55 0, #37373c 100%);
+  background: linear-gradient(to bottom, #4d4d55 0, #37373c 100%);
+  filter: progid:dximagetransform.microsoft.gradient(startColorstr='#4d4d55', endColorstr='#37373c', GradientType=0);
 }
+
 .has-switch input[type=checkbox] {
   display: none;
 }
+
 .has-switch span {
   cursor: pointer;
   font-size: 15px;
@@ -108,35 +119,35 @@
   transition: 0.25s ease-out;
   -webkit-backface-visibility: hidden;
 }
+
 .has-switch span.switch-left {
   border-radius: 30px 0 0 30px;
-
-  background-color: #DFDFDF;
-  color: #3D3D3D;
-  text-shadow: 1px 1px 1px #FFF;
-  -moz-box-shadow: inset 0 1px 3px #C1C1C1;
-  -webkit-box-shadow: inset 0 1px 3px #C1C1C1;
-  box-shadow: inset 0 1px 3px #C1C1C1;
-
+  background-color: #dfdfdf;
+  color: #3d3d3d;
+  text-shadow: 1px 1px 1px #fff;
+  -moz-box-shadow: inset 0 1px 3px #c1c1c1;
+  -webkit-box-shadow: inset 0 1px 3px #c1c1c1;
+  box-shadow: inset 0 1px 3px #c1c1c1;
   border-left: 1px solid transparent;
 }
+
 .has-switch span.switch-right {
   border-radius: 0 30px 30px 0;
-
-  background-color: #DFDFDF;
-  color: #3D3D3D;
-  text-shadow: 1px 1px 1px #FFF;
-  -moz-box-shadow: inset 0 1px 3px #C1C1C1;
-  -webkit-box-shadow: inset 0 1px 3px #C1C1C1;
-  box-shadow: inset 0 1px 3px #C1C1C1;
-  
+  background-color: #dfdfdf;
+  color: #3d3d3d;
+  text-shadow: 1px 1px 1px #fff;
+  -moz-box-shadow: inset 0 1px 3px #c1c1c1;
+  -webkit-box-shadow: inset 0 1px 3px #c1c1c1;
+  box-shadow: inset 0 1px 3px #c1c1c1;
   text-indent: 7px;
 }
+
 .has-switch span.switch-right [class*="fui-"] {
   text-indent: 0;
 }
+
 .has-switch label {
-  border: 4px solid #DFDFDF;
+  border: 4px solid #dfdfdf;
   border-radius: 50%;
   float: left;
   height: 29px;
@@ -152,25 +163,32 @@
   transition: 0.25s ease-out;
   -webkit-backface-visibility: hidden;
 }
+
 .switch-square {
   border-radius: 6px;
 }
+
 .switch-square > div.switch-off label {
   border-color: #7f8c9a;
   border-radius: 6px 0 0 6px;
 }
+
 .switch-square span.switch-left {
   border-radius: 6px 0 0 6px;
 }
+
 .switch-square span.switch-left [class*="fui-"] {
   text-indent: -10px;
 }
+
 .switch-square span.switch-right {
   border-radius: 0 6px 6px 0;
 }
+
 .switch-square span.switch-right [class*="fui-"] {
   text-indent: 5px;
 }
+
 .switch-square label {
   border-radius: 0 6px 6px 0;
   border-color: #4d4d55;

--- a/packages/manager/apps/dedicated/client/app/account/user/components/directives/sshkeySwitch/sshkeySwitch.css
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/directives/sshkeySwitch/sshkeySwitch.css
@@ -1,6 +1,6 @@
 .sshkey-switch {
   margin-bottom: 5px;
-  background: #DBDBDB;
+  background: #dbdbdb;
   border-radius: 4px;
 }
 
@@ -13,6 +13,7 @@
   background: #59d2ef;
   font-weight: bold;
 }
+
 .sshkey-switch span:first-child {
   border-radius: 4px 0 0 4px;
 }

--- a/packages/manager/apps/dedicated/client/app/app.less
+++ b/packages/manager/apps/dedicated/client/app/app.less
@@ -20,7 +20,7 @@
     font-size: inherit;
   }
 
-  ola-step-checker { // stylelint-disable-line selector-type-no-unknown
+  ola-step-checker {
     display: block;
 
     @media (min-width: 992px) {

--- a/packages/manager/apps/dedicated/client/app/css/billing/main.css
+++ b/packages/manager/apps/dedicated/client/app/css/billing/main.css
@@ -1,65 +1,65 @@
 .module-billing-menu > .sidebar {
-    left: 0;
-    top: 40px;
+  left: 0;
+  top: 40px;
 }
 
 .module-billing-menu .sidebar .navigation-left-title:hover {
-    background-color: #3f5167;
+  background-color: #3f5167;
 }
 
 .module-billing-menu .sidebar .extended-accordion-in {
-    height: auto;
-    visibility: visible;
+  height: auto;
+  visibility: visible;
 }
 
 .module-billing-menu .sidebar .navigation-left-title .fa-chevron-left {
-    opacity: .6;
-    font-size: 10px;
-    width: 8px;
-    height: 8px;
-    margin: 15px 0 0 15px;
+  opacity: 0.6;
+  font-size: 10px;
+  width: 8px;
+  height: 8px;
+  margin: 15px 0 0 15px;
 }
 
 .module-billing-menu .sidebar .navigation-left-title.not-expandable {
-    margin-left: 0;
-    padding-left: 23px;
+  margin-left: 0;
+  padding-left: 23px;
 }
 
 .module-billing-menu > .sidebar .navigation-left.module-billing-menu-back {
-    padding: 20px 0 10px 0;
+  padding: 20px 0 10px 0;
 }
 
 .module-billing-menu > .sidebar .navigation-left-title > span {
-    margin: 7px 10px 0 18px;
+  margin: 7px 10px 0 18px;
 }
 
 .module-billing-menu > .sidebar .navigation-left-list-container.active {
-    border-left-color: #00a2bf;
+  border-left-color: #00a2bf;
 }
 
 .module-billing-menu > .sidebar .navigation-left-list-container > li.active {
-    background-color: #00a2bf !important;
+  background-color: #00a2bf !important;
 }
 
 .module-billing-menu > .sidebar .navigation-left-list-container > li:hover {
-    background-color: rgba(255, 255, 255, 0.15);
+  background-color: rgba(255, 255, 255, 0.15);
 }
 
 .module-billing-menu > .sidebar .navigation-left-list-container > li a.navigation-left-item:hover,
 .module-billing-menu > .sidebar .navigation-left-list-container > li a.navigation-left-item:focus {
-    background-color: transparent;
+  background-color: transparent;
 }
 
 .module-billing-menu .sidebar .navigation-left-list-container > li a.navigation-left-item.active {
-    background-color: #00a2bf !important;
-    color: #122844;
+  background-color: #00a2bf !important;
+  color: #122844;
 }
 
-.module-billing-menu >.sidebar .navigation-left-title .module-billing-menu-small {
-    display: block;
-    font-weight: lighter;
-    font-size: 85%;
-    margin-top: 0;
-    padding-bottom: 12px;
-    line-height: 8px;
+.module-billing-menu > .sidebar .navigation-left-title .module-billing-menu-small {
+  display: block;
+  font-weight: lighter;
+  font-size: 85%;
+  margin-top: 0;
+  padding-bottom: 12px;
+  line-height: 8px;
 }

--- a/packages/manager/apps/dedicated/client/app/css/source.less
+++ b/packages/manager/apps/dedicated/client/app/css/source.less
@@ -70,12 +70,10 @@
 @actions-menu-item-link-icon-hover-bg-color: @ovh-universe-color;
 @SIDEBAR_MENU_ACTIVE_COLOR: @ovh-universe-color;
 
-/* stylelint-disable selector-type-no-unknown */
 oui-message,
 .oui-message {
   margin-bottom: 0;
 }
-/* stylelint-enable selector-type-no-unknown */
 
 h3.font-lite {
   font-weight: 300;

--- a/packages/manager/apps/dedicated/client/app/css/user-account/main.css
+++ b/packages/manager/apps/dedicated/client/app/css/user-account/main.css
@@ -1,17 +1,18 @@
 .center { text-align: center; }
 
 .left-height-full {
-    height: 100%;
-    float: left;
+  height: 100%;
+  float: left;
 }
+
 .lh30 {
-	line-height: 30px;
+  line-height: 30px;
 }
 
 .black-title {
-	color: #000;
-	font-weight: bold;
-	font-size: 18px;
+  color: #000;
+  font-weight: bold;
+  font-size: 18px;
 }
 
 .fa-10x {
@@ -37,7 +38,7 @@
 .marginb10 { margin-bottom: 10px !important; }
 
 .selectable {
-  cursor:pointer;
+  cursor: pointer;
 }
 
 .module-useraccount-menu > .sidebar {
@@ -55,7 +56,7 @@
 }
 
 .module-useraccount-menu .sidebar .navigation-left-title .fa-chevron-left {
-  opacity: .6;
+  opacity: 0.6;
   font-size: 10px;
   width: 8px;
   height: 8px;
@@ -97,7 +98,7 @@
   color: #122844;
 }
 
-.module-useraccount-menu >.sidebar .navigation-left-title .module-useraccount-menu-small {
+.module-useraccount-menu > .sidebar .navigation-left-title .module-useraccount-menu-small {
   display: block;
   font-weight: lighter;
   font-size: 85%;
@@ -111,79 +112,35 @@
 *******************/
 
 .module-useraccount-sections-container {
-	background: none repeat scroll 0 0 #FFFFFF;
-    // margin-right: 10px;
-    // padding: 0 40px;
-    width: auto;
-    max-width: 1610px;
-    color: #737373;
-    line-height: 20px;
+  background: none repeat scroll 0 0 #fff;
+  width: auto;
+  max-width: 1610px;
+  color: #737373;
+  line-height: 20px;
 }
 
 .module-useraccount-sections-wrapped {
-  background: none repeat scroll 0 0 #FFFFFF;
+  background: none repeat scroll 0 0 #fff;
   margin-left: 305px;
   max-width: 1610px;
   padding: 0 40px;
   line-height: 20px;
 }
 
-  /*.module-useraccount-sections-subscriptions-container,*/
-/*.module-useraccount-sections-ssh-container {*/
-	/*border: solid 1px #DDDDDD;*/
-	/*padding: 5px 19px 20px;*/
-	/*border-radius: 4px;*/
-	/*min-height: 100px;*/
-/*}*/
-
-
 /*******************
 	/SECTIONS
 *******************/
-
-/*********************************************************
-	ICONS STUFF
-*********************************************************/
-// .module-useraccount-container i.icon-glass,
-// .module-useraccount-container i.icon-trash,
-// .module-useraccount-container i.icon-ssh-default-on,
-// .module-useraccount-container i.icon-ssh-default-off {
-//     display: inline-block;
-//     width: 16px;
-//     height: 20px;
-//     margin: 0;
-//     background-color: transparent;
-//     background-repeat: no-repeat;
-//     background-position: 0 0;
-// }
-
-// .module-useraccount-container table i { cursor: pointer; }
-
-// .module-useraccount-container i.icon-glass { background: transparent url('../../images/user-account/icn/icn_glass.png') no-repeat 0 0; }
-// .module-useraccount-container i.icon-trash { background: transparent url('../../images/user-account/icn/icn_trash.png') no-repeat 0 0; }
-// .module-useraccount-container i.icon-ssh-default-on,
-// .module-useraccount-container table i.icon-ssh-default-off:hover { background: transparent url('../../images/user-account/icn/icn_ssh_default.png') no-repeat 0 2px; }
-// .module-useraccount-container i.icon-ssh-default-off,
-// .module-useraccount-container table i.icon-ssh-default-on:hover { background: transparent url('../../images/user-account/icn/icn_ssh_default.png') no-repeat 0 -18px; }
-
-
-/*********************************************************
-	!ICONS STUFF
-*********************************************************/
-
-
 
 /*********************************************************
 	SSH
 *********************************************************/
 
 .module-useraccount-container #sshAddKeyLabel {
-	max-width: 510px;
-	min-width: 220px;
-	min-height: 80px;
-	margin-bottom: 0;
+  max-width: 510px;
+  min-width: 220px;
+  min-height: 80px;
+  margin-bottom: 0;
 }
-
 
 /*********************************************************
 	/SSH
@@ -194,16 +151,16 @@
 **********************************************************/
 
 .module-useraccount-container .module-useraccount-sections-infos-container label {
-    color: #333333;
-    font-weight: 700;
+  color: #333;
+  font-weight: 700;
 }
 
 .module-useraccount-container .module-useraccount-sections-infos-container .top-space-5 {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .module-useraccount-container .module-useraccount-sections-infos-container .form-horizontal .control-group {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 /*********************************************************
@@ -219,35 +176,22 @@
 }
 
 .module-useraccount-container .fs-red {
-  color: #E85E5E !important;
+  color: #e85e5e !important;
 }
 
-// .module-useraccount-container h1 {
-//   font-size: 24px;
-// }
-
-// .module-useraccount-container h2 {
-//   font-size: 18px;
-// }
-
-// .module-useraccount-container h3 {
-//   font-size: 16px;
-// }
-
 .module-useraccount-sections-container .button,
-.module-useraccount-sections-container a[role=button]{
+.module-useraccount-sections-container a[role=button] {
   color: #fff;
   background: #7f8aaf;
   border: 0;
   padding: 10px;
   margin: 10px 0;
-  /*min-width: 213px;*/
   border-radius: 0;
 }
 
 .module-useraccount-sections-container .button[disabled],
-.module-useraccount-sections-container a[role=button][disabled]{
-  opacity: .5;
+.module-useraccount-sections-container a[role=button][disabled] {
+  opacity: 0.5;
 }
 
 .module-useraccount-container .btn-prev-step {
@@ -319,7 +263,6 @@
   overflow: inherit !important;
 }
 
-
 .module-useraccount-sections-contacts-container td .btn.btn-icon:hover,
 .module-useraccount-sections-contacts-container td .btn.btn-icon:focus,
 .module-useraccount-sections-contacts-container td .btn.btn-icon:active {
@@ -332,7 +275,7 @@
 }
 
 .module-useraccount-container .popover .popover-content .popover-menu .btn-link:hover {
-  color: #ffffff;
+  color: #fff;
   background-color: #54a89b;
   text-decoration: none;
   font-weight: bold;

--- a/packages/manager/apps/dedicated/client/app/css/user-account/newSecuritySection.css
+++ b/packages/manager/apps/dedicated/client/app/css/user-account/newSecuritySection.css
@@ -1,35 +1,35 @@
 .new-security-section {
-    margin-bottom: 32px;
+  margin-bottom: 32px;
 }
 
 .new-security-section > .span10 > .oui-header_2:first-child {
-    font-size: 36px;
+  font-size: 36px;
 }
 
 .new-security-section > .span10 > .oui-message {
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 32px;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 32px;
 }
 
 .new-security-section > .span10 > .oui-box {
-    margin-top: 32px;
+  margin-top: 32px;
 }
 
 .new-security-section .new-security-section__2fa-lists {
-    margin-top: 32px;
+  margin-top: 32px;
 }
 
 .new-security-section .new-security-section__2fa-lists > .media:not(:last-child) > .media-body {
-    margin-bottom: 32px;
-    padding-bottom: 32px;
-    border-bottom: 1px solid #e9ebed;
+  margin-bottom: 32px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid #e9ebed;
 }
 
 .new-security-section-wizard-choice-icon {
-    margin-right: 12px;
+  margin-right: 12px;
 }
 
 .new-security-section-wizard-backup-codes {
-    display: inline-block;
+  display: inline-block;
 }

--- a/packages/manager/apps/enterprise-cloud-database/index.scss
+++ b/packages/manager/apps/enterprise-cloud-database/index.scss
@@ -1,6 +1,5 @@
-  @import '~bootstrap4/scss/_functions';
-  @import '~bootstrap4/scss/_variables';
-  @import '~bootstrap4/scss/_mixins';
-  @import '~bootstrap4/scss/_utilities';
-  @import '~bootstrap4/scss/_grid';
-  
+@import '~bootstrap4/scss/_functions';
+@import '~bootstrap4/scss/_variables';
+@import '~bootstrap4/scss/_mixins';
+@import '~bootstrap4/scss/_utilities';
+@import '~bootstrap4/scss/_grid';

--- a/packages/manager/apps/public-cloud/src/assets/theme/dark/index.less
+++ b/packages/manager/apps/public-cloud/src/assets/theme/dark/index.less
@@ -32,7 +32,6 @@
   @status-warning-background-color: rgba(139, 97, 17, .25); // #8b6111;
   @status-warning-color: #ffed96;
 
-
   body {
     color: @text-color-copy;
     background-color: @dark-300;
@@ -246,7 +245,6 @@
     background-color: #404040;
     text-decoration: none;
   }
-
 
   .oui-button.oui-button_secondary,
   .oui-button.oui-button_secondary .oui-icon {

--- a/packages/manager/apps/sign-up/src/index.scss
+++ b/packages/manager/apps/sign-up/src/index.scss
@@ -20,7 +20,7 @@
   position: absolute;
   height: 100%;
   width: 100%;
-  background-color: #FFF;
+  background-color: #fff;
   z-index: 10;
 
   &.app-preload-hide {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.less
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.less
@@ -7,14 +7,13 @@
     }
   }
 
-  /* stylelint-disable selector-type-no-unknown */
+  /* stylelint-disable-next-line selector-type-no-unknown */
   slider,
   [slider] {
     .bar {
       background-color: @gray-light;
     }
   }
-  /* stylelint-enable selector-type-no-unknown */
 
   .table-action-buttons thead th > .btn > .fa {
     &[class*="-selected"] {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/orderFollowUp/pack-xdsl-orderFollowUp.less
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/orderFollowUp/pack-xdsl-orderFollowUp.less
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-type-no-unknown */
 // media query
 @timeline-mobile-width: 1000px;
 
@@ -198,4 +197,3 @@
     }
   }
 }
-/* stylelint-enable selector-type-no-unknown */

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/consumption/pie-chart/telephony-group-consumption-pie-chart.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/consumption/pie-chart/telephony-group-consumption-pie-chart.less
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-type-no-unknown */
 group-consumption-pie-chart {
   display: table;
   width: 100%;
@@ -102,4 +101,3 @@ group-consumption-pie-chart {
     }
   }
 }
-/* stylelint-enable selector-type-no-unknown */

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/telephony-scheduler.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/telephony-scheduler.less
@@ -88,13 +88,11 @@
     right: 0;
     margin: auto;
 
-    /* stylelint-disable selector-type-no-unknown */
     oui-spinner,
     success-drawing-check {
       height: auto;
       width: 100%;
     }
-    /* stylelint-enable selector-type-no-unknown */
   }
 }
 

--- a/packages/manager/apps/web/client/app/hosting/website-coach/website-coach.less
+++ b/packages/manager/apps/web/client/app/hosting/website-coach/website-coach.less
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line selector-type-no-unknown */
 hosting-website-coach {
   .website-coach-visualizer {
     position: relative;

--- a/packages/manager/modules/cloud-universe-components/src/cui/dropdown-menu/index.less
+++ b/packages/manager/modules/cloud-universe-components/src/cui/dropdown-menu/index.less
@@ -1,6 +1,5 @@
-/* stylelint-disable-next-line selector-type-no-unknown */
 cui-dropdown-menu,
-cui-dropdown-menu .cui-dropdown-menu { /* stylelint-disable-line selector-type-no-unknown */
+cui-dropdown-menu .cui-dropdown-menu {
   display: inline-block;
 
   &__body {

--- a/packages/manager/modules/cloud-universe-components/src/cui/guide-component/index.less
+++ b/packages/manager/modules/cloud-universe-components/src/cui/guide-component/index.less
@@ -6,8 +6,7 @@
 @cui-guide-item-title-color: @oui-color-zodiac;
 @cui-guide-footer-background-color: @oui-color-concrete;
 
-cui-guide-component { /* stylelint-disable-line selector-type-no-unknown */
-
+cui-guide-component {
   .cui-guide {
     font-family: "Source Sans Pro", sans-serif;
 
@@ -29,7 +28,7 @@ cui-guide-component { /* stylelint-disable-line selector-type-no-unknown */
       font-size: 18px;
       font-weight: 600;
 
-      &:hover &-title  {
+      &:hover &-title {
         text-decoration: underline;
       }
     }
@@ -95,7 +94,7 @@ cui-guide-component { /* stylelint-disable-line selector-type-no-unknown */
       height: 30px;
       background-color: @cui-guide-footer-background-color;
 
-      &-link  {
+      &-link {
         vertical-align: middle;
         display: table-cell;
         color: @cui-guide-item-color;
@@ -105,7 +104,7 @@ cui-guide-component { /* stylelint-disable-line selector-type-no-unknown */
           visibility: hidden;
         }
 
-        &:hover .fa-external-link  {
+        &:hover .fa-external-link {
           visibility: visible;
         }
       }

--- a/packages/manager/modules/cloud-universe-components/src/cui/tabs/index.less
+++ b/packages/manager/modules/cloud-universe-components/src/cui/tabs/index.less
@@ -1,4 +1,4 @@
-cui-tabs { /* stylelint-disable-line selector-type-no-unknown */
+cui-tabs {
   .cui-tabs {
     list-style: none;
     display: flex;

--- a/packages/manager/modules/emailpro/src/css/exchangeDiagnostic.css
+++ b/packages/manager/modules/emailpro/src/css/exchangeDiagnostic.css
@@ -1,31 +1,31 @@
 .exchange-diagnostic-result-item {
-    border-bottom: solid 1px #DDD;
-    padding: 15px 30px 15px 30px;
+  border-bottom: solid 1px #ddd;
+  padding: 15px 30px 15px 30px;
 }
 
 .td-crop-long-name {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    max-width: 1px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 1px;
 }
 
 .exchange-diagnostic-result-item-error {
-    background-color: #FAFAFA;
+  background-color: #fafafa;
 }
 
 .exchange-diagnostic-icon-success {
-    color: #B0CA67;
+  color: #b0ca67;
 }
 
 .exchange-diagnostic-icon-error {
-    color: #E36947;
+  color: #e36947;
 }
 
 .exchange-diagnostic-page-bottom-padding {
-    padding-bottom: 100px;
+  padding-bottom: 100px;
 }
 
 .exchange-diagnostic-description {
-    max-width: 800px;
+  max-width: 800px;
 }

--- a/packages/manager/modules/enterprise-cloud-database/src/card/card.scss
+++ b/packages/manager/modules/enterprise-cloud-database/src/card/card.scss
@@ -5,88 +5,92 @@ $selected-background-color: rgba(129, 211, 248, 0.1);
 $selected-border-color: rgba(2, 167, 240, 1);
 
 .card {
-    border-radius: 3px;
-    border: 1px solid $default-border-color;
-    box-sizing: border-box;
-    height: 100%;
-    cursor: pointer;
-    background-color: $default-background-color;
+  border-radius: 3px;
+  border: 1px solid $default-border-color;
+  box-sizing: border-box;
+  height: 100%;
+  cursor: pointer;
+  background-color: $default-background-color;
+}
+
+.card,
+.card-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.card,
+.card-body,
+.card .card-footer {
+  text-align: center;
+  width: 100%;
 }
 
 .card:hover {
-    background-color: $hover-background-color;
+  background-color: $hover-background-color;
 }
 
 .card .card-body {
-    flex-grow: 1;
-    outline: 0;
-    padding: 10px 40px;
+  flex-grow: 1;
+  outline: 0;
+  padding: 10px 40px;
 }
 
 .card .card-body .card-heading {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .card .card-footer {
-    border-top: 1px solid $default-border-color;
-    outline: 0;
-    padding: 10px 5px;
+  border-top: 1px solid $default-border-color;
+  outline: 0;
+  padding: 10px 5px;
 }
 
 .card .card-footer:empty {
-    display: none;
+  display: none;
 }
 
-.card, .card-body {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-}
-
-.card, .card-body, .card .card-footer {
-    text-align: center;
-    width: 100%;
-}
-
-.card-icon img, .card-icon span {
-    margin-bottom: 10px;
-}
-
+.card-icon img,
 .card-icon span {
-    font-size: 30px;
+  margin-bottom: 10px;
 }
 
-.card-icon img {
+.card-icon {
+  span {
+    font-size: 30px;
+  }
+
+  img {
     height: 47px;
     width: 47px;
-}
-
-.card-icon span {
-    font-size: 30px;
+  }
 }
 
 .card.selected {
-    border-color: $selected-border-color;
+  border-color: $selected-border-color;
 }
 
-.card.selected .card-body, .card.selected .card-footer, .card.selected:hover {
-    background-color: $selected-background-color;
+.card.selected .card-body,
+.card.selected .card-footer,
+.card.selected:hover {
+  background-color: $selected-background-color;
 }
 
 .card.selected .card-footer {
-    border-top: 1px solid $selected-border-color;
+  border-top: 1px solid $selected-border-color;
 }
 
 .card.selected .card-footer select {
-    background-color: inherit;
+  background-color: inherit;
 }
 
 .card.disabled {
-    opacity: 0.6;
-    cursor: default;
+  opacity: 0.6;
+  cursor: default;
 }
 
 .card.disabled:hover {
-    background-color: $default-background-color;
+  background-color: $default-background-color;
 }

--- a/packages/manager/modules/enterprise-cloud-database/src/index.scss
+++ b/packages/manager/modules/enterprise-cloud-database/src/index.scss
@@ -1,4 +1,5 @@
 $flag-icon-css-path: "flag-icon-css/flags";
+
 @import "~flag-icon-css/sass/flag-icon";
 
 .flag-icon-uk {
@@ -49,11 +50,13 @@ $flag-icon-css-path: "flag-icon-css/flags";
   @extend .flag-icon-de;
 }
 
-.flag-icon-sgp, .flag-icon-sgp1 {
+.flag-icon-sgp,
+.flag-icon-sgp1 {
   @extend .flag-icon-sg;
 }
 
-.flag-icon-syd, .flag-icon-syd1 {
+.flag-icon-syd,
+.flag-icon-syd1 {
   @extend .flag-icon-au;
 }
 
@@ -68,15 +71,15 @@ $flag-icon-css-path: "flag-icon-css/flags";
 
 .flag {
   &__icon {
-      &-md {
+    &-md {
       width: 2.25em;
       height: 1.6875em;
-      }
+    }
 
-      &-sm {
+    &-sm {
       width: 1.4em;
       height: 1.05em;
-      }
+    }
   }
 }
 

--- a/packages/manager/modules/exchange/src/css/exchangeDiagnostic.css
+++ b/packages/manager/modules/exchange/src/css/exchangeDiagnostic.css
@@ -1,60 +1,60 @@
 .exchange-diagnostic-result-item {
-    border-bottom: solid 1px #DDD;
-    padding: 15px 30px 15px 30px;
+  border-bottom: solid 1px #ddd;
+  padding: 15px 30px 15px 30px;
 }
 
 .td-crop-long-name {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    max-width: 1px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 1px;
 }
 
 .exchange-diagnostic-result-item-error {
-    background-color: #FAFAFA;
+  background-color: #fafafa;
 }
 
 .exchange-diagnostic-icon-success {
-    color: #B0CA67;
+  color: #b0ca67;
 }
 
 .exchange-diagnostic-icon-error {
-    color: #E36947;
+  color: #e36947;
 }
 
 .exchange-diagnostic-page-bottom-padding {
-    padding-bottom: 100px;
+  padding-bottom: 100px;
 }
 
 .exchange-diagnostic-description {
-    max-width: 800px;
+  max-width: 800px;
 }
 
 .image-container {
-    position: relative;
+  position: relative;
 }
 
 .center-image {
-    display: block;
-    margin: 0 auto;
+  display: block;
+  margin: 0 auto;
 }
 
 .resize-half {
-    width: 50%;
-    height: 50%;
+  width: 50%;
+  height: 50%;
 }
 
 .middle {
-    position: absolute;
-    top: 50%;
-    left: 50%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
 }
 
 .overlay-transition {
   opacity: 0;
-  transition: .5s ease;
+  transition: 0.5s ease;
   transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%)
+  -ms-transform: translate(-50%, -50%);
 }
 
 .image {
@@ -62,7 +62,7 @@
   display: block;
   width: 100%;
   height: 100%;
-  transition: .5s ease;
+  transition: 0.5s ease;
   backface-visibility: hidden;
 }
 
@@ -70,10 +70,10 @@
   opacity: 0.3;
 }
 
-.image-container:hover .overlay-transition{
+.image-container:hover .overlay-transition {
   opacity: 1;
 }
 
 .select-domain .oui-field__component {
-    margin-bottom: 0px;
+  margin-bottom: 0;
 }

--- a/packages/manager/modules/iplb/src/iplb.scss
+++ b/packages/manager/modules/iplb/src/iplb.scss
@@ -1,5 +1,6 @@
 .iplb {
   $flag-icon-css-path: '~flag-icon-css/flags';
+
   @import '~flag-icon-css/sass/flag-icon';
   @import 'bootstrap4/scss/_functions.scss';
   @import 'bootstrap4/scss/_variables.scss';
@@ -51,11 +52,13 @@
     @extend .flag-icon-de;
   }
 
-  .flag-icon-sgp, .flag-icon-sgp1 {
+  .flag-icon-sgp,
+  .flag-icon-sgp1 {
     @extend .flag-icon-sg;
   }
 
-  .flag-icon-syd, .flag-icon-syd1 {
+  .flag-icon-syd,
+  .flag-icon-syd1 {
     @extend .flag-icon-au;
   }
 

--- a/packages/manager/modules/navbar/src/navbar-menu-header/index.less
+++ b/packages/manager/modules/navbar/src/navbar-menu-header/index.less
@@ -1,5 +1,3 @@
-/* stylelint-disable selector-type-no-unknown */
-
 ovh-manager-navbar {
   @import "~ovh-ui-kit/packages/oui-color/_variables";
   @import "~ovh-ui-kit/packages/oui-icons/_icons";
@@ -52,5 +50,3 @@ ovh-manager-navbar {
     }
   }
 }
-
-/* stylelint-enable selector-type-no-unknown */

--- a/packages/manager/modules/pci/src/projects/new/new.scss
+++ b/packages/manager/modules/pci/src/projects/new/new.scss
@@ -22,7 +22,7 @@ pci-project-new { /* stylelint-disable-line */
       font-size: 14px;
       max-width: 200px;
       text-align: right;
-      margin-right: $spacer * .5;
+      margin-right: $spacer * 0.5;
     }
 
     .oui-progress-tracker {

--- a/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/deploy.scss
+++ b/packages/manager/modules/pci/src/projects/project/analytics-data-platform/deploy/deploy.scss
@@ -19,8 +19,9 @@ analytics-data-platform-deploy-component {
       margin-left: 0;
     }
   }
+
   .ovhstack .oui-input.oui-input_number {
-    border-radius: 0px;
+    border-radius: 0;
     border-bottom: inherit;
   }
 }
@@ -33,6 +34,7 @@ oui-modal {
       &::after {
         width: 6.7rem;
       }
+
       .oui-datagrid__cell-sticky:first-child {
         width: 6.7rem;
       }

--- a/packages/manager/modules/pci/src/projects/project/analytics-data-platform/details/progress/progress.scss
+++ b/packages/manager/modules/pci/src/projects/project/analytics-data-platform/details/progress/progress.scss
@@ -2,6 +2,7 @@
   from {
     background-position: 1rem 0;
   }
+
   to {
     background-position: 0 0;
   }
@@ -11,19 +12,20 @@
   from {
     background-position: 1rem 0;
   }
+
   to {
     background-position: 0 0;
   }
 }
 
 analytics-data-platform-details-progress-component {
-    .tracking-progress {
-        .progress-bar-striped {
-            .oui-progress__bar::before {
-                background-image: linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
-                background-size: 1rem 1rem;
-                animation: progress-bar-stripes 1s linear infinite;
-            }
-        }
+  .tracking-progress {
+    .progress-bar-striped {
+      .oui-progress__bar::before {
+        background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+        background-size: 1rem 1rem;
+        animation: progress-bar-stripes 1s linear infinite;
+      }
     }
+  }
 }

--- a/packages/manager/modules/pci/src/projects/project/creating/creating.scss
+++ b/packages/manager/modules/pci/src/projects/project/creating/creating.scss
@@ -4,7 +4,7 @@ pci-project-creating { /* stylelint-disable-line */
   @import "~bootstrap4/scss/mixins/_breakpoints";
 
   $spinner-size: 350px;
-  $colors: #3D86C3, #33BBEE, #2558C3;
+  $colors: #3d86c3, #3be, #2558c3;
   $d: 175;
 
   .pci-projects-creating {
@@ -15,7 +15,7 @@ pci-project-creating { /* stylelint-disable-line */
 
       a {
         &:hover {
-          background-color: #EFF9FD;
+          background-color: #eff9fd;
           text-decoration: none;
         }
 
@@ -82,11 +82,9 @@ pci-project-creating { /* stylelint-disable-line */
         display: block;
         margin: 0;
         padding: 0;
-
         position: absolute;
         left: 0;
         top: 0;
-
         transform: rotate(-90deg);
 
         @for $i from 1 through 3 {
@@ -94,8 +92,7 @@ pci-project-creating { /* stylelint-disable-line */
             stroke: nth($colors, $i);
             stroke-dasharray: 1, 300;
             stroke-dashoffset: 0;
-
-            animation: strokeanim 3s calc(.2s * (#{$i})) ease infinite;
+            animation: strokeanim 3s calc(0.2s * (#{$i})) ease infinite;
             transform-origin: center center;
           }
         }
@@ -108,10 +105,12 @@ pci-project-creating { /* stylelint-disable-line */
       stroke-dasharray: 1, 300;
       stroke-dashoffset: 0;
     }
+
     50% {
       stroke-dasharray: 120, 300;
       stroke-dashoffset: -$d / 3;
     }
+
     100% {
       stroke-dasharray: 120, 300;
       stroke-dashoffset: -$d;
@@ -120,7 +119,7 @@ pci-project-creating { /* stylelint-disable-line */
 
   @keyframes contanim {
     100% {
-      transform: rotate(360deg)
+      transform: rotate(360deg);
     }
   }
 }

--- a/packages/manager/modules/sign-up/src/components/country-flag/index.scss
+++ b/packages/manager/modules/sign-up/src/components/country-flag/index.scss
@@ -1,4 +1,5 @@
 $flag-icon-css-path: "flag-icon-css/flags";
+
 @import "~flag-icon-css/sass/flag-icon";
 
 .country-flag {
@@ -6,9 +7,9 @@ $flag-icon-css-path: "flag-icon-css/flags";
   white-space: nowrap;
 
   .flag-icon {
-      width: 30px;
-      height: 23px;
-      border-radius: 3px;
-      margin-right: .5rem;
+    width: 30px;
+    height: 23px;
+    border-radius: 3px;
+    margin-right: 0.5rem;
   }
 }

--- a/packages/manager/modules/sign-up/src/form/details/details.scss
+++ b/packages/manager/modules/sign-up/src/form/details/details.scss
@@ -1,20 +1,12 @@
 .sign-up-form-details {
   .oui-field {
-    &.oui-field_error .oui-input-group.zip-group {
-      span {
-        background-color: #ffd2dd;
-        border-color: #c11b1b;
-        color: #b04020;
-      }
-    }
-
     .oui-input-group.zip-group {
       box-shadow: -1px 0 0 rgba(40, 89, 192, 0.2), 1px 0 0 rgba(40, 89, 192, 0.2);
 
       span {
         padding: 0 0 0 0.688rem;
         border-bottom: 2px solid;
-        border-color: #2859C0;
+        border-color: #2859c0;
         line-height: 2.4;
       }
 
@@ -23,19 +15,27 @@
         padding-left: 0.1rem;
       }
     }
+
+    &.oui-field_error .oui-input-group.zip-group {
+      span {
+        background-color: #ffd2dd;
+        border-color: #c11b1b;
+        color: #b04020;
+      }
+    }
   }
 
   .phone-number-field {
     position: relative;
 
     .oui-ui-select {
-        margin-bottom: 0;
-        width: 100px;
-        position: initial;
+      margin-bottom: 0;
+      width: 100px;
+      position: initial;
 
-        .ui-select-match {
-          height: 2.4rem;
-        }
+      .ui-select-match {
+        height: 2.4rem;
+      }
     }
 
     .oui-input_phone {

--- a/packages/manager/modules/telecom-universe-components/src/ovh-password/ovh-password.less
+++ b/packages/manager/modules/telecom-universe-components/src/ovh-password/ovh-password.less
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line selector-type-no-unknown */
 tuc-ovh-password,
 [data-tuc-ovh-password] {
   .tuc-ovh-password-strength-check {

--- a/packages/manager/modules/telecom-universe-components/src/slider/slider.less
+++ b/packages/manager/modules/telecom-universe-components/src/slider/slider.less
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-type-no-unknown */
 @import '~bootstrap/less/variables';
 
 tuc-slider,
@@ -84,4 +83,3 @@ tuc-slider,
     }
   }
 }
-/* stylelint-enable selector-type-no-unknown */

--- a/packages/manager/modules/vps/src/modal/shortcut/kvm/novnc/index.less
+++ b/packages/manager/modules/vps/src/modal/shortcut/kvm/novnc/index.less
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line selector-type-no-unknown */
 dedicated-vps-kvm-novnc {
   #noVNC_screen {
     height: 600px;

--- a/packages/manager/modules/web-universe-components/src/incrementNumber/incrementNumber.less
+++ b/packages/manager/modules/web-universe-components/src/incrementNumber/incrementNumber.less
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line selector-type-no-unknown */
 wuc-increment-number,
 [data-wuc-increment-number],
 [wuc-increment-number] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5001,6 +5001,11 @@ cssesc@^0.1.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
   integrity sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=
 
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
 csslint@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/csslint/-/csslint-1.0.5.tgz#19cc3eda322160fd3f7232af1cb2a360e898a2e9"
@@ -10071,6 +10076,11 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -10080,6 +10090,16 @@ lodash.isobject@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
   integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
+
+lodash.isregexp@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isregexp/-/lodash.isregexp-4.0.1.tgz#e13e647b30cd559752a04cd912086faf7da1c30b"
+  integrity sha1-4T5kezDNVZdSoEzZEghvr32hwws=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -12484,6 +12504,15 @@ postcss-selector-parser@^3.1.0:
   integrity sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=
   dependencies:
     dot-prop "^4.1.1"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
+  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+  dependencies:
+    cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
@@ -14938,6 +14967,19 @@ stylelint-config-standard@^19.0.0:
   integrity sha512-VvcODsL1PryzpYteWZo2YaA5vU/pWfjqBpOvmeA8iB2MteZ/ZhI1O4hnrWMidsS4vmEJpKtjdhLdfGJmmZm6Cg==
   dependencies:
     stylelint-config-recommended "^3.0.0"
+
+stylelint-scss@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.13.0.tgz#875c76e61d95333c4f0ae737a310be6f1d27d780"
+  integrity sha512-SaLnvQyndaPcsgVJsMh6zJ1uKVzkRZJx+Wg/stzoB1mTBdEmGketbHrGbMQNymzH/0mJ06zDSpeCDvNxqIJE5A==
+  dependencies:
+    lodash.isboolean "^3.0.3"
+    lodash.isregexp "^4.0.1"
+    lodash.isstring "^4.0.1"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.0.2"
 
 stylelint@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
# Apply stylelint rules across all styles files

## :lipstick: Style

ef53c2f - style: apply stylelint rules across all styles files

add `.stylelintignore` file because some `.css` files must be deprecated.

## :link: Related

More resources:
- https://github.com/kristerkari/stylelint-scss
- https://github.com/kristerkari/stylelint-scss/tree/master/src/rules/at-rule-no-unknown
- https://stylelint.io/user-guide/rules/selector-type-no-unknown#ignore-custom-elements-default-namespace

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>