### PR TITLE
fix(order-tracking): add default element if there is no history

### DIFF
--- a/packages/manager/modules/hub/src/components/order-tracking/controller.js
+++ b/packages/manager/modules/hub/src/components/order-tracking/controller.js
@@ -9,6 +9,9 @@ export default class ManagerHubBillingSummaryCtrl {
   }
 
   $onInit() {
-    this.currentStatus = maxBy(this.order.history, 'date');
+    this.currentStatus = maxBy(this.order.history, 'date') || {
+      date: this.order.date,
+      label: 'custom_creation',
+    };
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4621
| License          | BSD 3-Clause

## Description

Add default information if order has no history yet 