### PR TITLE
[RFC] docs: add PULL_REQUEST_TEMPLATE.md file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+Hello 👋 Thank you for submitting a Pull Request.
+
+Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
+-->
+
 | Question         | Answer
 | ---------------- | ---
 | Branch?          | `master` for hotfix / `develop` for bug fixes <!-- see below -->
@@ -6,3 +12,7 @@
 | Breaking change? | yes/no
 | Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
 | License          | BSD 3-Clause
+
+## Description
+
+<!-- Write a brief description of the changes introduced by this PR -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+| Question         | Answer
+| ---------------- | ---
+| Branch?          | `master` for hotfix / `develop` for bug fixes <!-- see below -->
+| Bug fix?         | yes/no
+| New feature?     | yes/no
+| Breaking change? | yes/no
+| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
+| License          | BSD 3-Clause


### PR DESCRIPTION
## GitHub Pull Request template

We recently initiate discussions about having a `PULL_REQUEST_TEMPLATE`.

Here is a suggestion where we can discuss about it and iterate over it to cover
the right balance between having Pull Request well described and easy to fill.

## :link: Resources

- https://github.com/devspace/awesome-github-templates
- https://github.com/ovh/cds/blob/master/.github/PULL_REQUEST_TEMPLATE.md
- https://github.com/symfony/symfony/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>