### PR TITLE
fix(server-sidebar): fix ms-Icon hover effect

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/sidebar-menu/sidebar-menu.less
+++ b/packages/manager/apps/dedicated/client/app/components/sidebar-menu/sidebar-menu.less
@@ -7,21 +7,3 @@ toggle-class {
     background-image: none;
   }
 }
-
-#sidebar-menu {
-  .ms-Icon {
-    width: 1em;
-    display: 1em;
-    line-height: 1;
-    vertical-align: middle;
-    text-rendering: optimizeLegibility;
-    text-rendering: geometricPrecision;
-    /* stylelint-disable-next-line property-no-unknown */
-    font-smooth: always;
-    /* stylelint-disable-next-line property-no-unknown */
-    font-smoothing: antialiased;
-    -moz-font-smoothing: antialiased;
-    -webkit-font-smoothing: antialiased;
-    -webkit-font-smoothing: subpixel-antialiased;
-  }
-}

--- a/packages/manager/modules/server-sidebar/src/index.js
+++ b/packages/manager/modules/server-sidebar/src/index.js
@@ -8,6 +8,8 @@ import 'ovh-api-services';
 
 import sidebarComponent from './component';
 
+import './index.less';
+
 const moduleName = 'ovhManagerServerSidebar';
 
 angular

--- a/packages/manager/modules/server-sidebar/src/index.less
+++ b/packages/manager/modules/server-sidebar/src/index.less
@@ -1,0 +1,13 @@
+#sidebar-menu .ms-Icon {
+  line-height: 1;
+  vertical-align: middle;
+  text-rendering: optimizeLegibility;
+  text-rendering: geometricPrecision;
+  /* stylelint-disable-next-line property-no-unknown */
+  font-smooth: always;
+  /* stylelint-disable-next-line property-no-unknown */
+  font-smoothing: antialiased;
+  -moz-font-smoothing: antialiased;
+  -webkit-font-smoothing: antialiased;
+  -webkit-font-smoothing: subpixel-antialiased;
+}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | ``develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Fix the circle effect when hovering a ms-Icon in the order menu of the sidebar.
The style was not applied, so I move it directly in the module `server-sidebar`
