### PR TITLE
fix(hub): add loading when fetching bills

### DIFF
--- a/packages/manager/modules/hub/src/components/billing-summary/controller.js
+++ b/packages/manager/modules/hub/src/components/billing-summary/controller.js
@@ -51,14 +51,19 @@ export default class ManagerHubBillingSummaryCtrl {
     this.bills = null;
     this.formattedBillingPrice = null;
 
-    return this.fetchBills(this.billingPeriod.value).then(({ data }) => {
-      this.bills = data;
-      this.formattedBillingPrice = this.getFormattedPrice(
-        data.total,
-        get(data, 'currency.code'),
-      );
-      this.buildPeriodFilter(data.period);
-    });
+    this.loading = true;
+    return this.fetchBills(this.billingPeriod.value)
+      .then(({ data }) => {
+        this.bills = data;
+        this.formattedBillingPrice = this.getFormattedPrice(
+          data.total,
+          get(data, 'currency.code'),
+        );
+        this.buildPeriodFilter(data.period);
+      })
+      .finally(() => {
+        this.loading = false;
+      });
   }
 
   getFormattedPrice(price, currency) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/manager-hub
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

add loading when fetching bills to avoid error being dispayed

<!-- Write a brief description of the changes introduced by this PR -->
