### PR TITLE
fix(core): add slash to sign-up url

### DIFF
--- a/packages/manager/modules/core/src/index.js
+++ b/packages/manager/modules/core/src/index.js
@@ -192,7 +192,7 @@ angular
         `${OVH_SSO_AUTH_LOGIN_URL}?action=disconnect`,
       );
       ssoAuthenticationProvider.setSignUpUrl(
-        `${OVH_SSO_AUTH_LOGIN_URL}/signup/new`,
+        `${OVH_SSO_AUTH_LOGIN_URL}/signup/new/`,
       );
 
       // if (!constants.prodMode) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? |no
| Tickets          | -
| License          | BSD 3-Clause

## Description

Add a `/` to the end of core sign-up url in order to avoid bad redirect in CA (and other regions)
