### PR TITLE
fix(dedicated): use new github link

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/advanced/user-advanced.html
+++ b/packages/manager/apps/dedicated/client/app/account/user/advanced/user-advanced.html
@@ -60,10 +60,10 @@
                     </span>
                     <a
                         target="_blank"
-                        href="https://github.com/ovh-ux"
+                        href="https://github.com/ovh"
                         class="align-bottom"
                         rel="noopener">
-                        https://github.com/ovh-ux
+                        https://github.com/ovh
                     </a>
                 </li>
                 <li class="mb-2">

--- a/packages/manager/modules/beta-preference/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/beta-preference/src/translations/Messages_fr_FR.json
@@ -1,6 +1,6 @@
 {
   "user_account_advanced_section_beta": "Fonctionnalités Bêta",
   "user_account_advanced_section_beta_activate": "Activer les fonctionnalités Bêta",
-  "user_account_advanced_section_beta_success": "Vos préférences ont été enregistrées ",
+  "user_account_advanced_section_beta_success": "Vos préférences ont été enregistrées",
   "user_account_advanced_section_beta_error": "Une erreur est survenue lors de la modification de vos préférences"
 }


### PR DESCRIPTION
1. Use github.com/ovh instead of github.com/ovh-ux
2. Remove extra space on end of French translation

Signed-off-by: Tadhg Lewis tadhg.lewis@outlook.com