### PR TITLE
Make Registry M plan per default

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-registry/components/plan-upgrade/constants.js
+++ b/packages/manager/modules/pci/src/projects/project/private-registry/components/plan-upgrade/constants.js
@@ -1,5 +1,5 @@
 export const PLAN_CONSTANT = {
-  SMALL: 'S',
+  SMALL: 'M',
 };
 
 export const HOURLYTOMONTHLY = {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | DTRSD-13046
| License          | BSD 3-Clause

## Description
We recently made the M plan more feature full and it makes more sense to make it the default choice for new registries at creation time.