### PR TITLE
fix(deps): add missing moment dependency

### DIFF
--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -48,6 +48,7 @@
     "jquery": "^2.1.3",
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
+    "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.42.0",

--- a/packages/manager/apps/sms/src/index.js
+++ b/packages/manager/apps/sms/src/index.js
@@ -1,5 +1,9 @@
-import 'script-loader!jquery'; // eslint-disable-line
-import 'script-loader!lodash'; // eslint-disable-line
+/* eslint-disable import/no-webpack-loader-syntax */
+import 'script-loader!jquery';
+import 'script-loader!lodash';
+import 'script-loader!moment/min/moment.min';
+/* eslint-enable import/no-webpack-loader-syntax */
+
 import ovhManagerSms from '@ovh-ux/manager-sms';
 import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Trying to access to the application reports the following error in the console:
```js
ReferenceError: moment is not defined
    at _default.$onInit (telecom-sms-dashboard.controller.js:63)
    at registerControllerCallbacks (viewDirective.js:368)
    at Object.eval (viewDirective.js:336)
    at eval (angular.js:1390)
    at invokeLinkFn (angular.js:11269)
    at nodeLinkFn (angular.js:10588)
    at compositeLinkFn (angular.js:9835)
    at publicLinkFn (angular.js:9700)
    at lazyCompilation (angular.js:10114)
    at updateView (viewDirective.js:262) "<div data-ng-if="!TelecomSmsCtrl.loading.init" data-ui-view="smsInnerView" class="ng-scope">"
```

### 🐛 Bug Fixes

49ffdb9 - fix(deps): add missing moment dependency

uses: `$ yarn workspace @ovh-ux/manager-sms-app add moment`

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
