### PR TITLE
feat(components.choice): return object if payment method is selected

### DIFF
--- a/packages/components/ng-ovh-payment-method/src/components/choice/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/choice/controller.js
@@ -16,7 +16,9 @@ export default class {
       .getDefaultPaymentMethod()
       .then((defaultPaymentMethod) => {
         this.defaultPaymentMethod = defaultPaymentMethod;
-        this.model = true;
+        this.model = this.defaultPaymentMethod
+          ? this.defaultPaymentMethod
+          : false;
       })
       .catch((error) => {
         this.$log.error(

--- a/packages/components/ng-ovh-payment-method/src/components/choice/template.html
+++ b/packages/components/ng-ovh-payment-method/src/components/choice/template.html
@@ -11,7 +11,7 @@
     <oui-radio
         data-name="paymentMethod"
         data-model="$ctrl.model"
-        data-value="true"
+        data-value="$ctrl.defaultPaymentMethod"
         data-disabled="!$ctrl.defaultPaymentMethod"
         data-required
     >

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/payment/domain-webhosting-order-steps-payment.controller.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/payment/domain-webhosting-order-steps-payment.controller.js
@@ -39,6 +39,7 @@ export default class {
   }
 
   preparePayment() {
-    this.stepper.autoPayWithPreferredPaymentMethod = this.autoPayWithPreferredPaymentMethod;
+    this.stepper.autoPayWithPreferredPaymentMethod = !!this
+      .defaultPaymentMethod;
   }
 }

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/payment/domain-webhosting-order-steps-payment.html
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/payment/domain-webhosting-order-steps-payment.html
@@ -2,7 +2,7 @@
     data-header="{{:: 'domain_webhosting_order_payment_step_title' | translate }}"
     data-on-focus="$ctrl.getCheckout()"
     data-loading="$ctrl.stepper.loadingCheckout"
-    data-valid="$ctrl.autoPayWithPreferredPaymentMethod != null && $ctrl.agreeContracts"
+    data-valid="$ctrl.defaultPaymentMethod != null && $ctrl.agreeContracts"
     data-prevent-next="true"
     data-on-cancel="$ctrl.goBackToDashboard()"
     data-on-submit="$ctrl.preparePayment()"
@@ -27,9 +27,7 @@
     </div>
 
     <form name="$ctrl.paymentMeans" novalidate>
-        <ovh-payment-method-choice
-            data-model="$ctrl.autoPayWithPreferredPaymentMethod"
-        >
+        <ovh-payment-method-choice data-model="$ctrl.defaultPaymentMethod">
         </ovh-payment-method-choice>
     </form>
 

--- a/packages/manager/apps/web/client/app/email-domain/order/email-domain-order.controller.js
+++ b/packages/manager/apps/web/client/app/email-domain/order/email-domain-order.controller.js
@@ -83,9 +83,10 @@ export default class MXPlanOrderCtrl {
 
   validateCheckout() {
     this.loading.checkout = true;
-    return this.order(this.model.autoPayWithPreferredPaymentMethod)
+    const autoPayWithPreferredPaymentMethod = !!this.model.defaultPaymentMethod;
+    return this.order(autoPayWithPreferredPaymentMethod)
       .then((order) => {
-        if (order.url && !this.model.autoPayWithPreferredPaymentMethod) {
+        if (order.url && !autoPayWithPreferredPaymentMethod) {
           this.$window.open(order.url, '_blank');
           return this.Alerter.success(
             this.$translate.instant('mxPlan_order_generated_purchase_success', {

--- a/packages/manager/apps/web/client/app/email-domain/order/email-domain-order.html
+++ b/packages/manager/apps/web/client/app/email-domain/order/email-domain-order.html
@@ -1,35 +1,43 @@
-<oui-page-header data-heading="{{:: 'mxPlan_order_title' | translate }}" class="mb-2"></oui-page-header>
+<oui-page-header
+    data-heading="{{:: 'mxPlan_order_title' | translate }}"
+    class="mb-2"
+></oui-page-header>
 
 <div class="container-fluid">
     <div data-ovh-alert></div>
-    <oui-message
-        data-type="success"
-        data-ng-if="$ctrl.orderTrackingLink">
+    <oui-message data-type="success" data-ng-if="$ctrl.orderTrackingLink">
         <span data-translate="mxPlan_order_generated_success"></span>
-        <a data-ng-href="{{ $ctrl.orderTrackingLink }}" data-translate="mxPlan_order_generated_success_tracking"></a>
+        <a
+            data-ng-href="{{ $ctrl.orderTrackingLink }}"
+            data-translate="mxPlan_order_generated_success_tracking"
+        ></a>
     </oui-message>
 
     <oui-stepper
         data-current-index="$ctrl.currentIndex"
-        data-on-finish="$ctrl.validateCheckout(forms)">
+        data-on-finish="$ctrl.validateCheckout(forms)"
+    >
         <oui-step-form
             data-header="{{:: 'mxPlan_order_domain' | translate }}"
             data-valid="$ctrl.model.selectedDomain"
             data-loading="$ctrl.loading.domain"
-            data-editable="!$ctrl.loading.checkout">
+            data-editable="!$ctrl.loading.checkout"
+        >
             <oui-select
                 class="oui-select_m"
                 data-items="$ctrl.domains"
                 data-model="$ctrl.model.selectedDomain"
                 data-on-change="$ctrl.onDomainChange()"
-                data-placeholder="{{:: 'mxPlan_order_domain_pick' | translate }}">
+                data-placeholder="{{:: 'mxPlan_order_domain_pick' | translate }}"
+            >
             </oui-select>
         </oui-step-form>
         <oui-step-form
             data-header="{{:: 'mxPlan_order_offer' | translate }}"
             data-on-focus="$ctrl.displaySelectedOffer = false"
             data-on-submit="$ctrl.displaySelectedOffer = true"
-            data-editable="!$ctrl.loading.checkout">
+            data-editable="!$ctrl.loading.checkout"
+        >
             <p data-translate="mxPlan_order_offer_description_domain"></p>
             <div class="row">
                 <oui-select-picker
@@ -39,12 +47,14 @@
                     name="{{:: $ctrl.model.product.planCode }}"
                     data-model="$ctrl.model.product"
                     data-values="[$ctrl.model.product]"
-                    data-variant="light">
+                    data-variant="light"
+                >
                     <oui-select-picker-footer>
                         <ovh-manager-order-catalog-price
                             data-user="$ctrl.user"
                             data-price="$ctrl.model.product.getPrice('installation')"
-                            data-tax="$ctrl.getProductTaxAmount($ctrl.model.product)">
+                            data-tax="$ctrl.getProductTaxAmount($ctrl.model.product)"
+                        >
                         </ovh-manager-order-catalog-price>
                     </oui-select-picker-footer>
                 </oui-select-picker>
@@ -57,12 +67,14 @@
                     name="{{:: product.planCode }}"
                     data-model="$ctrl.model.product"
                     data-values="[product]"
-                    data-variant="light">
+                    data-variant="light"
+                >
                     <oui-select-picker-footer>
                         <ovh-manager-order-catalog-price
                             data-user="$ctrl.user"
                             data-price="product.getPrice('installation')"
-                            data-tax="$ctrl.getProductTaxAmount(product)">
+                            data-tax="$ctrl.getProductTaxAmount(product)"
+                        >
                         </ovh-manager-order-catalog-price>
                     </oui-select-picker-footer>
                 </oui-select-picker>
@@ -74,25 +86,32 @@
             data-loading="$ctrl.loading.checkout"
             data-editable="!$ctrl.loading.checkout"
             data-valid="($ctrl.checkout.contracts.length === 0 || $ctrl.model.contractsAccepted)"
-            data-submit-text="{{ ($ctrl.checkout.prices.withTax.value === 0 ? 'mxPlan_order_activate' : 'mxPlan_order_action') | translate }}">
-                <div class="row mb-2">
-                    <dl class="oui-description oui-description_horizontal oui-heading_underline col-md-2">
-                        <dt data-translate="mxPlan_price_without_tax"></dt>
-                        <dd data-ng-bind="$ctrl.checkout.prices.withoutTax.text"></dd>
-                        <dt data-translate="mxPlan_price_with_tax"></dt>
-                        <dd data-ng-bind="$ctrl.checkout.prices.withTax.text"></dd>
-                    </dl>
-                </div>
-                <ovh-payment-method-choice
-                    class="mb-1"
-                    data-model="$ctrl.model.autoPayWithPreferredPaymentMethod"
-                    data-error-callback="$ctrl.onPaymentError()">
-                </ovh-payment-method-choice>
-                <ovh-contracts-summary
-                    data-name="agreeContracts"
-                    data-items="$ctrl.checkout.contracts"
-                    data-model="$ctrl.model.contractsAccepted">
-                </ovh-contracts-summary>
+            data-submit-text="{{ ($ctrl.checkout.prices.withTax.value === 0 ? 'mxPlan_order_activate' : 'mxPlan_order_action') | translate }}"
+        >
+            <div class="row mb-2">
+                <dl
+                    class="oui-description oui-description_horizontal oui-heading_underline col-md-2"
+                >
+                    <dt data-translate="mxPlan_price_without_tax"></dt>
+                    <dd
+                        data-ng-bind="$ctrl.checkout.prices.withoutTax.text"
+                    ></dd>
+                    <dt data-translate="mxPlan_price_with_tax"></dt>
+                    <dd data-ng-bind="$ctrl.checkout.prices.withTax.text"></dd>
+                </dl>
+            </div>
+            <ovh-payment-method-choice
+                class="mb-1"
+                data-model="$ctrl.model.defaultPaymentMethod"
+                data-error-callback="$ctrl.onPaymentError()"
+            >
+            </ovh-payment-method-choice>
+            <ovh-contracts-summary
+                data-name="agreeContracts"
+                data-items="$ctrl.checkout.contracts"
+                data-model="$ctrl.model.contractsAccepted"
+            >
+            </ovh-contracts-summary>
         </oui-step-form>
     </oui-stepper>
 </div>

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
@@ -49,9 +49,7 @@ export default class {
 
     this.checkoutOrderCart(
       // Autovalidate if the order is free
-      this.isOptionFree
-        ? this.isOptionFree
-        : this.autoPayWithPreferredPaymentMethod,
+      this.isOptionFree ? this.isOptionFree : !!this.defaultPaymentMethod,
       this.cartId,
     );
   }

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.html
@@ -59,7 +59,7 @@
             <!-- Payment Means -->
             <ovh-payment-method-choice
                 data-ng-if="::!$ctrl.isOptionFree"
-                data-model="$ctrl.autoPayWithPreferredPaymentMethod"
+                data-model="$ctrl.defaultPaymentMethod"
                 data-error-callback="$ctrl.goBackWithError()"
             >
             </ovh-payment-method-choice>

--- a/packages/manager/apps/web/client/app/hosting/database/order-private/hosting-database-order-private.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order-private/hosting-database-order-private.controller.js
@@ -14,7 +14,7 @@ export default class HostingDatabaseOrderPrivateCtrl {
   checkout() {
     this.checkoutLoading = true;
 
-    this.checkoutOrderCart(this.autoPayWithPreferredPaymentMethod, this.cartId);
+    this.checkoutOrderCart(!!this.defaultPaymentMethod, this.cartId);
   }
 
   async initDurationStep() {

--- a/packages/manager/apps/web/client/app/hosting/database/order-private/hosting-database-order-private.html
+++ b/packages/manager/apps/web/client/app/hosting/database/order-private/hosting-database-order-private.html
@@ -165,9 +165,7 @@
             </div>
 
             <!-- Payment Means -->
-            <ovh-payment-method-choice
-                data-model="$ctrl.autoPayWithPreferredPaymentMethod"
-            >
+            <ovh-payment-method-choice data-model="$ctrl.defaultPaymentMethod">
             </ovh-payment-method-choice>
 
             <!-- Contracts -->

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
@@ -142,7 +142,7 @@ export default class PrivateDatabaseOrderCloudDbCtrl {
   validateCheckout() {
     this.loadingCheckout = true;
     return this.PrivateDatabaseOrderCloudDb.validateCheckout(this.cartId, {
-      autoPayWithPreferredPaymentMethod: this.autoPayWithPreferredPaymentMethod,
+      autoPayWithPreferredPaymentMethod: !!this.defaultPaymentMethod,
       waiveRetractionPeriod: false,
     })
       .then(({ prices, url }) => {

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
@@ -152,7 +152,7 @@
             </div>
 
             <ovh-payment-method-choice
-                data-model="$ctrl.autoPayWithPreferredPaymentMethod"
+                data-model="$ctrl.defaultPaymentMethod"
                 data-error-callback="$ctrl.displayErrorGetPaymentMethod()"
             >
             </ovh-payment-method-choice>


### PR DESCRIPTION
BREAKING CHANGE: the two-way binded model will now store an object representing default payment method, instead of just setting a boolean value

See MANAGER-3328 for the context

Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>