### PR TITLE
fix(portabilities.delete): fix route to display delete modal

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/delete/portabilities-delete.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/delete/portabilities-delete.routing.js
@@ -1,24 +1,27 @@
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider.state('telecom.telephony.alias.portabilities.delete', {
-    url: '/delete?portabilityId&documentId',
-    views: {
-      modal: {
-        component: 'telephonyPortabilitiesDelete',
+  $stateProvider.state(
+    'telecom.telephony.billingAccount.alias.portabilities.delete',
+    {
+      url: '/delete?portabilityId&documentId',
+      views: {
+        modal: {
+          component: 'telephonyPortabilitiesDelete',
+        },
+      },
+      layout: 'modal',
+      translations: {
+        value: ['.'],
+        format: 'json',
+      },
+      resolve: {
+        billingAccount: /* @ngInject */ ($transition$) =>
+          $transition$.params().billingAccount,
+        portabilityId: /* @ngInject */ ($transition$) =>
+          $transition$.params().portabilityId,
+        documentId: /* @ngInject */ ($transition$) =>
+          $transition$.params().documentId,
+        goBack: /* @ngInject */ (goToPortabilities) => goToPortabilities,
       },
     },
-    layout: 'modal',
-    translations: {
-      value: ['.'],
-      format: 'json',
-    },
-    resolve: {
-      billingAccount: /* @ngInject */ ($transition$) =>
-        $transition$.params().billingAccount,
-      portabilityId: /* @ngInject */ ($transition$) =>
-        $transition$.params().portabilityId,
-      documentId: /* @ngInject */ ($transition$) =>
-        $transition$.params().documentId,
-      goBack: /* @ngInject */ (goToPortabilities) => goToPortabilities,
-    },
-  });
+  );
 };

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/telecom-telephony-alias-portability-portabilities.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/telecom-telephony-alias-portability-portabilities.routing.js
@@ -22,11 +22,14 @@ export default /* @ngInject */ ($stateProvider) => {
         portability,
         documentId,
       ) =>
-        $state.go('telecom.telephony.alias.portabilities.delete', {
-          billingAccount,
-          portabilityId: portability.id,
-          documentId,
-        }),
+        $state.go(
+          'telecom.telephony.billingAccount.alias.portabilities.delete',
+          {
+            billingAccount,
+            portabilityId: portability.id,
+            documentId,
+          },
+        ),
       goToPortabilities: /* @ngInject */ ($state, billingAccount, TucToast) => (
         message = false,
         type = 'success',


### PR DESCRIPTION
Display delete modal when click on the delete button on the list of portabilities

Ref: UXCT-231

Signed-off-by: Stephanie Moallic <stephanie.moallic@corp.ovh.com>