### PR TITLE
feat(hosting.cron): display translated email value

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cron/CRON.html
+++ b/packages/manager/apps/web/client/app/hosting/cron/CRON.html
@@ -118,6 +118,9 @@
                         data-type="string"
                         data-searchable
                     >
+                        <span
+                            data-translate="{{:: 'hosting_tab_CRON_email_' +  $row.email }}"
+                        ></span>
                     </oui-column>
                     <oui-action-menu data-compact data-align="end">
                         <oui-action-menu-item


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          |  MANAGER-5054
| License          | BSD 3-Clause

## Description

display translated email value
