### PR TITLE
fix(dataprocessing): activation spinner added

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/onboarding.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/onboarding.controller.js
@@ -10,6 +10,7 @@ export default class {
     this.$q = $q;
     this.dataProcessingService = dataProcessingService;
     this.atInternet = atInternet;
+    this.isActivating = false;
   }
 
   $onInit() {
@@ -32,14 +33,20 @@ export default class {
   }
 
   authorizeService() {
+    this.isActivating = true;
     this.atInternet.trackClick({
       name:
         'public-cloud::pci::projects::project::data-processing::onboarding::first-job',
       type: 'action',
     });
-    this.dataProcessingService.authorize(this.projectId).then(() => {
-      this.goBack();
-    });
+    this.dataProcessingService
+      .authorize(this.projectId)
+      .then(() => {
+        this.goBack();
+      })
+      .finally(() => {
+        this.isActivating = false;
+      });
   }
 
   onGuideClick(guide) {

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/onboarding.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/onboarding.html
@@ -13,8 +13,13 @@
 
     <oui-button
         data-variant="primary"
+        data-ng-if="!$ctrl.isActivating"
         data-on-click="$ctrl.authorizeService()"
     >
         <span data-translate="data_processing_onboarding_action_label"></span>
     </oui-button>
+    <div class="text-center" data-ng-if="$ctrl.isActivating">
+        <oui-spinner></oui-spinner>
+        <p data-translate="data_processing_onboarding_activation"></p>
+    </div>
 </pci-project-empty>

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_de_DE.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Meinen ersten Auftrag starten",
   "data_processing_onboarding_guides_overview_title": "Präsentation von Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Meinen ersten Spark-Auftrag starten",
-  "data_processing_onboarding_guides_monitor_job_title": "Meine Aufträge überwachen"
+  "data_processing_onboarding_guides_monitor_job_title": "Meine Aufträge überwachen",
+  "data_processing_onboarding_activation": "Wird aktiviert..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_en_GB.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Start my first job",
   "data_processing_onboarding_guides_overview_title": "Data Processing introduction",
   "data_processing_onboarding_guides_quick_start_title": "Launch my first Spark job",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs",
+  "data_processing_onboarding_activation": "Activating..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_es_ES.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Iniciar mi primer job",
   "data_processing_onboarding_guides_overview_title": "Presentación de Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Lanzar mi primer job Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitorizar mis jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitorizar mis jobs",
+  "data_processing_onboarding_activation": "Activando..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fi_FI.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Start my first job",
   "data_processing_onboarding_guides_overview_title": "Data Processing introduction",
   "data_processing_onboarding_guides_quick_start_title": "Launch my first Spark job",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs",
+  "data_processing_onboarding_activation": "Activating..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fr_CA.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Démarrer mon premier job",
   "data_processing_onboarding_guides_overview_title": "Présentation de Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Lancer mon premier job Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitorer mes jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitorer mes jobs",
+  "data_processing_onboarding_activation": "Activation en cours..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_fr_FR.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Démarrer mon premier job",
   "data_processing_onboarding_guides_overview_title": "Présentation de Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Lancer mon premier job Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitorer mes jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitorer mes jobs",
+  "data_processing_onboarding_activation": "Activation en cours..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_it_IT.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Avvia il primo job",
   "data_processing_onboarding_guides_overview_title": "Presentazione di Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Avvia il primo job Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitora i tuoi job"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitora i tuoi job",
+  "data_processing_onboarding_activation": "Attivazione in corso..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_lt_LT.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Start my first job",
   "data_processing_onboarding_guides_overview_title": "Data Processing introduction",
   "data_processing_onboarding_guides_quick_start_title": "Launch my first Spark job",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitor my jobs",
+  "data_processing_onboarding_activation": "Activating..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_pl_PL.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Uruchom pierwsze zadanie",
   "data_processing_onboarding_guides_overview_title": "Prezentacja Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Uruchom pierwsze zadanie Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitoring moich zadań"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitoring moich zadań",
+  "data_processing_onboarding_activation": "Trwa aktywacja..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/onboarding/translations/Messages_pt_PT.json
@@ -5,5 +5,6 @@
   "data_processing_onboarding_action_label": "Iniciar o meu primeiro job",
   "data_processing_onboarding_guides_overview_title": "Apresentação do Data Processing",
   "data_processing_onboarding_guides_quick_start_title": "Lançar o meu primeiro job Spark",
-  "data_processing_onboarding_guides_monitor_job_title": "Monitorizar os meus jobs"
+  "data_processing_onboarding_guides_monitor_job_title": "Monitorizar os meus jobs",
+  "data_processing_onboarding_activation": "Ativação em curso..."
 }


### PR DESCRIPTION
Signed-off-by: Yann Pauly <yann.pauly@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `bugfix/MANAGER-5026`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

This PR adds a spinner when a user activate their Data Processing service instead of having the activation button staying enabled.
