### PR TITLE
fix(billing.terminate): encode uri

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/confirmTerminate/billing-confirmTerminate.service.js
+++ b/packages/manager/apps/dedicated/client/app/billing/confirmTerminate/billing-confirmTerminate.service.js
@@ -48,7 +48,12 @@ angular
       token,
     ) {
       return this.getServiceApi(serviceId)
-        .then((serviceApi) => serviceApi.route.url)
+        .then((serviceApi) =>
+          serviceApi.route.url.replace(
+            serviceApi.resource.name,
+            window.encodeURIComponent(serviceApi.resource.name),
+          ),
+        )
         .then((url) =>
           OvhHttp.post(`${url}/confirmTermination`, {
             rootPath: 'apiv6',


### PR DESCRIPTION
# Encode URI for confirm terminate

## Description of the change

Prevent 404 err call on api when posting IP confirm termination by encoding URI

## References 

DTRSD-8945

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>