### PR TITLE
 fix(pci.projects.data-processing): fixed spark sizing not working on…

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.controller.js
@@ -45,6 +45,7 @@ export default class {
     if (this.templates) {
       this.driverTemplates = this.templates;
       this.workerTemplates = this.templates;
+      this.updateStateFromTemplate();
     }
   }
 


### PR DESCRIPTION
 fix(pci.projects.data-processing): fixed spark sizing not working on page launch

 Signed-off-by: Yann Pauly <yann.pauly@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `feature/MANAGER-4584`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | None
| License          | BSD 3-Clause

## Description

This PR fixes a bug occurring when submitting a new data processing job with the simplified sizing selection, without changing the values of the combo boxes.
