### PR TITLE
fix(products-list): handle pagination change with static rows

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/products-list/exchange.routing.js
+++ b/packages/manager/apps/hub/src/dashboard/products-list/exchange.routing.js
@@ -1,3 +1,4 @@
+import mapValues from 'lodash/mapValues';
 import pick from 'lodash/pick';
 
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
@@ -6,7 +7,11 @@ import { urlQueryParams, params, component, resolves } from './config';
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.dashboard.exchange', {
     url: `email_exchange_service?${urlQueryParams}`,
-    params,
+    // prevent reloading all resolves as we already have the data but save to url for bookmarking
+    params: mapValues(params, (param) => ({
+      ...param,
+      dynamic: true,
+    })),
     component,
     resolve: {
       ...resolves,

--- a/packages/manager/modules/hub/src/components/product-list/controller.js
+++ b/packages/manager/modules/hub/src/components/product-list/controller.js
@@ -1,9 +1,27 @@
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
+import get from 'lodash/get';
 
 export default class ManagerHubBillingProductList extends ListLayoutHelper.ListLayoutCtrl {
   $onInit() {
     this.datagridId = `dg-${this.productType}`;
 
     super.$onInit();
+  }
+
+  loadStaticRows() {
+    return this.loadPage().then(({ meta }) => {
+      const offset = get(
+        this.ouiDatagridService,
+        `datagrids.${this.datagridId}.paging.offset`,
+      );
+      // $q is injected in super controller
+      return this.$q.resolve({
+        data: this.rows.slice(
+          offset - 1,
+          offset + parseInt(this.paginationSize, 10),
+        ),
+        meta,
+      });
+    });
   }
 }

--- a/packages/manager/modules/hub/src/components/product-list/template.html
+++ b/packages/manager/modules/hub/src/components/product-list/template.html
@@ -6,7 +6,7 @@
     <oui-datagrid
         data-ng-if="$ctrl.rows"
         id="{{ $ctrl.datagridId }}"
-        data-rows="$ctrl.rows"
+        data-rows-loader="$ctrl.loadStaticRows()"
         data-row-loader="$ctrl.loadRow($row)"
         data-columns="$ctrl.columns"
         data-customizable

--- a/packages/manager/modules/hub/src/components/products/products.html
+++ b/packages/manager/modules/hub/src/components/products/products.html
@@ -7,7 +7,7 @@
             heading="{{:: 'manager_hub_products_' + product.productType | translate }}"
             badge-text="{{ product.count }}"
             class="oui-list"
-            data-on-click="$ctrl.onProductSelect({ productType: product })"
+            data-on-click="$ctrl.onProductSelect({ productType: product.productType })"
         >
             <ul class="oui-list__items">
                 <li
@@ -18,7 +18,7 @@
                         data-ng-href="{{:: service.url }}"
                         data-ng-bind="service.resource.displayName || service.resource.name"
                         data-track-on="click"
-                        data-track-name="{{ $ctrl.trackingPrefix + '::product::' + product + '::go-to-service' }}"
+                        data-track-name="{{ $ctrl.trackingPrefix + '::product::' + product.productType + '::go-to-service' }}"
                     >
                     </a>
                 </li>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          |   MANAGER-4657
| License          | BSD 3-Clause

## Description

Prevent pagination from always reseting to page 1 when rows are all loaded. Also prevent reloading everything in that case 