### PR TITLE
fix(domain.attach): use hosting as param instead of domain

### DIFF
--- a/packages/manager/apps/web/client/app/domain/attach/domain-attached-domain-select.controller.js
+++ b/packages/manager/apps/web/client/app/domain/attach/domain-attached-domain-select.controller.js
@@ -29,7 +29,9 @@ angular.module('App').controller(
 
     getAttachedDomains() {
       this.loading = true;
-      return this.HostingDomain.getAttachedDomains(this.domainName)
+      return this.HostingDomain.getAttachedDomains(
+        this.$scope.currentActionData.hosting,
+      )
         .then((data) => {
           if (isArray(data) && data.length > 0) {
             this.attachedDomains = data;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/web-ca`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-12564
| License          | BSD 3-Clause

## Description

use hosting as param instead of domain