### PR TITLE
feat(exchange.external-contacts): use datagrid component through iceberg

### DIFF
--- a/packages/manager/modules/exchange/src/external-contact/external-contact.controller.js
+++ b/packages/manager/modules/exchange/src/external-contact/external-contact.controller.js
@@ -22,33 +22,27 @@ export default class ExchangeTabExternalContactsCtrl {
     this.$routerParams = Exchange.getParams();
     this.contactsLoading = false;
     this.contacts = null;
-    this.filter = null;
-
-    $scope.$on(Exchange.events.externalcontactsChanged, () =>
-      $scope.$broadcast('paginationServerSide.reload', 'externalContactsTable'),
-    );
 
     $scope.getContacts = () => this.contacts;
-    $scope.getContactsLoading = () => this.contactsLoading;
-    $scope.loadContacts = () => this.loadContacts();
   }
 
-  onSearchValueChange() {
-    this.loadContacts();
-  }
-
-  loadContacts(count, offset) {
+  loadContacts({ offset, pageSize, criteria }) {
     this.contactsLoading = true;
-
-    this.services.ExchangeExternalContacts.gettingContacts(
+    return this.services.ExchangeExternalContacts.gettingContacts(
       this.$routerParams.organization,
       this.$routerParams.productId,
-      count,
+      pageSize,
       offset,
-      this.filter,
+      criteria.length > 0 ? criteria[0].value : null,
     )
-      .then((contacts) => {
-        this.contacts = contacts;
+      .then(({ data, count }) => {
+        this.contacts = data;
+        return {
+          data,
+          meta: {
+            totalCount: count,
+          },
+        };
       })
       .catch((data) => {
         this.services.messaging.writeError(
@@ -60,11 +54,6 @@ export default class ExchangeTabExternalContactsCtrl {
       })
       .finally(() => {
         this.contactsLoading = false;
-        this.services.$scope.$broadcast(
-          'paginationServerSide.loadPage',
-          1,
-          'externalContactsTable',
-        );
       });
   }
 }

--- a/packages/manager/modules/exchange/src/external-contact/external-contact.html
+++ b/packages/manager/modules/exchange/src/external-contact/external-contact.html
@@ -2,221 +2,120 @@
     class="container-fluid px-0"
     data-ng-controller="ExchangeTabExternalContactsCtrl as ctrl"
 >
-    <div class="row">
-        <div class="col-md-9">
-            <form
-                class="form-inline d-md-flex justify-content-md-end mb-3"
-                name="searchExternalContactForm"
+    <div>
+        <oui-datagrid rows-loader="ctrl.loadContacts($config)" page-size="10">
+            <oui-column
+                data-title="'exchange_tab_EXTERNAL_CONTACTS_table_headers_externalEmailAddress' | translate"
+                property="externalEmailAddress"
+                searchable
+                type="string"
             >
-                <div class="form-group">
-                    <label
-                        class="sr-only"
-                        for="externalContactSearch"
-                        data-translate="common_search"
-                    ></label>
-                    <div class="input-group">
-                        <input
-                            type="text"
-                            class="form-control"
-                            id="externalContactSearch"
-                            maxlength="256"
-                            name="externalContactSearch"
-                            placeholder="{{::'exchange_tab_EXTERNAL_CONTACTS_search_placeholder' | translate}}"
-                            data-ng-change="ctrl.onSearchValueChange()"
-                            data-ng-disabled="ctrl.contactsLoading"
-                            data-ng-model="ctrl.filter"
-                            data-ng-model-options="{ debounce: 800 }"
-                        />
-                        <div class="input-group-btn" data-ng-if="ctrl.filter">
-                            <button
-                                class="btn btn-default"
-                                type="button"
-                                aria-label="{{'common_cancel' | translate}}"
-                                data-ng-click="ctrl.filter = '';ctrl.onSearchValueChange()"
-                                data-ng-disabled="ctrl.contactsLoading"
-                            >
-                                <span
-                                    class="fa fa-times"
-                                    aria-hidden="true"
-                                ></span>
-                            </button>
-                        </div>
-                        <span
-                            class="input-group-addon"
-                            data-ng-if="!ctrl.filter"
-                        >
-                            <span
-                                class="fa fa-search"
-                                aria-hidden="true"
-                            ></span>
-                        </span>
-                    </div>
-                </div>
-            </form>
+            </oui-column>
+            <oui-column
+                data-title="'exchange_tab_EXTERNAL_CONTACTS_table_headers_displayName' | translate"
+                property="displayName"
+            >
+            </oui-column>
+            <oui-column
+                data-title="'exchange_tab_EXTERNAL_CONTACTS_table_headers_creationDate' | translate"
+                property="creationDate"
+                type="date"
+            >
+                <span data-ng-bind="$value | date:'mediumDate'"></span>
+            </oui-column>
+            <oui-column
+                data-title="'exchange_tab_EXTERNAL_CONTACTS_table_headers_hiddenFromGAL' | translate"
+                property="hiddenFromGAL"
+            >
+                <span
+                    class="oui-icon"
+                    aria-hidden="true"
+                    data-ng-class="{'oui-icon-success text-success': !$value.hiddenFromGAL, 'oui-icon-error text-danger': $value.hiddenFromGAL}"
+                    data-oui-tooltip="{{('exchange_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_' + $value.hiddenFromGAL) | translate}}"
+                ></span>
+            </oui-column>
+            <oui-column
+                data-title="'exchange_tab_EXTERNAL_CONTACTS_table_headers_state' | translate"
+                property="state"
+            >
+                <span
+                    class="oui-status oui-status_info"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isOk($row) && $row.taskPendingId !== 0"
+                >
+                </span>
+                <span
+                    class="oui-status oui-status_info"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_CREATING"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isCreating($row)"
+                ></span>
+                <span
+                    class="oui-status oui-status_info"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_DELETING"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isDeleting($row)"
+                ></span>
+                <span
+                    class="oui-status oui-status_warning"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDED"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isSuspended($row)"
+                ></span>
+                <span
+                    class="oui-status oui-status_warning"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDING"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isSuspending($row)"
+                ></span>
+                <span
+                    class="oui-status oui-status_info"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_REOPENING"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isReopening($row)"
+                ></span>
+                <span
+                    class="oui-status oui-status_success"
+                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_OK"
+                    data-ng-if="ctrl.services.exchangeStates.constructor.isOk($row) && $row.taskPendingId === 0"
+                ></span>
+            </oui-column>
+            <oui-action-menu align="end" compact>
+                <oui-action-menu-item
+                    on-click="setAction('exchange/external-contact/update/external-contact-update', $row)"
+                    data-disabled="!ctrl.services.exchangeStates.constructor.isOk($row)"
+                >
+                    <span
+                        data-translate="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_modify"
+                    ></span>
+                </oui-action-menu-item>
+                <oui-action-menu-item
+                    on-click="setAction('exchange/external-contact/remove/external-contact-remove', $row.externalEmailAddress)"
+                    data-disabled="!ctrl.services.exchangeStates.constructor.isOk($row)"
+                >
+                    <span
+                        data-translate="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_delete"
+                    ></span>
+                </oui-action-menu-item>
+            </oui-action-menu>
 
-            <div class="table-responsive">
-                <table class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th
-                                scope="col"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_externalEmailAddress"
-                            ></th>
-                            <th
-                                scope="col"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_displayName"
-                            ></th>
-                            <th
-                                class="text-center"
-                                scope="col"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_creationDate"
-                            ></th>
-                            <th
-                                class="text-center"
-                                scope="col"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_hiddenFromGAL"
-                            ></th>
-                            <th
-                                class="text-center"
-                                scope="col"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state"
-                            ></th>
-                            <th class="min-width text-center"></th>
-                        </tr>
-                    </thead>
-
-                    <tbody data-ng-if="ctrl.contactsLoading">
-                        <tr>
-                            <td colspan="6" class="text-center">
-                                <oui-spinner></oui-spinner>
-                            </td>
-                        </tr>
-                    </tbody>
-
-                    <tbody
-                        data-ng-if="!ctrl.contactsLoading && ctrl.contacts.list.results.length === 0"
+            <extra-top>
+                <oui-action-menu
+                    text="{{'common_actions' | translate}}"
+                    align="start"
+                >
+                    <oui-action-menu-item
+                        on-click="setAction('exchange/external-contact/add/external-contact-add')"
                     >
-                        <tr>
-                            <td
-                                class="text-center"
-                                colspan="6"
-                                data-translate="exchange_tab_EXTERNAL_CONTACTS_table_empty"
-                            ></td>
-                        </tr>
-                    </tbody>
-
-                    <tbody data-ng-if="!ctrl.contactsLoading">
-                        <tr
-                            data-ng-repeat="element in ctrl.contacts.list.results track by $index"
-                        >
-                            <th
-                                class="word-break"
-                                scope="row"
-                                data-ng-bind="element.externalEmailAddress | wucSliceContent: 150"
-                            ></th>
-                            <td
-                                class="word-break"
-                                data-ng-bind="element.displayName | wucSliceContent: 150"
-                            ></td>
-                            <td
-                                class="text-center text-nowrap"
-                                data-ng-bind="element.creationDate | date:'mediumDate'"
-                            ></td>
-                            <td class="text-center">
-                                <span
-                                    class="oui-icon"
-                                    aria-hidden="true"
-                                    data-ng-class="{'oui-icon-success text-success': !element.hiddenFromGAL, 'oui-icon-error text-danger': element.hiddenFromGAL}"
-                                    data-oui-tooltip="{{('exchange_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_' + element.hiddenFromGAL) | translate}}"
-                                ></span>
-                            </td>
-
-                            <td class="text-center">
-                                <span
-                                    class="oui-status oui-status_info"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isOk(element) && element.taskPendingId !== 0"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_info"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_CREATING"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isCreating(element)"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_info"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_DELETING"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isDeleting(element)"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_warning"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDED"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isSuspended(element)"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_warning"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDING"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isSuspending(element)"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_info"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_REOPENING"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isReopening(element)"
-                                ></span>
-                                <span
-                                    class="oui-status oui-status_success"
-                                    data-translate="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_OK"
-                                    data-ng-if="ctrl.services.exchangeStates.constructor.isOk(element) && element.taskPendingId === 0"
-                                ></span>
-                            </td>
-
-                            <td class="text-center">
-                                <oui-action-menu data-compact data-align="end">
-                                    <oui-action-menu-item
-                                        data-on-click="setAction('exchange/external-contact/update/external-contact-update', element)"
-                                        data-disabled="!ctrl.services.exchangeStates.constructor.isOk(element)"
-                                    >
-                                        <span
-                                            data-translate="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_modify"
-                                        ></span>
-                                    </oui-action-menu-item>
-                                    <oui-action-menu-item
-                                        data-on-click="setAction('exchange/external-contact/remove/external-contact-remove', element.externalEmailAddress)"
-                                        data-disabled="!ctrl.services.exchangeStates.constructor.isOk(element)"
-                                    >
-                                        <span
-                                            data-translate="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_delete"
-                                        ></span>
-                                    </oui-action-menu-item>
-                                </oui-action-menu>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <div
-                class="clearfix"
-                data-ng-show="!ctrl.contactsLoading && ctrl.contacts.list.results.length > 0"
-                data-pagination-server-side="externalContactsTable"
-                data-pagination-server-side-function="loadContacts"
-                data-pagination-server-side-paginated-stuff="getContacts()"
-                data-pagination-server-side-table-loading="getContactsLoading()"
-            ></div>
-        </div>
-        <div class="col-md-3 mt-5 mt-lg-0">
-            <button
-                class="oui-button oui-button_secondary w-100"
-                type="button"
-                data-translate="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_title_button"
-                data-ng-click="setAction('exchange/external-contact/add/external-contact-add')"
-            ></button>
-            <button
-                class="oui-button oui-button_secondary w-100 mt-2"
-                type="button"
-                data-ng-click="ctrl.services.navigation.setAction('exchange/account/export-as-csv/account-export-as-csv', { search : ctrl.filter, total : ctrl.contacts.list.results.length, exchange : ctrl.exchange, csvExportType: 'external' })"
-                data-ng-disabled="ctrl.mailingLists.list.results.count === 0"
-                data-translate="exchange_tab_EXTERNAL_CONTACTS_export_csv"
-            ></button>
-        </div>
+                        <span
+                            data-translate="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_title_button"
+                        ></span>
+                    </oui-action-menu-item>
+                    <oui-action-menu-item
+                        on-click="ctrl.services.navigation.setAction('exchange/account/export-as-csv/account-export-as-csv', { search : ctrl.filter, total : ctrl.contacts.length, exchange : ctrl.exchange, csvExportType: 'external' })"
+                        data-ng-disabled="ctrl.mailingLists.list.results.count === 0"
+                    >
+                        <span
+                            data-translate="exchange_tab_EXTERNAL_CONTACTS_export_csv"
+                        ></span>
+                    </oui-action-menu-item>
+                </oui-action-menu>
+            </extra-top>
+        </oui-datagrid>
     </div>
 </div>


### PR DESCRIPTION
## Rework Exchange external contacts section

### Description of the Change

- Move from old table component to oui-datagrid
- Improve performances by using iceberg pagination & cache features

### Dependencies

- [x] 2api sws-exchange-externalcontacts