### PR TITLE
Feat/dev server registryurl

### DIFF
--- a/packages/manager/tools/dev-server-config/src/proxy/registry/index.js
+++ b/packages/manager/tools/dev-server-config/src/proxy/registry/index.js
@@ -5,14 +5,15 @@ const TARGET = {
   local: 'http://localhost:8888',
 };
 
-module.exports = (region, local = false) => ({
-  target: TARGET[local ? 'local' : region.toLowerCase()],
+module.exports = (region, { local = false, registryUrl }) => ({
+  target: registryUrl || TARGET[local ? 'local' : region.toLowerCase()],
   context: '/manager/fragments',
-  pathRewrite: local
-    ? {
-        '^/manager/fragments/': '/',
-      }
-    : {},
+  pathRewrite:
+    local || registryUrl
+      ? {
+          '^/manager/fragments/': '/',
+        }
+      : {},
   changeOrigin: true,
   logLevel: 'silent',
 });

--- a/packages/manager/tools/dev-server/bin/manager-dev-server.js
+++ b/packages/manager/tools/dev-server/bin/manager-dev-server.js
@@ -27,6 +27,11 @@ program
     'Use localRegistry proxy (localhost:8888)',
     process.env.local2API || false,
   )
+  .option(
+    '--registryUrl <registryUrl>',
+    'Add registry proxy to registryUrl',
+    process.env.registryUrl,
+  )
   .parse(process.argv);
 
 if (program.args.length === 0) {
@@ -38,4 +43,5 @@ const [path] = program.args;
 devServer(path, program.region, program.port, {
   local2API: program.local2API,
   localRegistry: program.localRegistry,
+  registryUrl: program.registryUrl,
 });

--- a/packages/manager/tools/dev-server/src/dev-server.js
+++ b/packages/manager/tools/dev-server/src/dev-server.js
@@ -9,7 +9,7 @@ module.exports = (
   path,
   region = defaultRegion,
   port = defautPort,
-  { local2API = false, localRegistry = false },
+  { local2API = false, localRegistry = false, registryUrl },
 ) => {
   const sso = new Sso(region);
 
@@ -24,7 +24,10 @@ module.exports = (
     app.use(proxy.aapi.context, createProxyMiddleware(proxy.aapi));
   }
 
-  const registryProxy = proxy.registry(region, localRegistry);
+  const registryProxy = proxy.registry(region, {
+    local: localRegistry,
+    registryUrl,
+  });
   app.use(createProxyMiddleware(registryProxy.context, registryProxy));
 
   const v6Proxy = proxy.v6(region);

--- a/packages/manager/tools/webpack-dev-server/src/config.ts
+++ b/packages/manager/tools/webpack-dev-server/src/config.ts
@@ -15,10 +15,13 @@ export = (env) => {
   ).toLowerCase();
   const proxy = [
     serverProxy.v6(region),
-    serverProxy.registry(
-      region,
-      yn(env.localRegistry) || yn(process.env.npm_package_config_localRegistry),
-    ),
+    serverProxy.registry(region, {
+      local:
+        yn(env.localRegistry) ||
+        yn(process.env.npm_package_config_localRegistry),
+      registryUrl:
+        env.registryUrl || process.env.npm_package_config_registryUrl,
+    }),
   ];
 
   const sso = new Sso(region);


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `ufrontend`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix MANAGER-5349
| License          | BSD 3-Clause

## Description

* add `registryUrl` params to registry proxy config (in `@ovh-ux/manager-dev-server-config`) to allow to use a custom registry url
* add the possibility to define a registry url in `@ovh-ux/manager-webpack-dev-server` (using `--env.registryUrl`) 
* add `--registryUrl` option in `@ovh-ux/manager-dev-server`

## Related

* https://github.com/ovh/manager/pull/3245
