### PR TITLE
fix(pci-flavors-list): add addon information

### DIFF
--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavor-group.class.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavor-group.class.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import get from 'lodash/get';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
 import union from 'lodash/union';
@@ -23,6 +24,30 @@ export default class FlavorGroup {
     this.flavors = flavors;
 
     this.osTypes = uniq(map(this.flavors, (flavor) => flavor.osType));
+  }
+
+  getGpu() {
+    return get(this, 'technicalBlob.gpu');
+  }
+
+  getGpuCount() {
+    return get(this.getGpu(), 'number');
+  }
+
+  getGpuModel() {
+    return get(this.getGpu(), 'model');
+  }
+
+  getNvme() {
+    return get(this, 'technicalBlob.nvme');
+  }
+
+  getNvmeCount() {
+    return get(this.getNvme(), 'disks[0].number');
+  }
+
+  getNvmeCapacity() {
+    return get(this.getNvme(), 'disks[0].capacity');
   }
 
   isAvailableInRegion(region) {

--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.html
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.html
@@ -66,6 +66,27 @@
                                     data-ng-bind="(flavor.disk | cucBytes:2:false:'GB') + ' ' + (flavor.diskType | uppercase)"
                                 ></span>
                             </div>
+                            <div
+                                class="d-flex justify-content-between"
+                                data-ng-if="flavor.getNvme()"
+                            >
+                                <span
+                                    data-translate="pci_project_flavors_spec_nvme"
+                                ></span>
+                                <span>
+                                    <span
+                                        data-ng-if="flavor.getNvmeCount() > 1"
+                                    >
+                                        <span
+                                            data-ng-bind="flavor.getNvmeCount()"
+                                        ></span>
+                                        <span>x</span>
+                                    </span>
+                                    <span
+                                        data-ng-bind="flavor.getNvmeCapacity() | cucBytes:2:false:'GB'"
+                                    ></span>
+                                </span>
+                            </div>
                             <div class="d-flex justify-content-between">
                                 <span
                                     data-translate="pci_project_flavors_spec_bandwidth"
@@ -81,6 +102,25 @@
                                     data-ng-if="!flavor.outboundBandwidth"
                                     >-</span
                                 >
+                            </div>
+                            <div
+                                class="d-flex justify-content-between"
+                                data-ng-if="flavor.getGpu()"
+                            >
+                                <span
+                                    data-translate="pci_project_flavors_spec_model"
+                                ></span>
+                                <span>
+                                    <span data-ng-if="flavor.getGpuCount() > 1">
+                                        <span
+                                            data-ng-bind="flavor.getGpuCount()"
+                                        ></span>
+                                        <span>x</span>
+                                    </span>
+                                    <span
+                                        data-ng-bind="flavor.getGpuModel()"
+                                    ></span>
+                                </span>
                             </div>
                         </oui-select-picker-section>
                         <oui-select-picker-section>

--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
@@ -1,4 +1,5 @@
 import filter from 'lodash/filter';
+import find from 'lodash/find';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
 import isNil from 'lodash/isNil';
@@ -18,10 +19,18 @@ import {
 
 export default class FlavorsList {
   /* @ngInject */
-  constructor($q, CucPriceHelper, OvhApiCloudProjectFlavor) {
+  constructor(
+    $q,
+    CucPriceHelper,
+    OvhApiCloudProjectFlavor,
+    OvhApiMe,
+    OvhApiOrderCatalogPublic,
+  ) {
     this.$q = $q;
     this.CucPriceHelper = CucPriceHelper;
     this.OvhApiCloudProjectFlavor = OvhApiCloudProjectFlavor;
+    this.OvhApiMe = OvhApiMe;
+    this.OvhApiOrderCatalogPublic = OvhApiOrderCatalogPublic;
   }
 
   getFlavors(serviceName, currentRegion) {
@@ -32,8 +41,17 @@ export default class FlavorsList {
           region: currentRegion,
         }).$promise,
         prices: this.CucPriceHelper.getPrices(serviceName),
+        catalog: this.OvhApiMe.v6()
+          .get()
+          .$promise.then(
+            ({ ovhSubsidiary }) =>
+              this.OvhApiOrderCatalogPublic.v6().get({
+                productName: 'cloud',
+                ovhSubsidiary,
+              }).$promise,
+          ),
       })
-      .then(({ flavors, prices }) =>
+      .then(({ flavors, prices, catalog }) =>
         map(
           groupBy(
             flavors.filter(({ planCodes }) => !isNil(planCodes.hourly)),
@@ -42,6 +60,12 @@ export default class FlavorsList {
           (groupedFlavors) =>
             new Flavor({
               ...omit(groupedFlavors[0], ['available', 'id', 'region']),
+              technicalBlob: get(
+                find(catalog.addons, {
+                  invoiceName: groupedFlavors[0].name,
+                }),
+                'blobs.technical',
+              ),
               available: some(groupedFlavors, 'available'),
               prices: mapValues(
                 groupedFlavors[0].planCodes,

--- a/packages/manager/modules/pci/src/components/project/flavors-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/translations/Messages_fr_FR.json
@@ -14,6 +14,8 @@
   "pci_project_flavors_spec_disk": "Stockage :",
   "pci_project_flavors_spec_bandwidth": "Bande passante :",
   "pci_project_flavors_spec_bandwidth_detail": "{{ bandwidth }} Mbps",
+  "pci_project_flavors_spec_model": "Modèle :",
+  "pci_project_flavors_spec_nvme": "Stockage NVMe :",
 
   "pci_project_flavors_price_hourly": "{{price}} HT/h",
   "pci_project_flavors_price_monthly": "À partir de {{price}} HT/mois",


### PR DESCRIPTION
Added the addon information to the model select picker, in the create an instance page.

- The number of GPU cards and the model of the card has been added for GPU instances
- The number of NVME cards has been added for the IOPS instances

ref: MANAGER-3540