### PR TITLE
feat(xdsl.notifications): improve sms remaining credits for notif

### DIFF
--- a/packages/manager/apps/telecom/src/components/notification/notification-list.html
+++ b/packages/manager/apps/telecom/src/components/notification/notification-list.html
@@ -7,11 +7,7 @@
     data-ng-if="!NotificationListCtrl.loading"
     data-ng-repeat="smsDetail in NotificationListCtrl.smsDetails track by smsDetail.name"
 >
-    <oui-message
-        type="warning"
-        data-ng-if="smsDetail.creditsLeft === 0"
-        dismissable="false"
-    >
+    <oui-message type="warning" data-ng-if="smsDetail.creditsLeft === 0">
         <span
             data-translate="components_notification_sms_detail_warning"
             data-translate-values="{smsAccount: smsDetail.name}"

--- a/packages/manager/apps/telecom/src/components/notification/notification-list.html
+++ b/packages/manager/apps/telecom/src/components/notification/notification-list.html
@@ -4,6 +4,22 @@
 </div>
 
 <div
+    data-ng-if="!NotificationListCtrl.loading"
+    data-ng-repeat="smsDetail in NotificationListCtrl.smsDetails track by smsDetail.name"
+>
+    <oui-message
+        type="warning"
+        data-ng-if="smsDetail.creditsLeft === 0"
+        dismissable="false"
+    >
+        <span
+            data-translate="components_notification_sms_detail_warning"
+            data-translate-values="{smsAccount: smsDetail.name}"
+        ></span>
+    </oui-message>
+</div>
+
+<div
     class="table-responsive-vertical"
     data-ng-hide="NotificationListCtrl.loading"
 >
@@ -26,7 +42,19 @@
                         data-field-name="type"
                         data-title="{{:: 'table_sort' | translate}}"
                     >
-                        {{:: 'components_notification_type' | translate }}
+                        <span
+                            data-ng-bind=":: 'components_notification_type' | translate"
+                        ></span>
+                    </tuc-col-sort>
+                </th>
+                <th scope="col">
+                    <tuc-col-sort
+                        data-field-name="account"
+                        data-title="{{:: 'table_sort' | translate}}"
+                    >
+                        <span
+                            data-ng-bind=":: 'components_notification_account' | translate"
+                        ></span>
                     </tuc-col-sort>
                 </th>
                 <th scope="col">
@@ -34,7 +62,9 @@
                         data-field-name="contact"
                         data-title="{{:: 'table_sort' | translate}}"
                     >
-                        {{:: 'components_notification_contact' | translate }}
+                        <span
+                            data-ng-bind=":: 'components_notification_contact' | translate"
+                        ></span>
                     </tuc-col-sort>
                 </th>
                 <th scope="col">
@@ -42,7 +72,9 @@
                         data-field-name="frequency"
                         data-title="{{:: 'table_sort' | translate}}"
                     >
-                        {{:: 'components_notification_frequency' | translate }}
+                        <span
+                            data-ng-bind=":: 'components_notification_frequency' | translate"
+                        ></span>
                     </tuc-col-sort>
                 </th>
                 <th scope="col"></th>
@@ -62,34 +94,44 @@
                 <!-- Type -->
                 <td
                     class="form-group"
-                    data-ng-hide="element.editMode"
+                    data-ng-if="!element.editMode"
                     data-title="{{ 'components_notification_type' | translate }}"
                 >
-                    {{ 'components_notification_' + element.type | translate }}
+                    <span
+                        data-ng-bind="'components_notification_' + element.type | translate"
+                    ></span>
+                </td>
+                <!-- Compte -->
+                <td
+                    class="form-group"
+                    data-ng-if="!element.editMode"
+                    data-title="{{ 'components_notification_account' | translate }}"
+                >
+                    <span data-ng-bind=":: element.smsAccount"></span>
                 </td>
                 <!-- Contact -->
                 <td
                     class="form-group"
-                    data-ng-hide="element.editMode"
+                    data-ng-if="!element.editMode"
                     data-title="{{ 'components_notification_contact' | translate }}"
                 >
-                    <span>{{ element.email || element.phone }}</span>
+                    <span data-ng-bind="element.email || element.phone"></span>
                 </td>
                 <!-- Frequency -->
                 <td
                     class="form-group"
-                    data-ng-hide="element.editMode"
+                    data-ng-if="!element.editMode"
                     data-title="{{ 'components_notification_frequency' | translate }}"
                 >
                     <span
-                        >{{ 'components_notification_' + element.frequency |
-                        translate}}</span
-                    >
+                        data-ng-bind="'components_notification_' + element.frequency |
+                        translate"
+                    ></span>
                 </td>
                 <!-- Buttons -->
                 <td
                     class="form-group col-mobile-button-big text-center"
-                    data-ng-hide="element.editMode"
+                    data-ng-if="!element.editMode"
                 >
                     <button
                         type="button"
@@ -109,12 +151,12 @@
                 <!-- Type (edit mode)-->
                 <td
                     data-title="{{ 'components_notification_type' | translate }}"
-                    data-ng-hide="!element.editMode"
+                    data-ng-if="element.editMode"
                     class="form-group"
                 >
                     <span
                         data-translate="components_notification_error_noSmsAccount"
-                        data-ng-hide="NotificationListCtrl.isTypeValid(element.type)"
+                        data-ng-if="!NotificationListCtrl.isTypeValid(element.type)"
                         class="red"
                     >
                     </span>
@@ -129,15 +171,16 @@
                             >{{ notifType.label | translate }}</option
                         >
                     </select>
+                </td>
+                <td
+                    data-title="{{ 'components_notification_account' | translate }}"
+                    data-ng-if="element.editMode"
+                    class="form-group"
+                >
                     <div data-ng-if="element.type === 'sms' ">
                         <div
                             data-ng-show="NotificationListCtrl.accounts.length > 1"
                         >
-                            <label
-                                class="control-label"
-                                data-translate="components_notification_account"
-                                for="account"
-                            ></label>
                             <select
                                 id="account"
                                 class="form-control"
@@ -155,7 +198,7 @@
                 <!-- Contact (edit mode)-->
                 <td
                     data-title="{{ 'components_notification_contact' | translate }}"
-                    data-ng-hide="!element.editMode"
+                    data-ng-if="element.editMode"
                     class="form-group"
                 >
                     <input
@@ -176,7 +219,7 @@
                 <!-- Frequency (edit mode)-->
                 <td
                     data-title="{{ 'components_notification_frequency' | translate }}"
-                    data-ng-hide="!element.editMode"
+                    data-ng-if="element.editMode"
                     class="form-group"
                 >
                     <select
@@ -194,7 +237,7 @@
                 <!-- Buttons (edit mode)-->
                 <td
                     class="form-group actions col-mobile-button-big text-center"
-                    data-ng-hide="!element.editMode"
+                    data-ng-if="element.editMode"
                 >
                     <button
                         type="submit"

--- a/packages/manager/apps/telecom/src/components/notification/notification.component.js
+++ b/packages/manager/apps/telecom/src/components/notification/notification.component.js
@@ -213,12 +213,18 @@ angular.module('managerApp').component('notificationList', {
       // get the SMS accounts
       OvhApiSms.Aapi()
         .query({})
-        .$promise.then(
-          (data) => {
-            self.accounts = data;
-          },
-          (err) => self.processError(err),
-        );
+        .$promise.then((data) => {
+          self.accounts = data;
+          // get the SMS remaining credits by accounts
+          OvhApiSms.Aapi()
+            .detail({
+              smsIds: data,
+            })
+            .$promise.then((smsDetails) => {
+              self.smsDetails = smsDetails;
+            });
+        })
+        .catch((err) => self.processError(err));
 
       // Get the Notifications
       $scope.$watch(

--- a/packages/manager/apps/telecom/src/components/notification/notification.component.js
+++ b/packages/manager/apps/telecom/src/components/notification/notification.component.js
@@ -1,5 +1,6 @@
 import isArray from 'lodash/isArray';
 import set from 'lodash/set';
+import map from 'lodash/map';
 
 angular.module('managerApp').run(($translate, asyncLoader) => {
   asyncLoader.addTranslations(
@@ -20,7 +21,7 @@ angular.module('managerApp').component('notificationList', {
   },
   controllerAs: 'NotificationListCtrl',
   templateUrl: 'components/notification/notification-list.html',
-  controller($scope, OvhApiSms, OvhApiXdslNotifications, NotificationElement) {
+  controller($scope, iceberg, OvhApiXdslNotifications, NotificationElement) {
     const self = this;
 
     this.loading = true;
@@ -210,19 +211,14 @@ angular.module('managerApp').component('notificationList', {
         { name: '6h', label: 'components_notification_6h' },
       ];
 
-      // get the SMS accounts
-      OvhApiSms.Aapi()
-        .query({})
-        .$promise.then((data) => {
-          self.accounts = data;
-          // get the SMS remaining credits by accounts
-          OvhApiSms.Aapi()
-            .detail({
-              smsIds: data,
-            })
-            .$promise.then((smsDetails) => {
-              self.smsDetails = smsDetails;
-            });
+      // get the SMS accounts and the SMS remaining credits by accounts
+      iceberg('/sms')
+        .query()
+        .expand('CachedObjectList-Pages')
+        .execute()
+        .$promise.then(({ data: smsDetails }) => {
+          self.accounts = map(smsDetails, 'name');
+          self.smsDetails = smsDetails;
         })
         .catch((err) => self.processError(err));
 

--- a/packages/manager/apps/telecom/src/components/notification/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/components/notification/translations/Messages_fr_FR.json
@@ -6,7 +6,7 @@
   "components_notification_noNotification": "Il n'y a aucune alerte enregistrée.",
   "components_notification_frequency": "Fréquence d'envoi",
   "components_notification_contact": "Contact à notifier en cas d'alertes",
-  "components_notification_account": "Compte:",
+  "components_notification_account": "Compte",
   "components_notification_confirm": "Êtes-vous sûr(e) de vouloir supprimer la notification sur le service {{service}} pour {{contact}} ?",
   "components_notification_add": "Ajouter une alerte",
   "components_notification_mail": "E-mail",
@@ -14,5 +14,6 @@
   "components_notification_once": "Une fois",
   "components_notification_5m": "Toutes les 5 minutes",
   "components_notification_1h": "Toutes les heures",
-  "components_notification_6h": "Toutes les 6 heures"
+  "components_notification_6h": "Toutes les 6 heures",
+  "components_notification_sms_detail_warning": "Attention, le compte {{smsAccount}} n'a plus de crédit pour l'envoi de nouveaux SMS."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-280
| License          | BSD 3-Clause

## Description

- Show SMS account on notification creation and listing
- Show remaining credit on SMS notification with warning if 0
