### PR TITLE
fix(hub): use ovh-ui-angular and ovh-ui-kit

### DIFF
--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -32,7 +32,6 @@
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.1",
-    "@ovh-ux/ui-kit": "^3.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",
@@ -48,7 +47,9 @@
     "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.31.0"
+    "ovh-api-services": "^9.34.0",
+    "ovh-ui-angular": "^3.12.0",
+    "ovh-ui-kit": "^2.38.0"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.3.0",

--- a/packages/manager/apps/hub/src/components/manager-preload/manager-preload.less
+++ b/packages/manager/apps/hub/src/components/manager-preload/manager-preload.less
@@ -1,4 +1,4 @@
-@import '@ovh-ux/ui-kit/dist/less/_variables.less';
+@import 'ovh-ui-kit/packages/oui-color/_variables.less';
 
 #managerPreload {
   position: fixed;

--- a/packages/manager/apps/hub/src/index.js
+++ b/packages/manager/apps/hub/src/index.js
@@ -3,8 +3,7 @@ import { Environment } from '@ovh-ux/manager-config';
 import angular from 'angular';
 import uiRouter from '@uirouter/angularjs';
 
-import '@ovh-ux/ui-kit/dist/css/oui.css';
-import oui from '@ovh-ux/ui-kit';
+import 'ovh-ui-angular';
 import ovhManagerCore from '@ovh-ux/manager-core';
 import ovhManagerNavbar from '@ovh-ux/manager-navbar';
 
@@ -13,6 +12,7 @@ import preload from './components/manager-preload';
 
 import routing from './routing';
 import './index.scss';
+import 'ovh-ui-kit/dist/oui.css';
 
 Environment.setRegion(__WEBPACK_REGION__);
 Environment.setVersion(__VERSION__);
@@ -20,7 +20,7 @@ Environment.setVersion(__VERSION__);
 angular
   .module('managerHubApp', [
     atInternet,
-    oui,
+    'oui',
     ovhManagerCore,
     ovhManagerNavbar,
     preload,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,11 +2162,6 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
   integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
 
-"@ovh-ux/ui-kit@^3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-3.10.0.tgz#a3ab95aa9ba4179ead1582f4e73d1029fbb08463"
-  integrity sha512-IBvE6nmK21D4SSduebxniKTgSgCIDwks9I5Qt2JsioMCNUKROkQQQ2xkI9P/g5NVhTWFNjqwAMIuNrY4Y30UpQ==
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -12965,6 +12960,13 @@ ovh-ui-kit@^2.35.2:
   version "2.35.2"
   resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.35.2.tgz#a34d4e080a253cb851a0076af460aa80f0650785"
   integrity sha512-GMXKhh3/lsXPD3KRLKs1c5D5iO876KMG8gInnSRZCunqPzjRrLlJSi8P5Z5Qv7WUEaY4yWMg8J1Gsr7NTn0K6A==
+  dependencies:
+    less-plugin-remcalc "^0.1.0"
+
+ovh-ui-kit@^2.38.0:
+  version "2.38.0"
+  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.38.0.tgz#8b6e6fb7952b3519638d0543eb196a68ce827dac"
+  integrity sha512-WOBjGbIc2SF89fr0DWDwwPzRdf2AN+fqPODxbTZjX+P//zYZzcTrH6OvbhOhNZb+mY8cblY79TYHW5+SN+JKGA==
   dependencies:
     less-plugin-remcalc "^0.1.0"
 


### PR DESCRIPTION
Those are peers required by @ovh-ux/manager-navbar and @ovh-ux/manager-core. 
As navbar needs to be shared, module cannot be bumped to latest as it may cause conflicts 