### PR TITLE
build(deps): add missing ng-ovh-http dependency

### DIFF
--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -28,6 +28,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
     "@ovh-ux/ng-ovh-checkbox-table": "^1.0.4",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
+    "@ovh-ux/ng-ovh-http": "^4.0.6",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 👷 Build

uses: `$ yarn workspace @ovh-ux/manager-sms-app add @ovh-ux/ng-ovh-http`

Related to the following error:

```sh
@ovh-ux/manager-sms-app: ℹ Compiling OVH Manager
@ovh-ux/manager-sms-app: ✔ OVH Manager: Compiled with some errors in 27.00s
@ovh-ux/manager-sms-app:  ERROR  Failed to compile with 1 errors4:10:10 PM
@ovh-ux/manager-sms-app: This dependency was not found:
@ovh-ux/manager-sms-app: * @ovh-ux/ng-ovh-http in /home/foo/bar/manager/packages/manager/modules/core/dist/esm/index.js
@ovh-ux/manager-sms-app: To install it, you can run: npm install --save @ovh-ux/ng-ovh-http
```

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
