### PR TITLE
feat(component.livecalls): on ovhpabx dashboard display number agent

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
@@ -3,6 +3,7 @@ import angular from 'angular';
 import '@ovh-ux/ng-ovh-telecom-universe-components';
 
 import component from './pack-xdsl-modem.component';
+import { PACK_XDSL_MODEM } from './pack-xdsl-modem.constant';
 import routing from './pack-xdsl-modem.routing';
 
 const moduleName = 'ovhManagerTelecomPackXdslModem';
@@ -11,6 +12,7 @@ angular
   .module(moduleName, ['ngOvhTelecomUniverseComponents'])
   .component('packXdslModem', component)
   .config(routing)
+  .constant('PACK_XDSL_MODEM', PACK_XDSL_MODEM)
   .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/pack-xdsl-modem.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/pack-xdsl-modem.constant.js
@@ -1,4 +1,4 @@
-angular.module('managerApp').constant('PACK_XDSL_MODEM', {
+export const PACK_XDSL_MODEM = {
   mtu: {
     default: 1492,
     values: [
@@ -13,4 +13,6 @@ angular.module('managerApp').constant('PACK_XDSL_MODEM', {
       },
     ],
   },
-});
+};
+
+export default { PACK_XDSL_MODEM };

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
@@ -185,6 +185,20 @@ angular.module('managerApp').component('telecomTelephonyAliasLiveCalls', {
                 })
                 .$promise.then((agentStatus) => {
                   set(agentStatus, 'agentId', agentId);
+
+                  // Retrieve agent number
+                  self.apiEndpoint
+                    .Hunting()
+                    .Agent()
+                    .v6()
+                    .get({
+                      billingAccount: $stateParams.billingAccount,
+                      serviceName: $stateParams.serviceName,
+                      agentId,
+                    })
+                    .$promise.then((agent) => {
+                      set(agentStatus, 'agentNumber', agent.number);
+                    });
                   return agentStatus;
                 }),
             ),

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.component.js
@@ -187,7 +187,7 @@ angular.module('managerApp').component('telecomTelephonyAliasLiveCalls', {
                   set(agentStatus, 'agentId', agentId);
 
                   // Retrieve agent number
-                  self.apiEndpoint
+                  return self.apiEndpoint
                     .Hunting()
                     .Agent()
                     .v6()
@@ -196,10 +196,11 @@ angular.module('managerApp').component('telecomTelephonyAliasLiveCalls', {
                       serviceName: $stateParams.serviceName,
                       agentId,
                     })
-                    .$promise.then((agent) => {
-                      set(agentStatus, 'agentNumber', agent.number);
-                    });
-                  return agentStatus;
+                    .$promise.then((agent) => ({
+                      ...agentStatus,
+                      agentId,
+                      agentNumber: agent.number,
+                    }));
                 }),
             ),
           ),

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.html
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/alias/liveCalls/telecom-telephony-alias-configuration-liveCalls.html
@@ -171,7 +171,7 @@
     <oui-datagrid data-rows="$ctrl.agentsStatus">
         <oui-datagrid-column
             data-title="'telephony_alias_configuration_mode_calls_agent' | translate"
-            data-property="agentId"
+            data-property="agentNumber"
         ></oui-datagrid-column>
         <oui-datagrid-column
             data-title="'telephony_alias_configuration_mode_calls_agent_status' | translate"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/ovhpabx-dashboard-agent-number`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-297
| License          | BSD 3-Clause

## Description

On dashboard for calls statistics, display agent number instead of agent ID.
