### PR TITLE
fix(notifications-menu): force to display block

### DIFF
--- a/packages/manager/modules/navbar/src/notifications-menu/template.html
+++ b/packages/manager/modules/navbar/src/notifications-menu/template.html
@@ -18,7 +18,7 @@
             oui-navbar-menu_end
             oui-navbar-menu_panel"
     >
-        <ul class="oui-navbar-menu__body oui-navbar-list">
+        <ul class="oui-navbar-menu__body oui-navbar-list d-block overflow-auto">
             <li
                 class="oui-navbar-menu__item oui-navbar-notification"
                 data-ng-repeat="(time, sublinks) in ::$ctrl.groupedSublinks"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-4919
| License          | BSD 3-Clause

## Description

Temporary workaround due to some display: flex causing issue on Safari brower

Currently investigating with @AxelPeter 