### PR TITLE
fix(public-cloud): onboarding redirect

### DIFF
--- a/packages/manager/apps/public-cloud/src/index.routes.js
+++ b/packages/manager/apps/public-cloud/src/index.routes.js
@@ -8,8 +8,9 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
         .injector()
         .get('publicCloud')
         .getDefaultProject()
-        .then((projectId) =>
-          projectId
+        .then((projectId) => {
+          const $window = trans.injector().get('$window');
+          return projectId
             ? {
                 state: 'pci.projects.project',
                 params: {
@@ -17,11 +18,12 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
                 },
               }
             : {
-                state: trans.params().onboarding
-                  ? 'pci.projects.onboarding'
-                  : 'pci.projects.new',
-              },
-        ),
+                state:
+                  $window.location.search.search('onboarding') !== -1
+                    ? 'pci.projects.onboarding'
+                    : 'pci.projects.new',
+              };
+        }),
     resolve: {
       rootState: () => 'app',
     },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-10648
| License          | BSD 3-Clause

## Description

When visiting public cloud manager from any other managers (like web, dedicated etc), the user should be redirected to the onboarding page, when he does not have any project. But this is not happening. A search parameter `onboarding` is already being passed, but this parameter was not being considered properly. This has been handled
