### PR TITLE
fix(carousel): allow description to contain html

### DIFF
--- a/packages/manager/modules/hub/src/components/carousel/carousel.html
+++ b/packages/manager/modules/hub/src/components/carousel/carousel.html
@@ -12,7 +12,7 @@
         class="oui-message__body oui-message__body_error"
         data-ng-href="{{ item.urlDetails.href }}"
     >
-        <span data-ng-bind="item.description"></span>
+        <span data-ng-bind-html="item.description"></span>
     </a>
     <button
         class="oui-button oui-button_icon-alone float-right"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4728
| License          | BSD 3-Clause

## Description

allow description to contain html. Description is some content returned by one of our 2API (notifications)