### PR TITLE
build: rename docs scripts commands prefix from vuepress to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "build": "node --experimental-worker scripts/build.js",
     "clean": "lerna clean -y && yarn run clean:dist && npx rimraf node_modules",
     "clean:dist": "npx rimraf \"packages/**/dist?(-EU|-CA|-US)\"",
+    "docs:build": "yarn run docs:prebuild && vuepress build docs",
+    "docs:deploy": "yarn run docs:build && gh-pages -d docs/.vuepress/dist -m \"docs: update documentation\"",
+    "docs:dev": "yarn run docs:prebuild && vuepress dev docs",
+    "docs:prebuild": "scripts/list-packages.js",
     "format": "run-p format:*",
     "format:css": "yarn run lint:css --fix",
     "format:js": "yarn run lint:js --fix",
@@ -29,11 +33,7 @@
     "split": "scripts/split.js",
     "start": "node -r esm scripts/start/index.js",
     "test": "yarn lint",
-    "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "vuepress:build": "yarn run vuepress:prebuild && vuepress build docs",
-    "vuepress:deploy": "yarn run vuepress:build && gh-pages -d docs/.vuepress/dist -m \"docs: update documentation\"",
-    "vuepress:dev": "yarn run vuepress:prebuild && vuepress dev docs",
-    "vuepress:prebuild": "scripts/list-packages.js"
+    "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.3",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 👷 Build

42e6f6c - build: rename docs scripts commands prefix from vuepress to docs

### 🔗 Related

Inspired by scripts from the documentation:
https://vuepress.vuejs.org/guide/getting-started.html#inside-an-existing-project

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
