### PR TITLE
fix(kubernetes.details.service.terminate): add confirmation field

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/terminate/terminate.html
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/terminate/terminate.html
@@ -7,6 +7,7 @@
     <oui-modal
         data-title="{{ ::'kube_service_terminate_title' | translate }}"
         data-primary-label="{{ ::'kube_service_terminate_common_confirm' | translate }}"
+        data-primary-disabled="!$ctrl.terminateConfirmation"
         data-secondary-action="$ctrl.goBack()"
         data-secondary-label="{{ ::'kube_service_terminate_common_cancel' | translate }}"
         data-on-dismiss="$ctrl.goBack()"
@@ -20,5 +21,16 @@
         <oui-message data-type="warning">
             <span data-translate="kube_service_terminate_warning"></span>
         </oui-message>
+        <oui-field
+            data-label="{{:: 'kube_service_terminate_enter' | translate }}"
+        >
+            <input
+                class="oui-input"
+                type="text"
+                name="kubeClusterTerminateConfirm"
+                data-ng-model="$ctrl.terminateConfirmation"
+                data-ng-pattern="$ctrl.TERMINATE_INPUT"
+                required>
+        </oui-field>
     </oui-modal>
 </form>

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/terminate/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/terminate/translations/Messages_fr_FR.json
@@ -5,6 +5,6 @@
   "kube_service_terminate_description": "Êtes-vous sûr(e) de vouloir supprimer le cluster {{ clusterName }} ?",
   "kube_service_terminate_warning": "La suppression entraînera l'effacement définitif de toutes les données correspondantes. L'action de suppression n'octroie aucun remboursement.",
   "kube_service_terminate_enter": "Entrez \"TERMINATE\" dans le champ ci-dessous pour confirmer",
-  "kube_service_terminate_success": "Votre demande de suppression du cluster Kubernetes a bien été prise en compte. Un email vous permettant de valider votre demande de suppression vous a été envoyé",
+  "kube_service_terminate_success": "Votre demande de suppression du cluster Kubernetes a bien été prise en compte.",
   "kube_service_terminate_error": "Une erreur est survenue lors de la suppression de votre cluster : {{ message }}"
 }


### PR DESCRIPTION
## 🐛 Bug Fix

Prevent misleading information and add missing confirmation for cluster deletion

cc1e2aa - fix(kubernetes.details.service.terminate): add confirmation field
18e27e5 - fix(kubernetes.details.service.terminate): update success message

## 🏠 Internal

ref: DTRSD-8551

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>