### PR TITLE
fix(dashboard.products-list): be more specific to match api route

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/products-list/routing.js
+++ b/packages/manager/apps/hub/src/dashboard/products-list/routing.js
@@ -20,7 +20,7 @@ export default /* @ngInject */ ($stateProvider) => {
           .get('/')
           .then(({ data: schema }) =>
             find(schema.apis, ({ path }) =>
-              new RegExp(`^${path}`).test(resourcePath),
+              new RegExp(`^${path}/`).test(resourcePath),
             ),
           )
           .then(({ path }) => $http.get(`${path}.json`))


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     |no
| Breaking change? |no
| Tickets          | none 
| License          | BSD 3-Clause

## Description

This prevents from using schema of APIs having similar expressions (e.g :  for /ipLoadbaclancing, /ip was matched
