### PR TITLE
Cloud - replace ovh-jquery-ui-draggable-ng by ng-ovh-jquery-ui-draggable

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -94,7 +94,6 @@ angular
       ngOvhJsplumb,
       'tmh.dynamicLocale',
 
-      'ovh-jquery-ui-draggable-ng',
       ngOvhJqueryUiDroppable,
       ngOvhSlider,
       ngTailLogs,

--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -30,6 +30,7 @@ import ngTailLogs from '@ovh-ux/ng-tail-logs';
 import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
 import ngOvhActionsMenu from '@ovh-ux/ng-ovh-actions-menu';
 import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+import ngOvhJqueryUiDraggable from '@ovh-ux/ng-ovh-jquery-ui-draggable';
 import ngOvhJqueryUiDroppable from '@ovh-ux/ng-ovh-jquery-ui-droppable';
 import ngOvhResponsivePageSwitcher from '@ovh-ux/ng-ovh-responsive-page-switcher';
 import ovhManagerBanner from '@ovh-ux/manager-banner';
@@ -94,6 +95,7 @@ angular
       ngOvhJsplumb,
       'tmh.dynamicLocale',
 
+      ngOvhJqueryUiDraggable,
       ngOvhJqueryUiDroppable,
       ngOvhSlider,
       ngTailLogs,

--- a/packages/manager/apps/cloud/client/app/index.js
+++ b/packages/manager/apps/cloud/client/app/index.js
@@ -41,7 +41,6 @@ import 'matchmedia-ng';
 import 'ng-slide-down';
 import 'script-loader!uri.js/src/URI.min.js';
 import 'script-loader!validator-js/validator.js';
-import 'ovh-jquery-ui-draggable-ng';
 import 'script-loader!jsplumb/dist/js/jquery.jsPlumb-1.7.4-min.js';
 import 'ovh-common-style';
 import 'script-loader!messenger/build/js/messenger.js';

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -111,7 +111,6 @@
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
     "ovh-api-services": "^9.42.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
-    "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.0",
     "ovh-ui-kit": "~2.41.1",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -39,6 +39,7 @@
     "@ovh-ux/ng-ovh-doc-url": "^2.0.0",
     "@ovh-ux/ng-ovh-form-flat": "^5.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.0",
+    "@ovh-ux/ng-ovh-jquery-ui-draggable": "^2.0.0",
     "@ovh-ux/ng-ovh-jquery-ui-droppable": "^2.0.0",
     "@ovh-ux/ng-ovh-jsplumb": "^6.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12748,10 +12748,6 @@ ovh-common-style@^5.0.0:
   resolved "https://registry.yarnpkg.com/ovh-common-style/-/ovh-common-style-5.0.0.tgz#f99c19bdb78d3b5fba4ab7b1437229f430e2a282"
   integrity sha512-qe2fV+pLEFEJdZOlM33N3Rmlg582kJgc+b+E5/U8W56FkFYIxS3Lmvi1QrN/+ig7SKwt6ftvPmKLBbwwcGkKPQ==
 
-ovh-jquery-ui-draggable-ng@ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5:
-  version "0.0.5"
-  resolved "https://codeload.github.com/ovh-ux/ovh-jquery-ui-draggable-ng/tar.gz/1534d99081af3e8533049c20d940a50595bdc916"
-
 ovh-manager-webfont@^1.2.0:
   version "1.2.0"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/8aed9c71517188263faf5cf9c90e191aae98e302"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 👷 Build

a3a2609 - build(deps): remove extra ovh-jquery-ui-draggale-ng dependency
c4550f3  - build(deps): add ng-ovh-jquery-ui-draggable dependency

### 🔗 Related

#2540

### 🏠 Internal

No quality check required.