### PR TITLE
fix(exchange): add lazy loading futures states

### DIFF
--- a/packages/manager/modules/exchange/src/exchange.routes.js
+++ b/packages/manager/modules/exchange/src/exchange.routes.js
@@ -34,15 +34,6 @@ export default /* @ngInject */ ($stateProvider) => {
         ),
   });
 
-  $stateProvider.state('app.microsoft.exchange', {
-    abstract: true,
-    template: '<div data-ui-view></div>',
-    translations: {
-      value: ['.'],
-      format: 'json',
-    },
-  });
-
   $stateProvider.state('app.microsoft.exchange.dedicated', {
     url: '/configuration/exchange_dedicated/:organization/:productId?tab',
     template,

--- a/packages/manager/modules/exchange/src/index.js
+++ b/packages/manager/modules/exchange/src/index.js
@@ -15,15 +15,52 @@ angular
   .module(moduleName, [billingAccountRenew, 'ui.router', 'oc.lazyLoad'])
   .config(
     /* @ngInject */ ($stateProvider) => {
+      const lazyLoad = ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./exchange.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      };
+
       $stateProvider.state('app.exchange.**', {
         url: '/configuration/exchange/:organization/:productId',
-        lazyLoad: ($transition$) => {
-          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+        lazyLoad,
+      });
 
-          return import('./exchange.module').then((mod) =>
-            $ocLazyLoad.inject(mod.default || mod),
-          );
+      $stateProvider.state('app.microsoft.exchange', {
+        abstract: true,
+        template: '<div data-ui-view></div>',
+        translations: {
+          value: ['.'],
+          format: 'json',
         },
+      });
+
+      $stateProvider.state('app.microsoft.exchange.dedicated.**', {
+        url: '/configuration/exchange_dedicated/:organization/:productId?tab',
+        lazyLoad,
+      });
+
+      $stateProvider.state('app.microsoft.exchange.dedicatedCluster.**', {
+        url:
+          '/configuration/exchange_dedicatedCluster/:organization/:productId?tab',
+        lazyLoad,
+      });
+
+      $stateProvider.state('app.microsoft.exchange.hosted.**', {
+        url: '/configuration/exchange_hosted/:organization/:productId?tab',
+        lazyLoad,
+      });
+
+      $stateProvider.state('app.microsoft.exchange.provider.**', {
+        url: '/configuration/exchange_provider/:organization/:productId?tab',
+        lazyLoad,
+      });
+
+      $stateProvider.state('app.microsoft.exchange.order.**', {
+        url: '/configuration/exchange/order',
+        lazyLoad,
       });
     },
   )


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Before : when we load the exchange manager with a bookmarked url we are redirected to `#/configuration`
After: it loads as expected.
