### PR TITLE
build(deps): upgrade ovh-api-services to v9.44.2

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -55,7 +55,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -110,7 +110,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -127,7 +127,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -51,7 +51,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -59,7 +59,7 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "whatwg-fetch": "^3.0.0"

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -58,7 +58,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -52,7 +52,7 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -34,7 +34,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "angular-ui-bootstrap": "^1.3.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -50,7 +50,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -73,7 +73,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -51,7 +51,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -33,7 +33,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -45,7 +45,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit": "^2.42.8",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -42,7 +42,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-angular": "^3.16.3",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -123,7 +123,7 @@
     "ngSmoothScroll": "d-oliveros/angular-smooth-scroll#~1.7.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -48,7 +48,7 @@
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8"
   },

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -47,7 +47,7 @@
     "d3": "~3.5.13",
     "flatpickr": "~4.5.2",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -63,7 +63,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",
     "ovh-ui-kit-bs": "^2.4.6"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -109,7 +109,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^9.44.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-angular": "^3.16.3",
     "ovh-ui-kit": "^2.42.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13775,10 +13775,10 @@ ovh-angular-responsive-tabs@^4.0.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-responsive-tabs/-/ovh-angular-responsive-tabs-4.0.0.tgz#85b66d7032612c3ed1a14cb29f83d1331b50c1df"
   integrity sha1-hbZtcDJhLD7RoUyyn4PRMxtQwd8=
 
-ovh-api-services@^9.44.0:
-  version "9.44.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.44.0.tgz#f3c0b8ac479606c6abdd3e1b1c5a49659421d244"
-  integrity sha512-wuR2O2g5jGTT5BgMbAIT0stwIDNZd2CFv6M8oFWeycsrHPK62fo27BJnhDcECjg+bsDDmB1dXh4CVIDSJJWiTw==
+ovh-api-services@^9.44.2:
+  version "9.44.2"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.44.2.tgz#54d23a5c8d531103cb28dfb48a697cbc842a28e4"
+  integrity sha512-BsKL/M10IKMaf8xLcrhuupxiXiPh0c84GShq/P8aEmk+JGxyxkRlNb0AUkY2VKMqSl6G0cUXphMPNyAKxuYVaQ==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### ⬆️ Upgrade

6cc69f2  - build(deps): upgrade ovh-api-services to v9.44.2

uses: `$ yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@9.44.2

### 🏠 Internal

No quality check required.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
