### PR TITLE
build: ensure that imports sort automatically

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,8 @@ const path = require('path');
 module.exports = {
   root: true,
   parser: 'babel-eslint',
-  plugins: [
-    'angular',
-    'markdown',
-    'prettier',
-  ],
-  extends: ['airbnb-base', 'prettier'],
+  plugins: ['angular', 'markdown', 'prettier', 'simple-import-sort'],
+  extends: ['airbnb-base', 'prettier', 'plugin:import/recommended'],
   env: {
     'angular/mocks': true,
     browser: true,
@@ -17,7 +13,10 @@ module.exports = {
   rules: {
     'no-bitwise': ['error', { allow: ['~'] }],
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
-    'import/no-unresolved': 0,
+    'import/no-unresolved': 'off',
+    'simple-import-sort/sort': 'error', // sorts imports automatically
+    'sort-imports': 'off', // must be turned off for 'simple-import-sort/sort' to work fine
+    'import/order': 'off', // must be turned off for 'simple-import-sort/sort' to work fine
     'prettier/prettier': 'error',
   },
   settings: {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-markdown": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-simple-import-sort": "^5.0.2",
     "esm": "^3.2.25",
     "execa": "^2.0.5",
     "find-free-port": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7153,6 +7153,11 @@ eslint-plugin-prettier@^3.1.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-simple-import-sort@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.2.tgz#43b5c4ab5affa2dd8481ef40216c71723becd2e2"
+  integrity sha512-YPEGo7DbMANQ01d2OXlREcaHRszsW8LoUQ9mIjI7gXSdwpnWKfogtzL6FiBfDf1teCBx+AdcjcfDXSKpmhTWeA==
+
 eslint-rule-docs@^1.1.5:
   version "1.1.167"
   resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.167.tgz#c569599c05d3f4a337d05907ea0ce525803e3d14"


### PR DESCRIPTION
Now imports are sorted automatically so you don't have to care about it

# Example

```js
import React from "react";
import Button from "../Button";

import styles from "./styles.css";
import type { User } from "../../types";
import { getUser } from "../../api";

import PropTypes from "prop-types";
import classnames from "classnames";
import { truncate, formatNumber } from "../../utils";
```

⬇️

<!-- prettier-ignore -->
```js
import classnames from "classnames";
import PropTypes from "prop-types";
import React from "react";

import { getUser } from "../../api";
import type { User } from "../../types";
import { formatNumber, truncate } from "../../utils";
import Button from "../Button";
import styles from "./styles.css";
```

# Before testing
Please `yarn clean && yarn install` because it might fail because of a bug in `babel-eslint`

Sources:
- https://github.com/babel/babel-eslint/issues/799
- https://github.com/babel/babel-eslint/issues/530

# Performances

## Before `eslint-plugin-simple-import-sort`
`✨  Done in 236.82s.`

## After `eslint-plugin-simple-import-sort`
- First time `✨  Done in 281.92s.`
- The times after, in average, `✨  Done in 240.57s.`