### PR TITLE
fix(web.hosting): catch multiple email options error

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/hosting.routes.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.routes.js
@@ -48,7 +48,8 @@ export default /* @ngInject */ ($stateProvider) => {
                       serviceName: resource.name,
                     })
                     .$promise.catch(() => null),
-                ),
+                )
+                .catch(() => null),
             ),
           )
           .then((servicesInformation) =>


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-12632
| License          | BSD 3-Clause

## Description

Email option may have duplicates. Issue is with API, but the error is catch to not block hosting web loading.
