### PR TITLE
build(deps): remove extra ng-ovh-apiv7 dependency

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -25,7 +25,6 @@
     "@ovh-ux/manager-pci": "^3.0.0",
     "@ovh-ux/ng-at-internet": "^5.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
-    "@ovh-ux/ng-ovh-apiv7": "^2.0.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.4.3",
     "@ovh-ux/ng-ovh-contacts": "^3.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,13 +1897,6 @@
   dependencies:
     lodash "^4.17.15"
 
-"@ovh-ux/ng-ovh-apiv7@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-apiv7/-/ng-ovh-apiv7-2.0.0.tgz#838e6c224bb37928de84b4a0eb8c0c8a6713f1d7"
-  integrity sha512-EnJEEmoNCTjnCv/501GDZjxYt17YgGbVBr6BfqF6kD4FSf+TQpsP2sOKEXDLIj0oJUYRhU4z5d97AjX9zFSrFg==
-  dependencies:
-    lodash "^4.17.11"
-
 "@ovh-ux/ng-ovh-otrs@^7.1.12":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.12.tgz#37fc3e1dd1905d6dc6dd035ed118f36267006721"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 👷 Build

938686d - build(deps): remove extra ng-ovh-apiv7 dependency

uses:
```sh
$ yarn workspace @ovh-ux/manager-pci-app remove @ovh-ux/ng-ovh-apiv7
```

### 🏠 Internal

No quality  check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>