### PR TITLE
fix(navbar): overload max-height notification

### DIFF
--- a/packages/manager/apps/dedicated/client/app/css/source.less
+++ b/packages/manager/apps/dedicated/client/app/css/source.less
@@ -75,6 +75,10 @@ oui-message,
   margin-bottom: 0;
 }
 
+.oui-navbar-notification__description {
+  max-height: 10rem !important;
+}
+
 h3.font-lite {
   font-weight: 300;
 }

--- a/packages/manager/apps/public-cloud/src/index.scss
+++ b/packages/manager/apps/public-cloud/src/index.scss
@@ -7,6 +7,10 @@
   background: #fff;
 }
 
+.oui-navbar-notification__description {
+  max-height: 10rem !important;
+}
+
 a.oui-tile,
 .oui-link,
 .oui-button_link {

--- a/packages/manager/apps/web/client/app/css/source.less
+++ b/packages/manager/apps/web/client/app/css/source.less
@@ -48,3 +48,7 @@
     }
   }
 }
+
+.oui-navbar-notification__description {
+  max-height: 10rem !important;
+}


### PR DESCRIPTION
# Navbar notification broken

## Description of the change

Avoid truncated notifications content due to max-height

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>