### PR TITLE
fix(order-tracking): display orderId instead of domain

### DIFF
--- a/packages/manager/modules/hub/src/components/order-tracking/template.html
+++ b/packages/manager/modules/hub/src/components/order-tracking/template.html
@@ -2,7 +2,7 @@
     <h3 data-translate="hub_order_tracking_title"></h3>
     <span
         class="oui-status oui-status_info"
-        data-ng-bind="$ctrl.order.domain"
+        data-ng-bind="$ctrl.order.orderId"
     ></span>
     <div class="mb-3">
         <span


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4622
| License          | BSD 3-Clause

## Description

- Display orderId instead of domain 