### PR TITLE
fix(billing.history): display correct translation for total with VAT

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/main/history/billing-main-history.controller.js
+++ b/packages/manager/apps/dedicated/client/app/billing/main/history/billing-main-history.controller.js
@@ -57,7 +57,7 @@ export default class BillingMainHistoryCtrl extends ListLayoutHelper.ListLayoutC
       .catch((error) => {
         this.Alerter.error(
           [
-            this.$translate.instant('billing_main_history_export_error'),
+            this.$translate.instant('billing_main_history_table_export_error'),
             get(error, 'data.message'),
           ].join(' '),
           'billing_main_alert',

--- a/packages/manager/apps/dedicated/client/app/billing/main/history/billing-main-history.html
+++ b/packages/manager/apps/dedicated/client/app/billing/main/history/billing-main-history.html
@@ -94,7 +94,7 @@
             <span data-ng-bind="$row.priceWithoutTax.text"></span>
         </oui-column>
         <oui-column
-            title=":: $ctrl.currentUser.isVATNeeded ? 'billing_main_history_table_total_with_VAT' : 'billing_main_history_table_total' | translate"
+            title=":: 'billing_main_history_table_total_with_VAT' | translate"
             property="priceWithTax.value"
             sortable
         >


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none 
| License          | BSD 3-Clause
