### PR TITLE
build(dev-deps): add rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "scripts": {
     "build": "node --experimental-worker scripts/build.js",
-    "clean": "lerna clean -y && yarn run clean:dist && npx rimraf node_modules",
-    "clean:dist": "npx rimraf \"packages/**/dist?(-EU|-CA|-US)\"",
+    "clean": "lerna clean -y && yarn run clean:dist && rimraf node_modules",
+    "clean:dist": "rimraf \"packages/**/dist?(-EU|-CA|-US)\"",
     "docs:build": "vuepress prebuild docs && vuepress build docs",
     "docs:deploy": "yarn run docs:build && gh-pages -d docs/.vuepress/dist -m \"docs: update documentation\"",
     "docs:dev": "vuepress prebuild docs && vuepress dev docs",
@@ -33,10 +33,10 @@
     "split": "scripts/split.js",
     "start": "node -r esm scripts/start/index.js",
     "test": "yarn lint",
-    "test:e2e:chromium": "npx rimraf ./reports && testcafe chromium",
-    "test:e2e:chromium:headless": "npx rimraf ./reports && testcafe chromium:headless",
-    "test:e2e:firefox": "npx rimraf ./reports && testcafe firefox",
-    "test:e2e:firefox:headless": "npx rimraf ./reports && testcafe firefox:headless",
+    "test:e2e:chromium": "rimraf ./reports && testcafe chromium",
+    "test:e2e:chromium:headless": "rimraf ./reports && testcafe chromium:headless",
+    "test:e2e:firefox": "rimraf ./reports && testcafe firefox",
+    "test:e2e:firefox:headless": "rimraf ./reports && testcafe firefox:headless",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
   "devDependencies": {
@@ -77,6 +77,7 @@
     "remark-cli": "^7.0.1",
     "remark-lint": "^6.0.5",
     "remark-preset-lint-recommended": "^3.0.3",
+    "rimraf": "^3.0.2",
     "sao": "^1.7.0",
     "semver": "^5.6.0",
     "stylelint": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16310,6 +16310,13 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

since `rimraf` is widely used across multiple script entries then it
can be turned into a regular dev dependency.

### 👷 Build

424e941 - build(dev-deps): add rimraf

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>