### PR TITLE
DTRSD fix(hub): add bottom space to dashboard

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/dashboard.html
+++ b/packages/manager/apps/hub/src/dashboard/dashboard.html
@@ -9,7 +9,7 @@
             data-translate-values="{ url: $ctrl.feedbackUrl }"
         ></span>
     </div>
-    <div class="mt-5 mt-md-2">
+    <div class="mt-5 mt-md-2 pb-5">
         <hub-dashboard-welcome
             data-name="$ctrl.me.firstname"
         ></hub-dashboard-welcome>


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | hotfix
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-10553
| License          | BSD 3-Clause

## Description

add bottom space in the hub for browser compatibility issues (safari)
