### PR TITLE
fix: load renew module

### DIFF
--- a/packages/manager/modules/exchange/src/exchange.module.js
+++ b/packages/manager/modules/exchange/src/exchange.module.js
@@ -1,7 +1,6 @@
 import angular from 'angular';
 import ovhManagerCore from '@ovh-ux/manager-core';
 
-import accountRenew from './billing/account-renew/renew.module';
 import ExchangeAccountMfaCreate from './account/mfa/create';
 import ExchangeAccountMfaDelete from './account/mfa/delete';
 
@@ -29,7 +28,6 @@ angular
     'ui.bootstrap',
     'ngSanitize',
     'ng.ckeditor',
-    accountRenew,
     components,
     controllers,
     directives,

--- a/packages/manager/modules/exchange/src/index.js
+++ b/packages/manager/modules/exchange/src/index.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
+import billingAccountRenew from './billing/account-renew/renew.module';
+
 import APIExchange from './exchange.api';
 import Exchange from './exchange.service';
 import ExchangePassword from './exchange.password.service';
@@ -9,7 +11,7 @@ import ExchangePassword from './exchange.password.service';
 const moduleName = 'ovhManagerExchangeLazyLoading';
 
 angular
-  .module(moduleName, ['ui.router', 'oc.lazyLoad'])
+  .module(moduleName, [billingAccountRenew, 'ui.router', 'oc.lazyLoad'])
   .config(
     /* @ngInject */ ($stateProvider) => {
       $stateProvider.state('app.exchange.**', {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-10996
| License          | BSD 3-Clause

## Description

This module exposes component to handle renew that is used elsewhere. Adding lazyloading prevent the component from being loaded without loading exchange module first