### PR TITLE
build(webpack): set the parameter region

### DIFF
--- a/packages/manager/apps/cloud/webpack.config.js
+++ b/packages/manager/apps/cloud/webpack.config.js
@@ -36,7 +36,7 @@ fs.readdirSync(folder).forEach((file) => {
 });
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {

--- a/packages/manager/apps/dedicated/webpack.config.js
+++ b/packages/manager/apps/dedicated/webpack.config.js
@@ -34,6 +34,8 @@ fs.readdirSync(folder).forEach((file) => {
 });
 
 module.exports = (env = {}) => {
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
+
   const { config } = webpackConfig(
     {
       template: './client/app/index.html',
@@ -64,12 +66,8 @@ module.exports = (env = {}) => {
         ],
       },
     },
-    env,
+    REGION ? Object.assign(env, { region: REGION }) : env,
   );
-
-  const WEBPACK_REGION = `${_.upperCase(
-    env.region || process.env.REGION || 'EU',
-  )}`;
 
   config.plugins.push(
     new webpack.DefinePlugin({
@@ -81,7 +79,7 @@ module.exports = (env = {}) => {
   );
 
   // Extra config files
-  const extrasRegion = glob.sync(`./.extras-${WEBPACK_REGION}/**/*.js`);
+  const extrasRegion = glob.sync(`./.extras-${REGION}/**/*.js`);
   const extras = glob.sync('./.extras/**/*.js');
 
   return merge(config, {
@@ -116,7 +114,7 @@ module.exports = (env = {}) => {
         __NG_APP_INJECTIONS__: process.env.NG_APP_INJECTIONS
           ? `'${process.env.NG_APP_INJECTIONS}'`
           : 'null',
-        __WEBPACK_REGION__: `'${WEBPACK_REGION}'`,
+        __WEBPACK_REGION__: `'${REGION}'`,
       }),
     ],
     optimization: {

--- a/packages/manager/apps/iplb/webpack.config.js
+++ b/packages/manager/apps/iplb/webpack.config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {

--- a/packages/manager/apps/nasha/webpack.config.js
+++ b/packages/manager/apps/nasha/webpack.config.js
@@ -5,7 +5,7 @@ const webpack = require('webpack'); // eslint-disable-line
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {

--- a/packages/manager/apps/veeam-cloud-connect/webpack.config.js
+++ b/packages/manager/apps/veeam-cloud-connect/webpack.config.js
@@ -5,7 +5,7 @@ const merge = require('webpack-merge');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {

--- a/packages/manager/apps/vps/webpack.config.js
+++ b/packages/manager/apps/vps/webpack.config.js
@@ -5,7 +5,7 @@ const merge = require('webpack-merge');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {

--- a/packages/manager/apps/vrack/webpack.config.js
+++ b/packages/manager/apps/vrack/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
   const { config } = webpackConfig(
     {
       template: './src/index.html',

--- a/packages/manager/tools/sao-ovh-manager-app/template/webpack.config.js
+++ b/packages/manager/tools/sao-ovh-manager-app/template/webpack.config.js
@@ -5,7 +5,7 @@ const merge = require('webpack-merge');
 const webpackConfig = require('@ovh-ux/manager-webpack-config');
 
 module.exports = (env = {}) => {
-  const REGION = `${_.upperCase(env.region || process.env.REGION || 'EU')}`;
+  const REGION = _.upperCase(env.region || process.env.REGION || 'EU');
 
   const { config } = webpackConfig(
     {


### PR DESCRIPTION
## :construction_worker_man: Build

`env` was passed to the `webpackConfig` but always with its default value.

417ac64 - build(webpack): set the parameter region

## :recycle: Refactor

1560028 - refactor(webpack): remove extra template string

## :bug: Bug Fix

1d54c28 - fix(template): remove extra template string

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>