### PR TITLE
fix(payment-status): fix display for services with manual renew

### DIFF
--- a/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
+++ b/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
@@ -84,7 +84,7 @@
                                         >-</span
                                     >
                                     <span
-                                        data-ng-if="service.hasManualRenew() && !service.isResiliated() && service.hasDebt()"
+                                        data-ng-if="service.hasManualRenew() && !service.isResiliated() && !service.hasDebt()"
                                         data-translate="ovh_manager_hub_payment_status_tile_before"
                                         data-translate-values="{
                                                 date: service.formattedExpiration


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

* Display renew date for services in manual renew with no debt 
* Issue noticed with MANAGER-4908