### PR TITLE
build(deps): upgrade ng-ovh-ui-confirm-modal to v2.0.0

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.0",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",
-    "@ovh-ux/ng-ovh-ui-confirm-modal": "^1.0.0",
+    "@ovh-ux/ng-ovh-ui-confirm-modal": "^2.0.0",
     "@ovh-ux/ng-tail-logs": "^2.0.3",
     "@ovh-ux/ng-ui-router-title": "^3.0.0",
     "@uirouter/angularjs": "^1.0.23",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -33,7 +33,7 @@
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.0",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",
-    "@ovh-ux/ng-ovh-ui-confirm-modal": "^1.0.0",
+    "@ovh-ux/ng-ovh-ui-confirm-modal": "^2.0.0",
     "@ovh-ux/ng-pagination-front": "^9.0.0",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-telecom-styles": "^3.1.0",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",
-    "@ovh-ux/ng-ovh-ui-confirm-modal": "^1.0.0",
+    "@ovh-ux/ng-ovh-ui-confirm-modal": "^2.0.0",
     "@ovh-ux/ng-ui-router-title": "^3.0.0",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -29,7 +29,7 @@
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^4.0.0",
-    "@ovh-ux/ng-ovh-ui-confirm-modal": "^1.0.0",
+    "@ovh-ux/ng-ovh-ui-confirm-modal": "^2.0.0",
     "@ovh-ux/ng-pagination-front": "^9.0.0",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

```sh
$ git rev-parse HEAD
14b6d5b7b801a010c7d5ca8b8e9a49b324fc8da5

$ yarn upgrade-interactive --latest
yarn upgrade-interactive v1.22.4
error Outdated lockfile. Please run `yarn install` and try again.
```

### ⬆️ Upgrade

5d02fde - build(deps): upgrade ng-ovh-ui-confirm-modal to v2.0.0

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
