### PR TITLE
feat(telephony): split endpoint into ip list and list with incoming call

### DIFF
--- a/packages/manager/apps/carrier-sip/src/endpoints/routing.js
+++ b/packages/manager/apps/carrier-sip/src/endpoints/routing.js
@@ -3,6 +3,10 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/endpoints',
     component: 'carrierSipEndpoints',
     resolve: {
+      endpointIpList: /* @ngInject */ (endpoints) =>
+        endpoints.map(({ ip }) => ip),
+      endpointsWithIncomingCallsAllowed: /* @ngInject */ (endpoints) =>
+        endpoints.filter(({ enableIncomingCalls }) => enableIncomingCalls),
       endpoints: /* @ngInject */ (
         billingAccount,
         CarrierSipService,

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/carrierSip/dashboard/endpoints/endpoints.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/carrierSip/dashboard/endpoints/endpoints.routing.js
@@ -7,6 +7,10 @@ export default /* @ngInject */ ($stateProvider) => {
         '@telecom.telephony.billingAccount.carrierSip': 'carrierSipEndpoints',
       },
       resolve: {
+        endpointIpList: /* @ngInject */ (endpoints) =>
+          endpoints.map(({ ip }) => ip),
+        endpointsWithIncomingCallsAllowed: /* @ngInject */ (endpoints) =>
+          endpoints.filter(({ enableIncomingCalls }) => enableIncomingCalls),
         endpoints: /* @ngInject */ (
           billingAccount,
           CarrierSipService,

--- a/packages/manager/modules/carrier-sip/src/endpoints/endpoints.component.js
+++ b/packages/manager/modules/carrier-sip/src/endpoints/endpoints.component.js
@@ -2,7 +2,8 @@ import template from './endpoints.html';
 
 export default {
   bindings: {
-    endpoints: '<',
+    endpointIpList: '<',
+    endpointsWithIncomingCallsAllowed: '<',
   },
   name: 'carrierSipEndpoints',
   template,

--- a/packages/manager/modules/carrier-sip/src/endpoints/endpoints.html
+++ b/packages/manager/modules/carrier-sip/src/endpoints/endpoints.html
@@ -1,37 +1,44 @@
 <section>
-    <h3 data-translate="carrier_sip_endpoints"></h3>
-    <oui-datagrid data-rows="$ctrl.endpoints">
+    <h3 data-translate="carrier_sip_endpoints_list_IP"></h3>
+    <oui-datagrid class="small-width" rows="$ctrl.endpointIpList">
+        <oui-column title=":: 'carrier_sip_endpoints_ip_sip' | translate">
+            <span data-ng-bind="::$row"></span>
+        </oui-column>
+    </oui-datagrid>
+
+    <h3 data-translate="carrier_sip_endpoints_with_incoming_call_enabled"></h3>
+    <oui-datagrid rows="$ctrl.endpointsWithIncomingCallsAllowed">
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_id' | translate"
-            data-property="id"
+            title=":: 'carrier_sip_endpoints_id' | translate"
+            property="id"
         >
         </oui-column>
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_protocol' | translate"
-            data-property="protocol"
+            title=":: 'carrier_sip_endpoints_protocol' | translate"
+            property="protocol"
         >
             <span
                 data-translate="{{:: 'carrier_sip_endpoints_protocol_' + $row.protocol }}"
             ></span>
         </oui-column>
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_ip_sip' | translate"
-            data-property="ip"
+            title=":: 'carrier_sip_endpoints_ip_sip' | translate"
+            property="ip"
         >
         </oui-column>
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_port' | translate"
-            data-property="port"
+            title=":: 'carrier_sip_endpoints_port' | translate"
+            property="port"
         >
         </oui-column>
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_priority' | translate"
-            data-property="priority"
+            title=":: 'carrier_sip_endpoints_priority' | translate"
+            property="priority"
         >
         </oui-column>
         <oui-column
-            data-title=":: 'carrier_sip_endpoints_weight' | translate"
-            data-property="weight"
+            title=":: 'carrier_sip_endpoints_weight' | translate"
+            property="weight"
         >
         </oui-column>
     </oui-datagrid>

--- a/packages/manager/modules/carrier-sip/src/endpoints/endpoints.scss
+++ b/packages/manager/modules/carrier-sip/src/endpoints/endpoints.scss
@@ -1,0 +1,6 @@
+carrier-sip-endpoints {
+  oui-datagrid.small-width {
+    width: 25%;
+    min-width: 10rem;
+  }
+}

--- a/packages/manager/modules/carrier-sip/src/endpoints/index.js
+++ b/packages/manager/modules/carrier-sip/src/endpoints/index.js
@@ -7,6 +7,9 @@ import 'ovh-ui-angular';
 // Components.
 import component from './endpoints.component';
 
+// Styles
+import './endpoints.scss';
+
 const moduleName = 'ovhManagerCarrierSipEndpoints';
 
 angular

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_en_GB.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_en_GB.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "ID",
   "carrier_sip_endpoints_protocol": "Protocol",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_es_ES.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_es_ES.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "ID",
   "carrier_sip_endpoints_protocol": "Protocolo",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fi_FI.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "ID",
   "carrier_sip_endpoints_protocol": "Protocol",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fr_CA.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "Id",
   "carrier_sip_endpoints_protocol": "Protocole",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_fr_FR.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "Id",
   "carrier_sip_endpoints_protocol": "Protocole",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_it_IT.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_it_IT.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "Endpoint SIP",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "ID",
   "carrier_sip_endpoints_protocol": "Protocollo",
   "carrier_sip_endpoints_protocol_tcp": "TCP",

--- a/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/carrier-sip/src/endpoints/translations/Messages_lt_LT.json
@@ -1,5 +1,6 @@
 {
-  "carrier_sip_endpoints": "SIP Endpoints",
+  "carrier_sip_endpoints_list_IP": "Liste d'adresses IP autorisées pour les appels sortants",
+  "carrier_sip_endpoints_with_incoming_call_enabled": "Routage d'appels entrants",
   "carrier_sip_endpoints_id": "ID",
   "carrier_sip_endpoints_protocol": "Protocol",
   "carrier_sip_endpoints_protocol_tcp": "TCP",


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-5286
| License          | BSD 3-Clause

## Description

Split endpoints details into two lists:

- One of all endpoint ips
- One of endpoint with incoming call routing enabled
