### PR TITLE
fix(payment-mean): limit height and width of image

### DIFF
--- a/packages/manager/modules/account-sidebar/src/payment-mean/index.scss
+++ b/packages/manager/modules/account-sidebar/src/payment-mean/index.scss
@@ -15,6 +15,11 @@
     text-decoration: none;
   }
 
+  img {
+    width: 24px;
+    height: 24px;
+  }
+
   &_status {
     font-size: 0.8rem;
     font-weight: bold;

--- a/packages/manager/modules/account-sidebar/src/payment-mean/template.html
+++ b/packages/manager/modules/account-sidebar/src/payment-mean/template.html
@@ -14,6 +14,7 @@
             data-ng-src="{{:: $ctrl.paymentMethod.icon.data }}"
             alt="{{:: $ctrl.paymentMethod.label }}"
             aria-hidden="true"
+            class="mr-1"
         />
         <oui-skeleton size="s" data-ng-if="$ctrl.isLoading"> </oui-skeleton>
         <div class="m-auto" data-ng-if="!$ctrl.isLoading">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4718
| License          | BSD 3-Clause

## Description

- limit height and width of payment mean image 