### PR TITLE
feat(domain.webhosting): display available modules depending on offer

### DIFF
--- a/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.component.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.component.js
@@ -2,7 +2,7 @@ import template from './domain-webhosting-order.html';
 
 export default {
   bindings: {
-    availableModules: '<',
+    getAvailableModules: '<',
     availableOffers: '<',
     cartId: '<',
     deleteCartItems: '<',

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.constants.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.constants.js
@@ -17,8 +17,6 @@ export const DATABASE_ISOLATION_TYPES = {
   SHARED: 'shared',
 };
 
-export const DEFAULT_PLANCODE = 'cloudweb1';
-
 export const DISK_SIZE_MULTIPLE = {
   THOUSAND: 1000,
   MILLION: 1000000,
@@ -44,7 +42,6 @@ export const WEBHOSTING_ORDER_PRODUCT = 'webHosting';
 export default {
   CONFIGURATION_OPTIONS,
   DATABASE_ISOLATION_TYPES,
-  DEFAULT_PLANCODE,
   DISK_SIZE_MULTIPLE,
   DISK_SIZE_UNIT,
   HIGHLIGHTS,

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.html
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.html
@@ -6,7 +6,7 @@
 
 <ovh-manager-web-domain-webhosting-order-steps
     data-available-offers="$ctrl.availableOffers"
-    data-available-modules="$ctrl.availableModules"
+    data-get-available-modules="$ctrl.getAvailableModules(offer)"
     data-cart-id="$ctrl.cartId"
     data-delete-cart-items="$ctrl.deleteCartItems"
     data-display-error-message="$ctrl.displayErrorMessage"

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.routing.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.routing.js
@@ -5,8 +5,8 @@ const resolve = {
   assignCart: /* @ngInject */ (WucOrderCartService) => (cartId) =>
     WucOrderCartService.assignCart(cartId),
   /* @ngInject */
-  availableModules: (cartId, WebHostingOrder) =>
-    WebHostingOrder.getAvailableModules(cartId),
+  getAvailableModules: (cartId, WebHostingOrder) => (offer) =>
+    WebHostingOrder.getAvailableModules(cartId, offer),
   availableOffers: /* @ngInject */ (cartId, user, WebHostingOrder) =>
     WebHostingOrder.getAvailableOffers(cartId, user.ovhSubsidiary),
   cartId: /* @ngInject */ (assignCart, createCart) =>

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.service.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/domain-webhosting-order.service.js
@@ -3,7 +3,6 @@ import includes from 'lodash/includes';
 import WebHostingOffer from './domain-webhosting-order-offer.class';
 import {
   CONFIGURATION_OPTIONS,
-  DEFAULT_PLANCODE,
   OPTION_QUANTITY,
   PRODUCT_QUANTITY,
   WEBHOSTING_ORDER_PRODUCT,
@@ -23,11 +22,11 @@ export default class {
     this.WucOrderCartService = WucOrderCartService;
   }
 
-  getAvailableModules(cartId) {
+  getAvailableModules(cartId, offer) {
     return this.WucOrderCartService.getProductOptions(
       cartId,
       WEBHOSTING_ORDER_PRODUCT,
-      { planCode: DEFAULT_PLANCODE },
+      { planCode: offer.planCode },
     );
   }
 

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.component.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.component.js
@@ -3,7 +3,7 @@ import template from './domain-webhosting-order-steps.html';
 
 export default {
   bindings: {
-    availableModules: '<',
+    getAvailableModules: '&',
     availableOffers: '<',
     cartId: '<',
     deleteCartItems: '<',

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.html
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.html
@@ -14,7 +14,7 @@
     </ovh-manager-web-domain-webhosting-order-steps-hosting>
 
     <ovh-manager-web-domain-webhosting-order-steps-module
-        data-available-modules="$ctrl.availableModules"
+        data-get-available-modules="$ctrl.getAvailableModules({ offer })"
     >
     </ovh-manager-web-domain-webhosting-order-steps-module>
 

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.component.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.component.js
@@ -3,7 +3,7 @@ import template from './domain-webhosting-order-steps-module.html';
 
 export default {
   bindings: {
-    availableModules: '<',
+    getAvailableModules: '&',
   },
   controller,
   name: 'ovhManagerWebDomainWebhostingOrderStepsModule',

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.controller.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.controller.js
@@ -1,35 +1,39 @@
-import chunk from 'lodash/chunk';
 import sortBy from 'lodash/sortBy';
 
 import { LATEST_MODULES } from './domain-webhosting-order-steps-module.constants';
 
 export default class {
-  $onInit() {
-    this.availableModules = chunk(
-      sortBy(
-        this.availableModules
-          .filter(({ planCode }) =>
-            LATEST_MODULES.map(({ label }) => label).includes(planCode),
-          )
-          .map((module) => {
-            const { id, recommendedOffer } = LATEST_MODULES.find(
-              ({ label }) => label === module.planCode,
-            );
+  getModules() {
+    this.module = undefined;
+    this.isLoading = true;
+    return this.getAvailableModules({ offer: this.stepper.cartOption.offer })
+      .then((availableModules) => {
+        this.availableModules = sortBy(
+          availableModules
+            .filter(({ planCode }) =>
+              LATEST_MODULES.map(({ label }) => label).includes(planCode),
+            )
+            .map((module) => {
+              const { id, recommendedOffer } = LATEST_MODULES.find(
+                ({ label }) => label === module.planCode,
+              );
 
-            const [{ duration, pricingMode }] = module.prices;
+              const [{ duration, pricingMode }] = module.prices;
 
-            return {
-              id,
-              duration,
-              ...module,
-              pricingMode,
-              recommendedOffer,
-            };
-          }),
-        'id',
-      ),
-      3,
-    );
+              return {
+                id,
+                duration,
+                ...module,
+                pricingMode,
+                recommendedOffer,
+              };
+            }),
+          'id',
+        );
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
   }
 
   updateModule() {

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.html
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/module/domain-webhosting-order-steps-module.html
@@ -3,15 +3,13 @@
     data-description="{{:: 'domain_webhosting_order_module_step_subtitle' | translate }}"
     data-editable="!$ctrl.stepper.loadingCheckout"
     data-navigation="false"
-    data-on-focus="$ctrl.module = undefined"
+    data-loading="$ctrl.isLoading"
+    data-on-focus="$ctrl.getModules()"
 >
-    <div
-        class="row d-md-flex mb-3"
-        data-ng-repeat="chunkModules in ::$ctrl.availableModules track by $index"
-    >
+    <div class="row d-md-flex flex-wrap">
         <div
-            class="col-md-4"
-            data-ng-repeat="module in ::chunkModules track by module.id"
+            class="col-md-4 mb-3"
+            data-ng-repeat="module in ::$ctrl.availableModules track by $index"
         >
             <oui-select-picker
                 class="h-100"
@@ -45,7 +43,7 @@
                 </oui-select-picker-footer>
             </oui-select-picker>
         </div>
-        <div class="col-md-4" data-ng-if="$last">
+        <div class="col-md-4">
             <oui-select-picker
                 data-label="{{:: 'domain_webhosting_order_module_step_none_label' | translate }}"
                 data-model="$ctrl.module"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5102
| License          | BSD 3-Clause

## Description

'cloudweb1' offer is only available in EU so it can't be considered as a default plan code
