### PR TITLE
fix(pci.instances): notification instances baremetal early adopter

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instances.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.html
@@ -3,8 +3,19 @@
     data-type="warning"
     data-dismissable
 >
+    <span
+        data-translate="pci_projects_project_instances_beta_subscribe_labs"
+    ></span>
+</oui-message>
+
+<oui-message
+    data-ng-if="$ctrl.betaWarning"
+    data-type="warning"
+    data-dismissable
+>
     <span data-ng-bind="$ctrl.betaWarning"></span>
 </oui-message>
+
 <div data-ui-view>
     <oui-page-header
         data-heading="{{:: 'pci_projects_project_instances_title' | translate }}"

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_de_DE.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instanzen",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Name",
   "pci_projects_project_instances_region_label": "Standort",
   "pci_projects_project_instances_flavor_label": "Modell",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_en_GB.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instances",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Name",
   "pci_projects_project_instances_region_label": "Location",
   "pci_projects_project_instances_flavor_label": "Model",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_es_ES.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instancias",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Nombre",
   "pci_projects_project_instances_region_label": "Localización",
   "pci_projects_project_instances_flavor_label": "Modelo",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fi_FI.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instances",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Name",
   "pci_projects_project_instances_region_label": "Location",
   "pci_projects_project_instances_flavor_label": "Model",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fr_CA.json
@@ -1,6 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instances",
-
+  "pci_projects_project_instances_beta_subscribe_labs": "Accédez en avant-première à nos instances BareMetal en remplissant le formulaire d’inscription disponible sur la page <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">OVH Labs dédiée</a>.",
   "pci_projects_project_instances_name_label": "Nom",
   "pci_projects_project_instances_region_label": "Localisation",
   "pci_projects_project_instances_flavor_label": "Modèle",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_fr_FR.json
@@ -1,6 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instances",
-
+  "pci_projects_project_instances_beta_subscribe_labs": "Accédez en avant-première à nos instances BareMetal en remplissant le formulaire d’inscription disponible sur la page <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">OVH Labs dédiée</a>.",
   "pci_projects_project_instances_name_label": "Nom",
   "pci_projects_project_instances_region_label": "Localisation",
   "pci_projects_project_instances_flavor_label": "Modèle",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_it_IT.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Istanze",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Nome",
   "pci_projects_project_instances_region_label": "Localizzazione",
   "pci_projects_project_instances_flavor_label": "Modello",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_lt_LT.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instances",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Name",
   "pci_projects_project_instances_region_label": "Location",
   "pci_projects_project_instances_flavor_label": "Model",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_pl_PL.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instancje",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Nazwa",
   "pci_projects_project_instances_region_label": "Lokalizacja",
   "pci_projects_project_instances_flavor_label": "Model",

--- a/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/translations/Messages_pt_PT.json
@@ -1,5 +1,6 @@
 {
   "pci_projects_project_instances_title": "Instâncias",
+  "pci_projects_project_instances_beta_subscribe_labs": "Get an early access to our BareMetal instances by filling out the registration form available on <a href=\"https://labs.ovh.com/bare-metal-on-public-cloud\" target=\"_blank\">the dedicated OVH Labs page.</a>.",
   "pci_projects_project_instances_name_label": "Nome",
   "pci_projects_project_instances_region_label": "Localização",
   "pci_projects_project_instances_flavor_label": "Modelo",


### PR DESCRIPTION
# Instances Bare Metal

## Description of the change

Add a notification with the registration form in order to request an activation of a region and so to be able to test baremetal instances.

## References

DTRSD-8664

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>