### PR TITLE
fix(web.hosting): set autopay only if default payment method exists

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.controller.js
@@ -47,11 +47,7 @@ export default class {
   checkout() {
     this.checkoutLoading = true;
 
-    this.checkoutOrderCart(
-      // Autovalidate if the order is free
-      this.isOptionFree ? this.isOptionFree : !!this.defaultPaymentMethod,
-      this.cartId,
-    );
+    this.checkoutOrderCart(!!this.defaultPaymentMethod, this.cartId);
   }
 
   getDuration(interval) {


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix # MANAGER-4747
| License          | BSD 3-Clause

## Description

Use 'autoPayWithPreferredPaymentMethod' only if default payment method exists, even for free order
