### PR TITLE
fix(hub): remove height 100%

### DIFF
--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -52,11 +52,11 @@
         <div class="position-relative w-100 h-100 overflow-auto">
             <div class="position-absolute w-100 h-100">
                 <div
-                    class="px-3 px-md-0 d-sm-flex justify-content-center h-100 mb-5"
+                    class="px-3 px-md-0 d-sm-flex justify-content-center mb-5"
                     data-ui-view="app"
                 >
                     <div
-                        class="h-100 hub-main-view pt-4"
+                        class="hub-main-view pt-4"
                         data-ng-class="{
                             'hub-main-view_sidebar_expanded': shouldExpandSidebar
                          }"


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/manager-hub
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal MANAGER-4743
| License          | BSD 3-Clause

## Description

Remove useless height 100 attributes causing display bugs
