### PR TITLE
test(lint-staged): run prettier on json files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -4,19 +4,9 @@
     "prettier --write",
     "git add"
   ],
-  "*.js": [
-    "eslint --fix",
-    "git add"
-  ],
-  "*.{css,less,scss}": [
-    "stylelint --fix",
-    "git add"
-  ],
-  "!(*CHANGELOG).md": [
-    "remark -qf ."
-  ],
-  "**/package.json": [
-    "npx sort-package-json",
-    "git add"
-  ]
+  "*.js": ["eslint --fix", "git add"],
+  "*.{css,less,scss}": ["stylelint --fix", "git add"],
+  "!(*CHANGELOG).md": ["remark -qf ."],
+  "**/package.json": ["npx sort-package-json", "git add"],
+  "*.json": ["prettier --write", "git add"]
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Inspired by: https://github.com/ovh/manager/pull/2916/files#diff-f00aeeca78471b21244f7ecf16a79361R56.

By updating the lint-staged configuration to run Prettier against JSON files,
it will allow us to be correctly aligned with our EditorConfig rules.

### ✅ Tests

cd50786 - test(lint-staged): run prettier on json files

### 🏠 Internal

No quality check required.

cc @cbourgois 

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>