### PR TITLE
build(deps): add missing dependencies

### DIFF
--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -39,6 +39,8 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.5.0",
     "@ovh-ux/ng-ovh-contacts": "^2.0.3",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
+    "@ovh-ux/ng-ovh-form-flat": "^4.0.3",
+    "@ovh-ux/ng-ovh-http": "^4.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^6.0.1",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.1",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Starting the Public Cloud control panel report the following error:

```sh
@ovh-ux/manager-public-cloud: ℹ Compiling OVH Manager
@ovh-ux/manager-public-cloud: [BABEL] Note: The code generator has deoptimised the styling of /home/foo/bar/manager/packages/manager/modules/cloud-universe-components/dist/cjs/index.js as it exceeds the max of 500KB.
@ovh-ux/manager-public-cloud: ✔ OVH Manager: Compiled with some errors in 1.23m
@ovh-ux/manager-public-cloud:  ERROR  Failed to compile with 1 errors2:52:35 PM
@ovh-ux/manager-public-cloud: This dependency was not found:
@ovh-ux/manager-public-cloud: * @ovh-ux/ng-ovh-http in /home/foo/bar/manager/packages/manager/modules/core/dist/esm/index.js
@ovh-ux/manager-public-cloud: To install it, you can run: npm install --save @ovh-ux/ng-ovh-http
```

Related to the `@ovh-ux/manager-core` module that has defined `@ovh-ux/ng-ovh-http` as a peer dependency.

Some for `@ovh-ux/ng-ovh-cloud-universe-components` that has defined `@ovh-ux/ng-ovh-form-flat` as a peer dependency.

### 👷 Build

9c23aaf - build(deps): add missing dependencies

uses:

```sh
$ yarn workspace @ovh-ux/manager-public-cloud add @ovh-ux/ng-ovh-form-flat
$ yarn workspace @ovh-ux/manager-public-cloud add @ovh-ux/ng-ovh-http
```

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

