### PR TITLE
build(lint-staged): apply stylelint across all styles files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -6,8 +6,8 @@
     "eslint --fix",
     "git add"
   ],
-  "*.less": [
-    "stylelint 'packages/**/*.less' --fix",
+  "*.{css,less,scss}": [
+    "stylelint --fix",
     "git add"
   ],
   "!(*CHANGELOG).md": [


### PR DESCRIPTION
# Apply stylelint across all styles files

## 👷 Build

add missing `.css` and `.scss` extensions

2f6f3d4 - build(lint-staged): apply stylelint across all styles files

## 🔗 Related

- #1995

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>