### PR TITLE
fix(instances.add): typo in translations file for extra bandwith

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -37,7 +37,7 @@
   "pci_projects_project_instances_add_success_multiple_message": "The instances have been added",
   "pci_projects_project_instances_add_error_save": "An error has occurred adding the {{ instance }} instance: {{ message }}",
   "pci_projects_project_instances_add_error_multiple_save": "An error has occurred adding the instances: {{ message }}",
-  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
+  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
   "pci_projects_project_instances_add_automated_backup_label": "Automatic instance backup",
   "pci_projects_project_instances_add_automated_backup_infos": "You can use this feature to back up your instance automatically, as often as you like."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
@@ -37,7 +37,7 @@
   "pci_projects_project_instances_add_success_multiple_message": "The instances have been added",
   "pci_projects_project_instances_add_error_save": "An error has occurred adding the {{ instance }} instance: {{ message }}",
   "pci_projects_project_instances_add_error_multiple_save": "An error has occurred adding the instances: {{ message }}",
-  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
+  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
   "pci_projects_project_instances_add_automated_backup_label": "Automatic instance backup",
   "pci_projects_project_instances_add_automated_backup_infos": "You can use this feature to back up your instance automatically, as often as you like."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
@@ -37,7 +37,7 @@
   "pci_projects_project_instances_add_success_multiple_message": "The instances have been added",
   "pci_projects_project_instances_add_error_save": "An error has occurred adding the {{ instance }} instance: {{ message }}",
   "pci_projects_project_instances_add_error_multiple_save": "An error has occurred adding the instances: {{ message }}",
-  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
+  "pci_project_instances_instance_add_region_bandwidth_extra": "Outgoing public network traffic for instances is included in the instance prices for all regions apart from the Asia-Pacific region (Singapore and Sydney). In these two regions, 1TB/month of outgoing public traffic is included for each Public Cloud project. Above this quota, each additional GB of traffic is charged at {{price}}. Incoming network traffic from the public network is included in all cases, and in all regions.",
   "pci_projects_project_instances_add_automated_backup_label": "Automatic instance backup",
   "pci_projects_project_instances_add_automated_backup_infos": "You can use this feature to back up your instance automatically, as often as you like."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-16242
| License          | BSD 3-Clause

## Description

### :ambulance: Hotfix

f809396  - fix(instances.add): typo in translations file for extra bandwith

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
