### PR TITLE
DTRSD fix(pci): add supported ssh key info

### DIFF
--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/ssh-keys.html
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/ssh-keys.html
@@ -31,9 +31,8 @@
         </oui-button>
 
         <div class="oui-field__helper">
-            <span
-                data-translate="pci_project_instance_ssh_key_help_required"
-            ></span>
+            <p data-translate="pci_project_instance_ssh_key_help_required"></p>
+            <p data-translate="pci_project_instance_ssh_key_infos"></p>
         </div>
     </oui-field>
 
@@ -74,6 +73,10 @@
                 <span
                     class="d-inline-block"
                     data-translate="pci_project_instance_ssh_key_help_availability"
+                ></span>
+                <span
+                    class="d-inline-block"
+                    data-translate="pci_project_instance_ssh_key_infos"
                 ></span>
             </div>
         </oui-field>

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_de_DE.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "SSH-Schlüssel",
- "pci_project_instance_ssh_pick": "Auswählen",
- "pci_project_instance_ssh_add": "Schlüssel hinzufügen",
- "pci_project_instance_ssh_cancel": "Abbrechen",
- "pci_project_instance_ssh_key_name": "Name des SSH-Schlüssels",
- "pci_project_instance_ssh_key_query_error": "Beim Abruf Ihrer SSH-Schlüssel ist ein Fehler aufgetreten: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "Beim Hinzufügen des SSH-Schlüssels ist ein Fehler aufgetreten: {{message}}.",
- "pci_project_instance_ssh_key_help_required": "SSH-Schlüssel sind erforderlich, um sich mit Ihrem Dienst zu verbinden.",
- "pci_project_instance_ssh_key_help_availability": "Ihr SSH-Schlüssel wird in allen Regionen und OVH Rechenzentren verfügbar sein."
+  "pci_project_instance_ssh_key": "SSH-Schlüssel",
+  "pci_project_instance_ssh_pick": "Auswählen",
+  "pci_project_instance_ssh_add": "Schlüssel hinzufügen",
+  "pci_project_instance_ssh_cancel": "Abbrechen",
+  "pci_project_instance_ssh_key_name": "Name des SSH-Schlüssels",
+  "pci_project_instance_ssh_key_query_error": "Beim Abruf Ihrer SSH-Schlüssel ist ein Fehler aufgetreten: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Beim Hinzufügen des SSH-Schlüssels ist ein Fehler aufgetreten: {{message}}.",
+  "pci_project_instance_ssh_key_help_required": "SSH-Schlüssel sind erforderlich, um sich mit Ihrem Dienst zu verbinden.",
+  "pci_project_instance_ssh_key_help_availability": "Ihr SSH-Schlüssel wird in allen Regionen und OVH Rechenzentren verfügbar sein.",
+  "pci_project_instance_ssh_key_infos": "Nur SSH-Schlüssel vom Typ RSA oder ECDSA werden angenommen. Sie können keine SSH-Schlüssel vom Typ ED25519 verwenden."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_en_GB.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "SSH key",
- "pci_project_instance_ssh_pick": "Select",
- "pci_project_instance_ssh_add": "Add a key",
- "pci_project_instance_ssh_cancel": "Cancel",
- "pci_project_instance_ssh_key_name": "SSH key name",
- "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
- "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
- "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres."
+  "pci_project_instance_ssh_key": "SSH key",
+  "pci_project_instance_ssh_pick": "Select",
+  "pci_project_instance_ssh_add": "Add a key",
+  "pci_project_instance_ssh_cancel": "Cancel",
+  "pci_project_instance_ssh_key_name": "SSH key name",
+  "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
+  "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
+  "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres.",
+  "pci_project_instance_ssh_key_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_es_ES.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "Llave SSH",
- "pci_project_instance_ssh_pick": "Seleccionar",
- "pci_project_instance_ssh_add": "Añadir una llave",
- "pci_project_instance_ssh_cancel": "Cancelar",
- "pci_project_instance_ssh_key_name": "Nombre de la llave SSH",
- "pci_project_instance_ssh_key_query_error": "Se ha producido un error al cargar las llaves SSH: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "Se ha producido un error al añadir la llave SSH: {{message}}.",
- "pci_project_instance_ssh_key_help_required": "Es obligatorio utilizar una llave SSH para conectarse al servicio.",
- "pci_project_instance_ssh_key_help_availability": "Su llave SSH estará disponible en todas las regiones y en todos los datacenters de OVH."
+  "pci_project_instance_ssh_key": "Llave SSH",
+  "pci_project_instance_ssh_pick": "Seleccionar",
+  "pci_project_instance_ssh_add": "Añadir una llave",
+  "pci_project_instance_ssh_cancel": "Cancelar",
+  "pci_project_instance_ssh_key_name": "Nombre de la llave SSH",
+  "pci_project_instance_ssh_key_query_error": "Se ha producido un error al cargar las llaves SSH: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Se ha producido un error al añadir la llave SSH: {{message}}.",
+  "pci_project_instance_ssh_key_help_required": "Es obligatorio utilizar una llave SSH para conectarse al servicio.",
+  "pci_project_instance_ssh_key_help_availability": "Su llave SSH estará disponible en todas las regiones y en todos los datacenters de OVH.",
+  "pci_project_instance_ssh_key_infos": "Solo se aceptan llaves SSH de tipo RSA o ECDSA. No es posible utilizar llaves SSH de tipo ED25519."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fi_FI.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "SSH key",
- "pci_project_instance_ssh_pick": "Select",
- "pci_project_instance_ssh_add": "Add a key",
- "pci_project_instance_ssh_cancel": "Cancel",
- "pci_project_instance_ssh_key_name": "SSH key name",
- "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
- "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
- "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres."
+  "pci_project_instance_ssh_key": "SSH key",
+  "pci_project_instance_ssh_pick": "Select",
+  "pci_project_instance_ssh_add": "Add a key",
+  "pci_project_instance_ssh_cancel": "Cancel",
+  "pci_project_instance_ssh_key_name": "SSH key name",
+  "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
+  "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
+  "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres.",
+  "pci_project_instance_ssh_key_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fr_CA.json
@@ -1,0 +1,14 @@
+{
+  "pci_project_instance_ssh_key": "Clé SSH",
+  "pci_project_instance_ssh_pick": "Sélectionner",
+  "pci_project_instance_ssh_add": "Ajouter une clé",
+  "pci_project_instance_ssh_cancel": "Annuler",
+
+  "pci_project_instance_ssh_key_name": "Nom de la clé SSH",
+  "pci_project_instance_ssh_key_query_error": "Une erreur est survenue lors de la récupération de vos clés SSH : {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Une erreur est survenue lors de l'ajout de la clé SSH : {{message}}.",
+
+  "pci_project_instance_ssh_key_help_required": "Les clés SSH sont obligatoires pour se connecter à votre service.",
+  "pci_project_instance_ssh_key_help_availability": "Votre clé SSH sera disponible sur l'ensemble des régions et des data centers OVH.",
+  "pci_project_instance_ssh_key_infos": "Seules les clés SSH de type RSA ou ECDSA sont acceptées. Vous ne pouvez utiliser de clés SSH de type ED25519."
+}

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_fr_FR.json
@@ -9,5 +9,6 @@
   "pci_project_instance_ssh_key_add_error": "Une erreur est survenue lors de l'ajout de la clé SSH : {{message}}.",
 
   "pci_project_instance_ssh_key_help_required": "Les clés SSH sont obligatoires pour se connecter à votre service.",
-  "pci_project_instance_ssh_key_help_availability": "Votre clé SSH sera disponible sur l'ensemble des régions et des data centers OVH."
+  "pci_project_instance_ssh_key_help_availability": "Votre clé SSH sera disponible sur l'ensemble des régions et des data centers OVH.",
+  "pci_project_instance_ssh_key_infos": "Seules les clés SSH de type RSA ou ECDSA sont acceptées. Vous ne pouvez utiliser de clés SSH de type ED25519."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_it_IT.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "Chiave SSH",
- "pci_project_instance_ssh_pick": "Seleziona",
- "pci_project_instance_ssh_add": "Aggiungi una chiave",
- "pci_project_instance_ssh_cancel": "Annulla",
- "pci_project_instance_ssh_key_name": "Nome della chiave SSH",
- "pci_project_instance_ssh_key_query_error": "Si è verificato un errore durante il recupero delle tue chiavi SSH: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "Si è verificato un errore durante l’aggiunta della chiave SSH: {{message}}",
- "pci_project_instance_ssh_key_help_required": "Le chiavi SSH sono necessarie per accedere al tuo servizio.",
- "pci_project_instance_ssh_key_help_availability": "La tua chiave SSH sarà disponibile in tutte le Region e datacenter OVH."
+  "pci_project_instance_ssh_key": "Chiave SSH",
+  "pci_project_instance_ssh_pick": "Seleziona",
+  "pci_project_instance_ssh_add": "Aggiungi una chiave",
+  "pci_project_instance_ssh_cancel": "Annulla",
+  "pci_project_instance_ssh_key_name": "Nome della chiave SSH",
+  "pci_project_instance_ssh_key_query_error": "Si è verificato un errore durante il recupero delle tue chiavi SSH: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Si è verificato un errore durante l’aggiunta della chiave SSH: {{message}}",
+  "pci_project_instance_ssh_key_help_required": "Le chiavi SSH sono necessarie per accedere al tuo servizio.",
+  "pci_project_instance_ssh_key_help_availability": "La tua chiave SSH sarà disponibile in tutte le Region e datacenter OVH.",
+  "pci_project_instance_ssh_key_infos": "Sono accettate solo le chiavi SSH di tipo RSA e ECDSA Non è possibile utilizzare chiavi SSH di tipo ED25519."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_lt_LT.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "SSH key",
- "pci_project_instance_ssh_pick": "Select",
- "pci_project_instance_ssh_add": "Add a key",
- "pci_project_instance_ssh_cancel": "Cancel",
- "pci_project_instance_ssh_key_name": "SSH key name",
- "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
- "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
- "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres."
+  "pci_project_instance_ssh_key": "SSH key",
+  "pci_project_instance_ssh_pick": "Select",
+  "pci_project_instance_ssh_add": "Add a key",
+  "pci_project_instance_ssh_cancel": "Cancel",
+  "pci_project_instance_ssh_key_name": "SSH key name",
+  "pci_project_instance_ssh_key_query_error": "An error has occurred retrieving your SSH keys: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "An error has occurred adding the SSH key: {{message}}",
+  "pci_project_instance_ssh_key_help_required": "SSH keys are required to connect to your service.",
+  "pci_project_instance_ssh_key_help_availability": "Your SSH key will be available for all regions and OVH datacentres.",
+  "pci_project_instance_ssh_key_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_pl_PL.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "Klucz SSH",
- "pci_project_instance_ssh_pick": "Wybierz",
- "pci_project_instance_ssh_add": "Dodaj klucz",
- "pci_project_instance_ssh_cancel": "Anuluj",
- "pci_project_instance_ssh_key_name": "Nazwa klucza SSH",
- "pci_project_instance_ssh_key_query_error": "Wystąpił błąd podczas pobierania kluczy SSH: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "Wystąpił błąd podczas dodawania klucza SSH: {{message}}.",
- "pci_project_instance_ssh_key_help_required": "Klucze SSH są niezbędne, aby zalogować się do usługi Public Cloud.",
- "pci_project_instance_ssh_key_help_availability": "Twój klucz SSH będzie dostępny we wszystkich strefach geograficznych i centrach danych OVH."
+  "pci_project_instance_ssh_key": "Klucz SSH",
+  "pci_project_instance_ssh_pick": "Wybierz",
+  "pci_project_instance_ssh_add": "Dodaj klucz",
+  "pci_project_instance_ssh_cancel": "Anuluj",
+  "pci_project_instance_ssh_key_name": "Nazwa klucza SSH",
+  "pci_project_instance_ssh_key_query_error": "Wystąpił błąd podczas pobierania kluczy SSH: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Wystąpił błąd podczas dodawania klucza SSH: {{message}}.",
+  "pci_project_instance_ssh_key_help_required": "Klucze SSH są niezbędne, aby zalogować się do usługi Public Cloud.",
+  "pci_project_instance_ssh_key_help_availability": "Twój klucz SSH będzie dostępny we wszystkich strefach geograficznych i centrach danych OVH.",
+  "pci_project_instance_ssh_key_infos": "Akceptowane są tylko klucze SSH typu RSA lub ECDSA. Nie można używać kluczy SSH typu ED25519."
 }

--- a/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/components/project/instance/ssh-keys/translations/Messages_pt_PT.json
@@ -1,11 +1,12 @@
 {
- "pci_project_instance_ssh_key": "Chave SSH",
- "pci_project_instance_ssh_pick": "Selecionar",
- "pci_project_instance_ssh_add": "Adicionar uma chave",
- "pci_project_instance_ssh_cancel": "Anular",
- "pci_project_instance_ssh_key_name": "Nome da chave SSH",
- "pci_project_instance_ssh_key_query_error": "Ocorreu um erro ao recuperar as suas chaves SSH: {{message}}.",
- "pci_project_instance_ssh_key_add_error": "Ocorreu um erro ao adicionar a chave SSH: {{message}}.",
- "pci_project_instance_ssh_key_help_required": "As chaves SSH são obrigatórias para aceder ao seu serviço.",
- "pci_project_instance_ssh_key_help_availability": "A sua chave SSH estará disponível em todas as regiões e em todos os datacenters da OVH."
+  "pci_project_instance_ssh_key": "Chave SSH",
+  "pci_project_instance_ssh_pick": "Selecionar",
+  "pci_project_instance_ssh_add": "Adicionar uma chave",
+  "pci_project_instance_ssh_cancel": "Anular",
+  "pci_project_instance_ssh_key_name": "Nome da chave SSH",
+  "pci_project_instance_ssh_key_query_error": "Ocorreu um erro ao recuperar as suas chaves SSH: {{message}}.",
+  "pci_project_instance_ssh_key_add_error": "Ocorreu um erro ao adicionar a chave SSH: {{message}}.",
+  "pci_project_instance_ssh_key_help_required": "As chaves SSH são obrigatórias para aceder ao seu serviço.",
+  "pci_project_instance_ssh_key_help_availability": "A sua chave SSH estará disponível em todas as regiões e em todos os datacenters da OVH.",
+  "pci_project_instance_ssh_key_infos": "Só são aceites as chaves SSH de tipo RSA ou ECDSA. Não é possível utilizar chaves SSH de tipo ED25519."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/add.html
@@ -34,6 +34,10 @@
                 rows="5"
                 required
             ></oui-textarea>
+            <p
+                class="oui-field__helper"
+                data-translate="pci_projects_project_sshKeys_add_infos"
+            ></p>
         </oui-field>
     </oui-modal>
 </form>

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_de_DE.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "SSH-Schlüssel hinzufügen",
- "pci_projects_project_sshKeys_add_submit_label": "Hinzufügen",
- "pci_projects_project_sshKeys_add_cancel_label": "Abbrechen",
- "pci_projects_project_sshKeys_add_success": "Der SSH-Schlüssel wurde erfolgreich hinzugefügt",
- "pci_projects_project_sshKeys_add_error": "Beim Hinzufügen des SSH-Schlüssels ist ein Fehler aufgetreten: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Name",
- "pci_projects_project_sshKeys_add_key": "Schlüssel",
- "pci_projects_project_sshKeys_add_key_description": "Geben Sie Ihren Schlüssel mit 4096 Bytes an."
+  "pci_projects_project_sshKeys_add_title": "SSH-Schlüssel hinzufügen",
+  "pci_projects_project_sshKeys_add_submit_label": "Hinzufügen",
+  "pci_projects_project_sshKeys_add_cancel_label": "Abbrechen",
+  "pci_projects_project_sshKeys_add_success": "Der SSH-Schlüssel wurde erfolgreich hinzugefügt",
+  "pci_projects_project_sshKeys_add_error": "Beim Hinzufügen des SSH-Schlüssels ist ein Fehler aufgetreten: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Name",
+  "pci_projects_project_sshKeys_add_key": "Schlüssel",
+  "pci_projects_project_sshKeys_add_key_description": "Geben Sie Ihren Schlüssel mit 4096 Bytes an.",
+  "pci_projects_project_sshKeys_add_infos": "Nur SSH-Schlüssel vom Typ RSA oder ECDSA werden angenommen. Sie können keine SSH-Schlüssel vom Typ ED25519 verwenden."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_en_GB.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Add an SSH key",
- "pci_projects_project_sshKeys_add_submit_label": "Add",
- "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
- "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
- "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Name",
- "pci_projects_project_sshKeys_add_key": "Key",
- "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key"
+  "pci_projects_project_sshKeys_add_title": "Add an SSH key",
+  "pci_projects_project_sshKeys_add_submit_label": "Add",
+  "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
+  "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
+  "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Name",
+  "pci_projects_project_sshKeys_add_key": "Key",
+  "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key",
+  "pci_projects_project_sshKeys_add_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_es_ES.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Añadir una llave SSH",
- "pci_projects_project_sshKeys_add_submit_label": "Añadir",
- "pci_projects_project_sshKeys_add_cancel_label": "Cancelar",
- "pci_projects_project_sshKeys_add_success": "La clave SSH se ha añadido correctamente.",
- "pci_projects_project_sshKeys_add_error": "Se ha producido un error al añadir la llave SSH: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Nombre",
- "pci_projects_project_sshKeys_add_key": "Clave",
- "pci_projects_project_sshKeys_add_key_description": "Introduzca su llave de 4096 bytes."
+  "pci_projects_project_sshKeys_add_title": "Añadir una llave SSH",
+  "pci_projects_project_sshKeys_add_submit_label": "Añadir",
+  "pci_projects_project_sshKeys_add_cancel_label": "Cancelar",
+  "pci_projects_project_sshKeys_add_success": "La clave SSH se ha añadido correctamente.",
+  "pci_projects_project_sshKeys_add_error": "Se ha producido un error al añadir la llave SSH: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Nombre",
+  "pci_projects_project_sshKeys_add_key": "Clave",
+  "pci_projects_project_sshKeys_add_key_description": "Introduzca su llave de 4096 bytes.",
+  "pci_projects_project_sshKeys_add_infos": "Solo se aceptan llaves SSH de tipo RSA o ECDSA. No es posible utilizar llaves SSH de tipo ED25519."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fi_FI.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Add an SSH key",
- "pci_projects_project_sshKeys_add_submit_label": "Add",
- "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
- "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
- "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Name",
- "pci_projects_project_sshKeys_add_key": "Key",
- "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key"
+  "pci_projects_project_sshKeys_add_title": "Add an SSH key",
+  "pci_projects_project_sshKeys_add_submit_label": "Add",
+  "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
+  "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
+  "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Name",
+  "pci_projects_project_sshKeys_add_key": "Key",
+  "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key",
+  "pci_projects_project_sshKeys_add_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fr_CA.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_sshKeys_add_title": "Ajouter une clé SSH",
+  "pci_projects_project_sshKeys_add_submit_label": "Ajouter",
+  "pci_projects_project_sshKeys_add_cancel_label": "Annuler",
+  "pci_projects_project_sshKeys_add_success": "La clé SSH a été ajouté avec succès",
+  "pci_projects_project_sshKeys_add_error": "Une erreur est survenue lors de l'ajout de la clé SSH : {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Nom",
+  "pci_projects_project_sshKeys_add_key": "Clé",
+  "pci_projects_project_sshKeys_add_key_description": "Entrez votre clé de 4096 bytes",
+  "pci_projects_project_sshKeys_add_infos": "Seules les clés SSH de type RSA ou ECDSA sont acceptées. Vous ne pouvez utiliser de clés SSH de type ED25519."
+}

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_fr_FR.json
@@ -6,5 +6,6 @@
   "pci_projects_project_sshKeys_add_error": "Une erreur est survenue lors de l'ajout de la clé SSH : {{ error }}",
   "pci_projects_project_sshKeys_add_name": "Nom",
   "pci_projects_project_sshKeys_add_key": "Clé",
-  "pci_projects_project_sshKeys_add_key_description": "Entrez votre clé de 4096 bytes"
+  "pci_projects_project_sshKeys_add_key_description": "Entrez votre clé de 4096 bytes",
+  "pci_projects_project_sshKeys_add_infos": "Seules les clés SSH de type RSA ou ECDSA sont acceptées. Vous ne pouvez utiliser de clés SSH de type ED25519."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_it_IT.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Aggiungi una chiave SSH",
- "pci_projects_project_sshKeys_add_submit_label": "Aggiungi",
- "pci_projects_project_sshKeys_add_cancel_label": "Annulla",
- "pci_projects_project_sshKeys_add_success": "La chiave SSH è stata aggiunta correttamente",
- "pci_projects_project_sshKeys_add_error": "Si è verificato un errore durante l’aggiunta della chiave SSH: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Nome",
- "pci_projects_project_sshKeys_add_key": "Chiave",
- "pci_projects_project_sshKeys_add_key_description": "Inserisci la chiave da 4096 byte."
+  "pci_projects_project_sshKeys_add_title": "Aggiungi una chiave SSH",
+  "pci_projects_project_sshKeys_add_submit_label": "Aggiungi",
+  "pci_projects_project_sshKeys_add_cancel_label": "Annulla",
+  "pci_projects_project_sshKeys_add_success": "La chiave SSH è stata aggiunta correttamente",
+  "pci_projects_project_sshKeys_add_error": "Si è verificato un errore durante l’aggiunta della chiave SSH: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Nome",
+  "pci_projects_project_sshKeys_add_key": "Chiave",
+  "pci_projects_project_sshKeys_add_key_description": "Inserisci la chiave da 4096 byte.",
+  "pci_projects_project_sshKeys_add_infos": "Sono accettate solo le chiavi SSH di tipo RSA e ECDSA Non è possibile utilizzare chiavi SSH di tipo ED25519."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_lt_LT.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Add an SSH key",
- "pci_projects_project_sshKeys_add_submit_label": "Add",
- "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
- "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
- "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Name",
- "pci_projects_project_sshKeys_add_key": "Key",
- "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key"
+  "pci_projects_project_sshKeys_add_title": "Add an SSH key",
+  "pci_projects_project_sshKeys_add_submit_label": "Add",
+  "pci_projects_project_sshKeys_add_cancel_label": "Cancel",
+  "pci_projects_project_sshKeys_add_success": "The SSH key was added successfully.",
+  "pci_projects_project_sshKeys_add_error": "An error has occurred adding the SSH key: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Name",
+  "pci_projects_project_sshKeys_add_key": "Key",
+  "pci_projects_project_sshKeys_add_key_description": "Enter your 4096 byte key",
+  "pci_projects_project_sshKeys_add_infos": "Only RSA and ECDSA SSH keys are accepted. You cannot use ED25519 SSH keys."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_pl_PL.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Dodaj klucz SSH",
- "pci_projects_project_sshKeys_add_submit_label": "Dodaj",
- "pci_projects_project_sshKeys_add_cancel_label": "Anuluj",
- "pci_projects_project_sshKeys_add_success": "Klucz SSH został poprawnie dodany.",
- "pci_projects_project_sshKeys_add_error": "Wystąpił błąd podczas dodawania klucza SSH: {{ error }}.",
- "pci_projects_project_sshKeys_add_name": "Nazwa",
- "pci_projects_project_sshKeys_add_key": "Klucz",
- "pci_projects_project_sshKeys_add_key_description": "Wpisz klucz o rozmiarze 4096 bajtów."
+  "pci_projects_project_sshKeys_add_title": "Dodaj klucz SSH",
+  "pci_projects_project_sshKeys_add_submit_label": "Dodaj",
+  "pci_projects_project_sshKeys_add_cancel_label": "Anuluj",
+  "pci_projects_project_sshKeys_add_success": "Klucz SSH został poprawnie dodany.",
+  "pci_projects_project_sshKeys_add_error": "Wystąpił błąd podczas dodawania klucza SSH: {{ error }}.",
+  "pci_projects_project_sshKeys_add_name": "Nazwa",
+  "pci_projects_project_sshKeys_add_key": "Klucz",
+  "pci_projects_project_sshKeys_add_key_description": "Wpisz klucz o rozmiarze 4096 bajtów.",
+  "pci_projects_project_sshKeys_add_infos": "Akceptowane są tylko klucze SSH typu RSA lub ECDSA. Nie można używać kluczy SSH typu ED25519."
 }

--- a/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/ssh-keys/add/translations/Messages_pt_PT.json
@@ -1,10 +1,11 @@
 {
- "pci_projects_project_sshKeys_add_title": "Adicionar chave SSH",
- "pci_projects_project_sshKeys_add_submit_label": "Adicionar",
- "pci_projects_project_sshKeys_add_cancel_label": "Anular",
- "pci_projects_project_sshKeys_add_success": "A chave SSH foi adicionada com sucesso.",
- "pci_projects_project_sshKeys_add_error": "Ocorreu um erro ao adicionar a chave SSH: {{ error }}",
- "pci_projects_project_sshKeys_add_name": "Nome",
- "pci_projects_project_sshKeys_add_key": "Chave",
- "pci_projects_project_sshKeys_add_key_description": "Introduza a sua chave de 4096 bytes"
+  "pci_projects_project_sshKeys_add_title": "Adicionar chave SSH",
+  "pci_projects_project_sshKeys_add_submit_label": "Adicionar",
+  "pci_projects_project_sshKeys_add_cancel_label": "Anular",
+  "pci_projects_project_sshKeys_add_success": "A chave SSH foi adicionada com sucesso.",
+  "pci_projects_project_sshKeys_add_error": "Ocorreu um erro ao adicionar a chave SSH: {{ error }}",
+  "pci_projects_project_sshKeys_add_name": "Nome",
+  "pci_projects_project_sshKeys_add_key": "Chave",
+  "pci_projects_project_sshKeys_add_key_description": "Introduza a sua chave de 4096 bytes",
+  "pci_projects_project_sshKeys_add_infos": "Só são aceites as chaves SSH de tipo RSA ou ECDSA. Não é possível utilizar chaves SSH de tipo ED25519."
 }


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-10682
| License          | BSD 3-Clause

## Description

add info message to display the list of supported ssh keys format

### TODO

- [x] TRANS-24592