### PR TITLE
build(deps): upgrade ovh-api-services to v9.31.0

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -49,7 +49,7 @@
     "moment": "^2.15.2",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -102,7 +102,7 @@
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
     "ovh-angular-responsive-page-switcher": "^1.1.1",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -119,7 +119,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -43,7 +43,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -47,7 +47,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "moment": "^2.19",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -43,7 +43,7 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -28,7 +28,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "angular-ui-bootstrap": "^1.3.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -45,7 +45,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.12.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -65,7 +65,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.22.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.12.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -42,7 +42,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -26,7 +26,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.36.1",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -36,7 +36,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit": "^2.35.2",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -33,7 +33,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.12.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -114,7 +114,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-timeline": "^1.5.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -37,7 +37,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.3"
   },

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -39,7 +39,7 @@
     "d3": "~3.5.13",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -47,7 +47,7 @@
     "jquery": "^2.1.3",
     "jsurl": "0.1.5",
     "moment": "^2.19",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.3",
     "ovh-ui-kit-bs": "^2.2.0"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -37,7 +37,7 @@
     "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "^2.35.2"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -97,7 +97,7 @@
     "ng-ckeditor": "^2.0.5",
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^9.30.0",
+    "ovh-api-services": "^9.31.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-ui-angular": "^3.12.0",
     "ovh-ui-kit": "2.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11813,10 +11813,10 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^9.30.0:
-  version "9.30.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.30.0.tgz#87225f2cc05d4f46ec6d5131e6a95cacfb736355"
-  integrity sha512-GC28Nw0JJyMskK6C1zRMvGlXT+u5hiAv4co/zykhOqCSkuxGp37M2hqZ9G7Q0GhddDWW2Dw7BEyUfxz0YoV0qg==
+ovh-api-services@^9.31.0:
+  version "9.31.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.31.0.tgz#974cf3df5b50380f63ec8d7ff853e7b9cabffa3c"
+  integrity sha512-zCXq5nq5QF14qy2RaAlkfWlL8GcV+2rh9wUEXFaxdA2ke23J/mtk8VU6t6njzHNSkAXjqNhE0oA0Hc9x1Fl3MQ==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
## :arrow_up: Upgrade

uses: `yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@9.31.0

7bbf093 - build(deps): upgrade ovh-api-services to v9.31.0

## :link: Related

- https://github.com/ovh-ux/ovh-api-services/pull/269

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>