### PR TITLE
fix(ng-ovh-payment-method): default payment method

### DIFF
--- a/packages/components/ng-ovh-payment-method/src/payment-method.service.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method.service.js
@@ -63,7 +63,7 @@ export default class OvhPaymentMethodService {
     }).then(
       (paymentMethods) =>
         find(paymentMethods, {
-          default: true,
+          defaultPaymentMean: true,
         }) || null,
     );
   }


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

default field does not exists in apiv6, it's defaultPaymentMean