### PR TITLE
fix(domain.dns.sec): allow modal to close properly

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dns/sec/domain-dns-sec.controller.js
+++ b/packages/manager/apps/web/client/app/domain/dns/sec/domain-dns-sec.controller.js
@@ -32,7 +32,7 @@ angular.module('controllers').controller(
       return this.DomainsDnsSec.updateDnssecState(newState, [this.domain.name])
         .then((data) => {
           if (data.state !== 'OK') {
-            this.Alerter.alertFromSWS(
+            return this.Alerter.alertFromSWS(
               this.$translate.instant(
                 `domain_configuration_dnssec_error_${newState}`,
               ),
@@ -41,7 +41,13 @@ angular.module('controllers').controller(
             );
           }
 
-          return this.$state.reload();
+          return this.Alerter.alertFromSWS(
+            this.$translate.instant(
+              `domain_configuration_dnssec_ok_${newState}`,
+            ),
+            data,
+            this.$scope.alerts.main,
+          );
         })
         .catch((err) =>
           this.Alerter.alertFromSWS(


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-12506
| License          | BSD 3-Clause

## Description

allow modal to close properly: as we use a legacy modal system, triggering `$state.reload` prevents bootstrap modal from being closed properly and leaves the backdrop
