### PR TITLE
perf(list-packages): keep only needed properties

### DIFF
--- a/scripts/list-packages.js
+++ b/scripts/list-packages.js
@@ -3,13 +3,22 @@
 const fs = require('fs');
 const getMonorepoPackages = require('get-monorepo-packages');
 const path = require('path');
+const pick = require('lodash/pick');
 
 // Get all workspaces defined in the `package.json` file.
 const { workspaces } = require('../package.json');
 
+// Keep the bare minimum entries from all package.json files.
+const entries = ['name', 'version', 'description', 'repository'];
+
 // Get all packages contained inside the monorepo.
 const directoryPath = path.resolve();
-const packages = getMonorepoPackages(directoryPath);
+const packages = getMonorepoPackages(directoryPath).map(
+  ({ location, package: pkg }) => ({
+    location,
+    package: pick(pkg, entries),
+  }),
+);
 
 // Group packages by their corresponding workspaces.
 const groupedWorkspaces = workspaces.map((workspace) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ⚡️ Performance

All `package.json` were concatened in order to be able to display some metadata into the [Documentation](https://ovh.github.io/manager/).

But only a few properties is used, so by filter down the amount of entries we are able to reduce
the size of the output files by 80%. 

**Before**:
147K packages.json

**After**:
30K packages.json

fac441b - perf(list-packages): keep only needed properties

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
