### PR TITLE
fix(private-registry): wrong translation in create page

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-registry/create/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/private-registry/create/translations/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "private_registry_create": "Créer un registre privé",
   "private_registry_create_region": "Sélectionnez une localisation",
-  "private_registry_create_name_cluster": "Nom du cluster",
+  "private_registry_create_name_cluster": "Nom du Private Registry",
   "private_registry_create_choose_plan": "Choisissez votre plan",
   "private_registry_create_button": "Créer"
 }


### PR DESCRIPTION
rename "Nom du cluster" to "Nom du Private Registry"

Closes #MANAGER-4852

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-4852
| License          | BSD 3-Clause

## Description

When creating a registry the name field is called "Nom du cluster" should be "Nom du Private Registry". Renamed it to "Nom du Private Registry"