### PR TITLE
feat(cloud.logs): new supported protocol

### DIFF
--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/home/formatsports/logs-home-formatsports.html
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/home/formatsports/logs-home-formatsports.html
@@ -1,45 +1,55 @@
 <oui-modal
     data-title="{{ 'logs_home_formatsports_title' | translate : {entryPoint: ctrl.accountDetails.graylogEntryPoint} }}"
     data-on-dismiss="ctrl.cancel()"
+    class="modal-lg"
 >
-    <oui-table
+    <oui-datagrid
         class="table-without-pagination"
         data-rows="ctrl.accountDetails.portsAndMessages"
     >
-        <column
-            title="'logs_home_formatsports_name' | translate"
-            property="name"
-        ></column>
-        <column
-            title="ctrl.LogsConstants.MESSAGE_TYPES.RFC5424"
-            property="RFC5424"
+        <oui-column
+            data-title="'logs_home_formatsports_name' | translate"
+            data-property="name"
+        ></oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.RFC5424"
+            data-property="RFC5424"
         >
             {{$row.RFC5424 || 'logs_home_formatsports_not_supported' |
             translate}}
-        </column>
-        <column title="ctrl.LogsConstants.MESSAGE_TYPES.GELF" property="GELF">
+        </oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.GELF"
+            data-property="GELF"
+        >
             {{$row.GELF || 'logs_home_formatsports_not_supported' | translate}}
-        </column>
-        <column
-            title="ctrl.LogsConstants.MESSAGE_TYPES.LTSV_LINE"
-            property="LTSV_LINE"
+        </oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.LTSV_LINE"
+            data-property="LTSV_LINE"
         >
             {{$row.LTSV_LINE || 'logs_home_formatsports_not_supported' |
             translate}}
-        </column>
-        <column
-            title="ctrl.LogsConstants.MESSAGE_TYPES.LTSV_NUL"
-            property="LTSV_NUL"
+        </oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.LTSV_NUL"
+            data-property="LTSV_NUL"
         >
             {{$row.LTSV_NUL || 'logs_home_formatsports_not_supported' |
             translate}}
-        </column>
-        <column
-            title="ctrl.LogsConstants.MESSAGE_TYPES.CAP_N_PROTO"
-            property="CAP_N_PROTO"
+        </oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.CAP_N_PROTO"
+            data-property="CAP_N_PROTO"
         >
             {{$row.CAP_N_PROTO || 'logs_home_formatsports_not_supported' |
             translate}}
-        </column>
-    </oui-table>
+        </oui-column>
+        <oui-column
+            data-title="ctrl.LogsConstants.MESSAGE_TYPES.BEATS"
+            data-property="BEATS"
+        >
+            {{$row.BEATS || 'logs_home_formatsports_not_supported' | translate}}
+        </oui-column>
+    </oui-datagrid>
 </oui-modal>

--- a/packages/manager/apps/cloud/client/app/dbaas/logs/logs-constants.js
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/logs-constants.js
@@ -100,6 +100,7 @@ angular.module('managerApp').constant('LogsConstants', {
     LTSV_LINE: 'LTSV line',
     LTSV_NUL: 'LTSV nul',
     CAP_N_PROTO: 'Cap’n’Proto',
+    BEATS: 'Beats',
   },
   URL_TYPES: {
     TCP_TLS_GELF: {
@@ -161,6 +162,10 @@ angular.module('managerApp').constant('LogsConstants', {
     UDP_CAP_N_PROTO: {
       PORT: 'UDP',
       MESSAGE: 'CAP_N_PROTO',
+    },
+    TCP_TLS_BEATS: {
+      PORT: 'TCP_TLS',
+      MESSAGE: 'BEATS',
     },
   },
   DATA_STORAGE: {


### PR DESCRIPTION
Hello,

This small patch will allow LDP customers to know the availability of a new supported protocol: Beats (https://www.elastic.co/beats).

As always, thank you for your review, merge & prod time.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>