### PR TITLE
feat(vps): new VPS renew

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
@@ -281,6 +281,7 @@ export default class {
   }
 
   initActions() {
+    const isEuRegion = this.coreConfig.isRegion('EU');
     return this.CucControllerHelper.navigation
       .getConstant(get(CHANGE_OWNER_URL, this.coreConfig.getRegion(), {}))
       .then((changeOwnerHref) => {
@@ -313,8 +314,9 @@ export default class {
             ),
             isAvailable: () =>
               !this.loaders.plan &&
-              this.hasFeature(DASHBOARD_FEATURES.autorenew),
-            external: !this.coreConfig.isRegion('EU'),
+              this.hasFeature(DASHBOARD_FEATURES.autorenew) &&
+              !(this.plan.renew.automatic && this.plan.renew.forced),
+            external: !isEuRegion,
           },
           manageContact: {
             text: this.$translate.instant('vps_common_manage'),
@@ -322,7 +324,7 @@ export default class {
               get(CONTACTS_URL, this.coreConfig.getRegion()),
               { serviceName: this.serviceName },
             ),
-            isAvailable: this.coreConfig.isRegion('EU'),
+            isAvailable: isEuRegion,
           },
           manageIps: {
             text: this.$translate.instant(


### PR DESCRIPTION
New VPS comes with forced autorenew so it can not be manually renewed. Hide order link to manual renew.

Closes #DTRSD-11568

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-11568
| License          | BSD 3-Clause

## Description

New VPS comes with forced auto renew, so it can not be manually renewed. Hide order link to manual renew if force flag is true.
