### PR TITLE
fix(dashboard): handle empty bill list

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/dashboard.html
+++ b/packages/manager/apps/hub/src/dashboard/dashboard.html
@@ -46,6 +46,7 @@
                 class="col-md-4 mb-3 mb-md-4 order-3 order-md-2"
                 data-ng-if="!$ctrl.me.isEnterprise"
                 bills="$ctrl.bills"
+                me="$ctrl.me"
                 tracking-prefix="hub::dashboard::activity"
                 refresh="$ctrl.refresh('bills')"
             >

--- a/packages/manager/modules/hub/src/components/billing-summary/component.js
+++ b/packages/manager/modules/hub/src/components/billing-summary/component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     bills: '<?',
     debt: '<?',
+    me: '<',
     trackingPrefix: '@',
     refresh: '&',
   },

--- a/packages/manager/modules/hub/src/components/billing-summary/controller.js
+++ b/packages/manager/modules/hub/src/components/billing-summary/controller.js
@@ -69,7 +69,7 @@ export default class ManagerHubBillingSummaryCtrl {
   getFormattedPrice(price, currency) {
     return Intl.NumberFormat(this.$translate.use().replace('_', '-'), {
       style: 'currency',
-      currency,
+      currency: currency || get(this.me, 'currency.code'),
       maximumSignificantdigits: 1,
     }).format(price);
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 🚑 Hotfix

54c27f5 - fix(dashboard): handle empty bill list

if there is no bill then fallback to the default user currency code

relates to the following console error:

```js
vendor.c43370429ad3d3397821.bundle.js:formatted:33921 RangeError: Invalid currency codes : 
    at Object.NumberFormat (<anonymous>)
    at e.value (306.465f45ab677468eb3e66.bundle.js:formatted:27529)
    at 306.465f45ab677468eb3e66.bundle.js:formatted:27479
    at vendor.c43370429ad3d3397821.bundle.js:formatted:34795
    at vendor.c43370429ad3d3397821.bundle.js:formatted:34805
    at u.$digest (vendor.c43370429ad3d3397821.bundle.js:formatted:35187)
    at u.$apply (vendor.c43370429ad3d3397821.bundle.js:formatted:35300)
    at vendor.c43370429ad3d3397821.bundle.js:formatted:33152
    at x (vendor.c43370429ad3d3397821.bundle.js:formatted:33349)
    at XMLHttpRequest.y.onload (vendor.c43370429ad3d3397821.bundle.js:formatted:33298) "Possibly unhandled rejection: {}"
```
  

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
