### PR TITLE
feat(web): hosting boost offer action

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
@@ -242,4 +242,8 @@ export default class HostingGeneralInformationsCtrl {
       this.$scope.hosting.offer,
     );
   }
+
+  goToBoostTab() {
+    this.$scope.$parent.$ctrl.setSelectedTab('BOOST');
+  }
 }

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -162,6 +162,17 @@
                                 ></span>
                             </div>
                         </oui-tile-description>
+                        <oui-action-menu
+                            data-compact
+                            data-align="end"
+                            data-ng-if="!hosting.boostOffer && hosting.availableBoostOffer && hosting.availableBoostOffer.length > 0"
+                        >
+                            <oui-action-menu-item
+                                data-on-click="$ctrl.goToBoostTab()"
+                            >
+                                <span data-translate="hosting_tab_BOOST"></span>
+                            </oui-action-menu-item>
+                        </oui-action-menu>
                     </oui-tile-definition>
                     <oui-tile-definition
                         data-term="{{ ::'hosting_dashboard_service_datacenter' | translate }}"


### PR DESCRIPTION
See : DTRSD-7220

The boost offer action was not clearly visible since the tab to boost the offer was hidden behind the "expand tab" button