### PR TITLE
fix(web-emailpro): add server field

### DIFF
--- a/packages/manager/modules/emailpro/src/information/emailpro-information.html
+++ b/packages/manager/modules/emailpro/src/information/emailpro-information.html
@@ -194,8 +194,11 @@
                                                 data-align="end"
                                             >
                                                 <oui-action-menu-item
-                                                    data-href="{{ $ctrl.upgradeLink }}">
-                                                    <span data-translate="emailpro_dashboard_accounts_upgrade_mxPlan"></span>
+                                                    data-href="{{ $ctrl.upgradeLink }}"
+                                                >
+                                                    <span
+                                                        data-translate="emailpro_dashboard_accounts_upgrade_mxPlan"
+                                                    ></span>
                                                 </oui-action-menu-item>
                                             </oui-action-menu>
                                         </div>
@@ -312,6 +315,15 @@
                 ></h3>
                 <div class="oui-tile__body">
                     <ul class="list-unstyled">
+                        <li class="oui-tile__item">
+                            <div class="oui-tile__definition">
+                                <strong
+                                    class="oui-tile__term d-block"
+                                    data-translate="emailpro_tab_INFORMATIONS_server"
+                                ></strong>
+                                <span data-ng-bind="exchange.hostname"></span>
+                            </div>
+                        </li>
                         <li class="oui-tile__item">
                             <div class="oui-tile__definition">
                                 <strong

--- a/packages/manager/modules/emailpro/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_fr_FR.json
@@ -551,6 +551,7 @@
   "emailpro_tab_INFORMATIONS_summary": "Résumé",
   "emailpro_tab_INFORMATIONS_wait_activation": "En attente d'activation",
   "emailpro_tab_INFORMATIONS_webmail": "Webmail",
+  "emailpro_tab_INFORMATIONS_server": "Server",
   "emailpro_tab_TASKS": "Tâches récentes",
   "emailpro_tab_TASKS_table_empty": "Vous n'avez pas de tâches",
   "emailpro_tab_TASKS_table_function": "Tâche",


### PR DESCRIPTION
add a server field in the connection menu for professional email
DTRSD-6572

Signed-off-by: Varun257 <varun257@gmail.com>

