### PR TITLE
Improve build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -51,7 +51,10 @@ function unstack() {
       (dep) => !modules.done.find((el) => el.name === dep.name),
     );
 
-    if (deps.length === 0) {
+    if (
+      deps.length === 0 &&
+      (!program.numWorkers || modules.doing.length < program.numWorkers)
+    ) {
       const workerData = remove(modules.todo, (p) => p.name === pck.name)[0];
       modules.doing.push(workerData);
 
@@ -100,11 +103,16 @@ function unstack() {
 program
   .option('--dry-run', 'Launch the build script without creating dist')
   .option(
+    '--num-workers [maxWorkers]',
+    'Limit the number of worker threads',
+    parseInt,
+  )
+  .option(
     '-p, --package [package]',
     'Scope build to a specific package and its dependencies',
   )
   .action(() => {
-    execa
+    return execa
       .command(
         `lerna list -alp --json ${
           program.package

--- a/scripts/worker/build_module.js
+++ b/scripts/worker/build_module.js
@@ -6,4 +6,8 @@ execa
     shell: true,
   })
   .then(() => parentPort.postMessage(`done - ${workerData.name}`))
-  .catch((err) => parentPort.postMessage(`error - ${err}`));
+  .catch((err) => {
+    parentPort.postMessage(`error - ${err.message}
+${err.all}`);
+    process.exit(err.exitCode);
+  });


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

* Add `--num-workers` option to define number of worker to use when launch the worskapces packages build :
_Example:_ `yarn run build --num-workers 2`
* Stop the execution of the build script if a package build script fails instead of logging the error and continue to build others packages.
Examples:_ 
  * if `@ovh-ux/manager-server-sidebar` failed to build, applications using this package (`@ovh-ux/manager-cloud`, `@ovh-ux/manager-dedicated`, `@ovh-ux/manager-web`) will failed too
  * if an app package (like `@ovh-ux/manager-web`) failed to build, we can consider that the `build` script failed (its objective is to build all the workspaces packages)





