### PR TITLE
fix(web): hosting tabs

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/hosting.html
+++ b/packages/manager/apps/web/client/app/hosting/hosting.html
@@ -89,7 +89,7 @@
         <oui-header-tabs>
             <oui-header-tabs-item
                 data-ng-if="$ctrl.tabs"
-                data-ng-repeat="tab in $ctrl.tabs track by $index"
+                data-ng-repeat="tab in $ctrl.tabs"
                 data-text="{{:: 'hosting_tab_' + tab | translate }}"
                 data-href="{{:: $ctrl.$state.href('app.hosting', { 'tab': tab }) }}"
                 data-active="$ctrl.selectedTab === tab"
@@ -99,7 +99,7 @@
                 data-ng-if="$ctrl.tabMenu"
                 data-text="{{:: $ctrl.tabMenu.title }}">
                 <oui-header-tabs-item
-                    data-ng-repeat-start="item in $ctrl.tabMenu.items track by $index"
+                    data-ng-repeat-start="item in $ctrl.tabMenu.items track by item.target"
                     data-ng-if="item.type === 'SWITCH_TABS'"
                     data-text="{{:: item.label }}"
                     data-href="{{:: $ctrl.$state.href('app.hosting', { 'tab': item.target }) }}"


### PR DESCRIPTION
See : DTRSD-6916

There is an issue caused by "track by index" because in the controller the array is modified by replacing some of his items using the "splice" method (see for example : https://github.com/ovh/manager/blob/master/packages/manager/apps/web/client/app/hosting/hosting.controller.js#L372)

So, we are not modifying array indexes but the content of the array changed ...
The issue occurs randomly but is reproductible, i think the random effect is related to the digest cycle.

Removing the track by should not be an issue because we don't have and should not have duplicate tabs.