### PR TITLE
feat(web.hosting): get statistics route through api call

### DIFF
--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -137,8 +137,6 @@ angular
     UNIVERSES: config.constants.UNIVERSES,
     TOP_GUIDES: config.constants.TOP_GUIDES,
     swsProxyRootPath: 'apiv6/',
-    urchin: config.constants.LOGS_URCHIN,
-    urchin_gra: config.constants.LOGS_URCHIN_GRA,
     stats_logs: config.constants.STATS_LOGS,
     stats_logs_gra: config.constants.STATS_LOGS_GRA,
     aapiHeaderName: 'X-Ovh-Session',

--- a/packages/manager/apps/web/client/app/config/constants.config.js
+++ b/packages/manager/apps/web/client/app/config/constants.config.js
@@ -11,9 +11,6 @@ module.exports = {
       'https://www.ovh.com/manager/dedicated/#/billing/payment/method',
     RENEW_URL:
       'https://eu.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
-    LOGS_URCHIN: 'https://logs.ovh.net/{serviceName}/urchin6/',
-    LOGS_URCHIN_GRA:
-      'https://logs.{cluster}.hosting.ovh.net/{serviceName}/urchin6/',
     STATS_LOGS: 'https://logs.ovh.net/{serviceName}/',
     STATS_LOGS_GRA: 'https://logs.{cluster}.hosting.ovh.net/{serviceName}/',
     loginUrl: '/auth',
@@ -1154,7 +1151,6 @@ module.exports = {
     AUTORENEW_URL: 'https://ca.ovh.com/manager/dedicated/#/billing/autoRenew',
     RENEW_URL:
       'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
-    LOGS_URCHIN: 'https://logs.ovh.net/{serviceName}/urchin6/',
     STATS_LOGS: 'https://logs.ovh.net/{serviceName}/',
     loginUrl: 'https://www.ovh.com/manager/web/login/',
     UNIVERS: 'web',

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -245,19 +245,9 @@
                         ></span>
                     </oui-tile-button>
                     <oui-tile-button
-                        data-ng-if="$ctrl.userLogsToken"
+                        data-ng-if="statisticsRoute"
                         aria-label="{{ ::'hosting_tab_USER_LOGS_dashboard_stats_newtab' | translate }}"
-                        data-href="{{:: urchin  + '?token=' +  $ctrl.userLogsToken}}"
-                        data-external
-                    >
-                        <span
-                            data-translate="hosting_tab_USER_LOGS_dashboard_stats"
-                        ></span>
-                    </oui-tile-button>
-                    <oui-tile-button
-                        data-ng-if="!$ctrl.userLogsToken"
-                        aria-label="{{ ::'hosting_tab_USER_LOGS_dashboard_stats_newtab' | translate }}"
-                        data-href="{{:: urchin }}"
+                        data-href="{{:: statisticsRoute }}"
                         data-external
                     >
                         <span

--- a/packages/manager/apps/web/client/app/hosting/hosting.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.controller.js
@@ -36,10 +36,12 @@ export default class {
     HostingOvhConfig,
     HostingTask,
     PrivateDatabase,
+    statisticsRoute,
     HOSTING_STATUS,
   ) {
     this.$scope = $scope;
     this.$scope.HOSTING_STATUS = HOSTING_STATUS;
+    this.$scope.statisticsRoute = statisticsRoute;
     this.$rootScope = $rootScope;
     this.$location = $location;
     this.$q = $q;
@@ -622,21 +624,6 @@ export default class {
     });
   }
 
-  setUrchin() {
-    if (['gra1', 'gra2'].includes(this.$scope.hostingProxy.datacenter)) {
-      // FOR GRAVELINE
-      this.$scope.urchin = URI.expand(this.constants.urchin_gra, {
-        serviceName: this.$scope.hosting.serviceName,
-        cluster: this.$scope.hostingProxy.cluster,
-      }).toString();
-    } else {
-      this.$scope.urchin = URI.expand(this.constants.urchin, {
-        serviceName: this.$scope.hosting.serviceName,
-        cluster: this.$scope.hostingProxy.cluster,
-      }).toString();
-    }
-  }
-
   getPrivateDatabases() {
     return this.HostingDatabase.getPrivateDatabaseIds(
       this.$stateParams.productId,
@@ -734,7 +721,6 @@ export default class {
         this.$scope.sshUrl = `ssh://${hostingProxy.serviceManagementAccess.ssh.url}:${hostingProxy.serviceManagementAccess.ssh.port}/`;
         this.$scope.urls.hosting = hostingUrl;
         this.$scope.urlDomainOrder = domainOrderUrl;
-        this.setUrchin();
 
         return this.User.getUrlOf('guides');
       })

--- a/packages/manager/apps/web/client/app/hosting/hosting.routes.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.routes.js
@@ -14,6 +14,10 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       serviceName: /* @ngInject */ ($transition$) =>
         $transition$.params().productId,
+      statisticsRoute: /* @ngInject */ (HostingStatistics, serviceName) =>
+        HostingStatistics.getStatisticsInterfaceRoute(serviceName),
+      goToDetachEmail: /* @ngInject */ ($state) => () =>
+        $state.go('app.hosting.detachEmail'),
       goToHosting: /* @ngInject */ ($state, $timeout, Alerter) => (
         message = false,
         type = 'success',

--- a/packages/manager/apps/web/client/app/hosting/statistics/hosting-statistics.service.js
+++ b/packages/manager/apps/web/client/app/hosting/statistics/hosting-statistics.service.js
@@ -3,12 +3,29 @@ angular.module('services').service(
   class HostingStatistics {
     /**
      * Constructor
+     * @param $http
      * @param $q
      * @param OvhHttp
      */
-    constructor($q, OvhHttp) {
+    constructor($http, $q, OvhHttp) {
+      this.$http = $http;
       this.$q = $q;
       this.OvhHttp = OvhHttp;
+    }
+
+    getStatisticsInterfaceRoute(serviceName) {
+      return this.$http
+        .get(`/hosting/web/${serviceName}/ownLogs`, {
+          params: {
+            fqdn: serviceName,
+          },
+        })
+        .then(({ data }) =>
+          data.length > 0
+            ? this.$http.get(`/hosting/web/${serviceName}/ownLogs/${data[0]}`)
+            : { data: {} },
+        )
+        .then(({ data: ownLog }) => ownLog.stats);
     }
 
     getStatisticsConstants() {

--- a/packages/manager/apps/web/client/app/hosting/user-logs/USER_LOGS.html
+++ b/packages/manager/apps/web/client/app/hosting/user-logs/USER_LOGS.html
@@ -21,33 +21,25 @@
             </p>
             <p data-translate="hosting_tab_USER_LOGS_dashboard_information"></p>
             <dl>
-                <dt data-translate="hosting_tab_USER_LOGS_dashboard_stats"></dt>
-                <dd>
-                    <a
-                        data-ng-href="{{ctrl.urlUrchin}}"
-                        target="_blank"
-                        title="{{hosting_tab_USER_LOGS_dashboard_stats_newtab}}"
-                        data-ng-if="!ctrl.userLogsToken"
-                    >
-                        <span data-ng-bind="ctrl.urlUrchin"></span>
-                        <span
-                            class="fa fa-external-link"
-                            aria-hidden="true"
-                        ></span>
-                    </a>
-                    <a
-                        data-ng-href="{{ctrl.urlUrchin + '?token=' + ctrl.userLogsToken}}"
-                        target="_blank"
-                        title="{{hosting_tab_USER_LOGS_dashboard_stats_newtab}}"
-                        data-ng-if="ctrl.userLogsToken"
-                    >
-                        <span data-ng-bind="ctrl.urlUrchin"></span>
-                        <span
-                            class="fa fa-external-link"
-                            aria-hidden="true"
-                        ></span>
-                    </a>
-                </dd>
+                <div data-ng-if="ctrl.statisticsRoute">
+                    <dt
+                        data-translate="hosting_tab_USER_LOGS_dashboard_stats"
+                    ></dt>
+                    <dd>
+                        <a
+                            data-ng-href="{{ctrl.statisticsRoute}}"
+                            target="_blank"
+                            rel="noopener"
+                            title="{{hosting_tab_USER_LOGS_dashboard_stats_newtab}}"
+                        >
+                            <span data-ng-bind="ctrl.statisticsRoute"></span>
+                            <span
+                                class="oui-icon oui-icon_external-link"
+                                aria-hidden="true"
+                            ></span>
+                        </a>
+                    </dd>
+                </div>
 
                 <dt data-translate="hosting_tab_USER_LOGS_dashboard_logs"></dt>
                 <dd>

--- a/packages/manager/apps/web/client/app/hosting/user-logs/hosting-user-logs.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/user-logs/hosting-user-logs.controller.js
@@ -26,6 +26,7 @@ angular.module('App').controller(
 
     $onInit() {
       this.hosting = this.$scope.hosting;
+      this.statisticsRoute = this.$scope.statisticsRoute;
       this.userLogsToken = null;
 
       this.$scope.$on('hosting.userLogs.refresh', () => {
@@ -46,22 +47,11 @@ angular.module('App').controller(
       });
 
       if (['gra1', 'gra2'].includes(this.$scope.hostingProxy.datacenter)) {
-        // FOR GRAVELINE
-        this.urlUrchin = URI.expand(this.constants.urchin_gra, {
-          serviceName: this.$stateParams.productId,
-          cluster: this.$scope.hostingProxy.cluster,
-        }).toString();
-
         this.urlLogs = URI.expand(this.constants.stats_logs_gra, {
           serviceName: this.$stateParams.productId,
           cluster: this.$scope.hostingProxy.cluster,
         }).toString();
       } else {
-        this.urlUrchin = URI.expand(this.constants.urchin, {
-          serviceName: this.$stateParams.productId,
-          cluster: this.$scope.hostingProxy.cluster,
-        }).toString();
-
         this.urlLogs = URI.expand(this.constants.stats_logs, {
           serviceName: this.$stateParams.productId,
           cluster: this.$scope.hostingProxy.cluster,


### PR DESCRIPTION
ref: MANAGER-4913
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | #MANAGER-4913
| License          | BSD 3-Clause

## Description

Get hosting statistics interface route through the /hosting API