### PR TITLE
fix(account-sidebar): hide nichandle if identical to email

### DIFF
--- a/packages/manager/modules/account-sidebar/src/user-infos/template.html
+++ b/packages/manager/modules/account-sidebar/src/user-infos/template.html
@@ -89,6 +89,7 @@
             </span>
             <span
                 class="d-block manager-hub-user-infos_text-small"
+                data-ng-if="$ctrl.me.email !== $ctrl.me.nichandle"
                 data-ng-bind="$ctrl.me.nichandle"
             ></span>
         </p>


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feaet/manager-hub
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal MANAGER-4721
| License          | BSD 3-Clause

## Description

on US accounts, nichandle is the same as user email, avoid to display it twice
