### PR TITLE
Feat/catalog price

### DIFF
--- a/packages/manager/modules/catalog-price/LICENSE
+++ b/packages/manager/modules/catalog-price/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2013-present, OVH SAS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/manager/modules/catalog-price/README.md
+++ b/packages/manager/modules/catalog-price/README.md
@@ -1,0 +1,29 @@
+# manager-catalog-price
+
+> Component to display catalog prices, formatted by locale. It can handle price in micro cents.
+
+[![npm version](https://badgen.net/npm/v/@ovh-ux/manager-catalog-price)](https://www.npmjs.com/package/@ovh-ux/manager-catalog-price) [![Downloads](https://badgen.net/npm/dt/@ovh-ux/manager-catalog-price)](https://npmjs.com/package/@ovh-ux/manager-catalog-price) [![Dependencies](https://badgen.net/david/dep/ovh/manager/packages/components/manager-catalog-price)](https://npmjs.com/package/@ovh-ux/manager-catalog-price?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh/manager/packages/components/manager-catalog-price)](https://npmjs.com/package/@ovh-ux/manager-catalog-price?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
+
+## Install
+
+```sh
+$ yarn add @ovh-ux/manager-catalog-price
+```
+
+## Usage
+
+```js
+import angular from 'angular';
+import ovhManagerCatalogPrice from '@ovh-ux/manager-catalog-price';
+
+// add the `ovhManagerCatalogPrice` module as dependency of your AngularJS project.
+angular.module('myApp', [ovhManagerCatalogPrice]);
+```
+
+## Contributing
+
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
+
+## License
+
+[BSD-3-Clause](LICENSE) © OVH SAS

--- a/packages/manager/modules/catalog-price/package.json
+++ b/packages/manager/modules/catalog-price/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@ovh-ux/manager-catalog-price",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Component to display catalog prices, formatted by locale",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ovh/manager.git",
+    "directory": "packages/manager/modules/catalog-price"
+  },
+  "license": "BSD-3-Clause",
+  "author": "OVH SAS",
+  "main": "./src/index.js",
+  "dependencies": {
+    "lodash": "^4.17.15"
+  },
+  "peerDependencies": {
+    "@ovh-ux/manager-core": "^7.6.2",
+    "@ovh-ux/ng-translate-async-loader": "^2.0.3",
+    "angular": "^1.7.9",
+    "angular-translate": "^2.18.2",
+    "bootstrap": "^4.3.1"
+  }
+}

--- a/packages/manager/modules/catalog-price/src/catalog-price.component.js
+++ b/packages/manager/modules/catalog-price/src/catalog-price.component.js
@@ -1,0 +1,17 @@
+import controller from './catalog-price.controller';
+import template from './catalog-price.html';
+
+const component = {
+  bindings: {
+    block: '<',
+    convertToUcents: '<',
+    interval: '<?',
+    price: '<',
+    tax: '<',
+    user: '<',
+  },
+  controller,
+  template,
+};
+
+export default component;

--- a/packages/manager/modules/catalog-price/src/catalog-price.constants.js
+++ b/packages/manager/modules/catalog-price/src/catalog-price.constants.js
@@ -1,0 +1,31 @@
+export const ASIA_FORMAT = ['SG', 'ASIA', 'AU'];
+export const FRENCH_FORMAT = [
+  'CZ',
+  'ES',
+  'FR',
+  'GB',
+  'IE',
+  'IT',
+  'LT',
+  'MA',
+  'NL',
+  'PL',
+  'PT',
+  'TN',
+];
+export const GERMAN_FORMAT = ['DE', 'FI', 'SN'];
+export const US_FORMAT = ['CA', 'WE', 'WS', 'QC', 'US'];
+export const INTERVAL_UNIT = {
+  DAY: 'day',
+  MONTH: 'month',
+  NONE: 'none',
+  YEAR: 'year',
+};
+
+export default {
+  ASIA_FORMAT,
+  FRENCH_FORMAT,
+  GERMAN_FORMAT,
+  US_FORMAT,
+  INTERVAL_UNIT,
+};

--- a/packages/manager/modules/catalog-price/src/catalog-price.controller.js
+++ b/packages/manager/modules/catalog-price/src/catalog-price.controller.js
@@ -1,0 +1,82 @@
+import get from 'lodash/get';
+import isUndefined from 'lodash/isUndefined';
+
+import {
+  ASIA_FORMAT,
+  FRENCH_FORMAT,
+  GERMAN_FORMAT,
+  US_FORMAT,
+  INTERVAL_UNIT,
+} from './catalog-price.constants';
+
+export default class {
+  /* @ngInject */
+  constructor($attrs, TranslateService) {
+    this.$attrs = $attrs;
+    this.TranslateService = TranslateService;
+  }
+
+  $onInit() {
+    // Support attribute without value to be evaluated to true
+    if (!isUndefined(this.$attrs.block) && this.$attrs.block === '') {
+      this.block = true;
+    }
+
+    if (
+      !isUndefined(this.$attrs.convertToUcents) &&
+      this.$attrs.convertToUcents === ''
+    ) {
+      this.convertToUcents = true;
+    }
+
+    if (this.convertToUcents) {
+      this.price *= 100000000;
+      this.tax *= 100000000;
+    }
+
+    this.ovhSubsidiary = get(this.user, 'ovhSubsidiary', '');
+  }
+
+  getPriceText(priceInCents) {
+    const locale = this.TranslateService.getUserLocale().replace('_', '-');
+    const price = this.getIntervalPrice(priceInCents / 100000000);
+
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: this.user.currency.code,
+    }).format(price);
+  }
+
+  getIntervalPrice(price) {
+    if (isUndefined(this.interval)) {
+      return Math.round(price * 100) / 100;
+    }
+
+    switch (this.interval) {
+      case INTERVAL_UNIT.DAY:
+        return Math.round((price / 365) * 100) / 100;
+      case INTERVAL_UNIT.MONTH:
+        return Math.round((price / 12) * 100) / 100;
+      case INTERVAL_UNIT.YEAR:
+        return Math.round(price * 100) / 100;
+      default:
+        return Math.round(price * 100) / 100;
+    }
+  }
+
+  isAsiaFormat() {
+    return ASIA_FORMAT.includes(this.ovhSubsidiary);
+  }
+
+  isFrenchFormat() {
+    return FRENCH_FORMAT.includes(this.ovhSubsidiary);
+  }
+
+  isGermanFormat() {
+    return GERMAN_FORMAT.includes(this.ovhSubsidiary);
+  }
+
+  isUSFormat() {
+    return US_FORMAT.includes(this.ovhSubsidiary);
+  }
+}

--- a/packages/manager/modules/catalog-price/src/catalog-price.html
+++ b/packages/manager/modules/catalog-price/src/catalog-price.html
@@ -1,0 +1,74 @@
+<span data-ng-if="::$ctrl.price">
+    <span data-ng-if="::$ctrl.isAsiaFormat()">
+        <strong data-ng-class="{ 'd-block': $ctrl.block }">
+            <span
+                data-ng-bind="{{'order_catalog_price_gst_excl_label' | translate}}"
+                data-translate-values="{ price: $ctrl.getPriceText($ctrl.price) }"
+            ></span>
+            <span data-ng-if="$ctrl.interval">
+                &#47;
+                <span
+                    data-translate="{{:: 'order_catalog_price_interval_' + $ctrl.interval}}"
+                ></span>
+            </span>
+        </strong>
+        <small data-ng-class="{ 'd-block': $ctrl.block }">
+            (<span
+                data-translate="order_catalog_price_gst_incl_label"
+                data-translate-values="{ price: $ctrl.getPriceText($ctrl.price + $ctrl.tax) }"
+            >
+            </span
+            >)
+        </small>
+    </span>
+    <span data-ng-if="::$ctrl.isFrenchFormat()">
+        <strong data-ng-class="{ 'd-block': $ctrl.block }">
+            <span
+                data-translate="order_catalog_price_tax_excl_label"
+                data-translate-values="{ price: $ctrl.getPriceText($ctrl.price) }"
+            ></span>
+            <span data-ng-if="$ctrl.interval">
+                &#47;
+                <span
+                    data-translate="{{:: 'order_catalog_price_interval_' + $ctrl.interval}}"
+                ></span>
+            </span>
+        </strong>
+        <small data-ng-class="{ 'd-block': $ctrl.block }">
+            (<span
+                data-translate="order_catalog_price_tax_incl_label"
+                data-translate-values="{ price: $ctrl.getPriceText($ctrl.price + $ctrl.tax) }"
+            >
+            </span
+            >)
+        </small>
+    </span>
+    <strong
+        data-ng-if="::$ctrl.isGermanFormat()"
+        data-ng-class="{ 'd-block': $ctrl.block }"
+    >
+        <span
+            data-ng-bind="::$ctrl.getPriceText($ctrl.price + $ctrl.tax)"
+        ></span>
+        <span data-ng-if="$ctrl.interval">
+            &#47;
+            <span
+                data-translate="{{:: 'order_catalog_price_interval_' + $ctrl.interval}}"
+            ></span>
+        </span>
+    </strong>
+    <strong
+        data-ng-if="::$ctrl.isUSFormat()"
+        data-ng-class="{ 'd-block': $ctrl.block }"
+    >
+        <span data-ng-bind="::$ctrl.getPriceText($ctrl.price)"></span>
+        <span data-ng-if="$ctrl.interval">
+            &#47;
+            <span
+                data-translate="{{:: 'order_catalog_price_interval_' + $ctrl.interval}}"
+            ></span>
+        </span>
+    </strong>
+</span>
+<strong data-ng-if="::!$ctrl.price" data-translate="order_catalog_price_free">
+</strong>

--- a/packages/manager/modules/catalog-price/src/index.js
+++ b/packages/manager/modules/catalog-price/src/index.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+import 'angular-translate';
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
+import ovhManagerCore from '@ovh-ux/manager-core';
+
+import component from './catalog-price.component';
+
+const moduleName = 'ovhManagerCatalogPrice';
+
+angular
+  .module(moduleName, [
+    ngTranslateAsyncLoader,
+    'oui',
+    ovhManagerCore,
+    'pascalprecht.translate',
+  ])
+  .component('ovhManagerCatalogPrice', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/catalog-price/src/translations/Messages_de_DE.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_de_DE.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Inklusive",
+  "order_catalog_price_tax_excl_label": "{{ price }} zzgl. MwSt.",
+  "order_catalog_price_tax_incl_label": "{{ price }} inkl. MwSt.",
+  "order_catalog_price_gst_excl_label": "{{ price }} zzgl. GST",
+  "order_catalog_price_gst_incl_label": "{{ price }} inkl. GST",
+  "order_catalog_price_interval_day": "Tag",
+  "order_catalog_price_interval_month": "Monat",
+  "order_catalog_price_interval_year": "jahr"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_en_GB.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_en_GB.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Included",
+  "order_catalog_price_tax_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_tax_incl_label": "{{price}} incl. VAT",
+  "order_catalog_price_gst_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_gst_incl_label": "{{ price }} incl. VAT",
+  "order_catalog_price_interval_day": "day",
+  "order_catalog_price_interval_month": "month",
+  "order_catalog_price_interval_year": "year"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_es_ES.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_es_ES.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Incluido",
+  "order_catalog_price_tax_excl_label": "{{ price }} + IVA",
+  "order_catalog_price_tax_incl_label": "{{ price }} IVA incl.",
+  "order_catalog_price_gst_excl_label": "{{ price }} + IVA",
+  "order_catalog_price_gst_incl_label": "{{ price }} IVA incl.",
+  "order_catalog_price_interval_day": "día",
+  "order_catalog_price_interval_month": "mes(es)",
+  "order_catalog_price_interval_year": "año"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_fi_FI.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Included",
+  "order_catalog_price_tax_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_tax_incl_label": "{{price}} incl. VAT",
+  "order_catalog_price_gst_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_gst_incl_label": "{{ price }} incl. VAT",
+  "order_catalog_price_interval_day": "day",
+  "order_catalog_price_interval_month": "month",
+  "order_catalog_price_interval_year": "year"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_fr_CA.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Inclus",
+  "order_catalog_price_tax_excl_label": "{{ price }} HT",
+  "order_catalog_price_tax_incl_label": "{{ price }} TTC",
+  "order_catalog_price_gst_excl_label": "{{ price }} ex. GST",
+  "order_catalog_price_gst_incl_label": "{{ price }} incl. GST",
+  "order_catalog_price_interval_day": "jour",
+  "order_catalog_price_interval_month": "mois",
+  "order_catalog_price_interval_year": "an"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_fr_FR.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Inclus",
+  "order_catalog_price_tax_excl_label": "{{ price }} HT",
+  "order_catalog_price_tax_incl_label": "{{ price }} TTC",
+  "order_catalog_price_gst_excl_label": "{{ price }} ex. GST",
+  "order_catalog_price_gst_incl_label": "{{ price }} incl. GST",
+  "order_catalog_price_interval_day": "jour",
+  "order_catalog_price_interval_month": "mois",
+  "order_catalog_price_interval_year": "an"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_it_IT.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_it_IT.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Incluso",
+  "order_catalog_price_tax_excl_label": "{{ price }} +IVA",
+  "order_catalog_price_tax_incl_label": "{{price}} IVA incl.",
+  "order_catalog_price_gst_excl_label": "{{ price }} GST escl.",
+  "order_catalog_price_gst_incl_label": "{{ price }} GST incl.",
+  "order_catalog_price_interval_day": "giorno",
+  "order_catalog_price_interval_month": "mese",
+  "order_catalog_price_interval_year": "anno"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_lt_LT.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Included",
+  "order_catalog_price_tax_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_tax_incl_label": "{{price}} incl. VAT",
+  "order_catalog_price_gst_excl_label": "{{ price }} ex. VAT",
+  "order_catalog_price_gst_incl_label": "{{ price }} incl. VAT",
+  "order_catalog_price_interval_day": "day",
+  "order_catalog_price_interval_month": "month",
+  "order_catalog_price_interval_year": "year"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_pl_PL.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "W ofercie",
+  "order_catalog_price_tax_excl_label": "{{price}} netto",
+  "order_catalog_price_tax_incl_label": "{{price}} brutto",
+  "order_catalog_price_gst_excl_label": "{{price}} netto",
+  "order_catalog_price_gst_incl_label": "{{price}} brutto",
+  "order_catalog_price_interval_day": "dzień",
+  "order_catalog_price_interval_month": "miesiąc",
+  "order_catalog_price_interval_year": "rok"
+}

--- a/packages/manager/modules/catalog-price/src/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/catalog-price/src/translations/Messages_pt_PT.json
@@ -1,0 +1,10 @@
+{
+  "order_catalog_price_free": "Incluído",
+  "order_catalog_price_tax_excl_label": "{{ price }} s/IVA",
+  "order_catalog_price_tax_incl_label": "{{ price }} IVA incl.",
+  "order_catalog_price_gst_excl_label": "{{ price }} + IVA",
+  "order_catalog_price_gst_incl_label": "{{ price }} c/ IVA incl.",
+  "order_catalog_price_interval_day": "dia",
+  "order_catalog_price_interval_month": "mês",
+  "order_catalog_price_interval_year": "ano"
+}

--- a/packages/manager/modules/product-offers/package.json
+++ b/packages/manager/modules/product-offers/package.json
@@ -16,6 +16,7 @@
     "moment": "^2.24.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-catalog-price": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-core": "^7.6.2",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
     "@ovh-ux/ng-ovh-payment-method": "^5.2.0",

--- a/packages/manager/modules/product-offers/src/index.js
+++ b/packages/manager/modules/product-offers/src/index.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import 'angular-translate';
 import 'ovh-ui-angular';
+import ovhManagerCatalogPrice from '@ovh-ux/manager-catalog-price';
 import ngOvhContracts from '@ovh-ux/ng-ovh-contracts';
 import ngOvhPaymentMethod from '@ovh-ux/ng-ovh-payment-method';
 import ngOvhWebUniverseComponents from '@ovh-ux/ng-ovh-web-universe-components';
@@ -24,6 +25,7 @@ angular
     ngOvhPaymentMethod,
     ngOvhWebUniverseComponents,
     ngTranslateAsyncLoader,
+    ovhManagerCatalogPrice,
     'pascalprecht.translate',
   ])
   .component('ovhManagerProductOffers', component)

--- a/packages/manager/modules/product-offers/src/pricing/extra-pricing-detail/extra-pricing-detail.html
+++ b/packages/manager/modules/product-offers/src/pricing/extra-pricing-detail/extra-pricing-detail.html
@@ -3,9 +3,9 @@
     data-translate="{{('ovh_product_offers_pricing_capacity_' + $ctrl.pricingCapacity)}}"
 ></strong>
 -
-<ovh-manager-order-catalog-price
+<ovh-manager-catalog-price
     price="$ctrl.pricing.price"
     tax="$ctrl.pricing.tax"
     user="$ctrl.user"
 >
-</ovh-manager-order-catalog-price>
+</ovh-manager-catalog-price>

--- a/packages/manager/modules/product-offers/src/pricing/extra-pricing-detail/index.js
+++ b/packages/manager/modules/product-offers/src/pricing/extra-pricing-detail/index.js
@@ -2,12 +2,14 @@ import angular from 'angular';
 import 'angular-translate';
 import 'ovh-ui-angular';
 
+import ovhManagerCatalogPrice from '@ovh-ux/manager-catalog-price';
+
 import extraPricingDetailComponent from './extra-pricing-detail.component';
 
 const moduleName = 'ovhManagerProductOffersPricingExtra';
 
 angular
-  .module(moduleName, ['oui', 'pascalprecht.translate'])
+  .module(moduleName, [ovhManagerCatalogPrice, 'oui', 'pascalprecht.translate'])
   .component(
     'ovhManagerProductOffersExtraPricingDetail',
     extraPricingDetailComponent,

--- a/packages/manager/modules/product-offers/src/product-offers.html
+++ b/packages/manager/modules/product-offers/src/product-offers.html
@@ -31,12 +31,12 @@
                 duration: ('ovh_product_offers_pricing_' + pricing.intervalUnit + (pricing.interval === 1 ? '' : 's') | translate:{ number: pricing.interval })
               }"
                     ></span>
-                    <ovh-manager-order-catalog-price
+                    <ovh-manager-catalog-price
                         data-price="pricing.price"
                         data-tax="pricing.tax"
                         data-user="$ctrl.workflow.user"
                     >
-                    </ovh-manager-order-catalog-price>
+                    </ovh-manager-catalog-price>
                 </oui-select-picker-label>
                 <oui-select-picker-description
                     data-ng-if="pricing.hasExtraPricing() && !pricing.extraPricing.isFree()"


### PR DESCRIPTION
### 🚜 Feature
Export of component to display catalog prices localized in web/client/app/components/manager-order-catalog-price scope.
This is done as the product-offers module uses this component, and so to clear the dependency to web. 

Nothing has changed except the name of the component. 

⚠️ Apart from mandatory changes, all reviews will be handle in a **separate** pull request. As the release of this component is necessary to release #2214 module. (Adaptation of product-offers is done through this PR).

Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>
Co-authored-by: Axel Peter <axel.peter@live.com>