### PR TITLE
refactor: remove extra @ovh-ux/ng-ovh-actions-menu import

### DIFF
--- a/packages/manager/apps/telecom/src/app/app.js
+++ b/packages/manager/apps/telecom/src/app/app.js
@@ -30,7 +30,6 @@ import ngQAllSettled from '@ovh-ux/ng-q-allsettled';
 import ngTailLogs from '@ovh-ux/ng-tail-logs';
 import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
 import ngOvhSidebarMenu from '@ovh-ux/ng-ovh-sidebar-menu';
-import ngOvhActionsMenu from '@ovh-ux/ng-ovh-actions-menu';
 import ngOvhSimpleCountryList from '@ovh-ux/ng-ovh-simple-country-list';
 import ngOvhLineDiagnostics from '@ovh-ux/ng-ovh-line-diagnostics';
 import ngOvhContact from '@ovh-ux/ng-ovh-contact';
@@ -88,7 +87,6 @@ angular
     ngOvhUiRouterLayout,
     ngOvhUiRouterLineProgress,
     ngOvhUiRouterTitle,
-    ngOvhActionsMenu,
     ngOvhContact,
     ngOvhLineDiagnostics,
     ngQAllSettled,


### PR DESCRIPTION
## :recycle: Refactor

this module is not required for the module `managerApp`.

it has already be defined/imported by the module `ngOvhSidebarMenu`.

3fdcbac - refactor: remove extra @ovh-ux/ng-ovh-actions-menu import

## :link: Related

ref: https://github.com/ovh-ux/ng-ovh-sidebar-menu/blob/master/src/index.js#L13

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>