### PR TITLE
fix: redirect to /configuration by default

### DIFF
--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -266,7 +266,8 @@ angular
   ])
   .config([
     '$stateProvider',
-    ($stateProvider) => {
+    '$urlRouterProvider',
+    ($stateProvider, $urlRouterProvider) => {
       /**
        * ALL DOM
        */
@@ -290,6 +291,8 @@ angular
         },
         translations: { value: ['domain', 'hosting'], format: 'json' },
       });
+
+      $urlRouterProvider.otherwise('/configuration');
     },
   ])
   .constant('COMPOSED_TLD', [


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4840, MANAGER-4839
| License          | BSD 3-Clause

## Description

Add default redirection if a url is not corresponding to a state
