### PR TITLE
feat(vps): add APAC plan codes for upgrade

### DIFF
--- a/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
+++ b/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
@@ -87,12 +87,23 @@ export default class VpsUpgradeCtrl {
       modelVersion,
       versionInfos.year < 2018 ? '2018v3' : '2018v4',
     );
-    const mappedType = get(OFFER_AGORA_MAPPING, modelType, modelType == 'ssd' && (modelVersion == "2017v1" || modelVersion == "2018v2") ? 'ssd-discovery' : modelType);
+    const mappedType = VpsUpgradeCtrl.getBillingModelType(modelType, modelVersion);
     const offerPlanCode = `vps_${mappedType}_${modelName}_${destVersion}`;
 
     return find(availableOffers, {
       planCode: offerPlanCode,
     });
+  }
+
+  /**
+   * Get the billing model type of the VPS
+   */
+  static getBillingModelType(modelType, modelVersion) {
+    if (modelType == 'ssd' && (modelVersion == '2017v1' || modelVersion == '2018v2')) {
+      return 'ssd-discovery';
+    }
+
+    return get(OFFER_AGORA_MAPPING, modelType, modelType);
   }
 
   /**

--- a/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
+++ b/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
@@ -87,7 +87,7 @@ export default class VpsUpgradeCtrl {
       modelVersion,
       versionInfos.year < 2018 ? '2018v3' : '2018v4',
     );
-    const mappedType = get(OFFER_AGORA_MAPPING, modelType, modelType);
+    const mappedType = get(OFFER_AGORA_MAPPING, modelType, modelType == 'ssd' && (modelVersion == "2017v1" || modelVersion == "2018v2") ? 'ssd-discovery' : modelType);
     const offerPlanCode = `vps_${mappedType}_${modelName}_${destVersion}`;
 
     return find(availableOffers, {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-4961
| License          | BSD 3-Clause

## Description

Ensure APAC plan codes will be used during upgrade.
Needed before migrating all APAC models.
