### PR TITLE
feat(assistance-menu): remove useless support contact support

### DIFF
--- a/packages/manager/modules/navbar/src/assistance-menu/constants.js
+++ b/packages/manager/modules/navbar/src/assistance-menu/constants.js
@@ -53,23 +53,6 @@ const EU = {
     SN: 'https://www.ovh.sn/support/',
     TN: 'https://www.ovh.com/tn/support/',
   },
-  support_contact: {
-    CZ: 'http://www.ovh.cz/podpora/',
-    DE: 'http://www.ovh.de/support/',
-    ES: 'http://www.ovh.es/soporte/',
-    FI: 'http://www.ovh-hosting.fi/tuki/',
-    FR: 'https://www.ovh.com/fr/support/nous-contacter/',
-    GB: 'http://www.ovh.co.uk/support/',
-    IE: 'http://www.ovh.ie/support/',
-    IT: 'http://www.ovh.it/supporto/',
-    LT: 'http://www.ovh.lt/pagalba/',
-    MA: 'https://www.ovh.ma/support/',
-    NL: 'http://www.ovh.nl/support/',
-    PL: 'https://www.ovh.pl/pomoc/',
-    PT: 'https://www.ovh.pt/suporte/',
-    SN: 'https://www.ovh.sn/support/',
-    TN: 'https://www.ovh.com/tn/support/',
-  },
   guides: {
     home: {
       CZ: 'https://docs.ovh.com/cz/cs/',

--- a/packages/manager/modules/navbar/src/assistance-menu/controller.js
+++ b/packages/manager/modules/navbar/src/assistance-menu/controller.js
@@ -120,21 +120,6 @@ export default class {
         }),
     });
 
-    if (!['US'].includes(this.REGION)) {
-      sublinks.push({
-        title: this.$translate.instant('navbar_assistance_telephony_contact'),
-        url:
-          get(this.URLS, 'support_contact', {})[this.subsidiary] ||
-          get(this.URLS, 'support_contact.FR'),
-        isExternal: true,
-        click: () =>
-          this.atInternet.trackClick({
-            name: 'assistance::helpline',
-            type: 'action',
-          }),
-      });
-    }
-
     if (CHATBOT_SUBSIDIARIES.includes(this.subsidiary)) {
       sublinks.push({
         title: `${this.$translate.instant(


### PR DESCRIPTION
# Navbar assistance menu

## Description of the change

Remove link to old support call form

ref: DTRSD-9262

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>