### PR TITLE
fix(cloud.logs): reduce polling interval to 3s

### DIFF
--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/logs-helper.service.js
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/logs-helper.service.js
@@ -43,6 +43,7 @@ class LogsHelperService {
   pollOperation(serviceName, operation) {
     this.killPoller();
     return this.CucCloudPoll.poll({
+      interval: 3000,
       item: operation,
       pollFunction: (opn) =>
         this.OperationApiService.get({


### PR DESCRIPTION
Hello,

To improve user experience on LDP Manager (most of the operation take less than 5 seconds) and to possibly solve an issue about Firefox h2 keep-alive session, i would like to reduce the interval of the poller.

Internal related issue: MANAGER-4362

Thank you for your review, merge & prod time.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>