### PR TITLE
fix(domain): add missing constants

### DIFF
--- a/packages/manager/apps/web/client/app/config/constants.config.js
+++ b/packages/manager/apps/web/client/app/config/constants.config.js
@@ -1166,6 +1166,9 @@ module.exports = {
       TELECOM: 'TELECOM',
       SUNRISE: 'SUNRISE',
     },
+    DOMAIN: {
+      domainUnlockRegistry: {},
+    },
     HOSTING: {
       OFFERS: {
         START_10_M: {
@@ -1307,6 +1310,9 @@ module.exports = {
         SN: 'https://www.ovh.sn/order/express/',
         TN: 'https://www.ovh.com/tn/order/express/',
         WE: 'https://www.ovh.com/us/order/express/',
+      },
+      TOOLS: {
+        ZONE_CHECK: 'https://www.zonemaster.net/',
       },
     },
     COMODO: {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5007, MANAGER-5008
| License          | BSD 3-Clause

## Description

Restore access to domain dashboard and domain DNS Servers tab in CA.