### PR TITLE
fix(telephony.alias.statistics): use agent line number and description

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/telecom-telephony-alias-statistics.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/telecom-telephony-alias-statistics.controller.js
@@ -72,10 +72,29 @@ angular.module('managerApp').controller(
     refreshStats() {
       return this.$q
         .all({
-          agentsStatus: this.tucVoipServiceAlias.fetchContactCenterSolutionNumberAgentsStatus(
-            this.serviceInfos,
-            this.queue.queueId,
-          ),
+          agentsStatus: this.tucVoipServiceAlias
+            .fetchContactCenterSolutionNumberAgentsStatus(
+              this.serviceInfos,
+              this.queue.queueId,
+            )
+            .then((agentsStatus) =>
+              this.$q.all(
+                agentsStatus.map((agentStatus) =>
+                  this.OvhApiTelephony.EasyHunting()
+                    .Hunting()
+                    .Agent()
+                    .v6()
+                    .get({
+                      ...this.serviceInfos,
+                      agentId: agentStatus.agentId,
+                    })
+                    .$promise.then((agentInfo) => ({
+                      ...agentInfo,
+                      ...agentStatus,
+                    })),
+                ),
+              ),
+            ),
           calls: this.tucVoipServiceAlias.fetchContactCenterSolutionNumberQueueCalls(
             this.serviceInfos,
             this.queue.queueId,

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/telecom-telephony-alias-statistics.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/telecom-telephony-alias-statistics.html
@@ -154,7 +154,11 @@
         <oui-datagrid class="my-5" data-rows="$ctrl.agentsStatus">
             <oui-column
                 data-title="::'telephony_alias_statistics_calls_agent_queue' | translate"
-                data-property="agentId"
+                data-property="number"
+            ></oui-column>
+            <oui-column
+                data-title=":: 'telephony_alias_statistics_calls_agent_description' | translate"
+                data-property="description"
             ></oui-column>
             <oui-column
                 data-title="::'telephony_alias_statistics_agent_status' | translate"

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_de_DE.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Eintritt in die Queue",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Anzahl der Agenten im Telefonat",
   "telephony_alias_statistics_agents_pending": "Anzahl der verfügbaren Agenten",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_en_GB.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_es_ES.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrada en la cola",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Número de agentes en llamada",
   "telephony_alias_statistics_agents_pending": "Número de agentes en espera",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_es_US.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_es_US.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrada en la cola",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Número de agentes en llamada",
   "telephony_alias_statistics_agents_pending": "Número de agentes en espera",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fi_FI.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fi_FI.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fr_CA.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_fr_FR.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d’appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d’agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d’agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_it_IT.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrato nella coda",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Numero di agenti al telefono",
   "telephony_alias_statistics_agents_pending": "Numero di agenti in attesa",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_lt_LT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_lt_LT.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_pl_PL.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/statistics/translations/Messages_pt_PT.json
@@ -22,6 +22,7 @@
   "telephony_alias_statistics_calls_queue_time": "Entrée dans la file",
   "telephony_alias_statistics_calls_time": "Prise d'appel",
   "telephony_alias_statistics_calls_agent_queue": "Ligne de la file (Agents)",
+  "telephony_alias_statistics_calls_agent_description": "Description",
   "telephony_alias_statistics_agents_ongoing": "Nombre d'agents en appel",
   "telephony_alias_statistics_agents_pending": "Nombre d'agents en attente",
   "telephony_alias_statistics_calls_agent_updated": "Dernier changement de statut",


### PR DESCRIPTION
DTRSD-15957
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-15957
| License          | BSD 3-Clause

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add missing agent line number and description in CCS statistics page