### PR TITLE
build(deps): add missing ng-ovh-form-flat dependency

### DIFF
--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -52,6 +52,7 @@
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
     "@ovh-ux/ng-ovh-doc-url": "^1.0.0",
     "@ovh-ux/ng-ovh-export-csv": "^1.0.2",
+    "@ovh-ux/ng-ovh-form-flat": "^4.0.3",
     "@ovh-ux/ng-ovh-http": "^4.0.6",
     "@ovh-ux/ng-ovh-jquery-ui-draggable": "^1.0.2",
     "@ovh-ux/ng-ovh-order-tracking": "^0.1.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 👷 Build

uses: `$ yarn workspace @ovh-ux/manager-dedicated add @ovh-ux/ng-ovh-form-flat`

Related to the following error:

```sh
@ovh-ux/manager-dedicated: ℹ Compiling OVH Manager
@ovh-ux/manager-dedicated: [BABEL] Note: The code generator has deoptimised the styling of /home/foo/bar/manager/packages/manager/modules/enterprise-cloud-database/dist/esm/service.module-37eb2061.js as it exceeds the max of 500KB.
@ovh-ux/manager-dedicated: [BABEL] Note: The code generator has deoptimised the styling of /home/foo/bar/manager/packages/manager/modules/cloud-universe-components/dist/cjs/index.js as it exceeds the max of 500KB.
@ovh-ux/manager-dedicated: ✔ OVH Manager: Compiled with some errors in 2.90m
@ovh-ux/manager-dedicated:  ERROR  Failed to compile with 1 errors10:35:12 AM
@ovh-ux/manager-dedicated: This dependency was not found:
@ovh-ux/manager-dedicated: * @ovh-ux/ng-ovh-form-flat in /home/foo/bar/manager/packages/manager/modules/cloud-universe-components/dist/cjs/index.js
@ovh-ux/manager-dedicated: To install it, you can run: npm install --save @ovh-ux/ng-ovh-form-flat
```

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>