### PR TITLE
style: apply eslint rules

### DIFF
--- a/packages/components/ng-ovh-otrs/src/index.js
+++ b/packages/components/ng-ovh-otrs/src/index.js
@@ -26,10 +26,7 @@ import './otrs.less';
 const moduleName = 'ngOvhOtrs';
 
 angular
-  .module(moduleName, [
-    'ovh-api-services',
-    'pascalprecht.translate',
-  ])
+  .module(moduleName, ['ovh-api-services', 'pascalprecht.translate'])
   .constant('OTRS_POPUP_API_ALIASES', API_ALIASES)
   .constant('OTRS_POPUP_API_EXCLUDED', API_EXCLUDED)
   .constant('OTRS_POPUP_API_EXTRAS_ENDPOINTS', API_EXTRAS_ENDPOINTS)

--- a/packages/components/ng-ovh-otrs/src/otrs-popup/intervention/otrs-popup-intervention.service.js
+++ b/packages/components/ng-ovh-otrs/src/otrs-popup/intervention/otrs-popup-intervention.service.js
@@ -23,7 +23,10 @@ export default class OtrsPopupInterventionService {
   }
 
   static canHotSwap(serverInfo, hardwareInfo) {
-    return serverInfo.commercialRange.toUpperCase() === 'HG' && includes(['2U', '4U'], hardwareInfo.formFactor.toUpperCase());
+    return (
+      serverInfo.commercialRange.toUpperCase() === 'HG' &&
+      includes(['2U', '4U'], hardwareInfo.formFactor.toUpperCase())
+    );
   }
 
   static hasMegaRaidCard(hardwareInfo) {
@@ -32,7 +35,10 @@ export default class OtrsPopupInterventionService {
 
   static slotInfo(serverInfo, hardwareInfo) {
     const canUseSlotId = serverInfo.commercialRange.toUpperCase() === 'HG';
-    const slotsCount = hardwareInfo.formFactor && hardwareInfo.formFactor.toUpperCase() === '4U' ? 24 : 12;
+    const slotsCount =
+      hardwareInfo.formFactor && hardwareInfo.formFactor.toUpperCase() === '4U'
+        ? 24
+        : 12;
 
     return {
       canUseSlotId,
@@ -47,24 +53,34 @@ export default class OtrsPopupInterventionService {
       diskToSend.comment = 'No message';
     }
 
-    return this.OvhApiDedicatedServer.v6().askHardDiskDriveReplacement({
-      serverName: serviceName,
-    }, {
-      comment: diskToSend.comment,
-      disks: diskToSend.disks,
-      inverse: diskToSend.inverse,
-    }).$promise;
+    return this.OvhApiDedicatedServer.v6().askHardDiskDriveReplacement(
+      {
+        serverName: serviceName,
+      },
+      {
+        comment: diskToSend.comment,
+        disks: diskToSend.disks,
+        inverse: diskToSend.inverse,
+      },
+    ).$promise;
   }
 
   getServerInterventionInfo(serviceName) {
-    return this.$q.all({
-      serverInfo: this.getServerInfo(serviceName),
-      hardwareInfo: this.getHardwareInfo(serviceName),
-    })
-      .then(results => ({
-        canHotSwap: this.constructor.canHotSwap(results.serverInfo, results.hardwareInfo),
+    return this.$q
+      .all({
+        serverInfo: this.getServerInfo(serviceName),
+        hardwareInfo: this.getHardwareInfo(serviceName),
+      })
+      .then((results) => ({
+        canHotSwap: this.constructor.canHotSwap(
+          results.serverInfo,
+          results.hardwareInfo,
+        ),
         hasMegaRaid: this.constructor.hasMegaRaidCard(results.hardwareInfo),
-        slotInfo: this.constructor.slotInfo(results.serverInfo, results.hardwareInfo),
+        slotInfo: this.constructor.slotInfo(
+          results.serverInfo,
+          results.hardwareInfo,
+        ),
       }));
   }
 }

--- a/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.directive.js
+++ b/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.directive.js
@@ -4,7 +4,7 @@ import controller from './otrs-popup.controller';
 import template from './otrs-popup.html';
 import './otrs-popup.less';
 
-export default function () {
+export default function() {
   return {
     restrict: 'A',
     scope: {},
@@ -62,20 +62,23 @@ export default function () {
       $scope.$on('otrs.popup.open', $scope.open);
       $scope.$on('otrs.popup.close', $scope.close);
 
-      const maximizeWatch = $scope.$watch('status.maximize', () => (
+      const maximizeWatch = $scope.$watch('status.maximize', () =>
         $scope.status.maximize
           ? $element.addClass('maximize')
-          : $element.removeClass('maximize')));
+          : $element.removeClass('maximize'),
+      );
 
-      const minimizeWatch = $scope.$watch('status.minimize', () => (
+      const minimizeWatch = $scope.$watch('status.minimize', () =>
         $scope.status.minimize
           ? $element.addClass('minimize')
-          : $element.removeClass('minimize')));
+          : $element.removeClass('minimize'),
+      );
 
-      const closeWatch = $scope.$watch('status.close', () => (
+      const closeWatch = $scope.$watch('status.close', () =>
         $scope.status.close
           ? $element.addClass('close')
-          : $element.removeClass('close')));
+          : $element.removeClass('close'),
+      );
 
       $element.addClass('otrs-container');
       $element.addClass('initial-setting');
@@ -90,14 +93,17 @@ export default function () {
           delete dragData.actualStartPosition;
           if (element.classList.contains('initial-setting')) {
             const boundingBox = element.getBoundingClientRect();
-            dragData.actualStartPosition = { x: boundingBox.left, y: boundingBox.top };
+            dragData.actualStartPosition = {
+              x: boundingBox.left,
+              y: boundingBox.top,
+            };
             element.classList.remove('initial-setting');
           }
         },
         limit: (currX, currY, x0, y0) => {
-          const position = (dragData.actualStartPosition
+          const position = dragData.actualStartPosition
             ? { x: currX, y: currY - (y0 - dragData.actualStartPosition.y) }
-            : { x: currX, y: currY });
+            : { x: currX, y: currY };
           // Prevent pop-up to be dragged above the window
           position.y = position.y < 0 ? 0 : position.y;
           return position;

--- a/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.provider.js
+++ b/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.provider.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 
-export default function () {
+export default function() {
   const self = this;
   let baseUrlTickets = null;
 

--- a/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.service.js
+++ b/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.service.js
@@ -11,15 +11,10 @@ export default class OtrsPopupService {
     this.loaded = false;
     this.opened = false;
 
-    const actions = [
-      'minimize',
-      'maximize',
-      'restore',
-      'close',
-      'open',
-    ];
+    const actions = ['minimize', 'maximize', 'restore', 'close', 'open'];
     angular.forEach(actions, (action) => {
-      this[action] = id => this.$rootScope.$broadcast(`otrs.popup.${action}`, id);
+      this[action] = (id) =>
+        this.$rootScope.$broadcast(`otrs.popup.${action}`, id);
     });
   }
 

--- a/packages/components/ng-ovh-otrs/src/ticket-categories.constants.js
+++ b/packages/components/ng-ovh-otrs/src/ticket-categories.constants.js
@@ -11,14 +11,7 @@ export const TICKET_CATEGORIES = {
       'web-billing',
       'web-other',
     ],
-    TELECOM: [
-      'adsl',
-      'voip',
-      'fax',
-      'sms',
-      'telecom-billing',
-      'telecom-other',
-    ],
+    TELECOM: ['adsl', 'voip', 'fax', 'sms', 'telecom-billing', 'telecom-other'],
     DEDICATED: [
       'dedicated',
       'dedicatedcloud',
@@ -26,9 +19,7 @@ export const TICKET_CATEGORIES = {
       'dedicated-other',
       'dedicated-billing',
     ],
-    CLOUD: [
-      'publiccloud',
-    ],
+    CLOUD: ['publiccloud'],
   },
   DEFAULT: 'billing',
 };

--- a/packages/manager/modules/pci/src/projects/project/load-balancer/load-balancer.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/load-balancer/load-balancer.controller.js
@@ -28,7 +28,10 @@ export default class {
   }
 
   getGuideUrl(guide) {
-    return this.PciLoadBalancerService.getGuideUrl(guide, this.user);
+    return this.PciLoadBalancerService.constructor.getGuideUrl(
+      guide,
+      this.user,
+    );
   }
 
   getLoadbalancerDetails({ id: loadBalancerId }) {

--- a/packages/manager/modules/pci/src/projects/project/load-balancer/load-balancer.service.js
+++ b/packages/manager/modules/pci/src/projects/project/load-balancer/load-balancer.service.js
@@ -27,7 +27,7 @@ export default class {
     });
   }
 
-  getGuideUrl(guide, user) {
+  static getGuideUrl(guide, user) {
     return get(
       guide.URLS,
       user.ovhSubsidiary.toUpperCase(),

--- a/packages/manager/modules/pci/src/projects/project/load-balancer/onboarding/onboarding.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/load-balancer/onboarding/onboarding.controller.js
@@ -21,7 +21,10 @@ export default class {
         ...list,
         {
           ...guide,
-          link: this.PciLoadBalancerService.getGuideUrl(guide, this.user),
+          link: this.PciLoadBalancerService.constructor.getGuideUrl(
+            guide,
+            this.user,
+          ),
           title: this.$translate.instant(
             `pci_projects_project_load_balancer_onboarding_guides_${guide.id}_title`,
           ),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Since `@ovh-ux/ng-ovh-otrs` package has been imported into the monorepo (#2895),
all sources did not be run against our ESLint configuration.

I've also turned the `getGuideUrl` method into a static one.

### 💅 Style

8d007e4 - style: apply eslint rules

uses: `$ yarn run format:js`

Based on the following commit:

```sh
$ git rev-parse HEAD
d94430eca79e03c02ab01cc4f1bd4dbf45857593
```

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

