### PR TITLE
Rename OVH to OVHcloud [skip ci]

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,41 +13,41 @@
 
 Adrien Carreira <adrien@xcid.fr>
 Alvéric Alie
-Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-Axel Peter <axel.peter@corp.ovh.com>
+Antoine Leblanc <antoine.leblanc@ovhcloud.com>
+Axel Peter <axel.peter@ovhcloud.com>
 Benjamin Coenen
-Camille Gicquel <camille.gicquel@corp.ovh.com>
-Cyril Biencourt <cyril.biencourt@corp.ovh.com>
-Cyrille Bourgois <cyrille.bourgois@corp.ovh.com>
+Camille Gicquel <camille.gicquel@ovhcloud.com>
+Cyril Biencourt <cyril.biencourt@ovhcloud.com>
+Cyrille Bourgois <cyrille.bourgois@ovhcloud.com>
 Cyrille Meichel
 Fabien Bagard <fabien.bagard@ovhcloud.com>
-Fabien Chabrolle <fabien.chabrolle@corp.ovh.com>
-Florian Renaut <florian.renaut@corp.ovh.com>
-François Eoche <francois.eoche@corp.ovh.com>
-Frédéric Espiau <frederic.espiau@corp.ovh.com>
-Ganesh Kumar <ganesh.kumar@corp.ovh.com>
+Fabien Chabrolle <fabien.chabrolle@ovhcloud.com>
+Florian Renaut <florian.renaut@ovhcloud.com>
+François Eoche <francois.eoche@ovhcloud.com>
+Frédéric Espiau <frederic.espiau@ovhcloud.com>
+Ganesh Kumar <ganesh.kumar@ovhcloud.com>
 Hugo Larcher <hugo.larcher@gmail.com>
-Jean-Baptiste Rabin <jean-baptiste.rabin@corp.ovh.com>
-Jean-Christophe Alleman <jean-christophe.alleman@corp.ovh.com>
-Jean-Philippe Blary <jean-philippe.blary@corp.ovh.com>
+Jean-Baptiste Rabin <jean-baptiste.rabin@ovhcloud.com>
+Jean-Christophe Alleman <jean-christophe.alleman@ovhcloud.com>
+Jean-Philippe Blary <jean-philippe.blary@ovhcloud.com>
 JF Durk <jfdurk@hotmail.fr>
-Joffrey Leveugle <joffrey.leveugle@corp.ovh.com>
+Joffrey Leveugle <joffrey.leveugle@ovhcloud.com>
 Julien Donque
 Julien Issler <julien@issler.net>
 Jérôme Martin
-Jérémy De Cesare <jeremy.de-cesare@corp.ovh.com>
+Jérémy De Cesare <jeremy.de-cesare@ovhcloud.com>
 Kévin Bonduelle
-Marie Jones <marie.jones@corp.ovh.com>
-Mathieu Dupont <mathieu.dupont@corp.ovh.com>
+Marie Jones <marie.jones@ovhcloud.com>
+Mathieu Dupont <mathieu.dupont@ovhcloud.com>
 Mathieu Tremblay
 Nicolas Pennec
-Pierre De Paepe <pierre.de-paepe@corp.ovh.com>
+Pierre De Paepe <pierre.de-paepe@ovhcloud.com>
 Pierre Gronlier <pierre@gronlier.fr>
-Pierre Kuhner <pierre.kuhner@corp.ovh.com>
-Ravindra Adireddy <ravindra.adireddy@corp.ovh.com>
-Stephanie Moallic <stephanie.moallic@corp.ovh.com>
+Pierre Kuhner <pierre.kuhner@ovhcloud.com>
+Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>
+Stephanie Moallic <stephanie.moallic@ovhcloud.com>
 Tadhg Lewis <tadhg.lewis@outlook.com>
-Varun Shivaprasad <varun.shivaprasad@corp.ovh.com>
+Varun Shivaprasad <varun.shivaprasad@ovhcloud.com>
 Vincent Casse <vincent@casse.me>
-Wassim DHIF <wassim.dhif@corp.ovh.com>
-Yann Pauly <yann.pauly@corp.ovh.com>
+Wassim DHIF <wassim.dhif@ovhcloud.com>
+Yann Pauly <yann.pauly@ovhcloud.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,15 +10,15 @@
 # Please keep the list sorted.
 #
 
-Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-Axel Peter <axel.peter@corp.ovh.com>
-Cyril Biencourt <cyril.biencourt@corp.ovh.com>
-Cyrille Bourgois <cyrille.bourgois@corp.ovh.com>
-Florian Renaut <florian.renaut@corp.ovh.com>
-Frédéric Espiau <frederic.espiau@corp.ovh.com>
-Ganesh Kumar <ganesh.kumar@corp.ovh.com>
-Jean-Christophe Alleman <jean-christophe.alleman@corp.ovh.com>
-Jérémy De Cesare <jeremy.de-cesare@corp.ovh.com>
-Marie Jones <marie.jones@corp.ovh.com>
-Ravindra Adireddy <ravindra.adireddy@corp.ovh.com>
-Varun Shivaprasad <varun.shivaprasad@corp.ovh.com>
+Antoine Leblanc <antoine.leblanc@ovhcloud.com>
+Axel Peter <axel.peter@ovhcloud.com>
+Cyril Biencourt <cyril.biencourt@ovhcloud.com>
+Cyrille Bourgois <cyrille.bourgois@ovhcloud.com>
+Florian Renaut <florian.renaut@ovhcloud.com>
+Frédéric Espiau <frederic.espiau@ovhcloud.com>
+Ganesh Kumar <ganesh.kumar@ovhcloud.com>
+Jean-Christophe Alleman <jean-christophe.alleman@ovhcloud.com>
+Jérémy De Cesare <jeremy.de-cesare@ovhcloud.com>
+Marie Jones <marie.jones@ovhcloud.com>
+Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>
+Varun Shivaprasad <varun.shivaprasad@ovhcloud.com>

--- a/packages/components/ng-ovh-export-csv/CHANGELOG.md
+++ b/packages/components/ng-ovh-export-csv/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 * module is now named as `ngOvhExportCsv`
 
-Co-authored-by: Florian Renaut <florian.renaut@corp.ovh.com>
-
 
 
 ## [1.0.2](https://github.com/ovh-ux/ng-ovh-export-csv/compare/v1.0.1...v1.0.2) (2020-01-07)
@@ -34,7 +32,6 @@ Co-authored-by: Florian Renaut <florian.renaut@corp.ovh.com>
 
 * module is now named as `ngOvhExportCsv`
 
-Co-authored-by: Florian Renaut <florian.renaut@corp.ovh.com>
 
 
 

--- a/packages/components/ng-ovh-payment-method/CHANGELOG.md
+++ b/packages/components/ng-ovh-payment-method/CHANGELOG.md
@@ -40,8 +40,6 @@
 
 * **components.choice:** the two-way binded model will now store an object the representing default payment method, instead of just setting a boolean value
 
-Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>
-
 
 
 # [5.2.0](https://github.com/ovh/manager/compare/@ovh-ux/ng-ovh-payment-method@5.1.1...@ovh-ux/ng-ovh-payment-method@5.2.0) (2019-12-20)

--- a/packages/components/ng-ui-router-title/CHANGELOG.md
+++ b/packages/components/ng-ui-router-title/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 # [2.0.0](https://github.com/ovh-ux/ng-uirouter-title/compare/v2.0.0-beta.3...v2.0.0) (2019-10-22)

--- a/packages/manager/apps/freefax/CHANGELOG.md
+++ b/packages/manager/apps/freefax/CHANGELOG.md
@@ -55,8 +55,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.2.3](https://github.com/ovh/manager/compare/@ovh-ux/manager-freefax-app@4.2.2...@ovh-ux/manager-freefax-app@4.2.3) (2019-10-25)

--- a/packages/manager/apps/overthebox/CHANGELOG.md
+++ b/packages/manager/apps/overthebox/CHANGELOG.md
@@ -37,8 +37,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.3.1](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-overthebox-app@4.3.0...@ovh-ux/manager-overthebox-app@4.3.1) (2019-09-03)

--- a/packages/manager/apps/telecom-dashboard/CHANGELOG.md
+++ b/packages/manager/apps/telecom-dashboard/CHANGELOG.md
@@ -46,8 +46,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 # [4.3.0](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-telecom-dashboard-app@4.2.1...@ovh-ux/manager-telecom-dashboard-app@4.3.0) (2019-09-10)

--- a/packages/manager/apps/telecom-task/CHANGELOG.md
+++ b/packages/manager/apps/telecom-task/CHANGELOG.md
@@ -46,8 +46,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.1.3](https://github.com/ovh/manager/compare/@ovh-ux/manager-telecom-task-app@4.1.2...@ovh-ux/manager-telecom-task-app@4.1.3) (2019-10-25)

--- a/packages/manager/apps/telecom/CHANGELOG.md
+++ b/packages/manager/apps/telecom/CHANGELOG.md
@@ -463,8 +463,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [10.40.4](https://github.com/ovh/manager/compare/@ovh-ux/manager-telecom@10.40.3...@ovh-ux/manager-telecom@10.40.4) (2019-11-08)

--- a/packages/manager/modules/catalog-price/CHANGELOG.md
+++ b/packages/manager/modules/catalog-price/CHANGELOG.md
@@ -39,8 +39,3 @@
 
 * **modules:** This component is just the export of the one located in web/app/components/manager-order-catalog-price.
 The web located component should be replaced by the new one (refactor will be done once this module is released)
-
-Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>
-
-
-

--- a/packages/manager/modules/core/CHANGELOG.md
+++ b/packages/manager/modules/core/CHANGELOG.md
@@ -127,8 +127,6 @@
 
 * **core:** remove ovh-api-services peer dependency
 
-Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>
-
 
 
 ## [7.6.3](https://github.com/ovh/manager/compare/@ovh-ux/manager-core@7.6.2...@ovh-ux/manager-core@7.6.3) (2019-12-10)

--- a/packages/manager/modules/freefax/CHANGELOG.md
+++ b/packages/manager/modules/freefax/CHANGELOG.md
@@ -82,8 +82,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [5.2.3](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-freefax@5.2.2...@ovh-ux/manager-freefax@5.2.3) (2019-10-17)

--- a/packages/manager/modules/hub/CHANGELOG.md
+++ b/packages/manager/modules/hub/CHANGELOG.md
@@ -129,7 +129,6 @@
 
 * create stable version for hub
 
-Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>
 * **hub:** init @ovh-ux/manager-account-sidebar module
 
 

--- a/packages/manager/modules/models/CHANGELOG.md
+++ b/packages/manager/modules/models/CHANGELOG.md
@@ -27,8 +27,3 @@
 ### BREAKING CHANGES
 
 * init @ovh-ux/manager-models module
-
-Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>
-
-
-

--- a/packages/manager/modules/navbar/CHANGELOG.md
+++ b/packages/manager/modules/navbar/CHANGELOG.md
@@ -115,7 +115,6 @@
 * **hub:** init @ovh-ux/manager-account-sidebar module
 * **navbar:** Language menu is no longer available from navbar
 
-Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>
 
 
 

--- a/packages/manager/modules/ng-layout-helpers/CHANGELOG.md
+++ b/packages/manager/modules/ng-layout-helpers/CHANGELOG.md
@@ -18,8 +18,3 @@
 ### BREAKING CHANGES
 
 * Init module
-
-Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>
-
-
-

--- a/packages/manager/modules/overthebox/CHANGELOG.md
+++ b/packages/manager/modules/overthebox/CHANGELOG.md
@@ -117,8 +117,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.3.4](https://github.com/ovh/manager/compare/@ovh-ux/manager-overthebox@4.3.3...@ovh-ux/manager-overthebox@4.3.4) (2019-10-24)

--- a/packages/manager/modules/preloader/CHANGELOG.md
+++ b/packages/manager/modules/preloader/CHANGELOG.md
@@ -18,8 +18,3 @@
 ### BREAKING CHANGES
 
 * **preloader:** add @ovh-ux/manager-preloader
-
-Signed-off-by: Cyrille Bourgois <cyrille.bourgois@corp.ovh.com>
-
-
-

--- a/packages/manager/modules/product-offers/CHANGELOG.md
+++ b/packages/manager/modules/product-offers/CHANGELOG.md
@@ -83,9 +83,3 @@
 ### BREAKING CHANGES
 
 * **modules:** This module initialize the component 'product-offers'
-
-Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>
-Co-authored-by: Frédéric Espiau <frederic.espiau@corp.ovh.com>
-
-
-

--- a/packages/manager/modules/telecom-dashboard/CHANGELOG.md
+++ b/packages/manager/modules/telecom-dashboard/CHANGELOG.md
@@ -37,8 +37,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.4.1](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-telecom-dashboard@4.4.0...@ovh-ux/manager-telecom-dashboard@4.4.1) (2019-10-17)

--- a/packages/manager/modules/telecom-task/CHANGELOG.md
+++ b/packages/manager/modules/telecom-task/CHANGELOG.md
@@ -46,8 +46,6 @@
 
 * module is now named as `ngUiRouterTitle
 
-Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
-
 
 
 ## [4.2.3](https://github.com/ovh-ux/manager/compare/@ovh-ux/manager-telecom-task@4.2.2...@ovh-ux/manager-telecom-task@4.2.3) (2019-10-17)

--- a/packages/manager/modules/web-universe-components/CHANGELOG.md
+++ b/packages/manager/modules/web-universe-components/CHANGELOG.md
@@ -19,8 +19,6 @@
 
 * **v6uiswitch:** v6UISwitch is deleted, as it is replaced by oui-switch, and is now no more used
 
-Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>
-
 
 
 # [7.4.0](https://github.com/ovh/manager/compare/@ovh-ux/ng-ovh-web-universe-components@7.3.0...@ovh-ux/ng-ovh-web-universe-components@7.4.0) (2020-01-24)


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### 📚 Documentation

023ab2c - docs: update CONTRIBUTORS file
6ed6c47 - docs: update MAINTAINERS file
7ba43ec - docs: remove extra signed-off-by and co-authored-by from CHANGELOG

### 🔗 Related

https://www.ovh.com/world/news/press/cpl1372.its-20th-anniversary-ovh-takes-and-becomes-ovhcloud

### 🏠 Internal

No quality check required.