### PR TITLE
feat(dashboard): display order dashboard only if there is no order

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/routing.js
+++ b/packages/manager/apps/hub/src/dashboard/routing.js
@@ -48,8 +48,10 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('manager_hub_dashboard'),
     },
-    componentProvider: /* @ngInject */ (services) =>
-      get(services, 'data.count') === 0 ? 'hubOrderDashboard' : 'hubDashboard',
+    componentProvider: /* @ngInject */ (order, services) =>
+      get(services, 'data.count') === 0 && !order.data
+        ? 'hubOrderDashboard'
+        : 'hubDashboard',
   });
 
   $urlRouterProvider.otherwise('/');


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-hub`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          |  MANAGER-4733
| License          | BSD 3-Clause

## Description

display order dashboard only if there is no order
