### PR TITLE
fix(pcc.datacenter.drp): use correct route to get drp status

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/drp/dedicatedCloud-datacenter-drp.service.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/drp/dedicatedCloud-datacenter-drp.service.js
@@ -14,6 +14,7 @@ import {
 export default class {
   /* @ngInject */
   constructor(
+    $http,
     $q,
     OvhApiDedicatedCloud,
     OvhApiMe,
@@ -21,6 +22,7 @@ export default class {
     ovhPaymentMethod,
     ovhUserPref,
   ) {
+    this.$http = $http;
     this.$q = $q;
     this.OvhApiDedicatedCloud = OvhApiDedicatedCloud;
     this.OvhApiMe = OvhApiMe;
@@ -100,11 +102,11 @@ export default class {
   }
 
   getDrpState(serviceInformations) {
-    return this.OvhApiDedicatedCloud.Datacenter()
-      .Zerto()
-      .v6()
-      .state(serviceInformations, null)
-      .$promise.then((state) => ({ ...state, ...serviceInformations }));
+    return this.$http
+      .get(
+        `/dedicatedCloud/${serviceInformations.serviceName}/datacenter/${serviceInformations.datacenterId}/disasterRecovery/zerto/status`,
+      )
+      .then(({ data: state }) => ({ ...state, ...serviceInformations }));
   }
 
   getDefaultLocalVraNetwork(serviceInformations) {


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-8190
| License          | BSD 3-Clause

## Description

Change of API route to get the drp status, for a given Private Cloud