### PR TITLE
fix(dedicated): legay bare metal servers

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/interfaces.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/interfaces.routing.js
@@ -35,7 +35,14 @@ export default /* @ngInject */ ($stateProvider) => {
         DedicatedServerInterfacesService,
         server,
         serverName,
-      ) => DedicatedServerInterfacesService.getOlaPrice(serverName, server),
+        ola,
+      ) => {
+        // option price is only available for servers migrated to agora
+        if (ola.isAvailable() && (!ola.isActivated() || !ola.isConfigured())) {
+          return DedicatedServerInterfacesService.getOlaPrice(serverName, server);
+        }
+        return [];
+      },
       orderPrivateBandwidthLink: /* @ngInject */ (
         $state,
         isLegacy,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-9904
| License          | BSD 3-Clause

## Description

Customers are not able to access network interface of servers that are not migrated to the agora. This is because we call /order API of agora to get OLA price details. I made a change to only call this API for servers migrated to Agora and OLA is enabled.