### PR TITLE
fix(hub): ovh-api-services dependency

### DIFF
--- a/packages/manager/apps/hub/src/components/at-internet/index.js
+++ b/packages/manager/apps/hub/src/components/at-internet/index.js
@@ -2,7 +2,6 @@ import angular from 'angular';
 import ngAtInternet from '@ovh-ux/ng-at-internet';
 import ngAtInternetUiRouterPlugin from '@ovh-ux/ng-at-internet-ui-router-plugin';
 import ovhManagerCore from '@ovh-ux/manager-core';
-import 'ovh-api-services';
 
 import TRACKING from './at-internet.constant';
 
@@ -10,7 +9,6 @@ const moduleName = 'hubAtInternet';
 
 angular
   .module(moduleName, [
-    'ovh-api-services',
     ovhManagerCore,
     ngAtInternet,
     ngAtInternetUiRouterPlugin,
@@ -31,12 +29,13 @@ angular
     },
   )
   .run(
-    /* @ngInject */ (atInternet, coreConfig, OvhApiMe) => {
+    /* @ngInject */ ($http, atInternet, coreConfig) => {
       const config = TRACKING[coreConfig.getRegion()] || {};
 
-      OvhApiMe.v6()
-        .get()
-        .$promise.then((me) => {
+      return $http
+        .get('/me')
+        .then(({ data }) => data)
+        .then((me) => {
           config.countryCode = me.country;
           config.currencyCode = me.currency && me.currency.code;
           config.visitorId = me.customerCode;

--- a/packages/manager/modules/hub/package.json
+++ b/packages/manager/modules/hub/package.json
@@ -16,13 +16,16 @@
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^7.5.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^5.2.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
+    "@ovh-ux/ng-ovh-swimming-poll": "^4.0.1",
     "@ovh-ux/ng-translate-async-loader": "^2.0.2",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
+    "ovh-api-services": "^9.27.1",
     "ovh-ui-kit": "^3.6.0"
   }
 }

--- a/packages/manager/modules/hub/src/components/carousel/index.js
+++ b/packages/manager/modules/hub/src/components/carousel/index.js
@@ -11,7 +11,6 @@ angular
   .module(moduleName, [
     'oui',
     'ngTranslateAsyncLoader',
-    'ovh-api-services',
     'pascalprecht.translate',
   ])
   .component('ovhManagerHubCarousel', carousel)

--- a/packages/manager/modules/hub/src/components/user-panel/payment-mean/index.js
+++ b/packages/manager/modules/hub/src/components/user-panel/payment-mean/index.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import component from './component';
 import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-swimming-poll';
+import '@ovh-ux/ng-ovh-api-wrappers';
 import '@ovh-ux/ng-ovh-payment-method';
 import '@ovh-ux/ng-translate-async-loader';
 import 'angular-translate';
@@ -11,9 +13,12 @@ const moduleName = 'ovhManagerHubPaymentMean';
 
 angular
   .module(moduleName, [
+    'ngOvhSwimmingPoll',
+    'ngOvhApiWrappers',
     'ngOvhPaymentMethod',
     'ngTranslateAsyncLoader',
     'oui',
+    'ovh-api-services',
     'ovhManagerCore',
     'pascalprecht.translate',
   ])


### PR DESCRIPTION
Fix hub because ovh-api-services removed from manager-core.

ovh-api-services will be removed later but some dependencies need to be fixed first such as ng-ovh-payement-method for example