### PR TITLE
build(deps): upgrade ovh-ui-angular to v3.16.0

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -57,7 +57,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "punycode": "^1.4.1",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -113,7 +113,7 @@
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.1.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "~2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "popper.js": "^1.16.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -126,7 +126,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "punycode": "^1.4.1",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -44,7 +44,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "zxcvbn": "^4.4.2"
   },

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -53,7 +53,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -59,7 +59,7 @@
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "whatwg-fetch": "^3.0.0"
   },

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -56,7 +56,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.19",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -52,7 +52,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -35,7 +35,7 @@
     "angular-ui-bootstrap": "^1.3.3",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -54,7 +54,7 @@
     "ovh-api-services": "^9.42.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -76,7 +76,7 @@
     "ovh-api-services": "^9.42.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "tweetnacl-util": "^0.15.0",

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -34,7 +34,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.15",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -45,7 +45,7 @@
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -127,7 +127,7 @@
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "popper.js": "^1.16.0",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -48,7 +48,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -48,7 +48,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -56,7 +56,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.19",
     "ovh-api-services": "^9.42.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1",
     "ovh-ui-kit-bs": "^2.3.1"
   },

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -48,7 +48,7 @@
     "messenger": "HubSpot/messenger#~1.4.1",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "^2.41.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -109,7 +109,7 @@
     "office-ui-fabric-core": "^11.0.0",
     "ovh-api-services": "^9.42.0",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-ui-angular": "^3.15.1",
+    "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "2.41.1",
     "ovh-ui-kit-bs": "^2.3.1",
     "properties": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12725,10 +12725,10 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
-ovh-ui-angular@^3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.15.1.tgz#b766938452630b06a3d59fbe9c5b94d6f7e05af2"
-  integrity sha512-EcfYUP5dZFSNX5Tqy0Bd1zaqyEVBnypMTGs6O/qoqemmhYEP6nXJLvheiqxXagt/wka/jyyJDzqMCQmo4EXUBQ==
+ovh-ui-angular@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/ovh-ui-angular/-/ovh-ui-angular-3.16.0.tgz#4fbbb623451e2014e17b0898b663712e3faa3ffc"
+  integrity sha512-qLCH6wEBx5sKzuTeo6i6ilyQHqDcsUbY/DfI5h4aQeHlKfyssVlAgDRx8c+xWBilGCayGaw8UuEIk9TUNO/KMA==
   dependencies:
     bloodhound-js "^1.2.3"
     clipboard "^2.0.1"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ⬆️ Upgrade

743b0cc - build(deps): upgrade ovh-ui-angular to v3.16.0

uses: `$ yarn upgrade-interactive --latest ovh-ui-angular`
- ovh-ui-angular@3.16.0

### 🔗 Related

https://github.com/ovh-ux/ovh-ui-angular/blob/master/CHANGELOG.md#3160-2020-04-07

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>