### PR TITLE
fix(hosting): fetch email service info only if available

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/hosting.routes.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.routes.js
@@ -34,23 +34,25 @@ export default /* @ngInject */ ($stateProvider) => {
         $q,
         emailOptionIds,
         hostingEmailService,
+        isEmailDomainAvailable,
         OvhApiEmailDomain,
         serviceName,
       ) =>
-        $q
-          .all(
-            emailOptionIds.map((emailOptionId) =>
-              hostingEmailService
-                .getEmailOptionServiceInformation(serviceName, emailOptionId)
-                .then(
-                  ({ resource }) =>
-                    OvhApiEmailDomain.v6().serviceInfos({
-                      serviceName: resource.name,
-                    }).$promise,
-                ),
-            ),
-          )
-          .then((servicesInformation) => servicesInformation.flatten()),
+        (isEmailDomainAvailable
+          ? $q.all(
+              emailOptionIds.map((emailOptionId) =>
+                hostingEmailService
+                  .getEmailOptionServiceInformation(serviceName, emailOptionId)
+                  .then(
+                    ({ resource }) =>
+                      OvhApiEmailDomain.v6().serviceInfos({
+                        serviceName: resource.name,
+                      }).$promise,
+                  ),
+              ),
+            )
+          : $q.resolve([])
+        ).then((servicesInformation) => servicesInformation.flatten()),
       pendingTasks: /* @ngInject */ (HostingTask, serviceName) =>
         HostingTask.getPending(serviceName).catch(() => []),
       serviceName: /* @ngInject */ ($transition$) =>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5114
| License          | BSD 3-Clause

## Description

Fetch email service info only if available as email domain are not available for every region