### PR TITLE
fix(overthebox): fix missing message for expiration warning help

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -69,5 +69,6 @@
   "overTheBox_resiliation_success": "Le service {{service}} sera résilié le {{date}}.",
   "overTheBox_resiliation_cancel_error": "Oups ! Nous n'avons pas pu annuler la résiliation en cours du service {{service}}.",
   "overTheBox_cancel_resiliation_success": "La résiliation de votre service {{service}} vient d'être annulée.",
-  "overTheBox_statistics_bits_per_sec_legend": "bits/s"
+  "overTheBox_statistics_bits_per_sec_legend": "bits/s",
+  "overTheBox_expiration_warning_help": "Vous pouvez annuler la résiliation avant la date d'expiration."
 }


### PR DESCRIPTION
Signed-off-by: Stephanie Moallic <stephanie.moallic@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | fix/otb-expiration-warning-label
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-10522
| License          | BSD 3-Clause

## Description

Fix missing label for expiration warning help
