### PR TITLE
fix(loading): hide elements during loading

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -17,7 +17,7 @@
   "space-tab-mixed-disabled": "space",
   "spec-char-escape": false,
   "src-not-empty": true,
-  "style-disabled": true,
+  "style-disabled": false,
   "tag-pair": true,
   "tag-self-close": false,
   "tagname-lowercase": true,

--- a/packages/manager/apps/dedicated/client/app/index.html
+++ b/packages/manager/apps/dedicated/client/app/index.html
@@ -10,6 +10,11 @@
         <link rel="shortcut icon" href="assets/images/favicon.png" />
         <link rel="apple-touch-icon" href="assets/images/touchicon-180.png" />
         <title>OVHcloud</title>
+        <style type="text/css">
+            .ng-cloak {
+                display: none !important;
+            }
+        </style>
     </head>
     <body
         data-ng-controller="SessionCtrl as $ctrl"

--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -9,6 +9,11 @@
         <link rel="shortcut icon" href="assets/images/favicon.png" />
         <link rel="apple-touch-icon" href="assets/images/touchicon-180.png" />
         <title>OVHcloud</title>
+        <style type="text/css">
+            .ng-cloak {
+                display: none !important;
+            }
+        </style>
     </head>
     <body
         data-ng-controller="HubController as $ctrl"
@@ -27,7 +32,7 @@
             data-sidebar-links="{}"
         >
         </ovh-manager-navbar>
-        <div class="position-relative w-100 h-100 overflow-auto">
+        <div class="position-relative w-100 h-100 overflow-auto ng-cloak">
             <div class="position-absolute w-100 h-100">
                 <div class="mb-5" data-ui-view="app">
                     <div

--- a/packages/manager/apps/public-cloud/src/index.html
+++ b/packages/manager/apps/public-cloud/src/index.html
@@ -9,6 +9,11 @@
         />
         <link rel="shortcut icon" href="assets/images/favicon.png" />
         <link rel="apple-touch-icon" href="assets/images/touchicon-180.png" />
+        <style type="text/css">
+            .ng-cloak {
+                display: none !important;
+            }
+        </style>
     </head>
     <body class="ovh-public-cloud-app h-100" style="overflow: hidden;">
         <div

--- a/packages/manager/apps/telecom/src/index.html
+++ b/packages/manager/apps/telecom/src/index.html
@@ -8,6 +8,11 @@
         <meta name="viewport" content="width=device-width" />
         <link rel="shortcut icon" href="assets/images/favicon.png" />
         <link rel="apple-touch-icon" href="assets/images/touchicon-180.png" />
+        <style type="text/css">
+            .ng-cloak {
+                display: none !important;
+            }
+        </style>
     </head>
     <body class="h-100 ovh-manager-telecom-app" style="overflow: hidden;">
         <div

--- a/packages/manager/apps/web/client/app/index.html
+++ b/packages/manager/apps/web/client/app/index.html
@@ -7,6 +7,11 @@
         <title>OVH</title>
         <link rel="shortcut icon" href="assets/images/favicon.png" />
         <link rel="apple-touch-icon" href="assets/images/touchicon-180.png" />
+        <style type="text/css">
+            .ng-cloak {
+                display: none !important;
+            }
+        </style>
     </head>
     <body
         data-ng-controller="WebAppCtrl as $ctrl"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Hide HTML Elements during the loading. Some components could be displayed before the preloader is added to the DOM. So we add `.ng-cloak` CSS rule to the html file to ensure that it is applied as soon as possible.
