### PR TITLE
fix(ng-ovh-payment-method): default payment method

### DIFF
--- a/packages/components/ng-ovh-payment-method/src/payment-method.service.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method.service.js
@@ -62,9 +62,10 @@ export default class OvhPaymentMethodService {
       transform: true,
     }).then(
       (paymentMethods) =>
-        find(paymentMethods, {
-          default: true,
-        }) || null,
+        find(
+          paymentMethods,
+          (method) => method.default || method.defaultPaymentMean,
+        ) || null,
     );
   }
 


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

The attribute for new payment mean call is named 'defaultPaymentMean' and not 'default' (which is used for legacy payment means)