### PR TITLE
build(deps): upgrade ng-ovh-mondial-relay to v7.0.0

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.0",
-    "@ovh-ux/ng-ovh-mondial-relay": "^6.0.3",
+    "@ovh-ux/ng-ovh-mondial-relay": "^7.0.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ⬆️ Upgrade

41be5db - build(deps): upgrade ng-ovh-mondial-relay to v7.0.0

uses: `$ yarn upgrade-interactive --latest @ovh-ux/ng-ovh-mondial-relay`
- @ovh-ux/ng-ovh-mondial-relay@7.0.0

### 🔗 Related

#2893 

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

