### PR TITLE
DTRSD fix(telephony): allow contact edition for foreign numbers

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/telecom-telephony-service-contact.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/telecom-telephony-service-contact.html
@@ -947,58 +947,59 @@
                             data-ng-bind=":: ServiceContactCtrl.getStatusLabel()"
                         ></p>
                     </div>
+                </div>
+                <!-- End of UNIVERSAL DIRECTORY -->
 
-                    <div class="form-group mt-4">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <hr />
-                                <tuc-telephony-bulk-action
-                                    data-service-type="all"
-                                    data-billing-account="{{ ServiceContactCtrl.bulkDatas.billingAccount }}"
-                                    data-service-name="{{ ServiceContactCtrl.bulkDatas.serviceName }}"
-                                    data-custom-class="link d-block pl-0 mb-3"
-                                    data-ng-disabled="!ServiceContactCtrl.isEditing || ServiceContactCtrl.isLoading ||  contactForm.$invalid"
-                                    data-bulk-infos="ServiceContactCtrl.bulkDatas.infos"
-                                    data-get-bulk-params="ServiceContactCtrl.getBulkParams"
-                                    data-on-success="ServiceContactCtrl.onBulkSuccess"
-                                    data-on-error="ServiceContactCtrl.onBulkError"
+                <!-- EDITING ACTIONS -->
+                <div class="form-group mt-4">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <hr />
+                            <tuc-telephony-bulk-action
+                                data-service-type="all"
+                                data-billing-account="{{ ServiceContactCtrl.bulkDatas.billingAccount }}"
+                                data-service-name="{{ ServiceContactCtrl.bulkDatas.serviceName }}"
+                                data-custom-class="link d-block pl-0 mb-3"
+                                data-ng-disabled="!ServiceContactCtrl.isEditing || ServiceContactCtrl.isLoading ||  contactForm.$invalid"
+                                data-bulk-infos="ServiceContactCtrl.bulkDatas.infos"
+                                data-get-bulk-params="ServiceContactCtrl.getBulkParams"
+                                data-on-success="ServiceContactCtrl.onBulkSuccess"
+                                data-on-error="ServiceContactCtrl.onBulkError"
+                            >
+                            </tuc-telephony-bulk-action>
+                            <button
+                                type="button"
+                                class="btn btn-default"
+                                data-ng-if="!ServiceContactCtrl.isEditing"
+                                data-translate="telephony_service_contact_edit"
+                                data-ng-click="ServiceContactCtrl.isEditing = true"
+                            ></button>
+                            <button
+                                type="submit"
+                                class="btn btn-primary"
+                                data-ng-if="ServiceContactCtrl.isEditing"
+                                data-ng-disabled="!ServiceContactCtrl.isEditing || ServiceContactCtrl.isUpdating || contactForm.$invalid"
+                            >
+                                <oui-spinner
+                                    class="mr-2"
+                                    data-ng-if="ServiceContactCtrl.isUpdating"
+                                    data-size="s"
                                 >
-                                </tuc-telephony-bulk-action>
-                                <button
-                                    type="button"
-                                    class="btn btn-default"
-                                    data-ng-if="!ServiceContactCtrl.isEditing"
-                                    data-translate="telephony_service_contact_edit"
-                                    data-ng-click="ServiceContactCtrl.isEditing = true"
-                                ></button>
-                                <button
-                                    type="submit"
-                                    class="btn btn-primary"
-                                    data-ng-if="ServiceContactCtrl.isEditing"
-                                    data-ng-disabled="!ServiceContactCtrl.isEditing || ServiceContactCtrl.isUpdating || contactForm.$invalid"
-                                >
-                                    <oui-spinner
-                                        class="mr-2"
-                                        data-ng-if="ServiceContactCtrl.isUpdating"
-                                        data-size="s"
-                                    >
-                                    </oui-spinner>
-                                    <span
-                                        data-translate="telephony_service_contact_apply"
-                                    ></span>
-                                </button>
-                                <button
-                                    type="button"
-                                    class="btn btn-link"
-                                    data-ng-if="ServiceContactCtrl.isEditing"
-                                    data-translate="cancel"
-                                    data-ng-click="ServiceContactCtrl.cancelEdition()"
-                                ></button>
-                            </div>
+                                </oui-spinner>
+                                <span
+                                    data-translate="telephony_service_contact_apply"
+                                ></span>
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-link"
+                                data-ng-if="ServiceContactCtrl.isEditing"
+                                data-translate="cancel"
+                                data-ng-click="ServiceContactCtrl.cancelEdition()"
+                            ></button>
                         </div>
                     </div>
                 </div>
-                <!-- End of UNIVERSAL DIRECTORY -->
                 <!-- /.widget-presentation -->
             </form>
         </div>


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-10414
| License          | BSD 3-Clause

## Description

For foreign numbers it's currently not possible to edit contact informations in the manager.
I moved the editing action part outside of the directory section so every customer is able to edit his contact informations.

For foreign customers it will still not be possible to edit directory infos (pages jaunes etc) as i'm not sure it's supported for every foreign country.
