### PR TITLE
fix(pack.xdsl): update access restriction

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.controller.js
@@ -26,6 +26,8 @@ export default class PackXdslCtrl {
     this.smoothScroll = smoothScroll;
     this.TucToast = TucToast;
     this.TucToastError = TucToastError;
+
+    this.accessDescriptionSave = this.accessDescriptionSave.bind(this);
   }
 
   $onInit() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-16833
| License          | BSD 3-Clause

## Description

### :bug: Bug Fix

979bf21  - fix(pack.xdsl): update access restriction

prevent following error in the console:
```txt
TypeError: this is undefined
    value https://www.ovhtelecom.fr/manager/3119.950530211cacef116a2a.bundle.js:1
    saveServiceName https://www.ovhtelecom.fr/manager/3119.950530211cacef116a2a.bundle.js:1
    fn https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js line 2 > Function:4
    i https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js:2
    $eval https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js:2
    $apply https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js:2
    compile https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js:2
    dispatch https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js line 2 > eval:4737
    handle https://www.ovhtelecom.fr/manager/vendor.3cdce0d85504ae7e5997.bundle.js line 2 > eval:4549
vendor.3cdce0d85504ae7e5997.bundle.js:2:982698
```

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>