### PR TITLE
refactor: lint some stylesheets files

### DIFF
--- a/packages/components/ng-ovh-toaster/src/messenger-theme-air.css
+++ b/packages/components/ng-ovh-toaster/src/messenger-theme-air.css
@@ -219,7 +219,7 @@ ul.messenger-theme-air {
   -webkit-user-select: none;
   -o-user-select: none;
   user-select: none;
-  font-family: "Raleway", sans-serif;
+  font-family: 'Raleway', sans-serif;
 }
 
 ul.messenger-theme-air .messenger-message {
@@ -232,9 +232,21 @@ ul.messenger-theme-air .messenger-message {
   -ms-border-radius: 5px;
   -o-border-radius: 5px;
   border-radius: 5px;
-  -webkit-box-shadow: inset 0 0 0 1px white, inset 0 2px white, 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.2);
-  -moz-box-shadow: inset 0 0 0 1px white, inset 0 2px white, 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.2);
-  box-shadow: inset 0 0 0 1px white, inset 0 2px white, 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow:
+    inset 0 0 0 1px white,
+    inset 0 2px white,
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    0 1px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow:
+    inset 0 0 0 1px white,
+    inset 0 2px white,
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    0 1px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    inset 0 0 0 1px white,
+    inset 0 2px white,
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    0 1px rgba(0, 0, 0, 0.2);
   border: 0;
   background-color: rgba(255, 255, 255, 0.8);
   position: relative;
@@ -280,9 +292,15 @@ ul.messenger-theme-air .messenger-message .messenger-actions {
 }
 
 ul.messenger-theme-air .messenger-message .messenger-actions a {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   -ms-border-radius: 4px;
@@ -297,15 +315,25 @@ ul.messenger-theme-air .messenger-message .messenger-actions a {
 }
 
 ul.messenger-theme-air .messenger-message .messenger-actions a:hover {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15);
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15);
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15);
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15);
   color: #444;
 }
 
 ul.messenger-theme-air .messenger-message .messenger-actions a:active {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18), inset 0 1px rgba(0, 0, 0, 0.05);
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18), inset 0 1px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.18),
+    inset 0 1px rgba(0, 0, 0, 0.05);
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.18),
+    inset 0 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18), inset 0 1px rgba(0, 0, 0, 0.05);
   background: rgba(0, 0, 0, 0.04);
   color: #444;
@@ -327,7 +355,7 @@ ul.messenger-theme-air .messenger-message .messenger-message-inner::before {
   position: absolute;
   left: 17px;
   display: block;
-  content: " ";
+  content: ' ';
   top: 50%;
   margin-top: -8px;
   height: 13px;
@@ -356,7 +384,7 @@ ul.messenger-theme-air .messenger-message.alert-error.messenger-retry-soon .mess
 }
 
 ul.messenger-theme-air .messenger-message.alert-error.messenger-retry-soon .messenger-spinner::after {
-  content: "";
+  content: '';
   background: white;
   position: absolute;
   width: 19px;
@@ -384,7 +412,7 @@ ul.messenger-theme-air .messenger-message.alert-error.messenger-retry-later .mes
 }
 
 ul.messenger-theme-air .messenger-message.alert-error.messenger-retry-later .messenger-spinner::after {
-  content: "";
+  content: '';
   background: white;
   position: absolute;
   width: 19px;

--- a/packages/components/ng-ovh-toaster/src/messenger-theme-ice.css
+++ b/packages/components/ng-ovh-toaster/src/messenger-theme-ice.css
@@ -3,7 +3,7 @@ ul.messenger-theme-ice {
   -webkit-user-select: none;
   -o-user-select: none;
   user-select: none;
-  font-family: "Raleway", sans-serif;
+  font-family: 'Raleway', sans-serif;
 }
 
 ul.messenger-theme-ice .messenger-message {
@@ -12,9 +12,18 @@ ul.messenger-theme-ice .messenger-message {
   -ms-border-radius: 5px;
   -o-border-radius: 5px;
   border-radius: 5px;
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.14), 0 4px #aaa, 0 5px rgba(0, 0, 0, 0.05);
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.14), 0 4px #aaa, 0 5px rgba(0, 0, 0, 0.05);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.14), 0 4px #aaa, 0 5px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.14),
+    0 4px #aaa,
+    0 5px rgba(0, 0, 0, 0.05);
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.14),
+    0 4px #aaa,
+    0 5px rgba(0, 0, 0, 0.05);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.14),
+    0 4px #aaa,
+    0 5px rgba(0, 0, 0, 0.05);
   border: 0;
   background-color: #f6f6f6;
   position: relative;
@@ -56,9 +65,15 @@ ul.messenger-theme-ice .messenger-message .messenger-actions {
 }
 
 ul.messenger-theme-ice .messenger-message .messenger-actions a {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.05);
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.05);
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   -ms-border-radius: 4px;
@@ -75,16 +90,34 @@ ul.messenger-theme-ice .messenger-message .messenger-actions a {
 
 ul.messenger-theme-ice .messenger-message .messenger-actions a:hover,
 ul.messenger-theme-ice .messenger-message .messenger-actions a:active {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 2px #aaa;
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 2px #aaa;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 2px #aaa;
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 2px #aaa;
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 2px #aaa;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 2px #aaa;
   color: #444;
 }
 
 ul.messenger-theme-ice .messenger-message .messenger-actions a:active {
-  -webkit-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 1px #aaa;
-  -moz-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 1px #aaa;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 1px rgba(255, 255, 255, 0.15), 0 1px #aaa;
+  -webkit-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 1px #aaa;
+  -moz-box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 1px #aaa;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.15),
+    0 1px #aaa;
   top: 1px;
 }
 
@@ -100,13 +133,13 @@ ul.messenger-theme-ice .messenger-message .messenger-message-inner::before {
 }
 
 ul.messenger-theme-ice .messenger-message.alert-success .messenger-message-inner::before {
-  content: "Success";
+  content: 'Success';
 }
 
 ul.messenger-theme-ice .messenger-message.alert-error .messenger-message-inner::before {
-  content: "Error";
+  content: 'Error';
 }
 
 ul.messenger-theme-ice .messenger-message.alert-info .messenger-message-inner::before {
-  content: "Information";
+  content: 'Information';
 }

--- a/packages/manager/apps/hub/src/index.scss
+++ b/packages/manager/apps/hub/src/index.scss
@@ -11,9 +11,7 @@
   .minw-0 {
     min-width: 0;
   }
-}
 
-.hub-main-view {
   &_container {
     max-width: 80rem; // 1280px with 16px font size
     margin: auto;

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.scss
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.scss
@@ -23,12 +23,12 @@ $logger-text-color: #5a6a7d;
   overflow-wrap: break-word;
   white-space: pre-wrap;
   letter-spacing: 0.14px;
-  font-family: "Roboto Mono Regular", monospace;
+  font-family: 'Roboto Mono Regular', monospace;
   font-size: 0.85rem;
 }
 
 .logger__cursor {
-  content: "";
+  content: '';
   display: inline-block;
   background-color: #ccc;
   vertical-align: top;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ♻️ Refactor

d804b48 - refactor: lint some stylesheets files

uses: `$ yarn run lint:css`

**Relates to**:
```sh
$ stylelint "packages/**/*.{css,less,scss}" --fix

packages/manager/apps/hub/src/index.scss
 16:1  ✖  Unexpected duplicate selector ".hub-main-view", first used at line 7   no-duplicate-selectors
```

### 🏠 Internal

No quality check required

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
