### PR TITLE
perf(ng-ovh-payment-method): use lodash-es instead of lodash 

### DIFF
--- a/packages/components/ng-ovh-payment-method/package.json
+++ b/packages/components/ng-ovh-payment-method/package.json
@@ -38,7 +38,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-payment-method' --include-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash-es": "^4.17.11"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^7.0.0"

--- a/packages/components/ng-ovh-payment-method/src/components/choice/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/choice/controller.js
@@ -1,4 +1,4 @@
-import camelCase from 'lodash/camelCase';
+import { camelCase } from 'lodash-es';
 
 export default class {
   /* @ngInject */

--- a/packages/components/ng-ovh-payment-method/src/components/integration/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/controller.js
@@ -1,10 +1,12 @@
-import defaults from 'lodash/defaults';
-import get from 'lodash/get';
-import isFunction from 'lodash/isFunction';
-import merge from 'lodash/merge';
-import noop from 'lodash/noop';
-import omit from 'lodash/omit';
-import values from 'lodash/values';
+import {
+  defaults,
+  get,
+  isFunction,
+  merge,
+  noop,
+  omit,
+  values,
+} from 'lodash-es';
 
 import { DEFAULT_BINDINGS_VALUES } from './constants';
 

--- a/packages/components/ng-ovh-payment-method/src/components/integration/directive.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/directive.js
@@ -1,5 +1,4 @@
-import get from 'lodash/get';
-import set from 'lodash/set';
+import { get, set } from 'lodash-es';
 
 import controller from './controller';
 import template from './index.html';

--- a/packages/components/ng-ovh-payment-method/src/components/integration/iframeVantiv/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/iframeVantiv/controller.js
@@ -1,6 +1,4 @@
-import get from 'lodash/get';
-import merge from 'lodash/merge';
-import snakeCase from 'lodash/snakeCase';
+import { get, merge, snakeCase } from 'lodash-es';
 
 import { VANTIV_IFRAME_CONFIGURATION, VANTIV_RESPONSE_CODE } from './constants';
 

--- a/packages/components/ng-ovh-payment-method/src/components/integration/iframeVantiv/directive.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/iframeVantiv/directive.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import { merge } from 'lodash-es';
 
 import controller from './controller';
 import {

--- a/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/controller.js
@@ -1,5 +1,4 @@
-import get from 'lodash/get';
-import merge from 'lodash/merge';
+import { get, merge } from 'lodash-es';
 
 export default class OvhPaymentMethodIntegrationInContextPaypalCtrl {
   /* @ngInject */

--- a/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/directive.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/directive.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import { merge } from 'lodash-es';
 
 import controller from './controller';
 

--- a/packages/components/ng-ovh-payment-method/src/components/integration/redirect/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/redirect/controller.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import { get } from 'lodash-es';
 
 import { AVAILABLE_CALLBACK_STATUS_ENUM } from '../constants'; // from integration constants
 

--- a/packages/components/ng-ovh-payment-method/src/components/register/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/register/controller.js
@@ -1,13 +1,15 @@
-import chunk from 'lodash/chunk';
-import find from 'lodash/find';
-import get from 'lodash/get';
-import has from 'lodash/has';
-import isFunction from 'lodash/isFunction';
-import isNil from 'lodash/isNil';
-import isObject from 'lodash/isObject';
-import map from 'lodash/map';
-import set from 'lodash/set';
-import some from 'lodash/some';
+import {
+  chunk,
+  find,
+  get,
+  has,
+  isFunction,
+  isNil,
+  isObject,
+  map,
+  set,
+  some,
+} from 'lodash-es';
 
 import {
   DEFAULT_DISPLAY_PER_LINE,

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-bank-account.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-bank-account.class.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import { merge } from 'lodash-es';
 
 import OvhPaymentMethod from '../../payment-method.class';
 import OvhPaymentMean from './payment-mean.class';

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-credit-card.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-credit-card.class.js
@@ -1,5 +1,4 @@
-import merge from 'lodash/merge';
-import snakeCase from 'lodash/snakeCase';
+import { merge, snakeCase } from 'lodash-es';
 
 import OvhPaymentMethod from '../../payment-method.class';
 import OvhPaymentMean from './payment-mean.class';

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-deferred-payment-account.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-deferred-payment-account.class.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import { merge } from 'lodash-es';
 
 import OvhPaymentMethod from '../../payment-method.class';
 import OvhPaymentMean from './payment-mean.class';

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-paypal.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-paypal.class.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import { merge } from 'lodash-es';
 
 import OvhPaymentMethod from '../../payment-method.class';
 import OvhPaymentMean from './payment-mean.class';

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-type.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean-type.class.js
@@ -1,4 +1,4 @@
-import snakeCase from 'lodash/snakeCase';
+import { snakeCase } from 'lodash-es';
 
 import OvhPaymentMethodType from '../../payment-method-type.class';
 

--- a/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean.class.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/mean/payment-mean.class.js
@@ -1,4 +1,4 @@
-import snakeCase from 'lodash/snakeCase';
+import { snakeCase } from 'lodash-es';
 
 export default class OvhPaymentMean {
   constructor(options = {}) {

--- a/packages/components/ng-ovh-payment-method/src/legacy/payment-method-legacy.js
+++ b/packages/components/ng-ovh-payment-method/src/legacy/payment-method-legacy.js
@@ -1,9 +1,4 @@
-import filter from 'lodash/filter';
-import flatten from 'lodash/flatten';
-import get from 'lodash/get';
-import has from 'lodash/has';
-import map from 'lodash/map';
-import startCase from 'lodash/startCase';
+import { filter, flatten, get, has, map, startCase } from 'lodash-es';
 
 import {
   DEFAULT_OPTIONS,

--- a/packages/components/ng-ovh-payment-method/src/payment-method-helper.service.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method-helper.service.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import { get } from 'lodash-es';
 
 import { IBAN_BIC_RULES } from './payment-method.constants';
 

--- a/packages/components/ng-ovh-payment-method/src/payment-method-type.class.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method-type.class.js
@@ -1,4 +1,4 @@
-import isNull from 'lodash/isNull';
+import { isNull } from 'lodash-es';
 
 import { TYPE_INTEGRATION_ENUM } from './payment-method.constants';
 

--- a/packages/components/ng-ovh-payment-method/src/payment-method.class.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method.class.js
@@ -1,4 +1,4 @@
-import isNull from 'lodash/isNull';
+import { isNull } from 'lodash-es';
 
 /**
  *  Describe a payment method object.

--- a/packages/components/ng-ovh-payment-method/src/payment-method.service.js
+++ b/packages/components/ng-ovh-payment-method/src/payment-method.service.js
@@ -1,9 +1,4 @@
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import has from 'lodash/has';
-import map from 'lodash/map';
-import remove from 'lodash/remove';
-import some from 'lodash/some';
+import { filter, find, has, map, remove, some } from 'lodash-es';
 
 import {
   DEFAULT_OPTIONS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,6 +11821,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.11:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Use lodash-es instead of lodash in order to reduce bundle size (few Ko gains)