### PR TITLE
build(deps): upgrade ng-tail-logs to v2.0.2

### DIFF
--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -55,7 +55,7 @@
     "@ovh-ux/ng-ovh-user-pref": "^1.0.2",
     "@ovh-ux/ng-pagination-front": "^8.0.1",
     "@ovh-ux/ng-q-allsettled": "^1.0.1",
-    "@ovh-ux/ng-tail-logs": "^2.0.1",
+    "@ovh-ux/ng-tail-logs": "^2.0.2",
     "@ovh-ux/ng-translate-async-loader": "^2.0.3",
     "@ovh-ux/ng-ui-router-layout": "^3.2.0",
     "@ovh-ux/ng-ui-router-line-progress": "^1.1.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -70,7 +70,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^7.1.0 || ^8.0.0",
     "@ovh-ux/ng-pagination-front": "^8.0.1",
     "@ovh-ux/ng-q-allsettled": "^1.0.1",
-    "@ovh-ux/ng-tail-logs": "^2.0.1",
+    "@ovh-ux/ng-tail-logs": "^2.0.2",
     "@ovh-ux/ng-translate-async-loader": "^2.0.3",
     "@ovh-ux/ng-ui-router-layout": "^3.2.0",
     "@ovh-ux/ng-ui-router-line-progress": "^1.1.0",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -29,7 +29,7 @@
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",
-    "@ovh-ux/ng-tail-logs": "^2.0.1",
+    "@ovh-ux/ng-tail-logs": "^2.0.2",
     "@ovh-ux/ng-ui-router-title": "^3.0.0",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -57,7 +57,7 @@
     "@ovh-ux/ng-ovh-user-pref": "^1.0.2",
     "@ovh-ux/ng-pagination-front": "^8.0.1",
     "@ovh-ux/ng-q-allsettled": "^1.0.1",
-    "@ovh-ux/ng-tail-logs": "^2.0.1",
+    "@ovh-ux/ng-tail-logs": "^2.0.2",
     "@ovh-ux/ng-translate-async-loader": "^2.0.3",
     "@ovh-ux/ng-ui-router-layout": "^3.2.0",
     "@ovh-ux/ng-ui-router-line-progress": "^1.1.0",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -52,7 +52,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^7.0.0 || ^8.0.0",
     "@ovh-ux/ng-pagination-front": "^8.0.1",
     "@ovh-ux/ng-q-allsettled": "^1.0.1",
-    "@ovh-ux/ng-tail-logs": "^2.0.1",
+    "@ovh-ux/ng-tail-logs": "^2.0.2",
     "@ovh-ux/ng-translate-async-loader": "^2.0.3",
     "@ovh-ux/ng-ui-router-layout": "^3.2.0",
     "@ovh-ux/ng-ui-router-line-progress": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,10 +2127,10 @@
   dependencies:
     lodash "^4.17.15"
 
-"@ovh-ux/ng-tail-logs@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-tail-logs/-/ng-tail-logs-2.0.1.tgz#3125ab929e3f70c3ef95770ea43a3db5aaf27896"
-  integrity sha512-MrXBeCzj3abdb8lREjYt5dx+jhOMyV/PaPTBoNn8wCZtweU223WHWS+FnUOCkae5ZHpBk33Hp6KvTBrkQ/SfBA==
+"@ovh-ux/ng-tail-logs@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-tail-logs/-/ng-tail-logs-2.0.2.tgz#0231443aa12878e80cc5e201be1359832e0f8c7c"
+  integrity sha512-OCMHTktcOIkIfSMOcF7/a6FcQzaJzNNzuEXDiZ/pfQRx2ZNRpnu2ESRifd75iIqY+KW6eU2y65r/pchgjpeA5g==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
## :arrow_up: Upgrade

46b27e2 - build(deps): upgrade ng-tail-logs to v2.0.2

uses: `yarn upgrade-interactive --latest @ovh-ux/ng-tail-logs`
- @ovh-ux/ng-tail-logs@2.0.2

## :link: Related

- ovh-ux/ng-tail-logs#38

## :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>