### PR TITLE
fix(payment-status): use id to track ng-repeat

### DIFF
--- a/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
+++ b/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
@@ -12,7 +12,7 @@
                     <tbody>
                         <tr
                             class="oui-datagrid__row"
-                            data-ng-repeat="service in $ctrl.services track by service.serviceId"
+                            data-ng-repeat="service in $ctrl.services track by service.id"
                         >
                             <td
                                 class="oui-datagrid__cell d-block d-md-table-cell h-100"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none 
| License          | BSD 3-Clause

## Description
 update tracked property because Some services can have the same serviceId which causes duplicate

## Related 
- 2API