### PR TITLE
fix(pci.project): remove outdated keystone banner

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/project.html
+++ b/packages/manager/modules/pci/src/projects/project/project.html
@@ -13,33 +13,6 @@
         </cloud-sidebar>
         <div class="h-100 position-relative p-0 col-lg-10 d-flex flex-column">
             <div
-                class="pci-project-banner d-flex justify-content-between p-2"
-                data-ng-if="$ctrl.region !== 'US'"
-            >
-                <div class="d-none d-md-block">
-                    <span
-                        class="oui-icon oui-icon-warning_extra-thin oui-color-warning-dark float-left mx-2"
-                    ></span>
-                    <span
-                        data-translate="pci_projects_project_keystone_upgrade"
-                    ></span>
-                    <a
-                        rel="noopener"
-                        target="_blank"
-                        class="oui-link_icon pci-project-link_light"
-                        href="http://travaux.ovh.net/?do=details&id=42179"
-                    >
-                        <span
-                            data-translate="pci_projects_project_keystone_upgrade_more"
-                        ></span>
-                        <span
-                            class="oui-icon oui-icon-external_link"
-                            aria-hidden="true"
-                        ></span>
-                    </a>
-                </div>
-            </div>
-            <div
                 class="pci-project-content w-100 h-100 pt-4 px-3 px-md-5"
                 style="overflow: auto;"
             >

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_de_DE.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Vorbereitung der Umgebung für die Verwendung der OpenStack-API",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Create and configure an additional disk on an instance",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "Zu den Public Cloud Anleitungen",
-  "pci_projects_project_welcome": "Willkommen bei der neuen Public Cloud-Schnittstelle",
-  "pci_projects_project_keystone_upgrade": "Am 23. Juni 2020 findet eine bedeutende Veränderung statt. Daher möchten wir Sie schon jetzt bitten, sich auf den Wechsel zu <strong>Keystone v3</strong> einzustellen.",
-  "pci_projects_project_keystone_upgrade_more": "Mehr erfahren"
+  "pci_projects_project_welcome": "Willkommen bei der neuen Public Cloud-Schnittstelle"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_en_GB.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Prepare the environment for using the OpenStack API",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Create and configure and additional disk on an instance",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "See all Public Cloud guides",
-  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface",
-  "pci_projects_project_keystone_upgrade": "An important change will take place on 23rd June 2020 — please prepare for the upgrade to <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Find out more"
+  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_es_ES.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Preparar el entorno para utilizar la API de OpenStack",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Crear un volumen adicional y asociarlo a una instancia",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "Ver todas las guías de Public Cloud",
-  "pci_projects_project_welcome": "Bienvenido a la nueva interfaz de Public Cloud",
-  "pci_projects_project_keystone_upgrade": "El 23 de junio de 2020 se producirá un cambio importante. Por favor, planifique su migración a <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Más información"
+  "pci_projects_project_welcome": "Bienvenido a la nueva interfaz de Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_fi_FI.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Prepare the environment for using the OpenStack API",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Create and configure and additional disk on an instance",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "See all Public Cloud guides",
-  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface",
-  "pci_projects_project_keystone_upgrade": "An important change will take place on 23rd June 2020 — please prepare for the upgrade to <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Find out more"
+  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_fr_CA.json
@@ -13,7 +13,5 @@
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Create and configure and additional disk on an instance",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "See all Public Cloud guides",
 
-  "pci_projects_project_welcome": "Bienvenue sur la nouvelle interface Public Cloud",
-  "pci_projects_project_keystone_upgrade": "Changement important le 23 juin 2020, merci d'anticiper dès maintenant le passage à <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "En savoir plus"
+  "pci_projects_project_welcome": "Bienvenue sur la nouvelle interface Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_fr_FR.json
@@ -16,7 +16,5 @@
   "pci_projects_project_documentation_how_to_deploy_a_public_cloud_instance": "How to Deploy a Public Cloud Instance",
   "pci_projects_project_documentation_getting_started_with_block_storage": "Getting Started with Block Storage",
 
-  "pci_projects_project_welcome": "Bienvenue sur la nouvelle interface Public Cloud",
-  "pci_projects_project_keystone_upgrade": "Changement important le 23 juin 2020, merci d'anticiper dès maintenant le passage à <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "En savoir plus"
+  "pci_projects_project_welcome": "Bienvenue sur la nouvelle interface Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_it_IT.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Preparare l’ambiente di sviluppo per utilizzare l’API OpenStack",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Creare e configurare un disco aggiuntivo su un’istanza",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "Visualizza tutte le guide Public Cloud",
-  "pci_projects_project_welcome": "Benvenuti nella nuova interfaccia di Public Cloud",
-  "pci_projects_project_keystone_upgrade": "Il 23 giugno 2020 avverrà un cambiamento importante. Preparati in anticipo al passaggio a <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Scopri di più"
+  "pci_projects_project_welcome": "Benvenuti nella nuova interfaccia di Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_lt_LT.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Prepare the environment for using the OpenStack API",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Create and configure and additional disk on an instance",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "See all Public Cloud guides",
-  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface",
-  "pci_projects_project_keystone_upgrade": "An important change will take place on 23rd June 2020 — please prepare for the upgrade to <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Find out more"
+  "pci_projects_project_welcome": "Welcome to the new Public Cloud interface"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_pl_PL.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Przygotowanie środowiska do korzystania z API OpenStack ",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Tworzenie i konfiguracja dodatkowego dysku w instancji",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "Inne przewodniki dotyczące Public Cloud, które mogą Cię zainteresować…",
-  "pci_projects_project_welcome": "Witamy w nowym interfejsie Public Cloud",
-  "pci_projects_project_keystone_upgrade": "W dniu 23 czerwca 2020 roku nastąpi istotna zmiana, dlatego już teraz prosimy o zaplanowanie działań związanych z aktualizacją Keystone do <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Dowiedz się więcej"
+  "pci_projects_project_welcome": "Witamy w nowym interfejsie Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/translations/Messages_pt_PT.json
@@ -12,7 +12,5 @@
   "pci_projects_project_documentation_prepare_the_environment_for_using_the_open_stack_api": "Preparar o ambiente para utilizar a API OpenStack",
   "pci_projects_project_documentation_create_and_configure_and_additional_disk_on_an_instance": "Criar e configurar um disco suplementar numa instância",
   "pci_projects_project_documentation_see_all_public_cloud_guides": "Consultar todos os manuais Public Cloud",
-  "pci_projects_project_welcome": "Bem-vindo à nova interface da Nuvem Pública",
-  "pci_projects_project_keystone_upgrade": "Uma importante mudança irá ter lugar a 23 de junho de 2020. Prepare-se para a passagem para <strong>Keystone v3</strong>.",
-  "pci_projects_project_keystone_upgrade_more": "Mais informações"
+  "pci_projects_project_welcome": "Bem-vindo à nova interface da Nuvem Pública"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-15861
| License          | BSD 3-Clause

## Description

Remove outdated banner since keystone migration is over

ref: DTRSD-15861

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>