### PR TITLE
VPS - Remove extra translations decorator

### DIFF
--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/manager-support": "^0.5.0",
     "@ovh-ux/manager-veeam-cloud-connect": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-veeam-enterprise": "^0.2.0",
-    "@ovh-ux/manager-vps": "^0.6.0",
+    "@ovh-ux/manager-vps": "^0.6.0 || ^1.0.0",
     "@ovh-ux/manager-vrack": "^0.6.0",
     "@ovh-ux/mfa-enrollment": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.0.0",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-filters": "^0.1.0",
     "@ovh-ux/manager-models": "^1.0.0",
     "@ovh-ux/manager-product-offers": "^1.0.1 || 2.0.0",
-    "@ovh-ux/manager-vps": "^0.6.0",
+    "@ovh-ux/manager-vps": "^0.6.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.4.3",

--- a/packages/manager/modules/vps/src/index.js
+++ b/packages/manager/modules/vps/src/index.js
@@ -17,10 +17,6 @@ angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
           currentUser: /* @ngInject */ (OvhApiMe) =>
             OvhApiMe.v6().get().$promise,
         },
-        translations: {
-          value: ['../common', '../vps'],
-          format: 'json',
-        },
       })
       .state('vps.detail.**', {
         url: '/{serviceName}',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | yes
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ♻️ Refactor

ea69424 - refactor(routing): remove extra translations decorator

### 👷 Build

18c39f3 - build(deps): set compatible semver range for vps module

### 💥 Breaking Change

All translations are now self-contained into the module (VPS).
