### PR TITLE
fix(billing.terminate): encode uri for ip block

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/confirmTerminate/billing-confirmTerminate.service.js
+++ b/packages/manager/apps/dedicated/client/app/billing/confirmTerminate/billing-confirmTerminate.service.js
@@ -26,7 +26,10 @@ angular
       return this.getServiceApi(serviceId)
         .then((serviceApi) => {
           serviceType = this.getServiceTypeFromPrefix(serviceApi.route.path);
-          return serviceApi.route.url;
+          return serviceApi.route.url.replace(
+            serviceApi.resource.name,
+            window.encodeURIComponent(serviceApi.resource.name),
+          );
         })
         .then((url) =>
           OvhHttp.get(`${url}/serviceInfos`, {

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_FR.json
@@ -964,6 +964,7 @@
   "terminate_service_type_hosting_privateDatabase": "Hébergement base SQL privée",
   "terminate_service_type_hosting_reseller": "Hébergement multisite",
   "terminate_service_type_hosting_web": "Hébergement web",
+  "terminate_service_type_ip_service": "IP",
   "terminate_service_type_ipLoadbalancing": "Load Balancing",
   "terminate_service_type_ip_loadBalancing": "Équilibreur de charge IP",
   "terminate_service_type_license_cloudLinux": "Licence CloudLinux",


### PR DESCRIPTION
# Confirm termination IPs

## Description of the change

Encode URI for IP blocks in order to avoid 404 err api call

## References

DTRSD-8552

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>