### PR TITLE
fix(bills): display view more button on small devices

### DIFF
--- a/packages/manager/modules/telecom-dashboard/src/bills/telecom-dashboard-bills.html
+++ b/packages/manager/modules/telecom-dashboard/src/bills/telecom-dashboard-bills.html
@@ -1,4 +1,4 @@
-<div class="widget-presentation">
+<div class="widget-presentation clearfix">
     <h2
         class="widget-presentation-title"
         data-translate="telecom_dashboard_bill_title"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5432
| License          | BSD 3-Clause

## Description

The button "see more invoices" is not correctly displayed on small devices.

**Before:**
![screenshot-before](https://user-images.githubusercontent.com/428384/87769631-37440480-c81e-11ea-9779-fefdf667def9.png)

**After:**
![screenshot-after](https://user-images.githubusercontent.com/428384/87769643-3b702200-c81e-11ea-853a-2c83bd87ee35.png)

### :bug: Bug Fixes

205d081 - fix(bills): display view more button on small devices

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
