### PR TITLE
feat: prevent calling /email/pro APIs in CA

### DIFF
--- a/packages/manager/modules/emailpro/src/emailpro.module.js
+++ b/packages/manager/modules/emailpro/src/emailpro.module.js
@@ -31,6 +31,14 @@ angular
   .constant('EMAILPRO_CONFIG_URL', EMAILPRO_CONFIG_URL)
   .constant('EMAILPRO_CONFIG', EMAILPRO_CONFIG)
   .config(routing)
+  .provider(
+    'EMAIL_CAPABILITIES',
+    /* @ngInject */ (coreConfigProvider) => ({
+      $get: () => ({
+        isEmailProAvailable: coreConfigProvider.isRegion('EU'),
+      }),
+    }),
+  )
   .run(cacheTemplate);
 
 export default moduleName;

--- a/packages/manager/modules/emailpro/src/emailpro.service.js
+++ b/packages/manager/modules/emailpro/src/emailpro.service.js
@@ -25,6 +25,7 @@ export default class EmailPro {
     constants,
     EMAILPRO_CONFIG,
     OvhHttp,
+    EMAIL_CAPABILITIES,
   ) {
     this.$cacheFactory = $cacheFactory;
     this.$location = $location;
@@ -33,6 +34,7 @@ export default class EmailPro {
     this.$stateParams = $stateParams;
     this.$timeout = $timeout;
     this.$translate = $translate;
+    this.EMAIL_CAPABILITIES = EMAIL_CAPABILITIES;
 
     this.apiRoutes = get(
       EMAILPRO_CONFIG.API_ROUTES,
@@ -1591,14 +1593,16 @@ export default class EmailPro {
   }
 
   gettingIsServiceMXPlan() {
-    return this.OvhHttp.get(
-      `/email/pro/${this.$stateParams.productId}/billingMigrated`,
-      {
-        rootPath: 'apiv6',
-      },
-    )
-      .then(() => false)
-      .catch(() => true);
+    return this.EMAIL_CAPABILITIES.isEmailProAvailable
+      ? this.OvhHttp.get(
+          `/email/pro/${this.$stateParams.productId}/billingMigrated`,
+          {
+            rootPath: 'apiv6',
+          },
+        )
+          .then(() => false)
+          .catch(() => true)
+      : this.$q.resolve(true);
   }
 
   gettingBaseAPIPath() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5012
| License          | BSD 3-Clause

## Description

Prevent calling /email/pro APIs in CA. 
This is due to mxplan  and emailpro sharing the same module and components 
