### PR TITLE
build(deps): add missing @ovh-ux/ng-ovh-feature-flipping deps

### DIFF
--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -28,6 +28,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^3.1.1",
+    "@ovh-ux/ng-ovh-feature-flipping": "^1.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.2.3",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Following command reports an error:
```sh
$ yarn workspace @ovh-ux/manager-sms-app run start
```

Output:
```sh
@ovh-ux/manager-sms-app: ERROR in /home/foo/bar/ovh/manager/packages/manager/modules/sms/src/sms/telecom-sms.component.js
@ovh-ux/manager-sms-app: Module not found: Error: Can't resolve '@ovh-ux/ng-ovh-feature-flipping' in '/home/foo/bar/ovh/manager/packages/manager/modules/sms/src/sms'
@ovh-ux/manager-sms-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/sms/src/sms/telecom-sms.component.js 8:0-67 29:216-236
@ovh-ux/manager-sms-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/sms/src/sms/index.js
@ovh-ux/manager-sms-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/sms/src/index.js
@ovh-ux/manager-sms-app:  @ ./src/index.js
```

### :bug: Bug Fix

b347366 - build(deps): add missing @ovh-ux/ng-ovh-feature-flipping deps

uses: `$ yarn workspace @ovh-ux/manager-sms-app add @ovh-ux/ng-ovh-feature-flipping`
- @ovh-ux/ng-ovh-feature-flipping@^1.0.0

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
