### PR TITLE
fix(xdsl.modem.config): fix the checkbox to activate/deactivate

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/index.js
@@ -1,5 +1,7 @@
 import angular from 'angular';
 
+import access from './access';
+
 import component from './pack-xdsl.component';
 import routing from './pack-xdsl.routing';
 import templates from './pack-xdsl.templates';
@@ -7,7 +9,7 @@ import templates from './pack-xdsl.templates';
 const moduleName = 'ovhManagerTelecomPackXdsl';
 
 angular
-  .module(moduleName, [])
+  .module(moduleName, [access])
   .component('packXdsl', component)
   .config(routing)
   .run(templates)

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/managedByOvh/pack-xdsl-modem-managedByOvh.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/managedByOvh/pack-xdsl-modem-managedByOvh.html
@@ -12,7 +12,7 @@
                     data-ng-disabled="!ManagedByCtrl.mediator.capabilities.canChangeManagement || ManagedBy.updating"
                     data-ng-really-click="ManagedByCtrl.changeManagedBy()"
                     data-ng-really-undo="ManagedByCtrl.undo()"
-                    data-ng-really-message="{{ ManagedByCtrl.mediator.info.managedByOvh ? 'xdsl_modem_managedBy_really_on' : 'xdsl_modem_managedBy_really_off' | translate }}
+                    data-ng-really-message="{{ ManagedByCtrl.mediator.info.managedByOvh ? 'xdsl_modem_managedBy_really_off' : 'xdsl_modem_managedBy_really_on' | translate }}
                         <div class='text-info mt-3'>
                             <h6 class='ovh-font ovh-font-info' aria-hidden='true'></h6>
                             <span data-translate='xdsl_modem_managedBy_description'></span>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
@@ -28,11 +28,7 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/xdsl/:serviceName/lines/:number',
     views: {
       'packView@telecom.packs': 'packXdsl',
-      'xdslView@telecom.packs.pack.xdsl': {
-        controller: 'XdslAccessCtrl',
-        controllerAs: 'XdslAccess',
-        templateUrl: 'app/telecom/pack/xdsl/access/pack-xdsl-access.html',
-      },
+      'xdslView@telecom.packs.pack.xdsl': 'packXdslAccess',
     },
     translations: {
       value: [


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | fix/xdsl-modem-remote-config
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-293
| License          | BSD 3-Clause

## Description

Fix the checkbox to activate/deactivate into the correct way for remote config on the modem
Fix the access tab which was not displayed correctly
