### PR TITLE
build(deps): upgrade manager-vrack to v0.5.0

### DIFF
--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/manager-veeam-cloud-connect": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-veeam-enterprise": "^0.1.0",
     "@ovh-ux/manager-vps": "^0.1.0",
-    "@ovh-ux/manager-vrack": "^0.4.0",
+    "@ovh-ux/manager-vrack": "^0.5.0",
     "@ovh-ux/mfa-enrollment": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^4.0.4",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.4",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/manager-cloud-styles": "^0.3.1",
     "@ovh-ux/manager-config": "^0.4.0",
     "@ovh-ux/manager-core": "^7.6.2",
-    "@ovh-ux/manager-vrack": "^0.4.0",
+    "@ovh-ux/manager-vrack": "^0.5.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.6",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.5.0",
     "@ovh-ux/ng-ovh-contracts": "^3.0.1",


### PR DESCRIPTION
## ⬆️ Upgrade

e0abc4e -  build(deps): upgrade manager-vrack to v0.5.0

relates to: https://github.com/ovh/manager/commit/30140e17be31cd084c96e1497ec7b9e64db4a5d2

## 🏠 Internal

- No quality check required

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>