### PR TITLE
fix(update.range.phone): fix selected phones ordered on pack xdsl

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
@@ -301,10 +301,12 @@ export default class PackVoipLineActivationCtrl {
     this.orderPending = true;
     const data = [];
     this.selectedPhones.forEach((line) => {
-      if (line.needShipping) {
-        data.push(
-          angular.extend({ hardwareName: line.name }, this.getTransporter()),
-        );
+      if (line.quantity > 0) {
+        for (let i = 0; i < line.quantity; i += 1) {
+          data.push(
+            angular.extend({ hardwareName: line.name }, this.getTransporter()),
+          );
+        }
       } else if (line.enabled) {
         data.push({ hardwareName: 'modem' });
       }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
@@ -301,7 +301,7 @@ export default class PackVoipLineActivationCtrl {
     this.orderPending = true;
     const data = [];
     this.selectedPhones.forEach((line) => {
-      if (line.needShipping && line.quantity > 0) {
+      if (line.needShipping) {
         for (let i = 0; i < line.quantity; i += 1) {
           data.push(
             angular.extend({ hardwareName: line.name }, this.getTransporter()),

--- a/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.controller.js
@@ -301,7 +301,7 @@ export default class PackVoipLineActivationCtrl {
     this.orderPending = true;
     const data = [];
     this.selectedPhones.forEach((line) => {
-      if (line.quantity > 0) {
+      if (line.needShipping && line.quantity > 0) {
         for (let i = 0; i < line.quantity; i += 1) {
           data.push(
             angular.extend({ hardwareName: line.name }, this.getTransporter()),

--- a/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/slots/voipLine/activation/pack-voipLine-activation.html
@@ -457,7 +457,9 @@
                         data-translate="telephony_activation_hardware_caution_label"
                     ></div>
                     <div class="col-xs-6 col-md-10 text-price font-weight-bold">
-                        <span data-ng-bind="$ctrl.phoneBill.deposit"></span>
+                        <span
+                            data-ng-bind="$ctrl.phoneBill.deposit.toFixed(2)"
+                        ></span>
                         €
                     </div>
                 </div>
@@ -467,7 +469,9 @@
                         data-translate="telephony_activation_hardware_setup_fees_label"
                     ></div>
                     <div class="col-xs-6 col-md-10 text-price font-weight-bold">
-                        <span data-ng-bind="$ctrl.phoneBill.fees"></span>
+                        <span
+                            data-ng-bind="$ctrl.phoneBill.fees.toFixed(2)"
+                        ></span>
                         €
                     </div>
                 </div>
@@ -478,7 +482,7 @@
                     ></div>
                     <div class="col-xs-6 col-md-10 text-price font-weight-bold">
                         <span
-                            data-ng-bind="$ctrl.phoneBill.transportCost"
+                            data-ng-bind="$ctrl.phoneBill.transportCost.toFixed(2)"
                         ></span>
                         €
                     </div>
@@ -489,7 +493,9 @@
                         data-translate="telephony_activation_total_price_label"
                     ></div>
                     <div class="col-xs-6 col-md-10 text-price font-weight-bold">
-                        <span data-ng-bind="$ctrl.phoneBill.total"></span>
+                        <span
+                            data-ng-bind="$ctrl.phoneBill.total.toFixed(2)"
+                        ></span>
                         €
                     </div>
                 </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | fix/urp-voip-phones-xdsl
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-277
| License          | BSD 3-Clause

## Description

On the pack xDSL, when you order more than one phone, complete list of available phones was sent to the AAPI activate method, instead of the selected phones. Now, just selected phones are sent to the AAPI activate method.
