### PR TITLE
fix(hosting.database): remove extra backup restore options

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/database/DATABASE_LIST.html
+++ b/packages/manager/apps/web/client/app/hosting/database/DATABASE_LIST.html
@@ -395,22 +395,6 @@
                                         ></span>
                                     </oui-action-menu-item>
                                     <oui-action-menu-item
-                                        data-ng-if="element.type === 'MYSQL'"
-                                        data-on-click="setAction('database/restore/confirm/hosting-database-restore-confirm', { bdd: element, backupType: $ctrl.backupType.DAILY })"
-                                    >
-                                        <span
-                                            data-translate="hosting_tab_DATABASES_table_popover_dump_restore_yesterday"
-                                        ></span>
-                                    </oui-action-menu-item>
-                                    <oui-action-menu-item
-                                        data-ng-if="element.type === 'MYSQL'"
-                                        data-on-click="setAction('database/restore/confirm/hosting-database-restore-confirm', { bdd: element, backupType: $ctrl.backupType.WEEKLY })"
-                                    >
-                                        <span
-                                            data-translate="hosting_tab_DATABASES_table_popover_dump_restore_one_week"
-                                        ></span>
-                                    </oui-action-menu-item>
-                                    <oui-action-menu-item
                                         data-ng-if="!hosting.isCloudWeb && element.type === 'MYSQL'"
                                         data-on-click="$ctrl.checkQuota(element)"
                                     >


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | #3248
| License          | BSD 3-Clause

## Description

### :bug: Bug Fix

f5e9409 - fix(hosting.database): remove extra backup restore options

### :link: Related

- #2925

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
