### PR TITLE
feat(pci.quota): request quota increase in-app

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.component.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.component.js
@@ -1,0 +1,13 @@
+import controller from './increase-request.controller';
+import template from './increase-request.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    goBack: '<',
+    issueTypes: '<',
+    projectId: '<',
+    region: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.controller.js
@@ -1,0 +1,81 @@
+import find from 'lodash/find';
+import get from 'lodash/get';
+import isNil from 'lodash/isNil';
+import { ISSUE_TYPE_ID } from './increase.constants';
+
+export default class PciProjectQuotaIncreaseController {
+  /* @ngInject */
+  constructor($translate, OvhApiSupport, PCI_REDIRECT_URLS) {
+    this.$translate = $translate;
+    this.OvhApiSupport = OvhApiSupport;
+    this.PCI_REDIRECT_URLS = PCI_REDIRECT_URLS;
+  }
+
+  $onInit() {
+    this.isLoading = false;
+    this.issueType = find(
+      this.issueTypes,
+      (issue) => issue.id === ISSUE_TYPE_ID,
+    );
+    this.issueTypeFieldsStr = get(this.issueType, 'fields', [])
+      .map((issueType) => get(issueType, 'label'))
+      .join('\n\n');
+    this.supportUrl = this.PCI_REDIRECT_URLS[this.region].support;
+  }
+
+  increaseQuota() {
+    if (isNil(this.issueType)) {
+      return this.goBack(
+        this.$translate.instant(
+          'pci_projects_project_quota_increase_error_message',
+          {
+            message: '',
+          },
+        ),
+        'error',
+      );
+    }
+
+    this.isLoading = true;
+
+    return this.OvhApiSupport.v6()
+      .createTickets({
+        issueTypeId: ISSUE_TYPE_ID,
+        serviceName: this.projectId,
+        subject: get(this.issueType, 'label'),
+        body: `
+${get(this.issueType, 'subject')}
+
+${this.issueTypeFieldsStr}
+
+${this.issueTypeDescription}
+        `,
+      })
+      .$promise.then(
+        ({ ticketId }) =>
+          this.goBack(
+            this.$translate.instant(
+              'pci_projects_project_quota_increase_success_message',
+              {
+                ticketUrl: `${this.supportUrl}/tickets/${ticketId}`,
+              },
+            ),
+          ),
+        'success',
+      )
+      .catch((err) =>
+        this.goBack(
+          this.$translate.instant(
+            'pci_projects_project_quota_increase_error_message',
+            {
+              message: get(err, 'data.message', null),
+            },
+          ),
+          'error',
+        ),
+      )
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.html
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.html
@@ -1,0 +1,28 @@
+<form novalidate name="increase-quota-form">
+    <oui-modal
+        data-heading="{{ 'pci_projects_project_quota_increase_title' | translate }}"
+        data-primary-action="$ctrl.increaseQuota()"
+        data-primary-label="{{:: 'pci_projects_project_quota_increase_submit_label' | translate }}"
+        data-primary-disabled="$ctrl.isLoading"
+        data-secondary-action="$ctrl.goBack()"
+        data-secondary-label="{{:: 'pci_projects_project_quota_increase_cancel_label' | translate }}"
+        data-on-dismiss="$ctrl.goBack()"
+        data-loading="$ctrl.isLoading"
+    >
+        <p
+            data-translate="pci_projects_project_quota_increase_content"
+            data-translate-values="{ 'projectId': $ctrl.projectId }"
+        ></p>
+
+        <oui-field label="{{ $ctrl.issueTypeFieldsStr }}" size="xl">
+            <textarea
+                class="oui-textarea"
+                id="description"
+                name="description"
+                ng-model="$ctrl.issueTypeDescription"
+                required
+            >
+            </textarea>
+        </oui-field>
+    </oui-modal>
+</form>

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.module.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.module.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-ui-angular';
+import 'ovh-api-services';
+
+import component from './increase-request.component';
+import routing from './increase-request.routing';
+
+const moduleName = 'ovhManagerPciProjectQuotaIncrease';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oui',
+    'ovh-api-services',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .config(routing)
+  .component('pciProjectQuotaIncrease', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase-request.routing.js
@@ -1,0 +1,41 @@
+import { ISSUE_CATEGORY, ISSUE_SERVICE_TYPE } from './increase.constants';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('pci.projects.project.quota.increase', {
+    url: '/increase',
+    views: {
+      modal: {
+        component: 'pciProjectQuotaIncrease',
+      },
+    },
+    layout: 'modal',
+    resolve: {
+      breadcrumb: () => null,
+      issueTypes: /* @ngInject */ (OvhApiSupport, $translate) =>
+        OvhApiSupport.v6().getIssueTypes({
+          category: ISSUE_CATEGORY,
+          language: $translate.use(),
+          serviceType: ISSUE_SERVICE_TYPE,
+        }).$promise,
+      goBack: /* @ngInject */ ($state, CucCloudMessage) => (
+        message = false,
+        type = 'success',
+      ) => {
+        const promise = $state.go('^');
+
+        if (message) {
+          promise.then(() =>
+            CucCloudMessage[type](
+              {
+                textHtml: message,
+              },
+              'pci.projects.project.quota',
+            ),
+          );
+        }
+
+        return promise;
+      },
+    },
+  });
+};

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/increase.constants.js
@@ -1,0 +1,9 @@
+export const ISSUE_CATEGORY = 'assistance';
+export const ISSUE_SERVICE_TYPE = 'cloud_project';
+export const ISSUE_TYPE_ID = 33381;
+
+export default {
+  ISSUE_CATEGORY,
+  ISSUE_SERVICE_TYPE,
+  ISSUE_TYPE_ID,
+};

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/index.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/index.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerPciProjectQuotaIncreaseLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state('pci.projects.project.quota.increase.**', {
+      url: '/increase',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./increase-request.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      },
+    });
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/quota/increase-request/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/quota/increase-request/translations/Messages_fr_FR.json
@@ -1,0 +1,8 @@
+{
+  "pci_projects_project_quota_increase_title": "Augmenter mes quotas",
+  "pci_projects_project_quota_increase_submit_label": "Confirmer",
+  "pci_projects_project_quota_increase_cancel_label": "Annuler",
+  "pci_projects_project_quota_increase_content": "Êtes-vous sûr de vouloir augmenter les quotas de votre projet <strong>{{ projectId }}</strong> ?",
+  "pci_projects_project_quota_increase_success_message": "Votre demande d'augmentation de quota a bien été prise en compte. <a class=\"oui-link_icon\" target=\"_blank\" href=\"{{ ticketUrl }}\">Cliquez ici pour suivre son évolution. <span class=\"oui-icon oui-icon-external_link\" aria-hidden=\"true\"></span></a>",
+  "pci_projects_project_quota_increase_error_message": "Une erreur est survenue lors de la demande d'augmentation de vos quotas : {{ message }}."
+}

--- a/packages/manager/modules/pci/src/projects/project/quota/quota.component.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/quota.component.js
@@ -8,6 +8,7 @@ export default {
     projectId: '<',
     quotas: '<',
     region: '<',
+    increaseQuotaLink: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/pci/src/projects/project/quota/quota.html
+++ b/packages/manager/modules/pci/src/projects/project/quota/quota.html
@@ -54,20 +54,10 @@
             <a
                 class="oui-button oui-button_primary oui-link_icon"
                 data-ng-if=":: $ctrl.quotas.length > 0"
-                data-ng-href="{{:: $ctrl.supportUrl }}"
-                rel="noopener"
-                target="_blank"
+                data-ng-href="{{ $ctrl.increaseQuotaLink }}"
             >
                 <span
                     data-translate="pci_projects_project_quota_protect_more_btn"
-                ></span>
-                <span
-                    class="oui-icon oui-icon-external_link"
-                    aria-hidden="true"
-                ></span>
-                <span
-                    class="sr-only"
-                    data-translate="pci_projects_project_quota_open_new_tab"
                 ></span>
             </a>
 

--- a/packages/manager/modules/pci/src/projects/project/quota/quota.module.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/quota.module.js
@@ -13,12 +13,14 @@ import header from '../../../components/project/quota-region-header';
 import component from './quota.component';
 import routing from './quota.routing';
 import service from './quota.service';
+import increaseQuota from './increase-request';
 
 const moduleName = 'ovhManagerPciProjectQuota';
 
 angular
   .module(moduleName, [
     header,
+    increaseQuota,
     'ovhManagerCore',
     'ngOvhCloudUniverseComponents',
     'ngTranslateAsyncLoader',

--- a/packages/manager/modules/pci/src/projects/project/quota/quota.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/quota/quota.routing.js
@@ -15,6 +15,11 @@ export default /* @ngInject */ ($stateProvider) => {
 
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('pci_projects_project_quota'),
+
+      increaseQuotaLink: /* @ngInject */ ($state, projectId) =>
+        $state.href('pci.projects.project.quota.increase', {
+          projectId,
+        }),
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Feat #DTRSD-7184
| License          | BSD 3-Clause

## Description

Currently, when a customer wants to increase his PCI project quota he is redirected to support ticket creation & has to create a new fresh ticket from scratch.

The request for increasing quota is now simplified & directly done in quota section.
