### PR TITLE
Fix: Prevent error if url is not specified for FR subsidiary

### DIFF
--- a/packages/manager/apps/web/client/app/components/user/user.service.js
+++ b/packages/manager/apps/web/client/app/components/user/user.service.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';
 
@@ -54,7 +55,7 @@ angular.module('services').service('User', [
           return constants.urls[data.ovhSubsidiary][link];
         }
 
-        return constants.urls.FR[link];
+        return get(constants, `urls.FR.${link}`);
       });
 
     /* The new structure in constants.config.js will be ...value.subsidiary and not subsidiary.value

--- a/packages/manager/apps/web/client/app/domain/domain.controller.js
+++ b/packages/manager/apps/web/client/app/domain/domain.controller.js
@@ -122,7 +122,7 @@ angular.module('App').controller(
       this.autorenewGuide = get(
         this.constants,
         `urls.${subsidiary}.guides.autoRenew`,
-        this.constants.urls.FR.guides.autoRenew,
+        get(this.constants, `urls.FR.guides.autoRenew`),
       );
       this.autorenewUrl = `${this.constants.AUTORENEW_URL}?selectedType=DOMAIN&searchText=${this.domainInfos.domain}`;
     }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | yes
| New feature?     |no
| Breaking change? | no
| Tickets          | MANAGER-5072
| License          | BSD 3-Clause

## Description

Prevent error if url is not specified for FR subsidiary
This happens for CA where FR subsidiary doesn't exist therefore there is no reason to declare a FR fallback
