### PR TITLE
feat(ng-ovh-responsive-tabs): replace lodash with lodash-es

### DIFF
--- a/packages/components/ng-ovh-responsive-tabs/package.json
+++ b/packages/components/ng-ovh-responsive-tabs/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "bootstrap": "~3.3.7",
     "jquery": "^2.1.3",
-    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.15",
     "ovh-ui-kit": "^2.42.7",
     "ovh-ui-kit-bs": "^2.4.6"
   },

--- a/packages/components/ng-ovh-responsive-tabs/src/controller.js
+++ b/packages/components/ng-ovh-responsive-tabs/src/controller.js
@@ -1,5 +1,4 @@
-import map from 'lodash/map';
-import set from 'lodash/set';
+import { map, set } from 'lodash-es';
 
 export default class {
   /* @ngInject */

--- a/packages/components/ng-ovh-responsive-tabs/src/directive.js
+++ b/packages/components/ng-ovh-responsive-tabs/src/directive.js
@@ -1,11 +1,13 @@
 import angular from 'angular';
-import debounce from 'lodash/debounce';
-import filter from 'lodash/filter';
-import findIndex from 'lodash/findIndex';
-import forEach from 'lodash/forEach';
-import has from 'lodash/has';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
+import {
+  debounce,
+  filter,
+  findIndex,
+  forEach,
+  has,
+  includes,
+  map,
+} from 'lodash-es';
 
 import controller from './controller';
 import template from './template.html';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,7 +11821,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.11:
+lodash-es@^4.17.11, lodash-es@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==


### PR DESCRIPTION
Signed-off-by: frenauvh <florian.renaut@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          |
| License          | BSD 3-Clause

## Description

Replace lodash with lodash-es to reduce bundle size
