### PR TITLE
fix(line-progress): fix progress bar z-index

### DIFF
--- a/packages/components/ng-ui-router-line-progress/src/ng-ui-router-line-progress.less
+++ b/packages/components/ng-ui-router-line-progress/src/ng-ui-router-line-progress.less
@@ -7,7 +7,7 @@
   .bar {
     background: @nprogress-background-color;
     position: fixed;
-    z-index: 1031;
+    z-index: 10000;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

The Loading bar was hidden by the navbar. I fix this issue by increasing the bar z-index. I take as reference the z-index of the manager-preload to avoid to be hidden by another component (https://github.com/ovh/manager/blob/master/packages/manager/apps/cloud/client/components/manager-preload/manager-preload.less#L8).

In another PR, we could try to centralize this kind of values, on all the Manager components.
