### PR TITLE
fix(scripts.start): use the right package name for the hub

### DIFF
--- a/scripts/start/index.js
+++ b/scripts/start/index.js
@@ -2,7 +2,7 @@ import execa from 'execa';
 import inquirer from 'inquirer';
 
 const applications = new Set([
-  '@ovh-ux/manager-hub',
+  '@ovh-ux/manager-hub-app',
   '@ovh-ux/manager-dedicated',
   '@ovh-ux/manager-cloud',
   '@ovh-ux/manager-public-cloud',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 🐛 Bug Fix

b0cc325 - fix(scripts.start): use the right package name for the hub

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

