### PR TITLE
fix(hub): expand sidebar only for dashboard

### DIFF
--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -45,7 +45,7 @@
                     event: 'sidebar:loaded',
                 },
             }"
-            data-sidebar-expand="true"
+            data-sidebar-expand="shouldExpandSidebar"
             data-sidebar-links="{}"
         >
         </ovh-manager-navbar>
@@ -55,7 +55,12 @@
                     class="px-3 px-md-0 d-sm-flex justify-content-center h-100 mb-5"
                     data-ui-view="app"
                 >
-                    <div class="h-100 hub-main-view pt-4">
+                    <div
+                        class="h-100 hub-main-view pt-4"
+                        data-ng-class="{
+                            'hub-main-view_sidebar_expanded': shouldExpandSidebar
+                         }"
+                    >
                         <ui-router-breadcrumb></ui-router-breadcrumb>
                         <div data-ui-view class="w-100"></div>
                     </div>

--- a/packages/manager/apps/hub/src/index.js
+++ b/packages/manager/apps/hub/src/index.js
@@ -16,6 +16,7 @@ import ovhManagerOrderTracking from '@ovh-ux/ng-ovh-order-tracking';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import head from 'lodash/head';
+import set from 'lodash/set';
 
 import atInternet from './components/at-internet';
 import errorPage from './components/error-page';
@@ -84,6 +85,16 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       $transitions.onSuccess({ to: 'error' }, () => {
         $rootScope.$emit('ovh::sidebar::hide');
+      });
+    },
+  )
+  .run(
+    /* @ngInject */ ($rootScope, $transitions) => {
+      $transitions.onEnter({}, () => {
+        set($rootScope, 'shouldExpandSidebar', false);
+      });
+      $transitions.onSuccess({ to: 'app.dashboard' }, () => {
+        set($rootScope, 'shouldExpandSidebar', true);
       });
     },
   )

--- a/packages/manager/apps/hub/src/index.less
+++ b/packages/manager/apps/hub/src/index.less
@@ -1,7 +1,7 @@
 @import 'ovh-ui-kit/packages/oui-responsive/_variables.less';
 @import '@ovh-ux/manager-account-sidebar/src/variables.less';
 
-.hub-main-view {
+.hub-main-view_sidebar_expanded {
   margin-right: @ovh-sidebar-width;
 }
 


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/manager-hub
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal MANAGER-4683
| License          | BSD 3-Clause

## Description

The sidebar should only be expanded in the dashboard state ...
I tried to avoid using the rootScope but couldn't because you need to detect that the state changed to 'app.dashboard' then updates attributes outside of the dashboard template (for the sidebar and the main view margin).