### PR TITLE
build(web): add ng app injections for CA region

### DIFF
--- a/packages/manager/apps/web/webpack.config.js
+++ b/packages/manager/apps/web/webpack.config.js
@@ -97,7 +97,7 @@ module.exports = (env = {}) => {
         /cs|de|en-gb|es|es-us|fi|fr-ca|fr|it|lt|pl|pt/,
       ),
       new webpack.DefinePlugin({
-        __NG_APP_INJECTIONS__: getNgAppInjections(['EU']),
+        __NG_APP_INJECTIONS__: getNgAppInjections(['EU', 'CA']),
       }),
     ],
   });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Add `CA` support in ng app injections.