### PR TITLE
fix(components.auth): prevent error page from looping

### DIFF
--- a/packages/manager/apps/cloud/client/components/auth/auth.config.js
+++ b/packages/manager/apps/cloud/client/components/auth/auth.config.js
@@ -11,8 +11,6 @@ angular.module('managerApp').run(($transitions, ssoAuthentication) => {
         toState.authenticate !== undefined ? toState.authenticate : true;
 
       if (needToBeAuthenticate && !isLogged) {
-        // eslint-disable-next-line no-restricted-globals
-        event.preventDefault();
         ssoAuthentication.goToLoginPage();
       }
     });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none 
| License          | BSD 3-Clause

## Description

On Firefox when trying to access Cloud manager, preloader loops continiously. This is due to `event` not being defined (because not being passed as a parameter anymore) and redirection to the error page. 
Investigating why this issue was only noticed (for now) on this browser
