### PR TITLE
docs: set default label for issue template file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+labels: bug
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels: enhancement
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Enhance default issue template files.

### 📚 Documentation

49177c6 - docs: set default label for issue template file

### 🔗 Related

https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

### 🏠 Internal

No quality check required.

### 💚 Continuous Integration

[skip ci]

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

