### PR TITLE
fix(products-list): keep column filter when page is updated

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/products-list/config.js
+++ b/packages/manager/apps/hub/src/dashboard/products-list/config.js
@@ -74,16 +74,6 @@ export const resolves = {
   },
   displayedColumns: /* @ngInject */ ($transition$) =>
     JSON.parse($transition$.params().columns),
-  onColumnChange: /* @ngInject */ ($state, $transition$) => (id, columns) =>
-    $state.go('.', {
-      ...$transition$.params(),
-      columns: JSON.stringify(
-        map(
-          columns.filter(({ hidden }) => !hidden),
-          'name',
-        ),
-      ),
-    }),
   loadRow: /* @ngInject */ (products, propertyId) => (service) => ({
     ...service,
     managerLink: get(
@@ -114,6 +104,7 @@ export const resolves = {
   hideBreadcrumb: () => false,
   breadcrumb: /* @ngInject */ ($translate, productType) =>
     $translate.instant(`manager_hub_products_${productType}`),
+  onParamsChange: ListLayoutHelper.stateResolves.onListParamsChange,
 };
 
 export default {

--- a/packages/manager/modules/hub/src/components/product-list/component.js
+++ b/packages/manager/modules/hub/src/components/product-list/component.js
@@ -1,4 +1,5 @@
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
+import omit from 'lodash/omit';
 import controller from './controller';
 import template from './template.html';
 
@@ -13,11 +14,11 @@ export default {
   controller,
   template,
   bindings: {
-    ...ListLayoutHelper.componentBindings,
+    ...omit(ListLayoutHelper.componentBindings, 'onListParamsChange'),
+    onParamsChange: '<',
     columns: '<',
     rows: '<?',
     loadRow: '<',
-    onColumnChange: '<',
     productType: '<',
     propertyId: '<',
   },

--- a/packages/manager/modules/hub/src/components/product-list/controller.js
+++ b/packages/manager/modules/hub/src/components/product-list/controller.js
@@ -1,10 +1,13 @@
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 import get from 'lodash/get';
+import map from 'lodash/map';
 
 export default class ManagerHubBillingProductList extends ListLayoutHelper.ListLayoutCtrl {
   $onInit() {
     this.datagridId = `dg-${this.productType}`;
     this.defaultFilterColumn = this.propertyId;
+
+    this.getDisplayedColumns(this.columns);
 
     super.$onInit();
   }
@@ -24,5 +27,27 @@ export default class ManagerHubBillingProductList extends ListLayoutHelper.ListL
         meta,
       });
     });
+  }
+
+  onListParamsChange(params) {
+    // workaround to prevent uirouter from resetting columns parameter as it is dynamic
+    return this.onParamsChange({
+      ...params,
+      columns: this.displayedColumns,
+    });
+  }
+
+  getDisplayedColumns(columns) {
+    this.displayedColumns = JSON.stringify(
+      map(
+        columns.filter(({ hidden }) => !hidden),
+        ({ name, property }) => name || property,
+      ),
+    );
+  }
+
+  onColumnChange(id, columns) {
+    this.getDisplayedColumns(columns);
+    return this.onListParamsChange();
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `fix/hub-impediments`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4861
| License          | BSD 3-Clause

## Description

When columns were selected and page was changed, column is not kept. Seems due to the fact that setting a param to dynamic doesn't update the `$transition$.params()` sent 
