### PR TITLE
feat(domain.dashboard): display start10m offer according to API

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -114,6 +114,7 @@
                 <oui-tile-definition
                     data-term-popover="{{ ::'domain_configuration_web_hosting_offer_START_explain' | translate }}"
                     data-term="{{ ::'domain_dashboard_enable_web_hosting' | translate }}"
+                    ng-if="$ctrl.isStart10mAvailable"
                 >
                     <oui-tile-description>
                         <a

--- a/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.controller.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.controller.js
@@ -33,6 +33,7 @@ export default class DomainTabGeneralInformationsCtrl {
     enableWebhostingLink,
     Hosting,
     HostingDomain,
+    isStart10mAvailable,
     OvhApiDomainRules,
     OvhApiScreenshot,
     User,
@@ -53,6 +54,7 @@ export default class DomainTabGeneralInformationsCtrl {
     this.enableWebhostingLink = enableWebhostingLink;
     this.Hosting = Hosting;
     this.HostingDomain = HostingDomain;
+    this.isStart10mAvailable = isStart10mAvailable;
     this.OvhApiDomainRules = OvhApiDomainRules;
     this.OvhApiScreenshot = OvhApiScreenshot.Aapi();
     this.User = User;

--- a/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.state.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.state.js
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import template from './GENERAL_INFORMATIONS.html';
 
 const commonResolves = {
@@ -15,6 +16,9 @@ const commonResolves = {
 
   start10mOffers: /* @ngInject */ (availableOptions) =>
     availableOptions.filter(({ family }) => family === 'hosting'),
+
+  isStart10mAvailable: /* @ngInject */ (start10mOffers) =>
+    !isEmpty(start10mOffers),
 };
 
 export default /* @ngInject */ ($stateProvider) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-5075
| License          | BSD 3-Clause

## Description

display start10m offer according to API