### PR TITLE
feat(veeam-backup): spla licence check

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.module.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.module.js
@@ -12,6 +12,7 @@ import routing from './backup.routing';
 import backupService from './backup.service';
 import backupOffers from './components/offers';
 import backupNew from './new';
+import splaLicence from './splaLicence';
 
 const moduleName = 'ovhManagerDedicatedCloudBackupModule';
 
@@ -24,6 +25,7 @@ angular
     'pascalprecht.translate',
     backupOffers,
     backupNew,
+    splaLicence,
   ])
   .config(routing)
   .component('dedicatedCloudDatacenterBackup', component)

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/component.js
@@ -1,0 +1,8 @@
+import template from './template.html';
+
+export default {
+  bindings: {
+    licenceLink: '<',
+  },
+  template,
+};

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/index.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/index.js
@@ -1,0 +1,21 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import '@ovh-ux/ng-translate-async-loader';
+import 'angular-translate';
+
+import component from './component';
+import routing from './routing';
+
+const moduleName = 'ovhManagerDedicatedCloudBackupSplaLicence';
+
+angular
+  .module(moduleName, [
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+    'ui.router',
+  ])
+  .config(routing)
+  .component('dedicatedCloudDatacenterBackupSplaLicence', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/routing.js
@@ -1,0 +1,6 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('app.dedicatedClouds.datacenter.backup.spla-licence', {
+    url: '/spla-licence',
+    component: 'dedicatedCloudDatacenterBackupSplaLicence',
+  });
+};

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/template.html
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/template.html
@@ -1,0 +1,5 @@
+<p
+    data-translate="dedicatedCloud_datacenter_backup_nospla"
+    data-translate-values="{ licenceLink: $ctrl.licenceLink }"
+    data-translate-compile
+></p>

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/splaLicence/translations/Messages_fr_FR.json
@@ -1,0 +1,3 @@
+{
+  "dedicatedCloud_datacenter_backup_nospla": "Votre Private Cloud doit avoir une licence SPLA avant de pouvoir activer le backup. Afin d'activer la licence SPLA, veuillez vous rendre dans la section <a href=\"{{ licenceLink }}\">Licence Windows</a> de votre produit."
+}


### PR DESCRIPTION
DO spla licence check on backup page. If licence is not available, veeam backup can not be created. How a message to add the licence first.

The review was done as part of https://github.com/ovh/manager/pull/2359