### PR TITLE
fix(editable-service-name): apply right cancel icon

### DIFF
--- a/packages/manager/modules/telecom-universe-components/src/editable-service-name/editable-service-name.html
+++ b/packages/manager/modules/telecom-universe-components/src/editable-service-name/editable-service-name.html
@@ -63,7 +63,7 @@
                 class="btn btn-editable px-2 h-100"
                 data-ng-click=":: $ctrl.cancelEdition()"
             >
-                <span class="oui-icon oui-icon-error" aria-hidden="true"></span>
+                <span class="oui-icon oui-icon-close" aria-hidden="true"></span>
                 <span
                     class="sr-only"
                     data-translate="tuc_editableServiceName_cancel"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fix

2e3ffdc - fix(editable-service-name): apply right cancel icon

`.oui-icon-error` look like a `warning` icone that can cause trouble
when cancelling the service name edition.

see: https://ovh.github.io/ovh-ui-kit/?path=/story/design-system-content-icons--system

### :house: Internal

No quality check required.
