### PR TITLE
fix(translations): clean translations files

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_de_DE.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Eine private SQL Datenbank aktivieren",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} nicht aktivierte private SQL Datenbank(en)",
   "hosting_dashboard_service_privatesql_active_doing": "Wird aktiviert",
+  "hosting_dashbaord_service_privatesql_detach": "Abtrennen",
   "hosting_dashboard_service_web_info_1": "von 1 empfohlenen",
   "hosting_dashboard_service_web_info_other": "von {{t0}} empfohlenen",
   "hosting_dashboard_service_renew": "Verlängern",
@@ -487,7 +488,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Domainname",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Auch die Subdomain {{t0}} ändern",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Wurzelverzeichnis",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Runtime Engine",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "CDN aktivieren",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Möchten Sie diese Änderungen wirklich auf folgende Domains anwenden?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Domainname",
@@ -1371,10 +1371,9 @@
   "hosting_dashboard_access": "Zugriff",
   "common_api_hostingWeb-1": "Sie können nicht zu diesem Angebot wechseln, da Ihr aktuelles Angebot mehr E-Mail-Adressen umfasst, als das gerade gewählte Angebot.",
   "hosting_dashboard_service_activate_email": "Mein E-Mail Angebot aktivieren",
+  "hosting_dashboard_service_detach_email_option": "Meine E-Mail-Option abtrennen",
   "hosting_dashboard_service_email_address": "E-Mail-Adressen",
   "hosting_dashboard_service_common_active": "Aktiv",
   "hosting_dashboard_service_common_inactive": "Inaktiv",
-  "hosting_dashboard_email_offer_get_error": "Es ist unmöglich, die E-Mail-Adresse wiederherzustellen.",
-  "hosting_dashboard_service_detach_email_option": "Meine E-Mail-Option abtrennen",
-  "hosting_dashbaord_service_privatesql_detach": "Abtrennen"
+  "hosting_dashboard_email_offer_get_error": "Es ist unmöglich, die E-Mail-Adresse wiederherzustellen."
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_en_GB.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Enable a Private SQL database",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} Private SQL databases not enabled",
   "hosting_dashboard_service_privatesql_active_doing": "Activating...",
+  "hosting_dashbaord_service_privatesql_detach": "Detach",
   "hosting_dashboard_service_web_info_1": "on 1 recommended",
   "hosting_dashboard_service_web_info_other": "on {{t0}} recommended",
   "hosting_dashboard_service_renew": "Renew",
@@ -475,7 +476,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Domain name",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Also modify the {{t0}} sub-domain",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Root folder",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Runtime software application",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Activate the CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Are you sure to want to carry out these modifications on the following domains?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Domain name",
@@ -1358,10 +1358,9 @@
   "hosting_dashboard_access": "Access",
   "common_api_hostingWeb-1": "You cannot migrate to this solution, because your current solution has more email capacity than the solution you have selected.",
   "hosting_dashboard_service_activate_email": "Enable email solution",
+  "hosting_dashboard_service_detach_email_option": "Detach my email option",
   "hosting_dashboard_service_email_address": "Email addresses",
   "hosting_dashboard_service_common_active": "Enabled",
   "hosting_dashboard_service_common_inactive": "Disabled",
-  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address",
-  "hosting_dashboard_service_detach_email_option": "Detach my email option",
-  "hosting_dashbaord_service_privatesql_detach": "Detach"
+  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address"
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_es_ES.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Activar una base de datos SQL privada",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} base(s) de datos SQL privada(s) no activa(s)",
   "hosting_dashboard_service_privatesql_active_doing": "Activando...",
+  "hosting_dashbaord_service_privatesql_detach": "Desvincular",
   "hosting_dashboard_service_web_info_1": "de 1 recomendado",
   "hosting_dashboard_service_web_info_other": "de {{t0}} recomendados",
   "hosting_dashboard_service_renew": "Renovar",
@@ -178,6 +179,7 @@
   "hosting_dashboard_service_datacenter_p19": "París",
   "hosting_dashboard_service_datacenter_gra1": "Gravelines 1",
   "hosting_dashboard_service_datacenter_gra2": "Gravelines 2",
+  "hosting_dashboard_service_datacenter_bhs1": "Beauharnois 1",
   "hosting_dashboard_service_default_runtime": "Motor de ejecución por defecto",
   "hosting_dashboard_available_space": "Espacio disponible",
   "hosting_tab_DOMAINS_OLD": "Sitios web",
@@ -487,7 +489,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Dominio",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Editar también el subdominio {{t0}}",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Carpeta raíz",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Motor de ejecución",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Activar la CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "¿Seguro que quiere aplicar los cambios en los siguientes dominios?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Dominio",
@@ -1371,11 +1372,9 @@
   "hosting_dashboard_access": "Acceso",
   "common_api_hostingWeb-1": "No puede migrar a esta opción, ya que su solución actual dispone de más cuentas de correo que la opción seleccionada.",
   "hosting_dashboard_service_activate_email": "Activar mi solución de correo",
+  "hosting_dashboard_service_detach_email_option": "Desvincular mi opción de correo",
   "hosting_dashboard_service_email_address": "Direcciones de correo",
   "hosting_dashboard_service_common_active": "Activo",
   "hosting_dashboard_service_common_inactive": "Inactivo",
-  "hosting_dashboard_email_offer_get_error": "No se ha podido cargar la dirección de correo.",
-  "hosting_dashboard_service_detach_email_option": "Desvincular mi opción de correo",
-  "hosting_dashbaord_service_privatesql_detach": "Desvincular",
-  "hosting_dashboard_service_datacenter_bhs1": "Beauharnois 1"
+  "hosting_dashboard_email_offer_get_error": "No se ha podido cargar la dirección de correo."
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_es_US.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_es_US.json
@@ -463,7 +463,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Nombre del dominio",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Editar también el subdominio {{t0}}",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Carpeta raíz",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Unidad funcional",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Activar el CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "¿Seguro que desea aplicar los cambios en los siguientes dominios?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Nombre del dominio",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fi_FI.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fi_FI.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Enable a Private SQL database",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} Private SQL databases not enabled",
   "hosting_dashboard_service_privatesql_active_doing": "Activating...",
+  "hosting_dashbaord_service_privatesql_detach": "Detach",
   "hosting_dashboard_service_web_info_1": "on 1 recommended",
   "hosting_dashboard_service_web_info_other": "on {{t0}} recommended",
   "hosting_dashboard_service_renew": "Renew",
@@ -475,7 +476,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Domain name",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Also modify the {{t0}} sub-domain",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Root folder",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Runtime software application",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Activate the CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Are you sure to want to carry out these modifications on the following domains?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Domain name",
@@ -1358,10 +1358,9 @@
   "hosting_dashboard_access": "Access",
   "common_api_hostingWeb-1": "You cannot migrate to this solution, because your current solution has more email capacity than the solution you have selected.",
   "hosting_dashboard_service_activate_email": "Enable email solution",
+  "hosting_dashboard_service_detach_email_option": "Detach my email option",
   "hosting_dashboard_service_email_address": "Email addresses",
   "hosting_dashboard_service_common_active": "Enabled",
   "hosting_dashboard_service_common_inactive": "Disabled",
-  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address",
-  "hosting_dashboard_service_detach_email_option": "Detach my email option",
-  "hosting_dashbaord_service_privatesql_detach": "Detach"
+  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address"
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_it_IT.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Attiva un database SQL Privato",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} database SQL Privati non attivati",
   "hosting_dashboard_service_privatesql_active_doing": "Attivazione in corso",
+  "hosting_dashbaord_service_privatesql_detach": "Scollega",
   "hosting_dashboard_service_web_info_1": "su 1 consigliato",
   "hosting_dashboard_service_web_info_other": "sui {{t0}} consigliati",
   "hosting_dashboard_service_renew": "Rinnova",
@@ -178,6 +179,7 @@
   "hosting_dashboard_service_datacenter_p19": "Parigi",
   "hosting_dashboard_service_datacenter_gra1": "Gravelines 1",
   "hosting_dashboard_service_datacenter_gra2": "Gravelines 2",
+  "hosting_dashboard_service_datacenter_bhs1": "Beauharnois 1",
   "hosting_dashboard_service_default_runtime": "Programma d'esecuzione di default",
   "hosting_dashboard_available_space": "Spazio disponibile",
   "hosting_tab_DOMAINS_OLD": "Siti Web",
@@ -487,7 +489,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Dominio",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Modifica anche il sottodominio {{t0}}",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Cartella di root",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Programma d'esecuzione",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Attiva la CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Vuoi davvero effettuare queste modifiche sui domini che seguono?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Dominio",
@@ -1371,11 +1372,9 @@
   "hosting_dashboard_access": "Accesso",
   "common_api_hostingWeb-1": "Non è possibile effettuare la migrazione verso questa offerta perché il servizio corrente dispone di un numero maggiore di email rispetto alla nuova soluzione scelta.",
   "hosting_dashboard_service_activate_email": "Attiva il tuo servizio di posta",
+  "hosting_dashboard_service_detach_email_option": "Scollega la tua opzione email",
   "hosting_dashboard_service_email_address": "Account email",
   "hosting_dashboard_service_common_active": "Attivo",
   "hosting_dashboard_service_common_inactive": "Disattivo",
-  "hosting_dashboard_email_offer_get_error": "Impossibile recuperare l’indirizzo email",
-  "hosting_dashboard_service_detach_email_option": "Scollega la tua opzione email",
-  "hosting_dashbaord_service_privatesql_detach": "Scollega",
-  "hosting_dashboard_service_datacenter_bhs1": "Beauharnois 1"
+  "hosting_dashboard_email_offer_get_error": "Impossibile recuperare l’indirizzo email"
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_lt_LT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_lt_LT.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Enable a Private SQL database",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} Private SQL databases not enabled",
   "hosting_dashboard_service_privatesql_active_doing": "Activating...",
+  "hosting_dashbaord_service_privatesql_detach": "Detach",
   "hosting_dashboard_service_web_info_1": "on 1 recommended",
   "hosting_dashboard_service_web_info_other": "on {{t0}} recommended",
   "hosting_dashboard_service_renew": "Renew",
@@ -475,7 +476,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Domain name",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Also modify the {{t0}} sub-domain",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Root folder",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Runtime software application",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Activate the CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Are you sure to want to carry out these modifications on the following domains?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Domain name",
@@ -1358,10 +1358,9 @@
   "hosting_dashboard_access": "Access",
   "common_api_hostingWeb-1": "You cannot migrate to this solution, because your current solution has more email capacity than the solution you have selected.",
   "hosting_dashboard_service_activate_email": "Enable email solution",
+  "hosting_dashboard_service_detach_email_option": "Detach my email option",
   "hosting_dashboard_service_email_address": "Email addresses",
   "hosting_dashboard_service_common_active": "Enabled",
   "hosting_dashboard_service_common_inactive": "Disabled",
-  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address",
-  "hosting_dashboard_service_detach_email_option": "Detach my email option",
-  "hosting_dashbaord_service_privatesql_detach": "Detach"
+  "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address"
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_pl_PL.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Włączenie prywatnej bazy SQL",
   "hosting_dashboard_service_privatesql_active_remaining": "Liczba niewłączonych prywatnych baz danych SQL: {{ count }}",
   "hosting_dashboard_service_privatesql_active_doing": "Trwa aktywacja...",
+  "hosting_dashbaord_service_privatesql_detach": "Odłącz",
   "hosting_dashboard_service_web_info_1": "na 1 zalecaną",
   "hosting_dashboard_service_web_info_other": "na {{t0}} zalecanych",
   "hosting_dashboard_service_renew": "Odnów",
@@ -486,7 +487,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Nazwa domeny",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Zmień również ustawienia subdomeny {{t0}}.",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Katalog główny",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Framework",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Włącz CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Czy chcesz wprowadzić te zmiany dla następujących domen?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Nazwa domeny",
@@ -1370,10 +1370,9 @@
   "hosting_dashboard_access": "Dostęp",
   "common_api_hostingWeb-1": "Nie możesz wybrać tej oferty, ponieważ Twój obecny pakiet zawiera więcej kont e-mail niż oferta, którą chciałeś wybrać.",
   "hosting_dashboard_service_activate_email": "Włącz mój pakiet e-mail",
+  "hosting_dashboard_service_detach_email_option": "Odłącz opcję e-mail",
   "hosting_dashboard_service_email_address": "Adresy e-mail",
   "hosting_dashboard_service_common_active": "Aktywny",
   "hosting_dashboard_service_common_inactive": "Nieaktywny",
-  "hosting_dashboard_email_offer_get_error": "Nie można pobrać adresu e-mail",
-  "hosting_dashboard_service_detach_email_option": "Odłącz opcję e-mail",
-  "hosting_dashbaord_service_privatesql_detach": "Odłącz"
+  "hosting_dashboard_email_offer_get_error": "Nie można pobrać adresu e-mail"
 }

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_pt_PT.json
@@ -155,6 +155,7 @@
   "hosting_dashboard_service_privatesql_active_long": "Encomendar uma base de dados SQL privada",
   "hosting_dashboard_service_privatesql_active_remaining": "{{ count }} Base(s) de dados SQL privada(s) não activada(s)",
   "hosting_dashboard_service_privatesql_active_doing": "Ativação em curso",
+  "hosting_dashbaord_service_privatesql_detach": "Desassociar",
   "hosting_dashboard_service_web_info_1": "de 1 recomendado",
   "hosting_dashboard_service_web_info_other": "de {{t0}} recomendados",
   "hosting_dashboard_service_renew": "Renovar",
@@ -487,7 +488,6 @@
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name": "Domínio",
   "hosting_tab_DOMAINS_configuration_modify_step1_domain_name_www_question": "Modificar também o subdomínio {{t0}}",
   "hosting_tab_DOMAINS_configuration_modify_step1_home": "Pasta raiz",
-  "hosting_tab_DOMAINS_configuration_modify_step1_runtime": "Aplicativo de software em tempo de execução",
   "hosting_tab_DOMAINS_configuration_modify_step1_cdn": "Ativar o CDN",
   "hosting_tab_DOMAINS_configuration_modify_step2_summary": "Deseja realmente levar a cabo estas alterações para os nomes de domínio seguintes?",
   "hosting_tab_DOMAINS_configuration_modify_step2_domain_name": "Domínio",
@@ -1371,10 +1371,9 @@
   "hosting_dashboard_access": "Acesso",
   "common_api_hostingWeb-1": "Não é possível migrar para esta oferta, porque a sua oferta atual dispõe de mais e-mails do que a oferta selecionada.",
   "hosting_dashboard_service_activate_email": "Ativar a minha oferta de e-mail",
+  "hosting_dashboard_service_detach_email_option": "Desassociar a minha opção de e-mail",
   "hosting_dashboard_service_email_address": "Endereços de e-mail",
   "hosting_dashboard_service_common_active": "Ativo",
   "hosting_dashboard_service_common_inactive": "Inativo",
-  "hosting_dashboard_email_offer_get_error": "Não é possível recuperar o endereço de e-mail",
-  "hosting_dashboard_service_detach_email_option": "Desassociar a minha opção de e-mail",
-  "hosting_dashbaord_service_privatesql_detach": "Desassociar"
+  "hosting_dashboard_email_offer_get_error": "Não é possível recuperar o endereço de e-mail"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_de_DE.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_de_DE.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Nicht vorprogrammiert",
   "vps_migration_status_planned": "Geplant",
   "vps_migration_table_vps_link": "Meinen Dienst anzeigen",
-  "vps_migration_table_planned_date": "Voraussichtliches Datum",
-  "vps_migration_description2": "Ihr derzeitiger VPS wird durch eine Maschine unserer <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>neuen Reihe<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a> ersetzt, zum gleichen oder einem niedrigeren Preis."
+  "vps_migration_table_planned_date": "Voraussichtliches Datum"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_en_GB.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_en_GB.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Not scheduled",
   "vps_migration_status_planned": "Scheduled",
   "vps_migration_table_vps_link": "View my service",
-  "vps_migration_table_planned_date": "Scheduled date",
-  "vps_migration_description2": "Your current VPS will be replaced with a server from our <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>new range<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, at an equal or lower price."
+  "vps_migration_table_planned_date": "Scheduled date"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_es_ES.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_es_ES.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "No programada",
   "vps_migration_status_planned": "Programada",
   "vps_migration_table_vps_link": "Ver mi servicio",
-  "vps_migration_table_planned_date": "Fecha prevista",
-  "vps_migration_description2": "El VPS actual será sustituido por una máquina de nuestra <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>nueva gama<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, a un precio inferior o equivalente."
+  "vps_migration_table_planned_date": "Fecha prevista"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_fi_FI.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Not scheduled",
   "vps_migration_status_planned": "Scheduled",
   "vps_migration_table_vps_link": "View my service",
-  "vps_migration_table_planned_date": "Scheduled date",
-  "vps_migration_description2": "Your current VPS will be replaced with a server from our <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>new range<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, at an equal or lower price."
+  "vps_migration_table_planned_date": "Scheduled date"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_it_IT.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_it_IT.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Non programmata",
   "vps_migration_status_planned": "Programmata",
   "vps_migration_table_vps_link": "Visualizza il tuo servizio",
-  "vps_migration_table_planned_date": "Data prevista",
-  "vps_migration_description2": "Il VPS corrente sarà sostituito con un modello della nostra <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>nuova gamma<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, con prezzo inferiore o equivalente."
+  "vps_migration_table_planned_date": "Data prevista"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_lt_LT.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Not scheduled",
   "vps_migration_status_planned": "Scheduled",
   "vps_migration_table_vps_link": "View my service",
-  "vps_migration_table_planned_date": "Scheduled date",
-  "vps_migration_description2": "Your current VPS will be replaced with a server from our <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>new range<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, at an equal or lower price."
+  "vps_migration_table_planned_date": "Scheduled date"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_pl_PL.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Niezaplanowana",
   "vps_migration_status_planned": "Zaplanowana",
   "vps_migration_table_vps_link": "Wyświetl informacje o mojej usłudze",
-  "vps_migration_table_planned_date": "Przewidywana data",
-  "vps_migration_description2": "Twój obecny VPS zostanie zastąpiony maszyną z naszej <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>nowej gamy<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, w niższej lub równoważnej cenie."
+  "vps_migration_table_planned_date": "Przewidywana data"
 }

--- a/packages/manager/modules/vps/src/migration/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/vps/src/migration/translations/Messages_pt_PT.json
@@ -14,6 +14,5 @@
   "vps_migration_status_toPlan": "Não programada",
   "vps_migration_status_planned": "Programada",
   "vps_migration_table_vps_link": "Ver o meu serviço",
-  "vps_migration_table_planned_date": "Data prevista",
-  "vps_migration_description2": "O seu VPS atual será substituído por uma máquina da nossa <a href='{{rangeLink}}' class='oui-link oui-link_icon' rel='noopener' target='_blank'>nova gama<span class='oui-icon oui-icon-external_link' aria-hidden='true'></span></a>, a um preço inferior ou equivalente."
+  "vps_migration_table_planned_date": "Data prevista"
 }


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description


Clean translations to sync translations files between source (`fr_FR`) and targets: 
* Some translations are no more present in source translations files (`fr_FR`) and are still in target translations files.
* Some translations moved from one path to another and are still present in the previous path. It could be an issue depending on the translations loading (if translations were changed, they are not changed in old path).




