### PR TITLE
Refactor SSO Auth modal plugin translation loading

### DIFF
--- a/packages/components/ng-ovh-sso-auth-modal-plugin/src/controller.js
+++ b/packages/components/ng-ovh-sso-auth-modal-plugin/src/controller.js
@@ -53,7 +53,6 @@ export default /* @ngInject */ function SsoAuthModalController(
   }
 
   function init() {
-    $translatePartialLoader.addPart(self.data.translationPath);
     return $translate
       .refresh()
       .then(() => {

--- a/packages/components/ng-ovh-sso-auth-modal-plugin/src/provider.js
+++ b/packages/components/ng-ovh-sso-auth-modal-plugin/src/provider.js
@@ -11,22 +11,7 @@ import template from './template.html';
  * Handle switch session, opens the modal
  */
 export default function ssoAuthModalPluginFct() {
-  let translationPath =
-    '../bower_components/ovh-angular-sso-auth-modal-plugin/dist/modal';
   let deferredObj;
-
-  /**
-   * @ngdoc function
-   * @name setTranslationsPath
-   * @methodOf ng-ovh-sso-auth-modal-plugin.ssoAuthModalPluginFct
-   * @description
-   * Set translation path
-   *
-   * @param {string} _translationPath translation path
-   */
-  this.setTranslationsPath = function setTranslationsPath(_translationPath) {
-    translationPath = _translationPath;
-  };
 
   this.$get = /* @ngInject */ function $get($injector) {
     return {
@@ -50,7 +35,6 @@ export default function ssoAuthModalPluginFct() {
               headers: ssoAuthentication.getHeaders(),
             },
             logoutUrl: ssoAuthentication.getLogoutUrl(),
-            translationPath,
           };
 
           if (ssoAuthentication.userId && !currentUserId) {

--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -121,7 +121,6 @@ import './components/filters.module';
 import './components/ng-ovh-contacts/ng-ovh-contacts.module';
 import './components/ovh-angular-actions-menu/ovh-angular-actions-menu.module';
 import './components/ovh-angular-http/ovh-angular-http.module';
-import './components/ovh-angular-sso-auth-modal-plugin/ovh-angular-sso-auth-modal-plugin.module';
 import './components/ovh-ui-angular/ovh-ui-angular.module';
 import './components/services.module';
 import './controllers.module';

--- a/packages/manager/apps/dedicated/client/app/components/ovh-angular-sso-auth-modal-plugin/ovh-angular-sso-auth-modal-plugin.module.js
+++ b/packages/manager/apps/dedicated/client/app/components/ovh-angular-sso-auth-modal-plugin/ovh-angular-sso-auth-modal-plugin.module.js
@@ -1,5 +1,0 @@
-angular.module('App').config((ssoAuthModalPluginFctProvider) => {
-  ssoAuthModalPluginFctProvider.setTranslationsPath(
-    'node_modules/ovh-angular-sso-auth-modal-plugin/dist/modal',
-  );
-});


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | yes
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ♻️ Refactor

6d08349 - refactor: remove unnecessary translation loading for sso auth modal
7e6640b  - refactor(provider): remove deprecated setTranslationsPath method

### 💥 Breaking Change

#### @ovh-ux/ng-ovh-sso-auth-modal-plugin

#####  provider

Remove `setTranslationsPath` method.
