### PR TITLE
feat(billing.orders): enable order tracking is us

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/billing-feature-availability.js
+++ b/packages/manager/apps/dedicated/client/app/billing/billing-feature-availability.js
@@ -5,7 +5,7 @@ export default class {
   }
 
   allowOrderTracking() {
-    return this.deny('US');
+    return this.allow('CA', 'EU', 'US');
   }
 
   allow(...args) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | OVHR-741
| License          | BSD 3-Clause

## Description

Enable order tracking feature in US