### PR TITLE
fix: prevent angular-chart.js from being instanciated twice

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.js
+++ b/packages/manager/apps/dedicated/client/app/app.js
@@ -34,6 +34,7 @@ import ovhManagerServerSidebar from '@ovh-ux/manager-server-sidebar';
 import ovhManagerSupport from '@ovh-ux/manager-support';
 import ovhPaymentMethod from '@ovh-ux/ng-ovh-payment-method';
 import uiRouter, { RejectType } from '@uirouter/angularjs';
+import chartjs from 'angular-chart.js';
 
 import moduleExchange from '@ovh-ux/manager-exchange';
 import ovhManagerVeeamEnterprise from '@ovh-ux/manager-veeam-enterprise';
@@ -71,7 +72,7 @@ angular
       account,
       ovhManagerCore,
       'Billing',
-      'chart.js',
+      chartjs,
       'controllers',
       contactsService,
       datacenterBackup,

--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -52,7 +52,6 @@ import '@ovh-ux/ng-ovh-actions-menu';
 import 'script-loader!matchmedia-ng/matchmedia-ng.js';
 import 'angular-aria';
 import 'script-loader!chart.js/dist/Chart.min.js';
-import 'script-loader!angular-chart.js/dist/angular-chart.min.js';
 import 'ovh-angular-responsive-tabs';
 import 'ckeditor';
 import 'script-loader!messenger/build/js/messenger.min.js';

--- a/packages/manager/apps/iplb/src/index.js
+++ b/packages/manager/apps/iplb/src/index.js
@@ -1,7 +1,8 @@
-/* eslint-disable import/no-webpack-loader-syntax */
+/* eslint-disable import/no-webpack-loader-syntax, import/extensions */
 import 'script-loader!jquery';
 import 'script-loader!moment/min/moment-with-locales.min';
-/* eslint-enable import/no-webpack-loader-syntax */
+import 'script-loader!chart.js/dist/Chart.min.js';
+/* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import { Environment } from '@ovh-ux/manager-config';
 

--- a/packages/manager/modules/iplb/src/iplb.module.js
+++ b/packages/manager/modules/iplb/src/iplb.module.js
@@ -12,11 +12,6 @@ import ngAtInternet from '@ovh-ux/ng-at-internet';
 import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
 import ngOvhDocUrl from '@ovh-ux/ng-ovh-doc-url';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/extensions */
-import 'script-loader!chart.js/dist/Chart.js';
-import 'script-loader!angular-chart.js/dist/angular-chart.js';
-/* eslint-enable import/no-webpack-loader-syntax */
-
 import IpLoadBalancerActionService from './iplb-action.service';
 import IpLoadBalancerCipherService from './iplb-cipher.service';
 import IpLoadBalancerConstant from './iplb.constants';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-12378
| License          | BSD 3-Clause

## Description

Prevent angular-chart.js from being instanciated twice. This can cause multiple directives error on some components as both instances try to apply the directive 
