### PR TITLE
fix(dbaas.logs.detail.inputs.console): set right component name

### DIFF
--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/inputs/console/logs-inputs-console.html
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/inputs/console/logs-inputs-console.html
@@ -7,7 +7,7 @@
     <div data-ng-if="!ctrl.logger.timer">
         <oui-spinner></oui-spinner>
     </div>
-    <ovh-tail-logs data-ng-if="ctrl.logger.timer">
+    <tail-logs data-ng-if="ctrl.logger.timer">
         <div
             class="row"
             data-ng-repeat="log in ctrl.logger.logs track by $index"
@@ -21,5 +21,5 @@
         <div class="row" data-ng-if="ctrl.logger.logs.length === 0">
             <span class="col-xs-12" data-translate="inputs_logs_no_logs"></span>
         </div>
-    </ovh-tail-logs>
+    </tail-logs>
 </div>


### PR DESCRIPTION
## :ambulance: Hotfix

340fda1 - fix(dbaas.logs.detail.inputs.console): set right component name

`<ovh-tail-logs>` has been renamed into `<tail-logs>`

## :house: Internal

ref: DTRSD-8462

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>