### PR TITLE
build(webpack): specify mainFields entry from the resolve option

### DIFF
--- a/packages/manager/apps/web/webpack.config.js
+++ b/packages/manager/apps/web/webpack.config.js
@@ -89,11 +89,9 @@ module.exports = (env = {}) => {
       path: path.resolve(__dirname, 'dist'),
       filename: '[name].[chunkhash].bundle.js',
     },
-    // resolve: {
-    //   alias: {
-    //     jquery: path.resolve(__dirname, 'node_modules/jquery'),
-    //   },
-    // },
+    resolve: {
+      mainFields: ['module', 'browser', 'main'],
+    },
     plugins: [
       new webpack.DefinePlugin({
         __WEBPACK_REGION__: `'${env.region.toUpperCase()}'`,


### PR DESCRIPTION
## :construction_worker_man: Build

fb12808 - build(webpack): specify mainFields entry from the resolve option

## :link: Related

- https://webpack.js.org/configuration/resolve/#resolvemainfields

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>