### PR TITLE
Feat/lazy loading

### DIFF
--- a/packages/manager/apps/freefax/src/index.js
+++ b/packages/manager/apps/freefax/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import angular from 'angular';
-import '@ovh-ux/manager-freefax';
+import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
+import ovhManagerFreeFax from '@ovh-ux/manager-freefax';
 
-angular.module('freefaxApp', ['ovhManagerFreeFax']);
+angular.module('freefaxApp', [ngOvhApiWrappers, ovhManagerFreeFax]);

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -55,6 +55,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/iplb/src/index.js
+++ b/packages/manager/apps/iplb/src/index.js
@@ -6,7 +6,9 @@ import 'script-loader!moment/min/moment-with-locales.min';
 import { Environment } from '@ovh-ux/manager-config';
 
 import angular from 'angular';
-import '@ovh-ux/manager-iplb';
+import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+import ovhManagerCore from '@ovh-ux/manager-core';
+import ovhManagerIplb from '@ovh-ux/manager-iplb';
 
 import { momentConfiguration } from './config';
 
@@ -15,7 +17,11 @@ import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
 Environment.setRegion(__WEBPACK_REGION__);
 
 angular
-  .module('iplbApp', ['ovhManagerIplb'])
+  .module('iplbApp', [
+    ngOvhCloudUniverseComponents,
+    ovhManagerCore,
+    ovhManagerIplb,
+  ])
   .config(
     /* @ngInject */ (CucConfigProvider, coreConfigProvider) => {
       CucConfigProvider.setRegion(coreConfigProvider.getRegion());

--- a/packages/manager/apps/nasha/src/index.js
+++ b/packages/manager/apps/nasha/src/index.js
@@ -7,10 +7,9 @@ import 'script-loader!jquery';
 import { Environment } from '@ovh-ux/manager-config';
 import angular from 'angular';
 
-import '@ovh-ux/manager-core';
-import '@ovh-ux/manager-nasha';
+import ovhManagerNasha from '@ovh-ux/manager-nasha';
 import './index.scss';
 
 Environment.setRegion(__WEBPACK_REGION__);
 
-angular.module('nashaApp', ['ovhManagerCore', 'ovhManagerNasha']);
+angular.module('nashaApp', [ovhManagerNasha]);

--- a/packages/manager/apps/overthebox/src/index.js
+++ b/packages/manager/apps/overthebox/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import angular from 'angular';
-import '@ovh-ux/manager-overthebox';
+import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
+import ovhManagerOtb from '@ovh-ux/manager-overthebox';
 
-angular.module('overtheboxApp', ['ovhManagerOtb']);
+angular.module('overtheboxApp', [ngOvhApiWrappers, ovhManagerOtb]);

--- a/packages/manager/apps/sms/src/index.js
+++ b/packages/manager/apps/sms/src/index.js
@@ -1,7 +1,8 @@
 import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
-import '@ovh-ux/manager-sms';
+import ovhManagerSms from '@ovh-ux/manager-sms';
+import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
 
 import angular from 'angular';
 
-angular.module('smsApp', ['ovhManagerSms']);
+angular.module('smsApp', [ngOvhApiWrappers, ovhManagerSms]);

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -47,6 +47,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0"

--- a/packages/manager/apps/veeam-cloud-connect/src/index.js
+++ b/packages/manager/apps/veeam-cloud-connect/src/index.js
@@ -1,14 +1,18 @@
 import 'script-loader!jquery'; // eslint-disable-line
-import '@ovh-ux/manager-veeam-cloud-connect';
-import { Environment } from '@ovh-ux/manager-config';
-import angular from 'angular';
 import 'script-loader!moment/min/moment-with-locales.min'; // eslint-disable-line
+
+import angular from 'angular';
+import ovhManagerCore from '@ovh-ux/manager-core';
+import ovhManagerVeeamCloudConnect from '@ovh-ux/manager-veeam-cloud-connect';
+import { Environment } from '@ovh-ux/manager-config';
 
 Environment.setRegion(__WEBPACK_REGION__);
 
-angular.module('veeamCloudConnectApp', ['ovhManagerVeeamCloudConnect']).config(
-  /* @ngInject */ (TranslateServiceProvider) => {
-    const defaultLanguage = TranslateServiceProvider.getUserLocale(true);
-    moment.locale(defaultLanguage);
-  },
-);
+angular
+  .module('veeamCloudConnectApp', [ovhManagerCore, ovhManagerVeeamCloudConnect])
+  .config(
+    /* @ngInject */ (TranslateServiceProvider) => {
+      const defaultLanguage = TranslateServiceProvider.getUserLocale(true);
+      moment.locale(defaultLanguage);
+    },
+  );

--- a/packages/manager/apps/veeam-enterprise/src/index.js
+++ b/packages/manager/apps/veeam-enterprise/src/index.js
@@ -5,11 +5,11 @@ import 'script-loader!moment/min/moment-with-locales.min';
 
 import angular from 'angular';
 
-import '@ovh-ux/manager-core';
-import '@ovh-ux/manager-veeam-enterprise';
+import ovhManagerCore from '@ovh-ux/manager-core';
+import ovhManagerVeeamEnterprise from '@ovh-ux/manager-veeam-enterprise';
 
 import { momentConfiguration } from './config';
 
 angular
-  .module('veeamEnterpriseApp', ['ovhManagerCore', 'ovhManagerVeeamEnterprise'])
+  .module('veeamEnterpriseApp', [ovhManagerCore, ovhManagerVeeamEnterprise])
   .config(momentConfiguration);

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -55,6 +55,7 @@
     "jquery": "^2.1.3",
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-ui-angular": "^3.15.1",
     "ovh-ui-kit": "^2.40.0",

--- a/packages/manager/apps/vps/src/index.js
+++ b/packages/manager/apps/vps/src/index.js
@@ -8,7 +8,9 @@ import 'script-loader!bootstrap/dist/js/bootstrap';
 import { Environment } from '@ovh-ux/manager-config';
 
 import angular from 'angular';
-import '@ovh-ux/manager-vps';
+import cloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+import ovhManagerVps from '@ovh-ux/manager-vps';
+import ovhManagerCore from '@ovh-ux/manager-core';
 
 import { momentConfiguration } from './config';
 
@@ -17,7 +19,7 @@ import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
 Environment.setRegion(__WEBPACK_REGION__);
 
 angular
-  .module('vpsApp', ['ovhManagerVps'])
+  .module('vpsApp', [cloudUniverseComponents, ovhManagerCore, ovhManagerVps])
   .config(
     /* @ngInject */ (CucConfigProvider, coreConfigProvider) => {
       CucConfigProvider.setRegion(coreConfigProvider.getRegion());

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -46,6 +46,7 @@
     "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.15.1",

--- a/packages/manager/apps/vrack/src/index.js
+++ b/packages/manager/apps/vrack/src/index.js
@@ -10,6 +10,7 @@ import 'script-loader!messenger/build/js/messenger-theme-flat.js';
 
 import angular from 'angular';
 import ovhManagerVrack from '@ovh-ux/manager-vrack';
+
 import './index.scss';
 
 angular.module('vrackApp', [ovhManagerVrack]).config(

--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -105,7 +105,6 @@ angular
       ovhManagerNavbar,
       'moment-picker',
       'oui',
-      'Module.exchange',
       emailpro,
       exchange,
       office,

--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -109,7 +109,6 @@ angular
       exchange,
       office,
       sharepoint,
-      'Module.emailpro',
       domain,
       domainDnsZone,
       emailDomainOrder,

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -106,6 +106,7 @@
     "moment": "^2.24.0",
     "ng-ckeditor": "^2.0.5",
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
+    "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -23,11 +23,13 @@
     "@ovh-ux/ng-ovh-utils": "^14.0.3",
     "@ovh-ux/ng-ovh-web-universe-components": "^7.0.0 || ^8.0.0",
     "@ovh-ux/ng-pagination-front": "^8.0.0-alpha.0",
+    "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "moment": "^2.24.0",
     "ng-ckeditor": "^2.0.5",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0"
   }

--- a/packages/manager/modules/emailpro/src/index.js
+++ b/packages/manager/modules/emailpro/src/index.js
@@ -1,3 +1,29 @@
-import module from './emailpro.module';
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
 
-export default module;
+const moduleName = 'ovhManagerEmailproLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    const lazyLoad = ($transition$) => {
+      const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+      return import('./emailpro.module').then((mod) =>
+        $ocLazyLoad.inject(mod.default || mod),
+      );
+    };
+
+    $stateProvider
+      .state('app.email-pro.**', {
+        url: '/configuration/email_pro/:productId?tab',
+        lazyLoad,
+      })
+      .state('app.email.mxplan.**', {
+        url: '/configuration/email_mxplan/:productId?tab',
+        lazyLoad,
+      });
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -30,6 +30,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "moment": "^2.24.0",
     "ng-ckeditor": "^2.0.5",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0"
   }

--- a/packages/manager/modules/exchange/src/exchange.module.js
+++ b/packages/manager/modules/exchange/src/exchange.module.js
@@ -1,0 +1,47 @@
+import angular from 'angular';
+import ovhManagerCore from '@ovh-ux/manager-core';
+
+import accountRenew from './billing/account-renew/renew.module';
+import ExchangeAccountMfaCreate from './account/mfa/create';
+import ExchangeAccountMfaDelete from './account/mfa/delete';
+
+import components from './exchangeComponents.module';
+import controllers from './exchangeControllers.module';
+import directives from './exchangeDirectives.module';
+import services from './exchangeServices.module';
+import routing from './exchange.routes';
+import cacheTemplate from './exchange.template';
+
+import {
+  EXCHANGE_MX_CONFIG,
+  EXCHANGE_CONFIG_URL,
+  EXCHANGE_CONFIG,
+} from './exchange.constants';
+
+import './css/exchangeDiagnostic.css';
+
+const moduleName = 'Module.exchange';
+
+angular
+  .module(moduleName, [
+    'ngOvhUtils',
+    'ngRoute',
+    'ui.bootstrap',
+    'ngSanitize',
+    'ng.ckeditor',
+    accountRenew,
+    components,
+    controllers,
+    directives,
+    ovhManagerCore,
+    services,
+    ExchangeAccountMfaCreate,
+    ExchangeAccountMfaDelete,
+  ])
+  .constant('EXCHANGE_MX_CONFIG', EXCHANGE_MX_CONFIG)
+  .constant('EXCHANGE_CONFIG_URL', EXCHANGE_CONFIG_URL)
+  .constant('EXCHANGE_CONFIG', EXCHANGE_CONFIG)
+  .config(routing)
+  .run(cacheTemplate);
+
+export default moduleName;

--- a/packages/manager/modules/exchange/src/exchangeServices.module.js
+++ b/packages/manager/modules/exchange/src/exchangeServices.module.js
@@ -5,9 +5,6 @@ import exchangeAccountTypes from './account/accountTypes.service';
 import exchangeAccountOutlook from './account/outlook/account-outlook.service';
 import diagnostic from './diagnostic/diagnostic.service';
 import ExchangeDomains from './domain/domain.service';
-import APIExchange from './exchange.api';
-import ExchangePassword from './exchange.password.service';
-import Exchange from './exchange.service';
 import ExchangeExternalContacts from './external-contact/external-contact.service';
 import group from './group/group.service';
 import exchangeHeader from './header/header.service';
@@ -35,9 +32,6 @@ angular
   .service('exchangeAccountOutlook', exchangeAccountOutlook)
   .service('diagnostic', diagnostic)
   .service('ExchangeDomains', ExchangeDomains)
-  .service('APIExchange', APIExchange)
-  .service('ExchangePassword', ExchangePassword)
-  .service('Exchange', Exchange)
   .service('ExchangeExternalContacts', ExchangeExternalContacts)
   .service('group', group)
   .service('exchangeHeader', exchangeHeader)

--- a/packages/manager/modules/exchange/src/index.js
+++ b/packages/manager/modules/exchange/src/index.js
@@ -1,47 +1,31 @@
 import angular from 'angular';
-import ovhManagerCore from '@ovh-ux/manager-core';
+import '@uirouter/angularjs';
+import 'oclazyload';
 
-import accountRenew from './billing/account-renew/renew.module';
-import ExchangeAccountMfaCreate from './account/mfa/create';
-import ExchangeAccountMfaDelete from './account/mfa/delete';
+import APIExchange from './exchange.api';
+import Exchange from './exchange.service';
+import ExchangePassword from './exchange.password.service';
 
-import components from './exchangeComponents.module';
-import controllers from './exchangeControllers.module';
-import directives from './exchangeDirectives.module';
-import services from './exchangeServices.module';
-import routing from './exchange.routes';
-import cacheTemplate from './exchange.template';
-
-import {
-  EXCHANGE_MX_CONFIG,
-  EXCHANGE_CONFIG_URL,
-  EXCHANGE_CONFIG,
-} from './exchange.constants';
-
-import './css/exchangeDiagnostic.css';
-
-const moduleName = 'Module.exchange';
+const moduleName = 'ovhManagerExchangeLazyLoading';
 
 angular
-  .module(moduleName, [
-    'ngOvhUtils',
-    'ngRoute',
-    'ui.bootstrap',
-    'ngSanitize',
-    'ng.ckeditor',
-    accountRenew,
-    components,
-    controllers,
-    directives,
-    ovhManagerCore,
-    services,
-    ExchangeAccountMfaCreate,
-    ExchangeAccountMfaDelete,
-  ])
-  .constant('EXCHANGE_MX_CONFIG', EXCHANGE_MX_CONFIG)
-  .constant('EXCHANGE_CONFIG_URL', EXCHANGE_CONFIG_URL)
-  .constant('EXCHANGE_CONFIG', EXCHANGE_CONFIG)
-  .config(routing)
-  .run(cacheTemplate);
+  .module(moduleName, ['ui.router', 'oc.lazyLoad'])
+  .config(
+    /* @ngInject */ ($stateProvider) => {
+      $stateProvider.state('app.exchange.**', {
+        url: '/configuration/exchange/:organization/:productId',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./exchange.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+    },
+  )
+  .service('APIExchange', APIExchange)
+  .service('Exchange', Exchange)
+  .service('ExchangePassword', ExchangePassword);
 
 export default moduleName;

--- a/packages/manager/modules/freefax/src/freefax.module.js
+++ b/packages/manager/modules/freefax/src/freefax.module.js
@@ -1,0 +1,24 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+import 'ovh-ui-angular';
+import '@ovh-ux/manager-telecom-styles';
+
+import '@ovh-ux/manager-core';
+
+import component from './freefaxes.component';
+import routing from './freefaxes.routing';
+
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+import './freefax/freefax.scss';
+
+const moduleName = 'ovhManagerFreeFaxes';
+
+angular
+  .module(moduleName, ['oc.lazyLoad', 'ovhManagerCore', 'oui', 'ui.router'])
+  .config(routing)
+  .component('ovhManagerFreefaxes', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/freefax/src/freefax/credit/index.js
+++ b/packages/manager/modules/freefax/src/freefax/credit/index.js
@@ -11,7 +11,7 @@ import template from './freefax-credit.html';
 const moduleName = 'managerFreefaxCredit';
 
 angular
-  .module(moduleName, ['ngOvhContracts'])
+  .module(moduleName, ['ngOvhContracts', 'oui'])
   .constant('FREEFAX_DISCRETE_CREDIT', DISCRETE_CREDIT)
   .controller('FreeFaxCreditCtrl', controller)
   .run(

--- a/packages/manager/modules/freefax/src/freefaxes.routing.js
+++ b/packages/manager/modules/freefax/src/freefaxes.routing.js
@@ -1,11 +1,6 @@
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider.state('freefaxes', {
-    url: '/freefax',
-    abstract: true,
-  });
-
   $stateProvider.state('freefaxes.index', {
     url: `?${ListLayoutHelper.urlQueryParams}`,
     component: 'ovhManagerFreefaxes',

--- a/packages/manager/modules/freefax/src/index.js
+++ b/packages/manager/modules/freefax/src/index.js
@@ -2,22 +2,31 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
-import '@ovh-ux/manager-core';
+import freefax from './freefax';
 
 import { FREEFAX_AVAILABILITY } from './feature-availability/feature-availability.constants';
 
-import component from './freefaxes.component';
-import routing from './freefaxes.routing';
-import freefax from './freefax';
+const moduleName = 'ovhManagerFreeFaxesLazyLoading';
 
-const moduleName = 'ovhManagerFreeFaxes';
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad', freefax]).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider
+      .state('freefaxes', {
+        url: '/freefax',
+        abstract: true,
+      })
+      .state('freefaxes.index.**', {
+        url: '',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-angular
-  .module(moduleName, ['ui.router', 'ovhManagerCore', 'oc.lazyLoad', freefax])
-  .config(routing)
-  .component('ovhManagerFreefaxes', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
-
-export { FREEFAX_AVAILABILITY };
+          return import('./freefax.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+  },
+);
 
 export default moduleName;
+export { FREEFAX_AVAILABILITY };

--- a/packages/manager/modules/iplb/package.json
+++ b/packages/manager/modules/iplb/package.json
@@ -29,6 +29,7 @@
     "bootstrap": "~3.3.0",
     "chart.js": "chartjs/Chart.js#^2.0",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "~2.35.2",

--- a/packages/manager/modules/iplb/src/index.js
+++ b/packages/manager/modules/iplb/src/index.js
@@ -1,100 +1,29 @@
 import angular from 'angular';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'ovh-api-services';
-import 'ovh-ui-angular';
-import 'angular-ui-bootstrap';
-import 'angular-chart.js';
-import '@ovh-ux/ng-ovh-sidebar-menu';
+import 'oclazyload';
 
-import ovhManagerCore from '@ovh-ux/manager-core';
-import ngAtInternet from '@ovh-ux/ng-at-internet';
-import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
-import ngOvhDocUrl from '@ovh-ux/ng-ovh-doc-url';
+const moduleName = 'ovhManagerIplbLazyLoading';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/extensions */
-import 'script-loader!chart.js/dist/Chart.js';
-import 'script-loader!angular-chart.js/dist/angular-chart.js';
-/* eslint-enable import/no-webpack-loader-syntax */
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider
+      .state('network', {
+        url: '/network',
+        template: `
+                  <div data-ui-view="networkContainer"></div>
+              `,
+        abstract: true,
+      })
+      .state('network.iplb.**', {
+        url: '/iplb',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-import IpLoadBalancerActionService from './iplb-action.service';
-import IpLoadBalancerCipherService from './iplb-cipher.service';
-import IpLoadBalancerConstant from './iplb.constants';
-import IpLoadBalancerDetailCtrl from './iplb-detail.controller';
-import IpLoadBalancerFailoverIpService from './iplb-failover-ip.service';
-import IpLoadBalancerMetricsService from './iplb-metrics.service';
-import IpLoadBalancerNatIpService from './iplb-nat-ip.service';
-import IpLoadBalancerZoneService from './iplb-zone.service';
-import IpLoadBalancerNatIpDetailCtrl from './modal/nat-ip/iplb-nat-ip-detail.controller';
-import IpLoadBalancerFailoverIpDetailCtrl from './modal/failover-ip/iplb-failover-ip-detail.controller';
-import IpLoadBalancerCipherChangeCtrl from './modal/cipher/iplb-cipher-change.controller';
-import IplbConfigurationModule from './configuration';
-import IplbFrontendsModule from './frontends';
-import IplbGraphModule from './graph';
-import IplbHomeModule from './home';
-import IplbServerFormModule from './serverFarm';
-import IplbSSLcertificateModule from './sslCertificate';
-import IplbTaskModule from './task';
-import IplbVrackModule from './vrack';
-import IplbZoneModule from './zone';
-
-import routing from './routing';
-
-import 'ovh-ui-kit/dist/oui.css';
-import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
-import './iplb.less';
-import './iplb.scss';
-
-const moduleName = 'ovhManagerIplb';
-
-angular
-  .module(moduleName, [
-    'chart.js',
-    'pascalprecht.translate',
-    'ui.router',
-    'ovh-api-services',
-    'oui',
-    'ui.bootstrap',
-    'ngOvhSidebarMenu',
-    ovhManagerCore,
-    ngAtInternet,
-    ngOvhDocUrl,
-    ngOvhCloudUniverseComponents,
-    IplbSSLcertificateModule,
-    IplbTaskModule,
-    IplbVrackModule,
-    IplbZoneModule,
-    IplbServerFormModule,
-    IplbHomeModule,
-    IplbGraphModule,
-    IplbFrontendsModule,
-    IplbConfigurationModule,
-  ])
-  .config(routing)
-  .config(
-    /* @ngInject */ (
-      $qProvider,
-      ovhDocUrlProvider,
-      TranslateServiceProvider,
-    ) => {
-      ovhDocUrlProvider.setUserLocale(TranslateServiceProvider.getUserLocale());
-      $qProvider.errorOnUnhandledRejections(false);
-    },
-  )
-  .controller('IpLoadBalancerDetailCtrl', IpLoadBalancerDetailCtrl)
-  .service('IpLoadBalancerActionService', IpLoadBalancerActionService)
-  .service('IpLoadBalancerCipherService', IpLoadBalancerCipherService)
-  .service('IpLoadBalancerFailoverIpService', IpLoadBalancerFailoverIpService)
-  .service('IpLoadBalancerMetricsService', IpLoadBalancerMetricsService)
-  .service('IpLoadBalancerNatIpService', IpLoadBalancerNatIpService)
-  .service('IpLoadBalancerZoneService', IpLoadBalancerZoneService)
-  .constant('IpLoadBalancerConstant', IpLoadBalancerConstant)
-  .controller('IpLoadBalancerNatIpDetailCtrl', IpLoadBalancerNatIpDetailCtrl)
-  .controller(
-    'IpLoadBalancerFailoverIpDetailCtrl',
-    IpLoadBalancerFailoverIpDetailCtrl,
-  )
-  .controller('IpLoadBalancerCipherChangeCtrl', IpLoadBalancerCipherChangeCtrl)
-  .run(/* @ngTranslationsInject:json ./translations */);
-
+          return import('./iplb.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+  },
+);
 export default moduleName;

--- a/packages/manager/modules/iplb/src/iplb.module.js
+++ b/packages/manager/modules/iplb/src/iplb.module.js
@@ -1,0 +1,100 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+import 'angular-ui-bootstrap';
+import 'angular-chart.js';
+import '@ovh-ux/ng-ovh-sidebar-menu';
+
+import ovhManagerCore from '@ovh-ux/manager-core';
+import ngAtInternet from '@ovh-ux/ng-at-internet';
+import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+import ngOvhDocUrl from '@ovh-ux/ng-ovh-doc-url';
+
+/* eslint-disable import/no-webpack-loader-syntax, import/extensions */
+import 'script-loader!chart.js/dist/Chart.js';
+import 'script-loader!angular-chart.js/dist/angular-chart.js';
+/* eslint-enable import/no-webpack-loader-syntax */
+
+import IpLoadBalancerActionService from './iplb-action.service';
+import IpLoadBalancerCipherService from './iplb-cipher.service';
+import IpLoadBalancerConstant from './iplb.constants';
+import IpLoadBalancerDetailCtrl from './iplb-detail.controller';
+import IpLoadBalancerFailoverIpService from './iplb-failover-ip.service';
+import IpLoadBalancerMetricsService from './iplb-metrics.service';
+import IpLoadBalancerNatIpService from './iplb-nat-ip.service';
+import IpLoadBalancerZoneService from './iplb-zone.service';
+import IpLoadBalancerNatIpDetailCtrl from './modal/nat-ip/iplb-nat-ip-detail.controller';
+import IpLoadBalancerFailoverIpDetailCtrl from './modal/failover-ip/iplb-failover-ip-detail.controller';
+import IpLoadBalancerCipherChangeCtrl from './modal/cipher/iplb-cipher-change.controller';
+import IplbConfigurationModule from './configuration';
+import IplbFrontendsModule from './frontends';
+import IplbGraphModule from './graph';
+import IplbHomeModule from './home';
+import IplbServerFormModule from './serverFarm';
+import IplbSSLcertificateModule from './sslCertificate';
+import IplbTaskModule from './task';
+import IplbVrackModule from './vrack';
+import IplbZoneModule from './zone';
+
+import routing from './routing';
+
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+import './iplb.less';
+import './iplb.scss';
+
+const moduleName = 'ovhManagerIplb';
+
+angular
+  .module(moduleName, [
+    'chart.js',
+    'pascalprecht.translate',
+    'ui.router',
+    'ovh-api-services',
+    'oui',
+    'ui.bootstrap',
+    'ngOvhSidebarMenu',
+    ovhManagerCore,
+    ngAtInternet,
+    ngOvhDocUrl,
+    ngOvhCloudUniverseComponents,
+    IplbSSLcertificateModule,
+    IplbTaskModule,
+    IplbVrackModule,
+    IplbZoneModule,
+    IplbServerFormModule,
+    IplbHomeModule,
+    IplbGraphModule,
+    IplbFrontendsModule,
+    IplbConfigurationModule,
+  ])
+  .config(routing)
+  .config(
+    /* @ngInject */ (
+      $qProvider,
+      ovhDocUrlProvider,
+      TranslateServiceProvider,
+    ) => {
+      ovhDocUrlProvider.setUserLocale(TranslateServiceProvider.getUserLocale());
+      $qProvider.errorOnUnhandledRejections(false);
+    },
+  )
+  .controller('IpLoadBalancerDetailCtrl', IpLoadBalancerDetailCtrl)
+  .service('IpLoadBalancerActionService', IpLoadBalancerActionService)
+  .service('IpLoadBalancerCipherService', IpLoadBalancerCipherService)
+  .service('IpLoadBalancerFailoverIpService', IpLoadBalancerFailoverIpService)
+  .service('IpLoadBalancerMetricsService', IpLoadBalancerMetricsService)
+  .service('IpLoadBalancerNatIpService', IpLoadBalancerNatIpService)
+  .service('IpLoadBalancerZoneService', IpLoadBalancerZoneService)
+  .constant('IpLoadBalancerConstant', IpLoadBalancerConstant)
+  .controller('IpLoadBalancerNatIpDetailCtrl', IpLoadBalancerNatIpDetailCtrl)
+  .controller(
+    'IpLoadBalancerFailoverIpDetailCtrl',
+    IpLoadBalancerFailoverIpDetailCtrl,
+  )
+  .controller('IpLoadBalancerCipherChangeCtrl', IpLoadBalancerCipherChangeCtrl)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/iplb/src/routing.js
+++ b/packages/manager/modules/iplb/src/routing.js
@@ -3,13 +3,6 @@ import iplbDetailTemplate from './iplb-detail.html';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider
-    .state('network', {
-      url: '/network',
-      template: `
-                <div data-ui-view="networkContainer"></div>
-            `,
-      abstract: true,
-    })
     .state('network.iplb', {
       url: '/iplb',
       views: {

--- a/packages/manager/modules/nasha/package.json
+++ b/packages/manager/modules/nasha/package.json
@@ -24,6 +24,7 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "~2.35.2",

--- a/packages/manager/modules/nasha/src/index.js
+++ b/packages/manager/modules/nasha/src/index.js
@@ -1,80 +1,39 @@
 import angular from 'angular';
-
 import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-ovh-cloud-universe-components';
-import '@ovh-ux/ng-ovh-doc-url';
-import '@ovh-ux/ng-ovh-responsive-popover';
-import '@ovh-ux/ng-ui-router-layout';
-
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'angular-ui-bootstrap';
-import 'ovh-api-services';
-import 'ovh-ui-angular';
+import 'oclazyload';
 
-import NashaCtrl from './controller';
-import NashaAddCtrl from './add/nasha-add.controller';
-import NashaOrderCompleteCtrl from './order/controller';
-import NashaUnavailableCtrl from './add/nasha-unavailable.controller';
-
-import informationTemplate from './information/nasha-information.html';
-import orderTemplate from './order/template.html';
-import usageHelpTemplate from './information/nasha-information-usage-help.html';
-
-import NashaAddService from './add/nasha-add.service';
-import partition from './partition';
-import routing from './routing';
-
-import './styles.less';
-import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
-import 'ovh-ui-kit/dist/oui.css';
-import './add/styles.less';
-
-const moduleName = 'ovhManagerNasha';
+const moduleName = 'ovhManagerNashaLazyLoading';
 
 angular
-  .module(moduleName, [
-    'ovhManagerCore',
-    'pascalprecht.translate',
-    'ui.router',
-    'ovh-api-services',
-    'ngOvhCloudUniverseComponents',
-    'ngOvhDocUrl',
-    'ngUiRouterLayout',
-    'ui.bootstrap',
-    'oui',
-    'ngOvhResponsivePopover',
-    partition,
-  ])
-  .config(routing)
+  .module(moduleName, ['ui.router', 'oc.lazyLoad', 'ovhManagerCore'])
   .config(
-    /* @ngInject */ (
-      $qProvider,
-      ovhDocUrlProvider,
-      TranslateServiceProvider,
-    ) => {
-      ovhDocUrlProvider.setUserLocale(TranslateServiceProvider.getUserLocale());
-      $qProvider.errorOnUnhandledRejections(false);
-    },
-  )
-  .controller('NashaCtrl', NashaCtrl)
-  .controller('NashaAddCtrl', NashaAddCtrl)
-  .controller('NashaOrderCompleteCtrl', NashaOrderCompleteCtrl)
-  .controller('NashaUnavailableCtrl', NashaUnavailableCtrl)
-  .service('NashaAddService', NashaAddService)
-  .run(/* @ngTranslationsInject:json ./translations */)
-  .run(
-    /* @ngInject */ ($templateCache) => {
-      $templateCache.put(
-        'nasha/information/nasha-information.html',
-        informationTemplate,
-      );
-      $templateCache.put(
-        'nasha/information/nasha-information-usage-help.html',
-        usageHelpTemplate,
-      );
-      $templateCache.put('nasha/order/template.html', orderTemplate);
+    /* @ngInject */ ($stateProvider) => {
+      const lazyLoad = ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./nasha.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      };
+
+      $stateProvider
+        .state('nasha.**', {
+          url: '/paas/nasha/:nashaId',
+          lazyLoad,
+        })
+        .state('nasha-order-complete.**', {
+          url: '/nasha/order/complete',
+          lazyLoad,
+        })
+        .state('nasha-add.**', {
+          url: '/nasha/new',
+          lazyLoad,
+        })
+        .state('nasha-unavailable.**', {
+          url: '/nasha/unavailable',
+          lazyLoad,
+        });
     },
   );
-
 export default moduleName;

--- a/packages/manager/modules/nasha/src/nasha.module.js
+++ b/packages/manager/modules/nasha/src/nasha.module.js
@@ -1,0 +1,80 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@ovh-ux/ng-ovh-doc-url';
+import '@ovh-ux/ng-ovh-responsive-popover';
+import '@ovh-ux/ng-ui-router-layout';
+
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'angular-ui-bootstrap';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+
+import NashaCtrl from './controller';
+import NashaAddCtrl from './add/nasha-add.controller';
+import NashaOrderCompleteCtrl from './order/controller';
+import NashaUnavailableCtrl from './add/nasha-unavailable.controller';
+
+import informationTemplate from './information/nasha-information.html';
+import orderTemplate from './order/template.html';
+import usageHelpTemplate from './information/nasha-information-usage-help.html';
+
+import NashaAddService from './add/nasha-add.service';
+import partition from './partition';
+import routing from './routing';
+
+import './styles.less';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+import 'ovh-ui-kit/dist/oui.css';
+import './add/styles.less';
+
+const moduleName = 'ovhManagerNasha';
+
+angular
+  .module(moduleName, [
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'ovh-api-services',
+    'ngOvhCloudUniverseComponents',
+    'ngOvhDocUrl',
+    'ngUiRouterLayout',
+    'ui.bootstrap',
+    'oui',
+    'ngOvhResponsivePopover',
+    partition,
+  ])
+  .config(routing)
+  .config(
+    /* @ngInject */ (
+      $qProvider,
+      ovhDocUrlProvider,
+      TranslateServiceProvider,
+    ) => {
+      ovhDocUrlProvider.setUserLocale(TranslateServiceProvider.getUserLocale());
+      $qProvider.errorOnUnhandledRejections(false);
+    },
+  )
+  .controller('NashaCtrl', NashaCtrl)
+  .controller('NashaAddCtrl', NashaAddCtrl)
+  .controller('NashaOrderCompleteCtrl', NashaOrderCompleteCtrl)
+  .controller('NashaUnavailableCtrl', NashaUnavailableCtrl)
+  .service('NashaAddService', NashaAddService)
+  .run(/* @ngTranslationsInject:json ./translations */)
+  .run(
+    /* @ngInject */ ($templateCache) => {
+      $templateCache.put(
+        'nasha/information/nasha-information.html',
+        informationTemplate,
+      );
+      $templateCache.put(
+        'nasha/information/nasha-information-usage-help.html',
+        usageHelpTemplate,
+      );
+      $templateCache.put('nasha/order/template.html', orderTemplate);
+    },
+  );
+
+export default moduleName;

--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -22,10 +22,12 @@
     "@ovh-ux/ng-ovh-http": "^5.0.0",
     "@ovh-ux/ng-ovh-utils": "^14.0.3",
     "@ovh-ux/ng-ovh-web-universe-components": "^7.0.0 || ^8.0.0",
+    "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-ui-angular": "^3.11.0"
   }
 }

--- a/packages/manager/modules/office/src/index.js
+++ b/packages/manager/modules/office/src/index.js
@@ -1,3 +1,31 @@
-import module from './microsoft.module';
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
 
-export default module;
+const moduleName = 'ovhManagerOfficeLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider
+      .state('app.microsoft.office', {
+        abstract: true,
+        template: '<div ui-view></div>',
+        translations: {
+          value: ['.'],
+          format: 'json',
+        },
+      })
+      .state('app.microsoft.office.product.**', {
+        url: '/configuration/microsoft/office/license/:serviceName?tab',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./microsoft.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/office/src/microsoft.routes.js
+++ b/packages/manager/modules/office/src/microsoft.routes.js
@@ -3,19 +3,8 @@ import set from 'lodash/set';
 import controller from './office/license/microsoft-office-license.controller';
 import template from './office/license/microsoft-office-license.html';
 
-const routeBase = 'app.microsoft.office';
-
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider.state(routeBase, {
-    abstract: true,
-    template: '<div ui-view></div>',
-    translations: {
-      value: ['.'],
-      format: 'json',
-    },
-  });
-
-  $stateProvider.state(`${routeBase}.product`, {
+  $stateProvider.state('app.microsoft.office.product', {
     url: '/configuration/microsoft/office/license/:serviceName?tab',
     template,
     controller,

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -34,6 +34,7 @@
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-angular-ui-confirm-modal": "^1.0.2",
+    "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.0.2",
     "ovh-ui-kit": "^2.33.3",
     "ovh-ui-kit-bs": "^2.1.1"

--- a/packages/manager/modules/overthebox/src/index.js
+++ b/packages/manager/modules/overthebox/src/index.js
@@ -2,28 +2,32 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
-import '@ovh-ux/manager-core';
+import overTheBox from './overthebox';
 
 import { OTB_AVAILABILITY } from './feature-availability/feature-availability.constants';
 
-import overTheBox from './overthebox';
+const moduleName = 'ovhManagerOverTheBoxesLazyLoading';
 
-import component from './overtheboxes.component';
-import routing from './overtheboxes.routing';
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad', overTheBox]).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider
+      .state('overTheBoxes', {
+        url: '/overTheBox',
+        abstract: true,
+      })
+      .state('overTheBoxes.index.**', {
+        url: '',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-const moduleName = 'ovhManagerOverTheBoxes';
-
-angular
-  .module(moduleName, [
-    'ui.router',
-    'ovhManagerCore',
-    'oc.lazyLoad',
-    overTheBox,
-  ])
-  .config(routing)
-  .component('ovhManagerOverTheBoxes', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
-
-export { OTB_AVAILABILITY };
+          return import('./overtheboxes.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+  },
+);
 
 export default moduleName;
+
+export { OTB_AVAILABILITY };

--- a/packages/manager/modules/overthebox/src/overtheboxes.module.js
+++ b/packages/manager/modules/overthebox/src/overtheboxes.module.js
@@ -1,0 +1,27 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+import 'ovh-api-services';
+
+import '@ovh-ux/manager-core';
+
+import component from './overtheboxes.component';
+import routing from './overtheboxes.routing';
+
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+
+const moduleName = 'ovhManagerOverTheBoxes';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'ovhManagerCore',
+    'oc.lazyLoad',
+    'ovh-api-services',
+  ])
+  .config(routing)
+  .component('ovhManagerOverTheBoxes', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/overthebox/src/overtheboxes.routing.js
+++ b/packages/manager/modules/overthebox/src/overtheboxes.routing.js
@@ -2,11 +2,6 @@ import get from 'lodash/get';
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider.state('overTheBoxes', {
-    url: '/overTheBox',
-    abstract: true,
-  });
-
   $stateProvider.state('overTheBoxes.index', {
     url: `?${ListLayoutHelper.urlQueryParams}`,
     component: 'ovhManagerOverTheBoxes',

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -20,7 +20,9 @@
   "peerDependencies": {
     "@ovh-ux/ng-ovh-utils": "^14.0.3",
     "@ovh-ux/web-universe-components": "^7.0.0",
+    "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "^2.33.3"

--- a/packages/manager/modules/sharepoint/src/index.js
+++ b/packages/manager/modules/sharepoint/src/index.js
@@ -1,3 +1,45 @@
-import module from './sharepoint.module';
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
 
-export default module;
+const moduleName = 'ovhManagerSharepointLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    const routeBase = 'app.microsoft.sharepoint';
+    const lazyLoad = ($transition$) => {
+      const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+      return import('./sharepoint.module').then((mod) =>
+        $ocLazyLoad.inject(mod.default || mod),
+      );
+    };
+
+    $stateProvider
+      .state(routeBase, {
+        abstract: true,
+        template: '<div ui-view></div>',
+        translations: {
+          value: ['.'],
+          format: 'json',
+        },
+      })
+      .state(`${routeBase}.order.**`, {
+        url: '/configuration/microsoft/sharepoint/order',
+        lazyLoad,
+      })
+      .state(`${routeBase}.config.**`, {
+        url: '/configuration/sharepoint/activate/:organizationId/:exchangeId',
+        lazyLoad,
+      })
+      .state(`${routeBase}.product.**`, {
+        url: '/configuration/sharepoint/:exchangeId/:productId?tab',
+        lazyLoad,
+      })
+      .state(`${routeBase}.setUrl.**`, {
+        url: '/configuration/sharepoint/:exchangeId/:productId/setUrl',
+        lazyLoad,
+      });
+  },
+);
+export default moduleName;

--- a/packages/manager/modules/sharepoint/src/sharepoint.routes.js
+++ b/packages/manager/modules/sharepoint/src/sharepoint.routes.js
@@ -21,15 +21,6 @@ export default /* @ngInject */ ($stateProvider) => {
     },
   };
 
-  $stateProvider.state(routeBase, {
-    abstract: true,
-    template: '<div ui-view></div>',
-    translations: {
-      value: ['.'],
-      format: 'json',
-    },
-  });
-
   $stateProvider.state(`${routeBase}.order`, {
     url: '/configuration/microsoft/sharepoint/order',
     template: sharepointOrderTpl,

--- a/packages/manager/modules/sms/src/index.js
+++ b/packages/manager/modules/sms/src/index.js
@@ -1,23 +1,35 @@
 import angular from 'angular';
-
-import '@ovh-ux/manager-core';
 import '@uirouter/angularjs';
 import 'oclazyload';
+import ovhManagerCore from '@ovh-ux/manager-core';
 
 import sms from './sms';
-import routing from './sms.routing';
-import component from './sms.component';
 
 import { SMS_AVAILABILITY } from './feature-availability/feature-availability.constants';
 
-const moduleName = 'ovhManagerSms';
+const moduleName = 'ovhManagerSmsLazyLoading';
 
 angular
-  .module(moduleName, ['ui.router', 'oc.lazyLoad', 'ovhManagerCore', sms])
-  .config(routing)
-  .component('ovhManagerSms', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .module(moduleName, ['ui.router', 'oc.lazyLoad', sms, ovhManagerCore])
+  .config(
+    /* @ngInject */ ($stateProvider) => {
+      $stateProvider
+        .state('sms', {
+          url: '/sms',
+          abstract: true,
+        })
+        .state('sms.index.**', {
+          url: '',
+          lazyLoad: ($transition$) => {
+            const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-export { SMS_AVAILABILITY };
+            return import('./sms.module').then((mod) =>
+              $ocLazyLoad.inject(mod.default || mod),
+            );
+          },
+        });
+    },
+  );
 
 export default moduleName;
+export { SMS_AVAILABILITY };

--- a/packages/manager/modules/sms/src/sms.module.js
+++ b/packages/manager/modules/sms/src/sms.module.js
@@ -1,0 +1,27 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@uirouter/angularjs';
+import 'oclazyload';
+import 'ovh-api-services';
+
+import routing from './sms.routing';
+import component from './sms.component';
+
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+
+const moduleName = 'ovhManagerSms';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'oc.lazyLoad',
+    'ovh-api-services',
+    'ovhManagerCore',
+  ])
+  .config(routing)
+  .component('ovhManagerSms', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/sms/src/sms.routing.js
+++ b/packages/manager/modules/sms/src/sms.routing.js
@@ -2,11 +2,6 @@ import get from 'lodash/get';
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider.state('sms', {
-    url: '/sms',
-    abstract: true,
-  });
-
   $stateProvider.state('sms.index', {
     url: `?${ListLayoutHelper.urlQueryParams}`,
     views: {

--- a/packages/manager/modules/veeam-cloud-connect/package.json
+++ b/packages/manager/modules/veeam-cloud-connect/package.json
@@ -24,6 +24,7 @@
     "angular-ui-bootstrap": "1.3.3",
     "flag-icon-css": "~0.8.5",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "~2.35.2",

--- a/packages/manager/modules/veeam-cloud-connect/src/index.js
+++ b/packages/manager/modules/veeam-cloud-connect/src/index.js
@@ -1,48 +1,33 @@
 import angular from 'angular';
-
-import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-ovh-cloud-universe-components';
-import '@ovh-ux/ng-ui-router-layout';
 import '@uirouter/angularjs';
-import 'angular-translate';
-import 'angular-ui-bootstrap';
-import 'ovh-api-services';
-import 'ovh-ui-angular';
+import 'oclazyload';
 
-import component from './component';
-import routing from './routing';
-import service from './service';
-import dashboard from './dashboard/veeam-dashboard.component';
-import storage from './storage/veeam-storage.component';
-import storageAdd from './storage/add/veeam-storage-add.component';
-import storageQuota from './storage/update-quota/veeam-storage-update-quota.component';
-import updateOffer from './dashboard/update-offer/veeam-update-offer.component';
+import template from './template.html';
 
-import './index.less';
+const moduleName = 'ovhManagerVeeamCloudConnectLazyLoading';
 
-import 'ovh-ui-kit/dist/oui.css';
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider
+      .state('veeam-cloud-connect', {
+        url: '/paas/veeam',
+        abstract: true,
+        template,
+        translations: {
+          value: ['.'],
+          format: 'json',
+        },
+      })
+      .state('veeam-cloud-connect.detail.**', {
+        url: '/{serviceName}',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-const moduleName = 'ovhManagerVeeamCloudConnect';
-
-angular
-  .module(moduleName, [
-    'ovhManagerCore',
-    'pascalprecht.translate',
-    'ui.router',
-    'ngOvhCloudUniverseComponents',
-    'ngUiRouterLayout',
-    'ui.bootstrap',
-    'ovh-api-services',
-    'oui',
-  ])
-  .config(routing)
-  .component('ovhManagerVeeamCloudConnectComponent', component)
-  .component('ovhManagerVeeamCloudConnectDashboardComponent', dashboard)
-  .component('ovhManagerVeeamCloudConnectStorageComponent', storage)
-  .component('ovhManagerVeeamCloudConnectStorageAddComponent', storageAdd)
-  .component('ovhManagerVeeamCloudConnectStorageQuotaComponent', storageQuota)
-  .component('ovhManagerVeeamCloudConnectUpdateOfferComponent', updateOffer)
-  .service('VeeamCloudConnectService', service)
-  .run(/* @ngTranslationsInject:json ./translations */);
-
+          return import('./veeam-cloud-connect.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+  },
+);
 export default moduleName;

--- a/packages/manager/modules/veeam-cloud-connect/src/routing.js
+++ b/packages/manager/modules/veeam-cloud-connect/src/routing.js
@@ -1,18 +1,8 @@
-import template from './template.html';
 import headerTemplate from './header/veeam-dashboard-header.html';
 import headerCtrl from './header/veeam-dashboard-header.controller';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider
-    .state('veeam-cloud-connect', {
-      url: '/paas/veeam',
-      abstract: true,
-      template,
-      translations: {
-        value: ['.'],
-        format: 'json',
-      },
-    })
     .state('veeam-cloud-connect.detail', {
       url: '/{serviceName}',
       views: {

--- a/packages/manager/modules/veeam-cloud-connect/src/veeam-cloud-connect.module.js
+++ b/packages/manager/modules/veeam-cloud-connect/src/veeam-cloud-connect.module.js
@@ -1,0 +1,48 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@ovh-ux/ng-ui-router-layout';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'angular-ui-bootstrap';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+
+import component from './component';
+import routing from './routing';
+import service from './service';
+import dashboard from './dashboard/veeam-dashboard.component';
+import storage from './storage/veeam-storage.component';
+import storageAdd from './storage/add/veeam-storage-add.component';
+import storageQuota from './storage/update-quota/veeam-storage-update-quota.component';
+import updateOffer from './dashboard/update-offer/veeam-update-offer.component';
+
+import './index.less';
+
+import 'ovh-ui-kit/dist/oui.css';
+
+const moduleName = 'ovhManagerVeeamCloudConnect';
+
+angular
+  .module(moduleName, [
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'ngOvhCloudUniverseComponents',
+    'ngUiRouterLayout',
+    'ui.bootstrap',
+    'ovh-api-services',
+    'oui',
+  ])
+  .config(routing)
+  .component('ovhManagerVeeamCloudConnectComponent', component)
+  .component('ovhManagerVeeamCloudConnectDashboardComponent', dashboard)
+  .component('ovhManagerVeeamCloudConnectStorageComponent', storage)
+  .component('ovhManagerVeeamCloudConnectStorageAddComponent', storageAdd)
+  .component('ovhManagerVeeamCloudConnectStorageQuotaComponent', storageQuota)
+  .component('ovhManagerVeeamCloudConnectUpdateOfferComponent', updateOffer)
+  .service('VeeamCloudConnectService', service)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/veeam-enterprise/package.json
+++ b/packages/manager/modules/veeam-enterprise/package.json
@@ -26,6 +26,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "~2.35.2",

--- a/packages/manager/modules/veeam-enterprise/src/index.js
+++ b/packages/manager/modules/veeam-enterprise/src/index.js
@@ -1,48 +1,21 @@
 import angular from 'angular';
-
-import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-ovh-cloud-universe-components';
 import '@uirouter/angularjs';
-import '@ovh-ux/ng-ui-router-layout';
-import 'angular-translate';
-import 'angular-ui-bootstrap';
-import 'ovh-api-services';
-import 'ovh-ui-angular';
+import 'oclazyload';
 
-import VeeamEnterpriseCtrl from './controller';
-import VeeamEnterpriseService from './service';
-import VeeamEnterpriseDashboardCtrl from './dashboard/controller';
-import VeeamEnterpriseLicenseComponent from './dashboard/license/license.component';
-import VeeamEnterpriseLicenseTerminateComponent from './dashboard/terminate/terminate.component';
+const moduleName = 'ovhManagerVeeamEnterpriseLazyLoading';
 
-import routing from './routing';
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state('veeam-enterprise.**', {
+      url: '/paas/veeam-enterprise/{serviceName}',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 
-import 'ovh-ui-kit/dist/oui.css';
-import './index.less';
-import './index.scss';
-
-const moduleName = 'ovhManagerVeeamEnterprise';
-
-angular
-  .module(moduleName, [
-    'ovhManagerCore',
-    'pascalprecht.translate',
-    'ui.router',
-    'ngOvhCloudUniverseComponents',
-    'ngUiRouterLayout',
-    'ui.bootstrap',
-    'ovh-api-services',
-    'oui',
-  ])
-  .config(routing)
-  .controller('VeeamEnterpriseDashboardCtrl', VeeamEnterpriseDashboardCtrl)
-  .controller('VeeamEnterpriseCtrl', VeeamEnterpriseCtrl)
-  .component('veeamEnterpriseLicense', VeeamEnterpriseLicenseComponent)
-  .component(
-    'veeamEnterpriseLicenseTerminate',
-    VeeamEnterpriseLicenseTerminateComponent,
-  )
-  .service('VeeamEnterpriseService', VeeamEnterpriseService)
-  .run(/* @ngTranslationsInject:json ./translations */);
-
+        return import('./veeam-enterprise.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      },
+    });
+  },
+);
 export default moduleName;

--- a/packages/manager/modules/veeam-enterprise/src/veeam-enterprise.module.js
+++ b/packages/manager/modules/veeam-enterprise/src/veeam-enterprise.module.js
@@ -1,0 +1,48 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@uirouter/angularjs';
+import '@ovh-ux/ng-ui-router-layout';
+import 'angular-translate';
+import 'angular-ui-bootstrap';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+
+import VeeamEnterpriseCtrl from './controller';
+import VeeamEnterpriseService from './service';
+import VeeamEnterpriseDashboardCtrl from './dashboard/controller';
+import VeeamEnterpriseLicenseComponent from './dashboard/license/license.component';
+import VeeamEnterpriseLicenseTerminateComponent from './dashboard/terminate/terminate.component';
+
+import routing from './routing';
+
+import 'ovh-ui-kit/dist/oui.css';
+import './index.less';
+import './index.scss';
+
+const moduleName = 'ovhManagerVeeamEnterprise';
+
+angular
+  .module(moduleName, [
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'ngOvhCloudUniverseComponents',
+    'ngUiRouterLayout',
+    'ui.bootstrap',
+    'ovh-api-services',
+    'oui',
+  ])
+  .config(routing)
+  .controller('VeeamEnterpriseDashboardCtrl', VeeamEnterpriseDashboardCtrl)
+  .controller('VeeamEnterpriseCtrl', VeeamEnterpriseCtrl)
+  .component('veeamEnterpriseLicense', VeeamEnterpriseLicenseComponent)
+  .component(
+    'veeamEnterpriseLicenseTerminate',
+    VeeamEnterpriseLicenseTerminateComponent,
+  )
+  .service('VeeamEnterpriseService', VeeamEnterpriseService)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/vps/package.json
+++ b/packages/manager/modules/vps/package.json
@@ -33,6 +33,7 @@
     "chart.js": "chartjs/Chart.js#^2.0",
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-ui-angular": "^3.11.0",
     "ovh-ui-kit": "~2.35.2",

--- a/packages/manager/modules/vps/src/routing.js
+++ b/packages/manager/modules/vps/src/routing.js
@@ -1,68 +1,52 @@
 import kebabCase from 'lodash/kebabCase';
 
-import template from './vps.html';
-
 import detailComponent from './detail/vps-detail.component';
 import headerComponent from './header/vps-header.component';
 
 export default /* @ngInject */ ($stateProvider) => {
-  $stateProvider
-    .state('vps', {
-      url: '/iaas/vps',
-      template,
-      abstract: true,
-      resolve: {
-        currentUser: /* @ngInject */ (OvhApiMe) => OvhApiMe.v6().get().$promise,
+  $stateProvider.state('vps.detail', {
+    url: '/{serviceName}',
+    redirectTo: 'vps.detail.dashboard',
+    resolve: {
+      connectedUser: /* @ngInject */ (OvhApiMe) => OvhApiMe.v6().get().$promise,
+      capabilities: /* @ngInject */ (serviceName, OvhApiVpsCapabilities) =>
+        OvhApiVpsCapabilities.Aapi()
+          .query({ serviceName })
+          .$promise.then((capabilities) =>
+            capabilities.map((capability) => kebabCase(capability)),
+          ),
+      serviceName: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceName,
+      stateVps: /* @ngInject */ ($q, serviceName, OvhApiVps) =>
+        OvhApiVps.v6()
+          .get({
+            serviceName,
+          })
+          .$promise.then((stateVps) =>
+            OvhApiVps.v6()
+              .version({
+                serviceName,
+              })
+              .$promise.then((response) => {
+                const vpsState = stateVps;
+                vpsState.isLegacy = response.version !== 2;
+                return vpsState;
+              }),
+          )
+          .catch((error) => {
+            if (error.status === 404) {
+              return $q.reject(error);
+            }
+            return true;
+          }),
+    },
+    views: {
+      'vpsHeader@vps': {
+        component: headerComponent.name,
       },
-      translations: {
-        value: ['../common', '../vps'],
-        format: 'json',
+      'vpsContainer@vps': {
+        component: detailComponent.name,
       },
-    })
-    .state('vps.detail', {
-      url: '/{serviceName}',
-      redirectTo: 'vps.detail.dashboard',
-      resolve: {
-        connectedUser: /* @ngInject */ (OvhApiMe) =>
-          OvhApiMe.v6().get().$promise,
-        capabilities: /* @ngInject */ (serviceName, OvhApiVpsCapabilities) =>
-          OvhApiVpsCapabilities.Aapi()
-            .query({ serviceName })
-            .$promise.then((capabilities) =>
-              capabilities.map((capability) => kebabCase(capability)),
-            ),
-        serviceName: /* @ngInject */ ($transition$) =>
-          $transition$.params().serviceName,
-        stateVps: /* @ngInject */ ($q, serviceName, OvhApiVps) =>
-          OvhApiVps.v6()
-            .get({
-              serviceName,
-            })
-            .$promise.then((stateVps) =>
-              OvhApiVps.v6()
-                .version({
-                  serviceName,
-                })
-                .$promise.then((response) => {
-                  const vpsState = stateVps;
-                  vpsState.isLegacy = response.version !== 2;
-                  return vpsState;
-                }),
-            )
-            .catch((error) => {
-              if (error.status === 404) {
-                return $q.reject(error);
-              }
-              return true;
-            }),
-      },
-      views: {
-        'vpsHeader@vps': {
-          component: headerComponent.name,
-        },
-        'vpsContainer@vps': {
-          component: detailComponent.name,
-        },
-      },
-    });
+    },
+  });
 };

--- a/packages/manager/modules/vps/src/vps.module.js
+++ b/packages/manager/modules/vps/src/vps.module.js
@@ -1,0 +1,73 @@
+import angular from 'angular';
+
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+import 'angular-ui-bootstrap';
+import 'angular-chart.js';
+
+import ovhManagerCore from '@ovh-ux/manager-core';
+import ngUiRouterLayout from '@ovh-ux/ng-ui-router-layout';
+import ngAtInternet from '@ovh-ux/ng-at-internet';
+import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+import ngOvhDocUrl from '@ovh-ux/ng-ovh-doc-url';
+
+import VpsTaskService from './vps-task.service';
+import VpsNotificationIpv6Service from './import/notification.service';
+import VpsService from './import/vps.service';
+
+import detailComponent from './detail/vps-detail.component';
+import headerComponent from './header/vps-header.component';
+import routing from './routing';
+
+import ovhManagerVpsAdditionnalDisk from './additional-disk';
+import ovhManagerVpsBackupStorage from './backup-storage';
+import ovhManagerVpsCloudDatabase from './cloud-database';
+import ovhManagerVpsDashboard from './dashboard';
+import ovhManagerVpsMonitoring from './monitoring';
+import ovhManagerVpsSecondaryDns from './secondary-dns';
+import ovhManagerVpsSnapshot from './snapshot';
+import ovhManagerVpsUpgrade from './upgrade';
+import ovhManagerVpsVeeam from './veeam';
+import ovhManagerVpsWindows from './windows';
+
+import 'ovh-ui-kit/dist/oui.css';
+import './vps.less';
+import './vps.scss';
+
+const moduleName = 'ovhManagerVps';
+
+angular
+  .module(moduleName, [
+    'chart.js',
+    ovhManagerCore,
+    'pascalprecht.translate',
+    'ui.router',
+    'ovh-api-services',
+    'oui',
+    'ui.bootstrap',
+    ngAtInternet,
+    ngOvhDocUrl,
+    ngOvhCloudUniverseComponents,
+    ngUiRouterLayout,
+    ovhManagerVpsAdditionnalDisk,
+    ovhManagerVpsBackupStorage,
+    ovhManagerVpsCloudDatabase,
+    ovhManagerVpsDashboard,
+    ovhManagerVpsMonitoring,
+    ovhManagerVpsSecondaryDns,
+    ovhManagerVpsSnapshot,
+    ovhManagerVpsUpgrade,
+    ovhManagerVpsVeeam,
+    ovhManagerVpsWindows,
+  ])
+  .component(detailComponent.name, detailComponent)
+  .component(headerComponent.name, headerComponent)
+  .service('VpsTaskService', VpsTaskService)
+  .service('VpsNotificationIpv6', VpsNotificationIpv6Service)
+  .service('VpsService', VpsService)
+  .config(routing)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -39,6 +39,7 @@
     "angular": "^1.7.5",
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
+    "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.39.1",
     "ovh-manager-webfont": "^1.1.0",
     "ovh-ui-angular": "^3.10.0",

--- a/packages/manager/modules/vrack/src/index.js
+++ b/packages/manager/modules/vrack/src/index.js
@@ -1,53 +1,35 @@
 import angular from 'angular';
-import 'angular-ui-bootstrap';
-import '@uirouter/angularjs';
-
-import '@ovh-ux/manager-cloud-styles';
 import '@ovh-ux/manager-core';
-import '@ovh-ux/ng-ovh-cloud-universe-components';
-import '@ovh-ux/ng-ovh-toaster';
-import 'ovh-api-services';
-import 'ovh-ui-angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
 
-import 'font-awesome/css/font-awesome.css';
-import 'ovh-manager-webfont/dist/css/ovh-font.css';
-import 'ovh-ui-kit/dist/oui.css';
-import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
-
-import './vrack.less';
-import './vrack-mapper.less';
-
-import actionsPartials from './partials/actions.html';
-import availablePartials from './partials/available.html';
-import component from './vrack.component';
-import mappedPartials from './partials/mapped.html';
-import routing from './vrack.routing';
-import vrackAdd from './add';
-import vrackMoveDialog from './move-dialog';
-
-const moduleName = 'ovhManagerVrack';
+const moduleName = 'ovhManagerVrackLazyLoading';
 
 angular
-  .module(moduleName, [
-    'ui.router',
-    'ui.bootstrap',
-    'oui',
-    'ovh-api-services',
-    'ovhManagerCore',
-    'ngOvhCloudUniverseComponents',
-    'ngOvhToaster',
-    'ui.router',
-    vrackAdd,
-    vrackMoveDialog,
-  ])
-  .component('ovhManagerVrackComponent', component)
-  .config(routing)
-  .run(
-    /* @ngInject */ ($templateCache) => {
-      $templateCache.put('vrack/partials/actions.html', actionsPartials);
-      $templateCache.put('vrack/partials/available.html', availablePartials);
-      $templateCache.put('vrack/partials/mapped.html', mappedPartials);
+  .module(moduleName, ['ui.router', 'oc.lazyLoad', 'ovhManagerCore'])
+  .config(
+    /* @ngInject */ ($stateProvider) => {
+      $stateProvider.state('vrack-home.**', {
+        url: '/vrack',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./vrack.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+
+      $stateProvider.state('vrack.**', {
+        url: '/vrack/:vrackId',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./vrack.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
     },
   );
-
 export default moduleName;

--- a/packages/manager/modules/vrack/src/vrack.module.js
+++ b/packages/manager/modules/vrack/src/vrack.module.js
@@ -1,0 +1,53 @@
+import angular from 'angular';
+import 'angular-ui-bootstrap';
+import '@uirouter/angularjs';
+
+import '@ovh-ux/manager-cloud-styles';
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@ovh-ux/ng-ovh-toaster';
+import 'ovh-api-services';
+import 'ovh-ui-angular';
+
+import 'font-awesome/css/font-awesome.css';
+import 'ovh-manager-webfont/dist/css/ovh-font.css';
+import 'ovh-ui-kit/dist/oui.css';
+import 'ovh-ui-kit-bs/dist/ovh-ui-kit-bs.css';
+
+import './vrack.less';
+import './vrack-mapper.less';
+
+import actionsPartials from './partials/actions.html';
+import availablePartials from './partials/available.html';
+import component from './vrack.component';
+import mappedPartials from './partials/mapped.html';
+import routing from './vrack.routing';
+import vrackAdd from './add';
+import vrackMoveDialog from './move-dialog';
+
+const moduleName = 'ovhManagerVrack';
+
+angular
+  .module(moduleName, [
+    'ui.router',
+    'ui.bootstrap',
+    'oui',
+    'ovh-api-services',
+    'ovhManagerCore',
+    'ngOvhCloudUniverseComponents',
+    'ngOvhToaster',
+    'ui.router',
+    vrackAdd,
+    vrackMoveDialog,
+  ])
+  .component('ovhManagerVrackComponent', component)
+  .config(routing)
+  .run(
+    /* @ngInject */ ($templateCache) => {
+      $templateCache.put('vrack/partials/actions.html', actionsPartials);
+      $templateCache.put('vrack/partials/available.html', availablePartials);
+      $templateCache.put('vrack/partials/mapped.html', mappedPartials);
+    },
+  );
+
+export default moduleName;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2020-w16-perf`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-4920
| License          | BSD 3-Clause

## Description

Add lazy loading on root states to avoid to download all chunks when loading the manager.

Done on: 
- `@ovh-ux/manager-exchange`
- `@ovh-ux/manager-freefax`
- `@ovh-ux/manager-iplb`
- `@ovh-ux/manager-nasha`
- `@ovh-ux/manager-office`
- `@ovh-ux/manager-overthebox`
- `@ovh-ux/manager-sharepoint`
- `@ovh-ux/manager-sms`
- `@ovh-ux/manager-veeam-cloud-connect`
- `@ovh-ux/manager-veeam-enterprise`
- `@ovh-ux/manager-vps`
- `@ovh-ux/manager-vrack`


