### PR TITLE
build(deps): upgrade ovh-api-services to v9.40.0

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -55,7 +55,7 @@
     "moment": "^2.15.2",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -108,7 +108,7 @@
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
     "ovh-angular-responsive-page-switcher": "^1.1.1",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -125,7 +125,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -49,7 +49,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -51,7 +51,7 @@
     "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0"
   },

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -53,7 +53,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "moment": "^2.19",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -49,7 +49,7 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -34,7 +34,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "angular-ui-bootstrap": "^1.3.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -51,7 +51,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -73,7 +73,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.22.2",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -48,7 +48,7 @@
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -32,7 +32,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -42,7 +42,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -39,7 +39,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.15.1",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -120,7 +120,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-timeline": "^1.5.2",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -44,7 +44,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0"
   },

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -45,7 +45,7 @@
     "d3": "~3.5.13",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -53,7 +53,7 @@
     "jquery": "^2.1.3",
     "jsurl": "0.1.5",
     "moment": "^2.19",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",
     "ovh-ui-kit-bs": "^2.3.1"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -43,7 +43,7 @@
     "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -105,7 +105,7 @@
     "ng-ckeditor": "^2.0.5",
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^9.40.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "2.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12782,10 +12782,10 @@ ovh-angular-ui-confirm-modal@^1.0.2:
   resolved "https://registry.yarnpkg.com/ovh-angular-ui-confirm-modal/-/ovh-angular-ui-confirm-modal-1.0.2.tgz#92e6736588a4fb1de6353f1a17ab1962679a698d"
   integrity sha512-3V17DbzWjUjl9sKCd25Oycn+7eqg6iW+DpizwVmixHFzDNDMnpKSGmxRLrOq+q9YNE7IepoAKWjoSiy2+zOEEg==
 
-ovh-api-services@^9.39.1:
-  version "9.39.1"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.39.1.tgz#efcdfde0d0874a4db65f21e0dc41210546227a18"
-  integrity sha512-0WMs78JamK8bDHtqj6VN9p8QkMvo+nRQhdzTDGcaOoQoZ2znYJgHbS2K8ZemXVrSKMKcA81Fb76s1jbGqWlYIw==
+ovh-api-services@^9.40.0:
+  version "9.40.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.40.0.tgz#c61fd9c23527ed5c8c9a50820f0d760f2bf965fa"
+  integrity sha512-lnCi2hsSTQ7+RKccWNIEWpJLbCvV1RgvrAFSWAXtfkq5EBOT6X6jpsgwmLVYvZeysiX9DQ5ur7DpDykomudLyw==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
## :arrow_up: Upgrade

ebb5fee - build(deps): upgrade ovh-api-services to v9.40.0

uses: `yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@9.40.0

## :link: Related

- ovh-ux/ovh-api-services#286

## :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>