### PR TITLE
fix(workflow): autopay order only if customer has payment mean

### DIFF
--- a/packages/manager/modules/product-offers/src/workflows/product-offers-order-workflow.class.js
+++ b/packages/manager/modules/product-offers/src/workflows/product-offers-order-workflow.class.js
@@ -205,9 +205,10 @@ export default class OrderWorkflow extends Workflow {
 
     const autoPayWithPreferredPaymentMethod = !!this.defaultPaymentMethod;
     const checkoutParameters = {
-      autoPayWithPreferredPaymentMethod: this.isFreePricing()
-        ? true
-        : autoPayWithPreferredPaymentMethod,
+      autoPayWithPreferredPaymentMethod:
+        this.isFreePricing() && this.defaultPaymentMethod
+          ? true
+          : autoPayWithPreferredPaymentMethod,
       waiveRetractationPeriod: false,
     };
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-12012
| License          | BSD 3-Clause

## Description

Do not autopay checkout if customer has no default payment method 
