### PR TITLE
build(deps): upgrade ovh-ui-kit-bs to v4.1.6

### DIFF
--- a/packages/components/ng-ovh-mondial-relay/package.json
+++ b/packages/components/ng-ovh-mondial-relay/package.json
@@ -43,7 +43,7 @@
     "@ovh-ux/ui-kit": "^4.1.12",
     "bootstrap": "~3.4.1",
     "lodash": "^4.17.15",
-    "ovh-ui-kit-bs": "^4.1.5"
+    "ovh-ui-kit-bs": "^4.1.6"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^7.0.0"

--- a/packages/components/ng-ovh-responsive-tabs/package.json
+++ b/packages/components/ng-ovh-responsive-tabs/package.json
@@ -43,7 +43,7 @@
     "bootstrap": "~3.3.7",
     "jquery": "^2.1.3",
     "lodash-es": "^4.17.15",
-    "ovh-ui-kit-bs": "^4.1.5"
+    "ovh-ui-kit-bs": "^4.1.6"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^7.0.0"

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -60,7 +60,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.46.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -117,7 +117,7 @@
     "ovh-api-services": "^9.46.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",
     "uri.js": "medialize/URI.js#~1.15.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -133,7 +133,7 @@
     "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-api-services": "^9.46.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
     "qrcode.js": "janantala/qrcode.js#~1.0.x",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -57,7 +57,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.46.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -62,7 +62,7 @@
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -56,7 +56,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -39,7 +39,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -57,7 +57,7 @@
     "ovh-api-services": "^9.46.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -80,7 +80,7 @@
     "ovh-api-services": "^9.46.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "tweetnacl-util": "^0.15.0",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -52,7 +52,7 @@
     "ovh-api-services": "^9.46.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -49,7 +49,7 @@
     "ovh-api-services": "^9.46.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -132,7 +132,7 @@
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -51,7 +51,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -68,7 +68,7 @@
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^9.46.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -113,7 +113,7 @@
     "office-ui-fabric-core": "^11.0.0",
     "ovh-api-services": "^9.46.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.1.5",
+    "ovh-ui-kit-bs": "^4.1.6",
     "popper.js": "^1.16.1",
     "properties": "latest",
     "punycode": "^1.4.1",

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -31,6 +31,6 @@
     "bootstrap": "~3.3.7",
     "font-awesome": "^4.0.0",
     "ovh-common-style": "^3.2.2",
-    "ovh-ui-kit-bs": "^4.1.5"
+    "ovh-ui-kit-bs": "^4.1.6"
   }
 }

--- a/packages/manager/modules/telecom-styles/package.json
+++ b/packages/manager/modules/telecom-styles/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ovh-ux/ui-kit": "^4.1.12",
     "bootstrap": "~3.3.7",
-    "ovh-ui-kit-bs": "^4.1.5"
+    "ovh-ui-kit-bs": "^4.1.6"
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14608,10 +14608,10 @@ ovh-ngstrap@^4.0.2:
   resolved "https://registry.yarnpkg.com/ovh-ngstrap/-/ovh-ngstrap-4.0.2.tgz#059291bfb9f59b78df991e476dd2ede0507cb3c9"
   integrity sha1-BZKRv7n1m3jfmR5HbdLt4FB8s8k=
 
-ovh-ui-kit-bs@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/ovh-ui-kit-bs/-/ovh-ui-kit-bs-4.1.5.tgz#98e2e3e5db69ba3ad54dc7ec08e94e672c34955c"
-  integrity sha512-3bjxTF56rI9cL1Blp31S3rv9ALV82bils4X7zT9RKvhyT9C2FPjDPp5PIWNstaJsy+Lx49BodoDcLNPAPhc0ew==
+ovh-ui-kit-bs@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/ovh-ui-kit-bs/-/ovh-ui-kit-bs-4.1.6.tgz#f242438a8cd9e5e37c34c948f8d7faf0b2baea01"
+  integrity sha512-RWRkaGrfbR+Mi0POWlp2GNE98whCCgIuHyoh32u1VzfGCyRq8e76ToRdoK7BpJJOS/GY4Mt5eVWJHJShKzU6Hg==
 
 p-defer@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no.
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

e093354  - build(deps): upgrade ovh-ui-kit-bs to v4.1.6

uses: `yarn upgrade-interactive --latest ovh-ui-kit-bs`
- ovh-ui-kit-bs@4.1.6

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

