### PR TITLE
feat(web-mxplan): hide dashboard options for canada

### DIFF
--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -18,6 +18,7 @@
   },
   "peerDependencies": {
     "@ovh-ux/manager-config": "^0.4.0",
+    "@ovh-ux/manager-core": "^8.0.0 || ^9.0.0",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.0",

--- a/packages/manager/modules/emailpro/src/emailpro.constants.js
+++ b/packages/manager/modules/emailpro/src/emailpro.constants.js
@@ -125,6 +125,16 @@ export const EMAILPRO_CONFIG = {
       },
     },
   },
+  API_ROUTES: {
+    CA: {},
+    EU: {
+      TASKS_REDIRECTION: '/email/domain/{domain}/task/redirection',
+      TASKS_MAILING_LIST: '/email/domain/{domain}/task/mailinglist',
+      TASK_MAILING_LIST: '/email/domain/{domain}/task/mailinglist/{id}',
+      TASK_REDIRECTION: '/email/domain/{domain}/task/redirection/{id}',
+    },
+    US: {},
+  },
 };
 
 export default {

--- a/packages/manager/modules/emailpro/src/emailpro.controller.js
+++ b/packages/manager/modules/emailpro/src/emailpro.controller.js
@@ -16,10 +16,12 @@ export default /* @ngInject */ function EmailProCtrl(
   getTabLink,
   User,
   EMAILPRO_CONFIG,
+  coreConfig,
 ) {
   this.getTabLink = getTabLink;
   let initialLoad = true;
 
+  $scope.currentRegionCA = coreConfig.isRegion('CA');
   $scope.accountTypeDedicated = EmailPro.accountTypeDedicated;
   $scope.accountTypeHosted = EmailPro.accountTypeHosted;
   $scope.accountTypeProvider = EmailPro.accountTypeProvider;
@@ -27,7 +29,6 @@ export default /* @ngInject */ function EmailProCtrl(
   $scope.alerts = {
     main: 'emailproDashboardAlert',
   };
-
   $scope.loadingEmailProInformations = true;
   $scope.loadingEmailProError = false;
   $scope.message = null;

--- a/packages/manager/modules/emailpro/src/emailpro.html
+++ b/packages/manager/modules/emailpro/src/emailpro.html
@@ -81,6 +81,7 @@
                 ></h2>
             </div>
             <oui-action-menu
+                data-ng-if="!currentRegionCA"
                 data-align="end"
                 data-text="{{:: 'common_actions' | translate }}"
             >

--- a/packages/manager/modules/emailpro/src/emailproServices.module.js
+++ b/packages/manager/modules/emailpro/src/emailproServices.module.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import ovhManagerCore from '@ovh-ux/manager-core';
 
 import emailproService from './emailpro.service';
 import ApiEmailPro from './api/emailpro-api.service';
@@ -10,7 +11,7 @@ import EmailproMxPlanMailingLists from './mailing-list/emailpro-mailing-list.ser
 const moduleName = 'Module.emailpro.services';
 
 angular
-  .module(moduleName, [])
+  .module(moduleName, [ovhManagerCore])
   .service('EmailPro', emailproService)
   .service('APIEmailPro', ApiEmailPro)
   .service('EmailProDomains', EmailProDomains)

--- a/packages/manager/modules/emailpro/src/information/emailpro-information-tab.js
+++ b/packages/manager/modules/emailpro/src/information/emailpro-information-tab.js
@@ -37,11 +37,19 @@ export default class EmailProTabInformationCtrl {
 
     if (this.$scope.exchange.isMXPlan) {
       this.$q.all({
-        quotas: this.getQuotas(),
+        quotas: this.$scope.currentRegionCA
+          ? this.$q.when({})
+          : this.getQuotas(),
         accounts: this.getAccountsConfigured(),
-        emailsDomain: this.getEmailsDomain(),
-        mailingLists: this.getMailingLists(),
-        redirections: this.getRedirections(),
+        emailsDomain: this.$scope.currentRegionCA
+          ? this.$q.when({})
+          : this.getEmailsDomain(),
+        mailingLists: this.$scope.currentRegionCA
+          ? this.$q.when({})
+          : this.getMailingLists(),
+        redirections: this.$scope.currentRegionCA
+          ? this.$q.when({})
+          : this.getRedirections(),
       });
 
       this.upgradeLink = this.$state.href('app.email.mxplan.upgrade', {

--- a/packages/manager/modules/emailpro/src/information/emailpro-information.html
+++ b/packages/manager/modules/emailpro/src/information/emailpro-information.html
@@ -27,7 +27,7 @@
                                     </div>
                                 </li>
                                 <li
-                                    data-ng-if="exchange.serverDiagnostic.version === 15"
+                                    data-ng-if="exchange.serverDiagnostic.version === 15 && !currentRegionCA"
                                     class="oui-tile__item"
                                 >
                                     <div class="oui-tile__definition">
@@ -105,7 +105,7 @@
                                 </li>
                                 <li
                                     class="oui-tile__item"
-                                    data-ng-if="exchange.isMXPlan"
+                                    data-ng-if="exchange.isMXPlan && !currentRegionCA"
                                 >
                                     <div class="oui-tile__definition">
                                         <strong
@@ -133,7 +133,7 @@
                                 </li>
                                 <li
                                     class="oui-tile__item"
-                                    data-ng-if="exchange.isMXPlan"
+                                    data-ng-if="exchange.isMXPlan && !currentRegionCA"
                                 >
                                     <div class="oui-tile__definition">
                                         <strong
@@ -189,7 +189,7 @@
                                                 data-ng-bind="exchange.accountsNumber"
                                             ></span>
                                             <oui-action-menu
-                                                data-ng-if="exchange.isMXPlan && exchange.accountsNumber <= 100"
+                                                data-ng-if="exchange.isMXPlan && exchange.accountsNumber <= 100 && !currentRegionCA"
                                                 data-compact
                                                 data-align="end"
                                             >
@@ -206,7 +206,7 @@
                                 </li>
                                 <li
                                     class="oui-tile__item"
-                                    data-ng-if="exchange.isMXPlan"
+                                    data-ng-if="exchange.isMXPlan && !currentRegionCA"
                                 >
                                     <div class="oui-tile__definition">
                                         <strong
@@ -221,7 +221,7 @@
 
                                 <li
                                     class="oui-tile__item"
-                                    data-ng-if="exchange.isMXPlan"
+                                    data-ng-if="exchange.isMXPlan && !currentRegionCA"
                                 >
                                     <div class="oui-tile__definition">
                                         <strong


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-4916
| License          | BSD 3-Clause

## Description

hide options that are not required for canada region

Signed-off-by: varun257 <varun257@gmail.com>