### PR TITLE
fix(ip): handle ip offers region based on available countries

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.constant.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.constant.js
@@ -15,7 +15,32 @@ export const PRODUCT_TYPES = {
   },
 };
 
+export const IP_LOCATION_GROUPS = [
+  { labels: ['APAC/CANADA', 'CANADA - ASIA'], countries: ['au', 'ca', 'sg'] },
+  {
+    labels: ['EUROPE'],
+    countries: [
+      'be',
+      'cz',
+      'de',
+      'es',
+      'fi',
+      'fr',
+      'gb',
+      'ie',
+      'it',
+      'lt',
+      'nl',
+      'pl',
+      'pt',
+      'uk',
+    ],
+  },
+  { labels: ['USA'], countries: ['us'] },
+];
+
 export default {
   FETCH_PRICE_MAX_TRIES,
+  IP_LOCATION_GROUPS,
   PRODUCT_TYPES,
 };

--- a/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.service.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.service.js
@@ -21,7 +21,7 @@ angular.module('Module.ip.services').service(
     handleErrorOrServices({ errors, results }) {
       const filteredErrors = errors.filter(({ msg }) => {
         const [errorCode] = msg.match(/\d+/);
-        return parseInt(errorCode, 10) !== 400;
+        return ![400, 404].includes(parseInt(errorCode, 10));
       });
       if (isArray(filteredErrors) && !isEmpty(filteredErrors)) {
         return this.$q.reject(filteredErrors);

--- a/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.service.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/agoraOrder/ip-ip-agoraOrder.service.js
@@ -176,10 +176,26 @@ angular.module('Module.ip.services').service(
       return productToOrder;
     }
 
-    getVpsIpCountryAvailable(serviceName) {
-      return this.OvhHttp.get(`/vps/${serviceName}/ipCountryAvailable`, {
-        rootPath: 'apiv6',
-      });
+    getIpCountryAvailablePromise(serviceName, serviceType) {
+      return this.OvhHttp.get(
+        this.constructor.getIpCountryAvailableRoute(serviceName, serviceType),
+        {
+          rootPath: 'apiv6',
+        },
+      );
+    }
+
+    static getIpCountryAvailableRoute(serviceName, serviceType) {
+      switch (serviceType) {
+        case PRODUCT_TYPES.dedicatedServer.typeName:
+          return `/dedicated/server/${serviceName}/ipCountryAvailable`;
+        case PRODUCT_TYPES.privateCloud.typeName:
+          return `/dedicatedCloud/${serviceName}/orderableIpCountries`;
+        case PRODUCT_TYPES.vps.typeName:
+          return `/vps/${serviceName}/ipCountryAvailable`;
+        default:
+          return null;
+      }
     }
   },
 );


### PR DESCRIPTION
ref: DTRSD-13004
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-13004
| License          | BSD 3-Clause

## Description

<!-- Write a brief description of the changes introduced by this PR -->

For the moment, only VPS new range (which uses agora routes) are using api route to get available countries where to order an IP. (e.g.: /vps/serviceName/ipCountryAvailable.

This PR allows each type of services to uses its dedicated route to get those countries.
Only service through agora are concerned by this changes.