### PR TITLE
test(remark): ignore dist folder

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,1 +1,2 @@
+dist
 CHANGELOG.md


### PR DESCRIPTION
## :green_heart: Continuous Integration

prevent displaying warning when running `yarn run lint:md` after
a build.

9f922e4 - test(remark): ignore dist folder

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>

cc @ganeshkumar1989 