### PR TITLE
Add missing dependency

### DIFF
--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -24,6 +24,7 @@
     "@ovh-ux/manager-overthebox": "^5.0.0",
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.6",
+    "@ovh-ux/ng-ovh-contracts": "^3.1.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -26,6 +26,7 @@
     "@ovh-ux/manager-core": "^7.6.2",
     "@ovh-ux/manager-veeam-cloud-connect": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.6",
+    "@ovh-ux/ng-ovh-cloud-universe-components": "^1.5.0",
     "@ovh-ux/ng-ovh-http": "^4.0.6",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",


### PR DESCRIPTION
## 👷 Build

ba35a4b - build(deps): add missing ng-ovh-contracts dependency
1df351d - build(deps): add missing ng-ovh-cloud-universe-components dependency

## 🔗 Related

Fix #2220 

## 🏠 Internal

No quality check required.
