### PR TITLE
feat(xdsl.profile): load profiles for constistent tooltip with list

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/index.js
@@ -3,6 +3,7 @@ import angular from 'angular';
 import internetAccess from './internet-access';
 import packVoipLineActivation from './slots/voipLine/activation/pack-voipLine-activation.module';
 import hostedEmailDetail from './slots/hostedEmail/detail';
+import packXdsl from './xdsl/pack-xdsl';
 
 import templates from './pack.templates';
 
@@ -16,6 +17,7 @@ angular
     internetAccess,
     hostedEmailDetail,
     packVoipLineActivation,
+    packXdsl,
   ])
   .controller('PackCtrl', controller)
   .config(routing)

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/index.js
@@ -1,0 +1,21 @@
+import angular from 'angular';
+
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
+import uiRouter from '@uirouter/angularjs';
+import angularTranslate from 'angular-translate';
+import 'ovh-ui-angular';
+
+import access from './pack-xdsl-access.component';
+
+const moduleName = 'ovhManagerTelecomPackXdslAccess';
+
+angular
+  .module(moduleName, [
+    ngTranslateAsyncLoader,
+    uiRouter,
+    angularTranslate,
+    'oui',
+  ])
+  .component('packXdslAccess', access);
+
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.component.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.component.js
@@ -1,0 +1,7 @@
+import controller from './pack-xdsl-access.controller';
+import template from './pack-xdsl-access.html';
+
+export default {
+  controller,
+  template,
+};

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
@@ -12,100 +12,101 @@ import {
   XDSL_EXCHANGE_MODEM,
 } from './pack-xdsl-access.constants';
 
-angular.module('managerApp').controller(
-  'XdslAccessCtrl',
-  class XdslAccessCtrl {
-    constructor(
-      $filter,
-      $q,
-      $rootScope,
-      $scope,
-      $state,
-      $stateParams,
-      $templateCache,
-      $translate,
-      $uibModal,
-      OvhApiPackXdsl,
-      OvhApiXdsl,
-      OvhApiXdslDiagnostic,
-      OvhApiXdslIps,
-      OvhApiXdslLines,
-      OvhApiXdslModem,
-      OvhApiXdslNotifications,
-      TucToast,
-      TucToastError,
-      XdslTaskPoller,
-      PACK,
-      PACK_IP,
-      REDIRECT_URLS,
-      URLS,
-    ) {
-      this.$filter = $filter;
-      this.$q = $q;
-      this.$rootScope = $rootScope;
-      this.$scope = $scope;
-      this.$state = $state;
-      this.$stateParams = $stateParams;
-      this.$templateCache = $templateCache;
-      this.$translate = $translate;
-      this.$uibModal = $uibModal;
-      this.OvhApiPackXdsl = OvhApiPackXdsl;
-      this.OvhApiXdsl = OvhApiXdsl;
-      this.OvhApiXdslDiagnostic = OvhApiXdslDiagnostic.v6();
-      this.OvhApiXdslIps = OvhApiXdslIps;
-      this.OvhApiXdslLines = OvhApiXdslLines;
-      this.OvhApiXdslModem = OvhApiXdslModem;
-      this.OvhApiXdslNotifications = OvhApiXdslNotifications;
-      this.TucToast = TucToast;
-      this.TucToastError = TucToastError;
-      this.XdslTaskPoller = XdslTaskPoller;
-      this.PACK = PACK;
-      this.PACK_IP = PACK_IP;
-      this.REDIRECT_URLS = REDIRECT_URLS;
-      this.URLS = URLS;
-    }
+export default class XdslAccessCtrl {
+  /* @ngInject */
+  constructor(
+    $filter,
+    $q,
+    $rootScope,
+    $scope,
+    $state,
+    $stateParams,
+    $templateCache,
+    $translate,
+    $uibModal,
+    OvhApiPackXdsl,
+    OvhApiXdsl,
+    OvhApiXdslDiagnostic,
+    OvhApiXdslIps,
+    OvhApiXdslLines,
+    OvhApiXdslLinesDslamPort,
+    OvhApiXdslModem,
+    OvhApiXdslNotifications,
+    TucToast,
+    TucToastError,
+    XdslTaskPoller,
+    PACK,
+    PACK_IP,
+    REDIRECT_URLS,
+    URLS,
+  ) {
+    this.$filter = $filter;
+    this.$q = $q;
+    this.$rootScope = $rootScope;
+    this.$scope = $scope;
+    this.$state = $state;
+    this.$stateParams = $stateParams;
+    this.$templateCache = $templateCache;
+    this.$translate = $translate;
+    this.$uibModal = $uibModal;
+    this.OvhApiPackXdsl = OvhApiPackXdsl;
+    this.OvhApiXdsl = OvhApiXdsl;
+    this.OvhApiXdslDiagnostic = OvhApiXdslDiagnostic.v6();
+    this.OvhApiXdslIps = OvhApiXdslIps;
+    this.OvhApiXdslLines = OvhApiXdslLines;
+    this.OvhApiXdslLinesDslamPort = OvhApiXdslLinesDslamPort;
+    this.OvhApiXdslModem = OvhApiXdslModem;
+    this.OvhApiXdslNotifications = OvhApiXdslNotifications;
+    this.TucToast = TucToast;
+    this.TucToastError = TucToastError;
+    this.XdslTaskPoller = XdslTaskPoller;
+    this.PACK = PACK;
+    this.PACK_IP = PACK_IP;
+    this.REDIRECT_URLS = REDIRECT_URLS;
+    this.URLS = URLS;
+  }
 
-    $onInit() {
-      this.packName = this.$stateParams.packName;
-      this.number = this.$stateParams.number;
+  $onInit() {
+    this.packName = this.$stateParams.packName;
+    this.number = this.$stateParams.number;
 
-      this.$scope.loaders = {
-        details: true,
-        tasks: true,
-        deconsolidation: true,
-        xdsl: true,
-        accessDiagnosticLaunched: false,
-        incident: true,
-      };
+    this.$scope.loaders = {
+      details: true,
+      tasks: true,
+      deconsolidation: true,
+      xdsl: true,
+      accessDiagnosticLaunched: false,
+      incident: true,
+    };
 
-      this.accessDiagnostic = null;
+    this.accessDiagnostic = null;
 
-      this.$scope.access = {
-        xdsl: null,
-        tasks: { current: {} },
-        brandName: null,
-        isZyxel: false,
-      };
+    this.$scope.access = {
+      xdsl: null,
+      tasks: { current: {} },
+      brandName: null,
+      isZyxel: false,
+    };
 
-      this.$scope.constants = {
-        rangeOfBaseIpv4IP: this.PACK_IP.baseIpv4Range,
-      };
+    this.$scope.constants = {
+      rangeOfBaseIpv4IP: this.PACK_IP.baseIpv4Range,
+    };
 
-      this.initTemplateCaches();
+    this.initTemplateCaches();
 
-      this.$scope.notificationsChanged = (elements) => {
-        if (this.$scope.access) {
-          this.$scope.access.notificationsCount = elements.length;
-        }
-      };
+    this.$scope.notificationsChanged = (elements) => {
+      if (this.$scope.access) {
+        this.$scope.access.notificationsCount = elements.length;
+      }
+    };
 
-      this.$scope.$on('changeAccessNameEvent', (event, data) => {
-        if (this.$scope.access.xdsl.accessName === data.xdslId) {
-          this.$scope.access.xdsl.description = data.description;
-        }
-      });
+    this.$scope.$on('changeAccessNameEvent', (event, data) => {
+      if (this.$scope.access.xdsl.accessName === data.xdslId) {
+        this.$scope.access.xdsl.description = data.description;
+      }
+    });
 
-      /*
+    /*
       HOW DIAGNOSTIC EVENTS WORK:
 
       When we open the details modal, it sends a 'accessDiagnosticDetails:get'
@@ -126,433 +127,454 @@ angular.module('managerApp').controller(
       Until the task is finished, the diagnostic we get from
       the API is IRRELEVANT and should not be displayed to the user.
     */
-      this.$rootScope.$on('accessDiagnosticDetails:launch', () =>
-        this.launchDiagnostic(),
-      );
+    this.$rootScope.$on('accessDiagnosticDetails:launch', () =>
+      this.launchDiagnostic(),
+    );
 
-      this.$rootScope.$on('accessDiagnosticDetails:get', () => {
-        if (
-          !this.accessDiagnostic &&
-          !this.$scope.loaders.accessDiagnosticLaunched
-        ) {
-          this.launchDiagnostic();
-        }
-        this.$rootScope.$broadcast(
-          'accessDiagnosticDetails:arrived',
-          this.accessDiagnostic,
-        );
-      });
-
-      this.diagPollerTicket = this.XdslTaskPoller.register(
-        'accessDiagnosticRun',
-        () => {
-          this.$scope.loaders.accessDiagnosticLaunched = false;
-          return this.getDiagnostic();
-        },
-      );
-
-      this.additionalIpPollerTicket = this.XdslTaskPoller.register(
-        'pendingOrderAdditionalIpOption',
-        () => {
-          this.ordering = false;
-          return this.getIps();
-        },
-      );
-
-      this.$scope.$on('$destroy', () => {
-        this.XdslTaskPoller.unregister(this.diagPollerTicket);
-        this.XdslTaskPoller.unregister(this.additionalIpPollerTicket);
-      });
-
-      return this.$q.all([
-        this.getLinesDetails(),
-        this.getDiagnostic(),
-        this.getIncident(),
-        this.getModemExchange(),
-      ]);
-    }
-
-    isLoading() {
-      return (
-        this.$scope.loaders.details ||
-        this.$scope.loaders.tasks ||
-        this.$scope.loaders.incident
-      );
-    }
-
-    openDetailsPopup() {
+    this.$rootScope.$on('accessDiagnosticDetails:get', () => {
       if (
-        this.accessDiagnostic === null &&
+        !this.accessDiagnostic &&
         !this.$scope.loaders.accessDiagnosticLaunched
       ) {
         this.launchDiagnostic();
       }
-      return this.$state.go(
-        'telecom.packs.pack.xdsl.access-diagnostic-details',
+      this.$rootScope.$broadcast(
+        'accessDiagnosticDetails:arrived',
+        this.accessDiagnostic,
       );
-    }
+    });
 
-    launchDiagnostic() {
-      this.accessDiagnostic = null;
-      this.$scope.loaders.accessDiagnosticLaunched = true;
-      return this.OvhApiXdslDiagnostic.launchDiagnostic(
-        { xdslId: this.$stateParams.serviceName },
-        {},
-      ).$promise;
-    }
+    this.diagPollerTicket = this.XdslTaskPoller.register(
+      'accessDiagnosticRun',
+      () => {
+        this.$scope.loaders.accessDiagnosticLaunched = false;
+        return this.getDiagnostic();
+      },
+    );
 
-    getDiagnostic() {
-      return this.OvhApiXdslDiagnostic.get({
+    this.additionalIpPollerTicket = this.XdslTaskPoller.register(
+      'pendingOrderAdditionalIpOption',
+      () => {
+        this.ordering = false;
+        return this.getIps();
+      },
+    );
+
+    this.$scope.$on('$destroy', () => {
+      this.XdslTaskPoller.unregister(this.diagPollerTicket);
+      this.XdslTaskPoller.unregister(this.additionalIpPollerTicket);
+    });
+
+    return this.$q.all([
+      this.getLinesDetails(),
+      this.getDiagnostic(),
+      this.getIncident(),
+      this.getModemExchange(),
+      this.getAvailableProfiles(),
+    ]);
+  }
+
+  isLoading() {
+    return (
+      this.$scope.loaders.details ||
+      this.$scope.loaders.tasks ||
+      this.$scope.loaders.incident
+    );
+  }
+
+  openDetailsPopup() {
+    if (
+      this.accessDiagnostic === null &&
+      !this.$scope.loaders.accessDiagnosticLaunched
+    ) {
+      this.launchDiagnostic();
+    }
+    return this.$state.go('telecom.packs.pack.xdsl.access-diagnostic-details');
+  }
+
+  launchDiagnostic() {
+    this.accessDiagnostic = null;
+    this.$scope.loaders.accessDiagnosticLaunched = true;
+    return this.OvhApiXdslDiagnostic.launchDiagnostic(
+      { xdslId: this.$stateParams.serviceName },
+      {},
+    ).$promise;
+  }
+
+  getDiagnostic() {
+    return this.OvhApiXdslDiagnostic.get({
+      xdslId: this.$stateParams.serviceName,
+    }).$promise.then((accessDiagnostic) => {
+      this.accessDiagnostic = accessDiagnostic;
+      this.$rootScope.$broadcast(
+        'accessDiagnosticDetails:arrived',
+        this.accessDiagnostic,
+      );
+    });
+  }
+
+  initTemplateCaches() {
+    /* eslint-disable max-len */
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-dslam.html',
+      '<div class="tooltip-description" data-translate="xdsl_access_dslam_reset_description"></div><div class="text-warning" data-translate="xdsl_access_dslam_reset_warning"></div>',
+    );
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-lnsApply.html',
+      '<div class="tooltip-description" data-translate="xdsl_access_lns_ratelimit_description"></div><div class="text-warning" data-translate="xdsl_access_lns_ratelimit_warning"></div>',
+    );
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-lns.html',
+      '<div class="tooltip-description" data-translate="xdsl_access_lns_description"></div><div class="text-warning" data-translate="xdsl_access_lns_warning"></div>',
+    );
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-deconsolidation.html',
+      '<div class="tooltip-description" data-ng-bind=" (\'xdsl_access_deconsolidation_warning_\' + XdslAccess.lineDetails.deconsolidation) | translate"></div>',
+    );
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-ipDelete.html',
+      '<div class="tooltip-description" data-translate="xdsl_details_ips_remove_only_extra"></div>',
+    );
+    this.$templateCache.put(
+      'pack-xdsl-access-tooltip-ips.html',
+      '<div class="tooltip-description" data-translate="xdsl_access_ipv6_description"></div><div class="text-warning" data-translate="xdsl_access_ipv6_warning"></div>',
+    );
+    /* eslint-enable max-len */
+  }
+
+  setStatusLabel(status) {
+    switch (status) {
+      case 'active':
+        this.statusLabel = `<h5 class="ovh-font ovh-font-success text-success mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
+          `xdsl_details_status_${status}`,
+        )}`;
+        break;
+      case 'doing':
+      case 'migration':
+      case 'upgradeOffer':
+        this.statusLabel = `<h5 class="ovh-font ovh-font-success text-success mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
+          `xdsl_details_status_${status}`,
+        )}`;
+        break;
+      case 'cancelled':
+      case 'close':
+      case 'deleting':
+      case 'slamming':
+        this.statusLabel = `<h5 class="ovh-font ovh-font-failure text-danger mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
+          `xdsl_details_status_${status}`,
+        )}`;
+        break;
+      default:
+        this.statusLabel = status;
+    }
+  }
+
+  getOldV6TransfertUrl() {
+    return this.REDIRECT_URLS.oldV6ServiceTransfert;
+  }
+
+  getIps() {
+    return this.OvhApiXdslIps.Aapi()
+      .ips({
         xdslId: this.$stateParams.serviceName,
-      }).$promise.then((accessDiagnostic) => {
-        this.accessDiagnostic = accessDiagnostic;
-        this.$rootScope.$broadcast(
-          'accessDiagnosticDetails:arrived',
-          this.accessDiagnostic,
-        );
-      });
-    }
+      })
+      .$promise.then((ips) => {
+        this.ips = ips;
+        this.ipsV6 = this.$filter('filter')(ips, { version: 'v6' });
+        this.ipsV4 = this.$filter('filter')(ips, { version: 'v4' });
+        ips.forEach((ip) => {
+          // eslint-disable-next-line no-param-reassign
+          ip.getBlock = function getBlock() {
+            return `${this.ip}/${this.range}`;
+          };
+        });
+      }, this.TucToastError);
+  }
 
-    initTemplateCaches() {
-      /* eslint-disable max-len */
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-dslam.html',
-        '<div class="tooltip-description" data-translate="xdsl_access_dslam_reset_description"></div><div class="text-warning" data-translate="xdsl_access_dslam_reset_warning"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-lnsApply.html',
-        '<div class="tooltip-description" data-translate="xdsl_access_lns_ratelimit_description"></div><div class="text-warning" data-translate="xdsl_access_lns_ratelimit_warning"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-lns.html',
-        '<div class="tooltip-description" data-translate="xdsl_access_lns_description"></div><div class="text-warning" data-translate="xdsl_access_lns_warning"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-deconsolidation.html',
-        '<div class="tooltip-description" data-ng-bind=" (\'xdsl_access_deconsolidation_warning_\' + XdslAccess.lineDetails.deconsolidation) | translate"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-ipDelete.html',
-        '<div class="tooltip-description" data-translate="xdsl_details_ips_remove_only_extra"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-ips.html',
-        '<div class="tooltip-description" data-translate="xdsl_access_ipv6_description"></div><div class="text-warning" data-translate="xdsl_access_ipv6_warning"></div>',
-      );
-      this.$templateCache.put(
-        'pack-xdsl-access-tooltip-dslamProfile.html',
-        '<div class="text-left"><p data-translate="xdsl_access_profile_tooltip_interleaved"></p><p data-translate="xdsl_access_profile_tooltip_fast"></p><p data-translate="xdsl_access_profile_tooltip_ginp"></p><p data-translate="xdsl_access_profile_tooltip_auto"></p><p data-translate="xdsl_access_profile_tooltip_snr"></p><p class="text-warning" data-translate="xdsl_access_profile_tooltip_time"></p></div>',
-      );
-      /* eslint-enable max-len */
-    }
+  hasPendingOrderAdditionalIpOption() {
+    return this.$scope.access.tasks.current.pendingOrderAdditionalIpOption;
+  }
 
-    setStatusLabel(status) {
-      switch (status) {
-        case 'active':
-          this.statusLabel = `<h5 class="ovh-font ovh-font-success text-success mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
-            `xdsl_details_status_${status}`,
-          )}`;
-          break;
-        case 'doing':
-        case 'migration':
-        case 'upgradeOffer':
-          this.statusLabel = `<h5 class="ovh-font ovh-font-success text-success mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
-            `xdsl_details_status_${status}`,
-          )}`;
-          break;
-        case 'cancelled':
-        case 'close':
-        case 'deleting':
-        case 'slamming':
-          this.statusLabel = `<h5 class="ovh-font ovh-font-failure text-danger mr-2" aria-hidden="true"></h5> ${this.$translate.instant(
-            `xdsl_details_status_${status}`,
-          )}`;
-          break;
-        default:
-          this.statusLabel = status;
-      }
-    }
+  canHaveMoreIps() {
+    return (
+      filter(this.ipsV4, (ip) => ip.range !== this.PACK_IP.baseIpv4Range)
+        .length === 0
+    );
+  }
 
-    getOldV6TransfertUrl() {
-      return this.REDIRECT_URLS.oldV6ServiceTransfert;
-    }
+  orderIps() {
+    const modal = this.$uibModal.open({
+      animation: true,
+      templateUrl:
+        'app/telecom/pack/xdsl/access/ip/order/pack-xdsl-access-ip-order.modal.html',
+      controller: 'XdslAccessIpOrderCtrl',
+      controllerAs: 'ctrl',
+      resolve: {
+        data: () => ({ xdslId: this.$stateParams.serviceName }),
+      },
+    });
+    modal.result.then((result) => {
+      this.$scope.access.tasks.current[result.function] = true;
+    });
+  }
 
-    getIps() {
-      return this.OvhApiXdslIps.Aapi()
-        .ips({
+  deleteIps(ip) {
+    set(ip, 'deleting', true);
+    this.OvhApiXdslIps.v6()
+      .unOrder(
+        {
           xdslId: this.$stateParams.serviceName,
-        })
-        .$promise.then((ips) => {
-          this.ips = ips;
-          this.ipsV6 = this.$filter('filter')(ips, { version: 'v6' });
-          this.ipsV4 = this.$filter('filter')(ips, { version: 'v4' });
-          ips.forEach((ip) => {
-            // eslint-disable-next-line no-param-reassign
-            ip.getBlock = function getBlock() {
-              return `${this.ip}/${this.range}`;
-            };
-          });
-        }, this.TucToastError);
-    }
-
-    hasPendingOrderAdditionalIpOption() {
-      return this.$scope.access.tasks.current.pendingOrderAdditionalIpOption;
-    }
-
-    canHaveMoreIps() {
-      return (
-        filter(this.ipsV4, (ip) => ip.range !== this.PACK_IP.baseIpv4Range)
-          .length === 0
-      );
-    }
-
-    orderIps() {
-      const modal = this.$uibModal.open({
-        animation: true,
-        templateUrl:
-          'app/telecom/pack/xdsl/access/ip/order/pack-xdsl-access-ip-order.modal.html',
-        controller: 'XdslAccessIpOrderCtrl',
-        controllerAs: 'ctrl',
-        resolve: {
-          data: () => ({ xdslId: this.$stateParams.serviceName }),
+          ip: ip.ip,
         },
-      });
-      modal.result.then((result) => {
-        this.$scope.access.tasks.current[result.function] = true;
-      });
-    }
-
-    deleteIps(ip) {
-      set(ip, 'deleting', true);
-      this.OvhApiXdslIps.v6()
-        .unOrder(
-          {
-            xdslId: this.$stateParams.serviceName,
-            ip: ip.ip,
-          },
-          null,
-        )
-        .$promise.then(
-          () => {
-            this.getIps();
-            set(ip, 'deleting', false);
-            this.TucToast.success(
-              this.$translate.instant('xdsl_access_ip_block_delete_success', {
-                ip: ip.ip,
-              }),
-            );
-          },
-          (err) => {
-            set(ip, 'deleting', false);
-            this.TucToastError(err);
-          },
-        );
-    }
-
-    onTaskPollError(err) {
-      if (!isEmpty(err)) {
-        this.TucToastError(err);
-      }
-      this.$scope.loaders.tasks = false;
-    }
-
-    onTaskPollSuccess(result) {
-      this.$scope.access.tasks.current = result.data;
-      this.$scope.loaders.tasks = false;
-    }
-
-    getLinesDetails() {
-      this.$scope.loaders.details = true;
-      this.$scope.loaders.tasks = true;
-
-      this.transfert = {};
-
-      this.XdslTaskPoller.start(
-        this.$stateParams.serviceName,
-        this.$scope,
-        (result) => this.onTaskPollSuccess(result),
-        (error) => this.onTaskPollError(error),
-      );
-
-      return this.$q
-        .allSettled([
-          // Get access Details
-          this.OvhApiXdsl.v6()
-            .get({
-              xdslId: this.$stateParams.serviceName,
-            })
-            .$promise.then(
-              (access) => {
-                this.$scope.loaders.xdsl = false;
-                this.$scope.access.xdsl = assign(access, {
-                  isFiber: includes(this.PACK.fiberAccess, access.accessType),
-                });
-                this.setStatusLabel(this.$scope.access.xdsl.status);
-                return this.$scope.access.xdsl;
-              },
-              (err) => {
-                this.$scope.loaders.xdsl = false;
-                return this.TucToastError(err);
-              },
-            ),
-
-          // Get line details
-          this.OvhApiXdslLines.v6()
-            .get({
-              xdslId: this.$stateParams.serviceName,
-              number: this.$stateParams.number,
-            })
-            .$promise.then(
-              (lineDetails) => {
-                this.lineDetails = lineDetails;
-                this.$scope.deconsolidation = lineDetails.deconsolidation;
-                this.$scope.loaders.deconsolidation = false;
-              },
-              (err) => {
-                this.$scope.loaders.deconsolidation = false;
-                return this.TucToastError.constructor(err);
-              },
-            ),
-
-          // Get MAC Address
-          this.OvhApiXdslModem.v6()
-            .get({
-              xdslId: this.$stateParams.serviceName,
-            })
-            .$promise.then(
-              (modemDetail) => {
-                this.$scope.access.brandName = modemDetail.brandName;
-                if (modemDetail.brandName === 'Zyxel') {
-                  this.$scope.access.isZyxel = true;
-                }
-                this.modem = modemDetail;
-              },
-              (err) => {
-                if (err.status === 404) {
-                  return;
-                }
-                this.TucToastError(err);
-              },
-            ),
-
-          this.getIps(),
-
-          // Get notification number
-          this.OvhApiXdslNotifications.v6()
-            .query({
-              xdslId: this.$stateParams.serviceName,
-            })
-            .$promise.then((ids) => {
-              this.$scope.access.notificationsCount = ids.length;
-            }, this.TucToastError),
-
-          // Get Order
-          this.OvhApiXdsl.v6()
-            .getOrder({
-              xdslId: this.$stateParams.serviceName,
-            })
-            .$promise.then((orders) => {
-              this.actualOrder = find(
-                orders,
-                (order) => order.status === 'doing',
-              );
-
-              if (!this.actualOrder) {
-                this.actualOrder = findLast(
-                  orders,
-                  (order) => order.status === 'done',
-                );
-              }
-
-              if (this.actualOrder.doneDate) {
-                this.actualOrder.doneDateLocale = new Date(
-                  this.actualOrder.doneDate,
-                ).toLocaleString();
-              }
-            }, this.TucToastError),
-
-          this.OvhApiPackXdsl.Task()
-            .v6()
-            .query({
-              packName: this.packName,
-              function: 'pendingAddressMove',
-            })
-            .$promise.then((result) => {
-              this.pendingAddressMove = result.length > 0;
+        null,
+      )
+      .$promise.then(
+        () => {
+          this.getIps();
+          set(ip, 'deleting', false);
+          this.TucToast.success(
+            this.$translate.instant('xdsl_access_ip_block_delete_success', {
+              ip: ip.ip,
             }),
-        ])
-        .finally(() => {
-          this.$scope.loaders.details = false;
-        });
-    }
+          );
+        },
+        (err) => {
+          set(ip, 'deleting', false);
+          this.TucToastError(err);
+        },
+      );
+  }
 
-    getIncident() {
-      return this.OvhApiXdsl.Incident()
-        .v6()
-        .get({
-          serviceName: this.$stateParams.serviceName,
-        })
-        .$promise.then(() => {
-          this.hasIncidentOccured = true;
-        })
-        .catch((error) => {
-          const errorStatus = get(error, 'status');
-          if (errorStatus === XDSL_NO_INCIDENT_CODE) {
-            this.hasIncidentOccured = false;
-          } else {
-            this.TucToast.error(
-              `${this.$translate.instant(
-                'xdsl_details_diagnostic_get_incident_error',
-              )} ${get(error, 'data.message', '')}`,
+  onTaskPollError(err) {
+    if (!isEmpty(err)) {
+      this.TucToastError(err);
+    }
+    this.$scope.loaders.tasks = false;
+  }
+
+  onTaskPollSuccess(result) {
+    this.$scope.access.tasks.current = result.data;
+    this.$scope.loaders.tasks = false;
+  }
+
+  getLinesDetails() {
+    this.$scope.loaders.details = true;
+    this.$scope.loaders.tasks = true;
+
+    this.transfert = {};
+
+    this.XdslTaskPoller.start(
+      this.$stateParams.serviceName,
+      this.$scope,
+      (result) => this.onTaskPollSuccess(result),
+      (error) => this.onTaskPollError(error),
+    );
+
+    return this.$q
+      .allSettled([
+        // Get access Details
+        this.OvhApiXdsl.v6()
+          .get({
+            xdslId: this.$stateParams.serviceName,
+          })
+          .$promise.then(
+            (access) => {
+              this.$scope.loaders.xdsl = false;
+              this.$scope.access.xdsl = assign(access, {
+                isFiber: includes(this.PACK.fiberAccess, access.accessType),
+              });
+              this.setStatusLabel(this.$scope.access.xdsl.status);
+              return this.$scope.access.xdsl;
+            },
+            (err) => {
+              this.$scope.loaders.xdsl = false;
+              return this.TucToastError(err);
+            },
+          ),
+
+        // Get line details
+        this.OvhApiXdslLines.v6()
+          .get({
+            xdslId: this.$stateParams.serviceName,
+            number: this.$stateParams.number,
+          })
+          .$promise.then(
+            (lineDetails) => {
+              this.lineDetails = lineDetails;
+              this.$scope.deconsolidation = lineDetails.deconsolidation;
+              this.$scope.loaders.deconsolidation = false;
+            },
+            (err) => {
+              this.$scope.loaders.deconsolidation = false;
+              return this.TucToastError.constructor(err);
+            },
+          ),
+
+        // Get MAC Address
+        this.OvhApiXdslModem.v6()
+          .get({
+            xdslId: this.$stateParams.serviceName,
+          })
+          .$promise.then(
+            (modemDetail) => {
+              this.$scope.access.brandName = modemDetail.brandName;
+              if (modemDetail.brandName === 'Zyxel') {
+                this.$scope.access.isZyxel = true;
+              }
+              this.modem = modemDetail;
+            },
+            (err) => {
+              if (err.status === 404) {
+                return;
+              }
+              this.TucToastError(err);
+            },
+          ),
+
+        this.getIps(),
+
+        // Get notification number
+        this.OvhApiXdslNotifications.v6()
+          .query({
+            xdslId: this.$stateParams.serviceName,
+          })
+          .$promise.then((ids) => {
+            this.$scope.access.notificationsCount = ids.length;
+          }, this.TucToastError),
+
+        // Get Order
+        this.OvhApiXdsl.v6()
+          .getOrder({
+            xdslId: this.$stateParams.serviceName,
+          })
+          .$promise.then((orders) => {
+            this.actualOrder = find(
+              orders,
+              (order) => order.status === 'doing',
             );
-          }
-        })
-        .finally(() => {
-          this.$scope.loaders.incident = false;
-        });
-    }
 
-    /**
-     * Retrieve modem detail for exchange if available
-     */
-    getModemExchange() {
-      return this.OvhApiXdsl.Modem()
-        .v6()
-        .getComfortExchange({
-          xdslId: this.$stateParams.serviceName,
-        })
-        .$promise.then((result) => {
-          this.$scope.access.xdsl.canExchange = true;
-          this.$scope.access.xdsl.newModel = result.newModel
-            .replace(/\./g, ' ')
-            .toUpperCase();
-          this.$scope.access.xdsl.priceHT = result.price.value;
-          this.$scope.access.xdsl.priceTTC = result.priceWithTax.value;
-        })
-        .catch((error) => {
-          if (error.data.message.includes(XDSL_EXCHANGE_MODEM.errBase)) {
-            // It's the last model modem or a RMA is already done
-            const typeMessage = error.data.message.substring(0, 6);
-            this.$scope.access.xdsl.canExchange = false;
-            switch (typeMessage) {
-              case XDSL_EXCHANGE_MODEM.errorCodeLast:
-                this.$scope.access.xdsl.messageCantExchange =
-                  'xdsl_modem_comfort_exchange_already_last_model';
-                break;
-              case XDSL_EXCHANGE_MODEM.errorCodeRMA:
-                this.$scope.access.xdsl.messageCantExchange =
-                  'xdsl_modem_comfort_exchange_already_opened_rma';
-                break;
-              case XDSL_EXCHANGE_MODEM.errorCodeSDSL:
-                this.$scope.access.xdsl.messageCantExchange =
-                  'xdsl_modem_comfort_exchange_not_replace_modem_sdsl';
-                break;
-              default:
-                this.TucToastError(error.data.message);
-                break;
+            if (!this.actualOrder) {
+              this.actualOrder = findLast(
+                orders,
+                (order) => order.status === 'done',
+              );
             }
+
+            if (this.actualOrder.doneDate) {
+              this.actualOrder.doneDateLocale = new Date(
+                this.actualOrder.doneDate,
+              ).toLocaleString();
+            }
+          }, this.TucToastError),
+
+        this.OvhApiPackXdsl.Task()
+          .v6()
+          .query({
+            packName: this.packName,
+            function: 'pendingAddressMove',
+          })
+          .$promise.then((result) => {
+            this.pendingAddressMove = result.length > 0;
+          }),
+      ])
+      .finally(() => {
+        this.$scope.loaders.details = false;
+      });
+  }
+
+  getIncident() {
+    return this.OvhApiXdsl.Incident()
+      .v6()
+      .get({
+        serviceName: this.$stateParams.serviceName,
+      })
+      .$promise.then(() => {
+        this.hasIncidentOccured = true;
+      })
+      .catch((error) => {
+        const errorStatus = get(error, 'status');
+        if (errorStatus === XDSL_NO_INCIDENT_CODE) {
+          this.hasIncidentOccured = false;
+        } else {
+          this.TucToast.error(
+            `${this.$translate.instant(
+              'xdsl_details_diagnostic_get_incident_error',
+            )} ${get(error, 'data.message', '')}`,
+          );
+        }
+      })
+      .finally(() => {
+        this.$scope.loaders.incident = false;
+      });
+  }
+
+  /**
+   * Retrieve modem detail for exchange if available
+   */
+  getModemExchange() {
+    return this.OvhApiXdsl.Modem()
+      .v6()
+      .getComfortExchange({
+        xdslId: this.$stateParams.serviceName,
+      })
+      .$promise.then((result) => {
+        this.$scope.access.xdsl.canExchange = true;
+        this.$scope.access.xdsl.newModel = result.newModel
+          .replace(/\./g, ' ')
+          .toUpperCase();
+        this.$scope.access.xdsl.priceHT = result.price.value;
+        this.$scope.access.xdsl.priceTTC = result.priceWithTax.value;
+      })
+      .catch((error) => {
+        if (error.data.message.includes(XDSL_EXCHANGE_MODEM.errBase)) {
+          // It's the last model modem or a RMA is already done
+          const typeMessage = error.data.message.substring(0, 6);
+          this.$scope.access.xdsl.canExchange = false;
+          switch (typeMessage) {
+            case XDSL_EXCHANGE_MODEM.errorCodeLast:
+              this.$scope.access.xdsl.messageCantExchange =
+                'xdsl_modem_comfort_exchange_already_last_model';
+              break;
+            case XDSL_EXCHANGE_MODEM.errorCodeRMA:
+              this.$scope.access.xdsl.messageCantExchange =
+                'xdsl_modem_comfort_exchange_already_opened_rma';
+              break;
+            case XDSL_EXCHANGE_MODEM.errorCodeSDSL:
+              this.$scope.access.xdsl.messageCantExchange =
+                'xdsl_modem_comfort_exchange_not_replace_modem_sdsl';
+              break;
+            default:
+              this.TucToastError(error.data.message);
+              break;
           }
+        }
+      });
+  }
+
+  /**
+   * Retrieve available profiles for connection to make tooltip
+   */
+  getAvailableProfiles() {
+    return this.OvhApiXdslLinesDslamPort.Aapi()
+      .getProfiles({
+        xdslId: this.$stateParams.serviceName,
+        number: this.$stateParams.number,
+      })
+      .$promise.then((profiles) => {
+        let profilesTemplate = '';
+        profiles.forEach((profile) => {
+          profilesTemplate = `${profilesTemplate}<p data-translate="xdsl_access_profile_tooltip_${profile.name.toLowerCase()}"></p>`;
         });
-    }
-  },
-);
+        this.$templateCache.put(
+          'pack-xdsl-access-tooltip-dslamProfile.html',
+          `<div class="text-left">${profilesTemplate}<p class="text-warning" data-translate="xdsl_access_profile_tooltip_time"></p></div>`,
+        );
+      })
+      .catch((err) => {
+        return new this.TucToastError(
+          err,
+          'xdsl_access_dslam_an_error_ocurred',
+        );
+      });
+  }
+}

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
@@ -1,11 +1,11 @@
 <section class="telecom-pack-xdsl-access" data-ui-view="accessView">
-    <div class="text-center" data-ng-if="XdslAccess.isLoading()">
+    <div class="text-center" data-ng-if="$ctrl.isLoading()">
         <oui-spinner></oui-spinner>
     </div>
 
     <tuc-toast-message></tuc-toast-message>
 
-    <div data-ng-if="!XdslAccess.isLoading()">
+    <div data-ng-if="!$ctrl.isLoading()">
         <div class="row d-md-flex mb-5">
             <div class="col-xs-12 col-md-6">
                 <div class="oui-tile h-100 mb-5">
@@ -27,11 +27,11 @@
                                             class="mb-3 d-flex align-items-center justify-content-between"
                                         >
                                             <div
-                                                data-ng-bind-html="XdslAccess.statusLabel"
+                                                data-ng-bind-html="$ctrl.statusLabel"
                                             ></div>
                                             <oui-button
                                                 data-variant="link"
-                                                data-on-click="XdslAccess.openDetailsPopup()"
+                                                data-on-click="$ctrl.openDetailsPopup()"
                                             >
                                                 <span
                                                     data-translate="xdsl_details_diagnostic_modal_button"
@@ -39,7 +39,7 @@
                                             </oui-button>
                                         </div>
                                         <div
-                                            data-ng-if="!XdslAccess.hasIncidentOccured"
+                                            data-ng-if="!$ctrl.hasIncidentOccured"
                                         >
                                             <p
                                                 data-ng-if="!access.xdsl.isFiber"
@@ -64,7 +64,7 @@
                                             </button>
                                         </div>
                                         <div
-                                            data-ng-if="XdslAccess.hasIncidentOccured"
+                                            data-ng-if="$ctrl.hasIncidentOccured"
                                         >
                                             <oui-message data-type="warning">
                                                 <p
@@ -76,12 +76,12 @@
                                                 ></span>
                                                 <a
                                                     class="oui-link_icon"
-                                                    data-ng-href="{{:: XdslAccess.URLS.xdslIncident }}"
+                                                    data-ng-href="{{:: $ctrl.URLS.xdslIncident }}"
                                                     rel="noopener"
                                                     target="_blank"
                                                 >
                                                     <span
-                                                        data-ng-bind="XdslAccess.URLS.xdslIncident"
+                                                        data-ng-bind="$ctrl.URLS.xdslIncident"
                                                     ></span>
                                                     <span
                                                         class="oui-icon oui-icon-external_link"
@@ -106,7 +106,7 @@
                                     <div class="oui-tile__description">
                                         <div
                                             class="text-uppercase"
-                                            data-ng-if="XdslAccess.lineDetails.syncDown"
+                                            data-ng-if="$ctrl.lineDetails.syncDown"
                                         >
                                             <span
                                                 class="fa fa-arrow-down"
@@ -114,13 +114,13 @@
                                             ></span>
                                             <span
                                                 data-translate="xdsl_details_syncDown"
-                                                data-translate-values="{ syncDown: XdslAccess.lineDetails.syncDown }"
+                                                data-translate-values="{ syncDown: $ctrl.lineDetails.syncDown }"
                                             >
                                             </span>
                                         </div>
                                         <div
                                             class="text-uppercase"
-                                            data-ng-if="XdslAccess.lineDetails.syncUp"
+                                            data-ng-if="$ctrl.lineDetails.syncUp"
                                         >
                                             <span
                                                 class="fa fa-arrow-up"
@@ -128,12 +128,12 @@
                                             ></span>
                                             <span
                                                 data-translate="xdsl_details_syncUp"
-                                                data-translate-values="{ syncUp: XdslAccess.lineDetails.syncUp }"
+                                                data-translate-values="{ syncUp: $ctrl.lineDetails.syncUp }"
                                             >
                                             </span>
                                         </div>
                                         <span
-                                            data-ng-if="!XdslAccess.lineDetails.syncUp && !XdslAccess.lineDetails.syncDown"
+                                            data-ng-if="!$ctrl.lineDetails.syncUp && !$ctrl.lineDetails.syncDown"
                                             >-</span
                                         >
                                     </div>
@@ -153,7 +153,7 @@
                                     <div
                                         class="oui-tile__description"
                                         data-translate="xdsl_details_db"
-                                        data-translate-values="{ mitigation: XdslAccess.lineDetails.mitigation }"
+                                        data-translate-values="{ mitigation: $ctrl.lineDetails.mitigation }"
                                     ></div>
                                 </div>
                             </li>
@@ -185,25 +185,25 @@
                                     ></div>
                                     <div
                                         class="oui-tile__description"
-                                        data-ng-if="XdslAccess.lineDetails.deconsolidation !== 'partial' || access.tasks.current.accessPartToTotal"
-                                        data-translate="xdsl_access_deconsolidation_{{XdslAccess.lineDetails.deconsolidation}}"
+                                        data-ng-if="$ctrl.lineDetails.deconsolidation !== 'partial' || access.tasks.current.accessPartToTotal"
+                                        data-translate="xdsl_access_deconsolidation_{{$ctrl.lineDetails.deconsolidation}}"
                                         data-uib-tooltip-template="'pack-xdsl-access-tooltip-deconsolidation.html'"
-                                        data-tooltip-enable="XdslAccess.lineDetails.deconsolidation"
+                                        data-tooltip-enable="$ctrl.lineDetails.deconsolidation"
                                         data-tooltip-placement="right"
                                     ></div>
                                     <div
                                         class="oui-tile__description"
-                                        data-ng-if="XdslAccess.lineDetails.deconsolidation === 'partial' && !access.tasks.current.accessPartToTotal"
+                                        data-ng-if="$ctrl.lineDetails.deconsolidation === 'partial' && !access.tasks.current.accessPartToTotal"
                                     >
                                         <a
                                             class="service-button"
                                             data-ui-sref="telecom.packs.pack.xdsl.access-deconsolidation"
                                             data-uib-tooltip-template="'pack-xdsl-access-tooltip-deconsolidation.html'"
-                                            data-tooltip-enable="XdslAccess.lineDetails.deconsolidation"
+                                            data-tooltip-enable="$ctrl.lineDetails.deconsolidation"
                                             data-tooltip-placement="right"
                                         >
                                             <div
-                                                data-translate="xdsl_access_deconsolidation_{{XdslAccess.lineDetails.deconsolidation}}"
+                                                data-translate="xdsl_access_deconsolidation_{{$ctrl.lineDetails.deconsolidation}}"
                                             ></div>
 
                                             <span
@@ -227,7 +227,7 @@
                                     ></div>
                                     <div class="oui-tile__description">
                                         <div
-                                            data-ng-if="XdslAccess.pendingAddressMove"
+                                            data-ng-if="$ctrl.pendingAddressMove"
                                         >
                                             <span
                                                 data-ng-bind="access.xdsl.address.numberStreet"
@@ -269,7 +269,7 @@
                                             ></span>
                                         </div>
                                         <div
-                                            data-ng-if="!XdslAccess.pendingAddressMove && access.xdsl.accessType !== 'sdsl'"
+                                            data-ng-if="!$ctrl.pendingAddressMove && access.xdsl.accessType !== 'sdsl'"
                                         >
                                             <div class="mb-3">
                                                 <span
@@ -317,13 +317,13 @@
                                         <div class="mb-3">
                                             <p
                                                 class="text-default"
-                                                data-ng-class="{ 'description-title-fullHeight' : !XdslAccess.actualOrder.doneDateLocale }"
-                                                data-translate="telecom_pack_xdsl_order_follow_up_step_name_{{XdslAccess.actualOrder.name}}"
+                                                data-ng-class="{ 'description-title-fullHeight' : !$ctrl.actualOrder.doneDateLocale }"
+                                                data-translate="telecom_pack_xdsl_order_follow_up_step_name_{{$ctrl.actualOrder.name}}"
                                             ></p>
                                             <p
                                                 class="text-default"
-                                                data-ng-if="XdslAccess.actualOrder.doneDateLocale"
-                                                data-ng-bind="XdslAccess.actualOrder.doneDateLocale"
+                                                data-ng-if="$ctrl.actualOrder.doneDateLocale"
+                                                data-ng-bind="$ctrl.actualOrder.doneDateLocale"
                                             ></p>
                                         </div>
                                         <a
@@ -398,10 +398,7 @@
                                 </div>
                             </li>
 
-                            <li
-                                class="oui-tile__item"
-                                data-ng-if="XdslAccess.modem"
-                            >
+                            <li class="oui-tile__item" data-ng-if="$ctrl.modem">
                                 <div
                                     class="oui-tile__definition"
                                     data-ng-if="access.xdsl.canExchange"
@@ -487,7 +484,7 @@
                                         <dd
                                             class="oui-tile__description"
                                             data-translate="xdsl_details_metters"
-                                            data-translate-values="{ distance: XdslAccess.lineDetails.distance }"
+                                            data-translate-values="{ distance: $ctrl.lineDetails.distance }"
                                         ></dd>
 
                                         <dt
@@ -496,13 +493,13 @@
                                         ></dt>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="XdslAccess.lineDetails.lineSectionsLength.length"
+                                            data-ng-if="$ctrl.lineDetails.lineSectionsLength.length"
                                             data-translate="xdsl_details_sectionLength_values"
-                                            data-translate-values="{ diameter: XdslAccess.lineDetails.lineSectionsLength[0].diameter, length: XdslAccess.lineDetails.lineSectionsLength[0].length }"
+                                            data-translate-values="{ diameter: $ctrl.lineDetails.lineSectionsLength[0].diameter, length: $ctrl.lineDetails.lineSectionsLength[0].length }"
                                         ></dd>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="!XdslAccess.lineDetails.lineSectionsLength.length"
+                                            data-ng-if="!$ctrl.lineDetails.lineSectionsLength.length"
                                         >
                                             -
                                         </dd>
@@ -513,12 +510,12 @@
                                         ></dt>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="XdslAccess.lineDetails.concentrationPoint.lineHead"
-                                            data-ng-bind="XdslAccess.lineDetails.concentrationPoint.lineHead"
+                                            data-ng-if="$ctrl.lineDetails.concentrationPoint.lineHead"
+                                            data-ng-bind="$ctrl.lineDetails.concentrationPoint.lineHead"
                                         ></dd>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="!XdslAccess.lineDetails.concentrationPoint.lineHead"
+                                            data-ng-if="!$ctrl.lineDetails.concentrationPoint.lineHead"
                                         >
                                             -
                                         </dd>
@@ -529,12 +526,12 @@
                                         ></dt>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="XdslAccess.lineDetails.concentrationPoint.lineInitialSection"
-                                            data-ng-bind="XdslAccess.lineDetails.concentrationPoint.lineInitialSection"
+                                            data-ng-if="$ctrl.lineDetails.concentrationPoint.lineInitialSection"
+                                            data-ng-bind="$ctrl.lineDetails.concentrationPoint.lineInitialSection"
                                         ></dd>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="!XdslAccess.lineDetails.concentrationPoint.lineInitialSection"
+                                            data-ng-if="!$ctrl.lineDetails.concentrationPoint.lineInitialSection"
                                         >
                                             -
                                         </dd>
@@ -545,12 +542,12 @@
                                         ></dt>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="XdslAccess.lineDetails.concentrationPoint.lineInitialSectionPair"
-                                            data-ng-bind="XdslAccess.lineDetails.concentrationPoint.lineInitialSectionPair"
+                                            data-ng-if="$ctrl.lineDetails.concentrationPoint.lineInitialSectionPair"
+                                            data-ng-bind="$ctrl.lineDetails.concentrationPoint.lineInitialSectionPair"
                                         ></dd>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-if="!XdslAccess.lineDetails.concentrationPoint.lineInitialSectionPair"
+                                            data-ng-if="!$ctrl.lineDetails.concentrationPoint.lineInitialSectionPair"
                                         >
                                             -
                                         </dd>
@@ -596,7 +593,7 @@
                                         ></dt>
                                         <dd
                                             class="oui-tile__description"
-                                            data-ng-bind="XdslAccess.lineDetails.number"
+                                            data-ng-bind="$ctrl.lineDetails.number"
                                         ></dd>
                                     </dl>
                                 </div>
@@ -609,9 +606,7 @@
                                         data-translate="xdsl_details_ips_title"
                                     ></h4>
                                     <!-- IP V4 -->
-                                    <div
-                                        data-ng-if="XdslAccess.ipsV4.length > 0"
-                                    >
+                                    <div data-ng-if="$ctrl.ipsV4.length > 0">
                                         <div
                                             class="oui-tile__term"
                                             data-translate="xdsl_details_ips_v4"
@@ -619,7 +614,7 @@
                                         <div class="oui-tile__description">
                                             <div
                                                 class="my-2 ip-row-height"
-                                                data-ng-repeat="ip in XdslAccess.ipsV4 | orderBy:'-range' track by ip.ip"
+                                                data-ng-repeat="ip in $ctrl.ipsV4 | orderBy:'-range' track by ip.ip"
                                             >
                                                 <div
                                                     class="d-inline-block my-2"
@@ -647,7 +642,7 @@
                                                         data-ng-disabled="ip.deleting || ip.range === constants.rangeOfBaseIpv4IP || ip.status === 'toDelete'"
                                                         class="btn btn-default"
                                                         title="{{ip.ip}} / {{ip.range}} {{:: 'common_table_delete' | translate }}"
-                                                        data-ng-really-click="XdslAccess.deleteIps(ip)"
+                                                        data-ng-really-click="$ctrl.deleteIps(ip)"
                                                         data-ng-really-message="{{::'xdsl_access_ip_delete_really' | translate:ip}}"
                                                         data-ng-really-confirm="{{::'ok' | translate }}"
                                                         data-ng-really-cancel="{{::'cancel' | translate }}"
@@ -667,9 +662,7 @@
                                         </div>
                                     </div>
                                     <!-- IP V6 -->
-                                    <div
-                                        data-ng-if="XdslAccess.ipsV6.length > 0"
-                                    >
+                                    <div data-ng-if="$ctrl.ipsV6.length > 0">
                                         <span
                                             class="tooltip-label oui-tile__term"
                                             data-uib-tooltip-template="'pack-xdsl-access-tooltip-ips.html'"
@@ -684,7 +677,7 @@
                                             ></div>
                                             <div
                                                 class="my-2 ip-row-height"
-                                                data-ng-repeat="ip in XdslAccess.ipsV6 | orderBy:'-range' track by ip.ip"
+                                                data-ng-repeat="ip in $ctrl.ipsV6 | orderBy:'-range' track by ip.ip"
                                             >
                                                 <div
                                                     class="d-inline-block my-2"
@@ -720,14 +713,14 @@
                                         <div class="oui-tile__actions">
                                             <em
                                                 class="text-warning pl-1"
-                                                data-ng-if="XdslAccess.hasPendingOrderAdditionalIpOption() && XdslAccess.canHaveMoreIps()"
+                                                data-ng-if="$ctrl.hasPendingOrderAdditionalIpOption() && $ctrl.canHaveMoreIps()"
                                                 data-translate="xdsl_details_ips_block_pending_order"
                                             ></em>
                                             <button
                                                 type="button"
                                                 class="oui-button oui-button_full-width oui-button_icon-left oui-button_primary mt-3"
-                                                data-ng-disabled="!XdslAccess.canHaveMoreIps() || XdslAccess.hasPendingOrderAdditionalIpOption()"
-                                                data-ng-click="XdslAccess.orderIps()"
+                                                data-ng-disabled="!$ctrl.canHaveMoreIps() || $ctrl.hasPendingOrderAdditionalIpOption()"
+                                                data-ng-click="$ctrl.orderIps()"
                                             >
                                                 <span
                                                     class="ovh-font ovh-font-cart mr-2"
@@ -829,7 +822,7 @@
                                         </div>
                                     </div>
 
-                                    <div data-ng-if="XdslAccess.modem">
+                                    <div data-ng-if="$ctrl.modem">
                                         <span
                                             data-ng-if="access.xdsl.isFiber"
                                             class="oui-tile__term"
@@ -856,7 +849,7 @@
                                         </div>
                                         <div
                                             class="oui-tile__description"
-                                            data-ng-bind="XdslAccess.modem.macAddress"
+                                            data-ng-bind="$ctrl.modem.macAddress"
                                         ></div>
 
                                         <div
@@ -865,7 +858,7 @@
                                         ></div>
                                         <div
                                             class="oui-tile__description"
-                                            data-ng-bind="XdslAccess.modem.model"
+                                            data-ng-bind="$ctrl.modem.model"
                                         ></div>
                                     </div>
                                 </div>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_de_DE.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_en_GB.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_es_ES.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved:</b> Perfil auto por defecto.",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast:</b> Perfil auto en fastPath (ping mejorado sin corrección de errores).",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP:</b> Esta extensión mejora la corrección de errores sin afectar al rendimiento de la línea. El DSLAM utiliza el modo de protección (INP, Impulse Noise Protection) contra el ruido.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valor]M:</b> El DSLAM sincroniza al máximo en el ancho de banda.",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valor]:</b> El DSLAM analiza la calidad de la línea y negocia una relación señal-ruido (SNR) al valor indicado. Cuando mayor es la cifra, mejor es la estabilidad de la línea, pero menor es el ancho de banda. En los perfiles sin SNR forzados, el DSLAM intenta conseguir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "El cambio se aplicará en los próximos 1-5 minutos.",
   "xdsl_access_dslam_an_error_ocurred": "DSLAM: Se ha producido un error.",
   "xdsl_access_profile_doing": "Cambiando el perfil..."

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_es_US.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_es_US.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fi_FI.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fi_FI.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profiili auto oletus",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profiili auto in fastPath (parannettu ping ilman virheiden korjausta)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Tämä laajennus parantaa virheidenkorjausta liittymän suorituskykyyn vaikuttamatta. DSLAM käyttää melua vastaa suojaustilaa(INP, Impulse Noise Protection). ",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> DSLAM synkronoi maksimaalisesti tiedonsiirtoon",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> DSLAM analysoi linjan laadun ja muodostaa signaali/melu(SNR) suhteen annetussa arvossa. Mitä korkeampi luku, sitä vakaampi linja, mutta tiedonsiirtonopeus on pienempi. Profiileissa ilman vahvaa SNR-lukua, DSLAM pyrkii saamaan SNR-arvon 6.    ",
   "xdsl_access_profile_tooltip_time": "Muokkaus on voimassa 1 - 5 minuutin kuluessa.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Tapahtui virhe!",
   "xdsl_access_profile_doing": "Vaihdetaan profiilia"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fr_CA.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_fr_FR.json
@@ -1,10 +1,12 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
-  "xdsl_access_profile_doing": "Changement de profil en cours"
+  "xdsl_access_profile_doing": "Changement de profil en cours",
+  "xdsl_access_profile_tooltip_adsl_24m": "<b>ADSL_24M :</b> Débit maximum à 24000 / 1024 marge au bruit à 6 dB",
+  "xdsl_access_profile_tooltip_adsl_2m": "<b>ADSL_2M :</b> Débit maximum à 2432 / 1024 marge au bruit supérieur à 6 dB",
+  "xdsl_access_profile_tooltip_adsl_512k": "<b>ADSL_512K :</b> Débit maximum à 608 / 160 marge au bruit supérieur à 6 dB",
+  "xdsl_access_profile_tooltip_adsl_safe1": "<b>ADSL_SAFE1 :</b> Débit maximum à 16128 / 1024 marge au bruit à 10 dB",
+  "xdsl_access_profile_tooltip_adsl_safe2": "<b>ADSL_SAFE2 :</b> Débit maximum à 16128 / 1024 marge au bruit à 16 dB",
+  "xdsl_access_profile_tooltip_adsl_perf1": "<b>ADSL_PERF1 :</b> Débit maximum à 24000 / 1024 marge au bruit à 3 dB",
+  "xdsl_access_profile_tooltip_adsl_perf2": "<b>ADSL_PERF2 :</b> Débit maximum à 24000 / 1024 marge au bruit à 1 dB"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_it_IT.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved</b>: profilo automatico predefinito",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast</b>: profilo automatico in fastPath (ping migliorato senza correzione di errori)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP</b>: questa estensione migliora la correzione di errori senza impatto sulle performance della linea. Il DSLAM utilizzerà la modalità di protezione (INP, Impulse Noise Protection) contro il rumore.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M:</b> Il DSLAM si sincronizzerà con la velocità di trasmissione massima",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur]: </b> Il DSLAM analizza la qualità della linea ed elabora un rapporto segnale/rumore (SNR) al valore indicato. Più il valore è alto, maggiore è la stabilità della linea e minore la velocità di trasmissione dei dati. Sui profili in cui SNR non è forzato, il DSLAM prova a ottenere un SNR da 6.   ",
   "xdsl_access_profile_tooltip_time": "La modifica diventerà effettiva tra 1-5 minuti.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Si è verificato un errore!",
   "xdsl_access_profile_doing": "Modifica del profilo in corso..."

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_lt_LT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_lt_LT.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved:</b> Automatinis profilis pagal nutylėjimą",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast: </b> Automatinis fastPath profilis (mažesnis ping be klaidų taisymo)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP: </b> Šis plėtinys pagerina klaidų taisymą nekeičiant linijos veikimo. DSLAM naudos apsaugos metodą prieš triukšmus (INP, Impulse Noise Protection).",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M:</b> DSLAM maksimaliai sinchronizuos srautą",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur]: </b> DSLAM analizuos linijos kokybę ir nustatys signalo/triukšmo santykį (SNR) pagal nurodytą skaičių. Kuo skaičius didesnis, tuo didesnis linijos stabilumas, tačiau mažės pralaidumas. Dėl SNR įtakos, DSLAM nustatomas SNR yra 6.",
   "xdsl_access_profile_tooltip_time": "Keitimai bus aktyvus po 1 - 5 minučių.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Klaida!",
   "xdsl_access_profile_doing": "Vykdomi profilio keitimai"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_pl_PL.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/profil/translations/Messages_pt_PT.json
@@ -1,9 +1,4 @@
 {
-  "xdsl_access_profile_tooltip_interleaved": "<b>Interleaved :</b> Profil auto par défaut",
-  "xdsl_access_profile_tooltip_fast": "<b>Fast : </b> Profil auto en fastPath (ping amélioré sans correction d'erreur)",
-  "xdsl_access_profile_tooltip_ginp": "<b>G.INP : </b> Cette extension améliore la correction d’erreur sans affecter la performance de la ligne. Le DSLAM va utiliser le mode de protection (INP, Impulse Noise Protection) contre le bruit.",
-  "xdsl_access_profile_tooltip_auto": "<b>AUTO-[valeur]M :</b> Le DSLAM va synchroniser au maximum sur le débit",
-  "xdsl_access_profile_tooltip_snr": "<b>SNR-[valeur] : </b> Le DSLAM va analyser la qualité de la ligne et va negocier un rapport signal/bruit (SNR) au chiffre indique. Plus le chiffre est grand plus la stablilité de la ligne sera bonne mais plus le débit sera petit. Sur les profils sans SNR forces, le DSLAM essaie ;d'avoir un SNR de 6.",
   "xdsl_access_profile_tooltip_time": "La modification sera effective sous 1 à 5 minutes.",
   "xdsl_access_dslam_an_error_ocurred": "[DSLAM] Une erreur est survenue !",
   "xdsl_access_profile_doing": "Changement de profil en cours"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.js
@@ -1,108 +1,52 @@
-import head from 'lodash/head';
+import angular from 'angular';
+
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
+import uiRouter from '@uirouter/angularjs';
+import angularTranslate from 'angular-translate';
+import 'ovh-ui-angular';
+
 import packXdslAccessIpv6 from './access/ipv6/pack-xdsl-access-ipv6.html';
 import packXdslAccessProfil from './access/profil/pack-xdsl-access-profil.html';
 import xdslAccessLnsRatelimit from './access/rateLimit/xdsl-access-lns-ratelimit.html';
 import packXdslAccessPortReset from './access/portReset/pack-xdsl-access-port-reset.html';
 import packXdslStatistics from './access/statistics/pack-xdsl-statistics.html';
+import packXdslAccess from './access';
 
-angular.module('managerApp').run(($templateCache) => {
-  // import templates required by ng-include
-  $templateCache.put(
-    'app/telecom/pack/xdsl/access/ipv6/pack-xdsl-access-ipv6.html',
-    packXdslAccessIpv6,
-  );
-  $templateCache.put(
-    'app/telecom/pack/xdsl/access/profil/pack-xdsl-access-profil.html',
-    packXdslAccessProfil,
-  );
-  $templateCache.put(
-    'app/telecom/pack/xdsl/access/rateLimit/xdsl-access-lns-ratelimit.html',
-    xdslAccessLnsRatelimit,
-  );
-  $templateCache.put(
-    'app/telecom/pack/xdsl/access/portReset/pack-xdsl-access-port-reset.html',
-    packXdslAccessPortReset,
-  );
-  $templateCache.put(
-    'app/telecom/pack/xdsl/access/statistics/pack-xdsl-statistics.html',
-    packXdslStatistics,
-  );
-});
+import routing from './pack-xdsl.routing';
 
-angular.module('managerApp').config(($stateProvider) => {
-  $stateProvider.state('telecom.packs.pack.xdsl-redirection', {
-    url: '/xdsl/:serviceName',
-    resolve: {
-      serviceName: /* @ngInject */ ($transition$) =>
-        $transition$.params().serviceName,
-      lines: /* @ngInject */ (OvhApiXdslLines, serviceName) =>
-        OvhApiXdslLines.v6().query({
-          xdslId: serviceName,
-        }).$promise,
-    },
-    redirectTo: (transition) =>
-      transition
-        .injector()
-        .getAsync('lines')
-        .then((lines) => ({
-          state: 'telecom.packs.pack.xdsl',
-          params: {
-            ...transition.params(),
-            number: head(lines),
-          },
-        })),
+const moduleName = 'ovhManagerTelecomPackXdsl';
+
+angular
+  .module(moduleName, [
+    ngTranslateAsyncLoader,
+    uiRouter,
+    angularTranslate,
+    'oui',
+    packXdslAccess,
+  ])
+  .config(routing)
+  .run(($templateCache) => {
+    // import templates required by ng-include
+    $templateCache.put(
+      'app/telecom/pack/xdsl/access/ipv6/pack-xdsl-access-ipv6.html',
+      packXdslAccessIpv6,
+    );
+    $templateCache.put(
+      'app/telecom/pack/xdsl/access/profil/pack-xdsl-access-profil.html',
+      packXdslAccessProfil,
+    );
+    $templateCache.put(
+      'app/telecom/pack/xdsl/access/rateLimit/xdsl-access-lns-ratelimit.html',
+      xdslAccessLnsRatelimit,
+    );
+    $templateCache.put(
+      'app/telecom/pack/xdsl/access/portReset/pack-xdsl-access-port-reset.html',
+      packXdslAccessPortReset,
+    );
+    $templateCache.put(
+      'app/telecom/pack/xdsl/access/statistics/pack-xdsl-statistics.html',
+      packXdslStatistics,
+    );
   });
 
-  $stateProvider.state('telecom.packs.pack.xdsl', {
-    url: '/xdsl/:serviceName/lines/:number',
-    views: {
-      'packView@telecom.packs': {
-        templateUrl: 'app/telecom/pack/xdsl/pack-xdsl.html',
-        controller: 'PackXdslCtrl',
-        controllerAs: 'PackXdslCtrl',
-      },
-      'xdslView@telecom.packs.pack.xdsl': {
-        controller: 'XdslAccessCtrl',
-        controllerAs: 'XdslAccess',
-        templateUrl: 'app/telecom/pack/xdsl/access/pack-xdsl-access.html',
-      },
-    },
-    translations: {
-      value: [
-        '../common',
-        '.',
-        './access',
-        './access/comfortExchange',
-        './access/deconsolidation',
-        './access/statistics',
-        './access/ipv6',
-        './access/portReset',
-        './access/profil',
-        './access/rateLimit',
-        './access/ip/order',
-        './orderFollowUp',
-      ],
-      format: 'json',
-    },
-    resolve: {
-      $title(translations, $translate, $stateParams, OvhApiXdsl) {
-        return OvhApiXdsl.v6()
-          .get({
-            xdslId: $stateParams.serviceName,
-          })
-          .$promise.then((data) =>
-            $translate.instant(
-              'xdsl_page_title',
-              { name: data.description || $stateParams.serviceName },
-              null,
-              null,
-              'escape',
-            ),
-          )
-          .catch(() =>
-            $translate('xdsl_page_title', { name: $stateParams.serviceName }),
-          );
-      },
-    },
-  });
-});
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
@@ -1,0 +1,75 @@
+import head from 'lodash/head';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('telecom.packs.pack.xdsl-redirection', {
+    url: '/xdsl/:serviceName',
+    resolve: {
+      serviceName: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceName,
+      lines: /* @ngInject */ (OvhApiXdslLines, serviceName) =>
+        OvhApiXdslLines.v6().query({
+          xdslId: serviceName,
+        }).$promise,
+    },
+    redirectTo: (transition) =>
+      transition
+        .injector()
+        .getAsync('lines')
+        .then((lines) => ({
+          state: 'telecom.packs.pack.xdsl',
+          params: {
+            ...transition.params(),
+            number: head(lines),
+          },
+        })),
+  });
+
+  $stateProvider.state('telecom.packs.pack.xdsl', {
+    url: '/xdsl/:serviceName/lines/:number',
+    views: {
+      'packView@telecom.packs': {
+        templateUrl: 'app/telecom/pack/xdsl/pack-xdsl.html',
+        controller: 'PackXdslCtrl',
+        controllerAs: 'PackXdslCtrl',
+      },
+      'xdslView@telecom.packs.pack.xdsl': 'packXdslAccess',
+    },
+    translations: {
+      value: [
+        '../common',
+        '.',
+        './access',
+        './access/comfortExchange',
+        './access/deconsolidation',
+        './access/statistics',
+        './access/ipv6',
+        './access/portReset',
+        './access/profil',
+        './access/rateLimit',
+        './access/ip/order',
+        './orderFollowUp',
+      ],
+      format: 'json',
+    },
+    resolve: {
+      $title(translations, $translate, $stateParams, OvhApiXdsl) {
+        return OvhApiXdsl.v6()
+          .get({
+            xdslId: $stateParams.serviceName,
+          })
+          .$promise.then((data) =>
+            $translate.instant(
+              'xdsl_page_title',
+              { name: data.description || $stateParams.serviceName },
+              null,
+              null,
+              'escape',
+            ),
+          )
+          .catch(() =>
+            $translate('xdsl_page_title', { name: $stateParams.serviceName }),
+          );
+      },
+    },
+  });
+};


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | UXCT-279
| License          | BSD 3-Clause

## Description

Display new KOSC profiles for connection profile tooltip (dynamic made from call API)
