### PR TITLE
fix: prevent override of background-color

### DIFF
--- a/packages/manager/modules/navbar/src/index.scss
+++ b/packages/manager/modules/navbar/src/index.scss
@@ -2,7 +2,6 @@
   @import '~oui4/dist/scss/_tokens';
 
   background-color: $p-000-white;
-  background-color: initial;
   box-shadow: $base-box-shadow-primary;
   z-index: 100;
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

Remove duplicate property which overrides background-color

