### PR TITLE
feat(emailpro): disable redirections for CA region

### DIFF
--- a/packages/manager/modules/emailpro/src/emailpro-tabs-controller.js
+++ b/packages/manager/modules/emailpro/src/emailpro-tabs-controller.js
@@ -19,7 +19,9 @@ export default /* @ngInject */ (
     Environment.getRegion() === 'EU' && $scope.exchange.isMXPlan
       ? 'MAILING_LIST'
       : null,
-    $scope.exchange.isMXPlan ? 'REDIRECTION' : null,
+    Environment.getRegion() === 'EU' && $scope.exchange.isMXPlan
+      ? 'REDIRECTION'
+      : null,
     'EXTERNAL_CONTACT',
   ].filter((tab) => !isNull(tab));
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca-mxplan-mailing-list`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-4915
| License          | BSD 3-Clause

## Description

Remove `Redirections` tab for MXPlan in `CA` region.
