### PR TITLE
perf: import minified ovh-ui-kit version

### DIFF
--- a/packages/manager/apps/hub/src/app.module.js
+++ b/packages/manager/apps/hub/src/app.module.js
@@ -28,7 +28,7 @@ import { BILLING_REDIRECTIONS } from './constants';
 
 import controller from './controller';
 import routing from './routing';
-import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit/dist/oui.min.css';
 import './index.less';
 import './index.scss';
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ⚡️ Performance

6c65447 - perf: import minified ovh-ui-kit version

### 🔗 Related

- https://unpkg.com/browse/ovh-ui-kit@2.40.0/dist/
- #2712 

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
