### PR TITLE
fix(exchange): export navigation service

### DIFF
--- a/packages/manager/modules/exchange/src/exchangeServices.module.js
+++ b/packages/manager/modules/exchange/src/exchangeServices.module.js
@@ -13,7 +13,6 @@ import officeAttach from './office-attach/office-attach.service';
 import ExchangeResources from './resource/resource.service';
 import formValidation from './services/exchange.formValidation.service';
 import messaging from './services/exchange.messaging.service';
-import navigation from './services/exchange.navigation.service';
 import exchangeSelectedService from './services/exchange.selectedService.service';
 import exchangeServiceInfrastructure from './services/exchange.serviceInfrastucture.service';
 import exchangeStates from './services/exchange.state.service';
@@ -40,7 +39,6 @@ angular
   .service('ExchangeResources', ExchangeResources)
   .service('formValidation', formValidation)
   .service('messaging', messaging)
-  .service('navigation', navigation)
   .service('exchangeSelectedService', exchangeSelectedService)
   .service('exchangeServiceInfrastructure', exchangeServiceInfrastructure)
   .service('exchangeStates', exchangeStates)

--- a/packages/manager/modules/exchange/src/index.js
+++ b/packages/manager/modules/exchange/src/index.js
@@ -7,6 +7,7 @@ import billingAccountRenew from './billing/account-renew/renew.module';
 import APIExchange from './exchange.api';
 import Exchange from './exchange.service';
 import ExchangePassword from './exchange.password.service';
+import navigation from './services/exchange.navigation.service'; // used by emailpro
 
 const moduleName = 'ovhManagerExchangeLazyLoading';
 
@@ -28,6 +29,7 @@ angular
   )
   .service('APIExchange', APIExchange)
   .service('Exchange', Exchange)
-  .service('ExchangePassword', ExchangePassword);
+  .service('ExchangePassword', ExchangePassword)
+  .service('navigation', navigation);
 
 export default moduleName;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5006
| License          | BSD 3-Clause

## Description

Expose `navigation` service when `@ovh-ux/manager-exchange` root AngularJS module is used, instead of declaring it when the first exchange route is lazy loaded.
This service is actually used by email pro for Emails footers configuration.

