### PR TITLE
feat(vps): disable shortcut tile for new range vps

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -11,7 +11,10 @@
             >
             </vps-dashboard-tile-information>
         </div>
-        <div class="col-xm-12 col-md-4" data-ng-if="!$ctrl.vps.isExpired">
+        <div
+            class="col-xm-12 col-md-4"
+            data-ng-if="!$ctrl.vps.isExpired && !$ctrl.isVpsNewRange"
+        >
             <oui-tile
                 data-heading="{{ ::'vps_tile_shortcut' | translate }}"
                 class="h-100"


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/vps-new-range-information` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-4476
| License          | BSD 3-Clause

## Description

Disable VPS shortcuts tile for new range products