### PR TITLE
feat(xdsl.access): add brand name to the modem model

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
@@ -573,9 +573,10 @@ export default class XdslAccessCtrl {
               '<p data-translate="xdsl_access_profile_tooltip_description"></p>';
           }
           if (
-            (profile.name.includes('VDSL') && profile.name.includes('SAFE2')) ||
-            profile.name.includes('PERF1') ||
-            profile.name.includes('PERF2')
+            profile.name.includes('VDSL') &&
+            (profile.name.includes('SAFE2') ||
+              profile.name.includes('PERF1') ||
+              profile.name.includes('PERF2'))
           ) {
             let translateVdslValues = '';
             if (profile.name.includes('SAFE2')) {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
@@ -848,10 +848,14 @@
                                             class="oui-tile__term"
                                             data-translate="xdsl_details_modem_model"
                                         ></div>
-                                        <div
-                                            class="oui-tile__description"
-                                            data-ng-bind="$ctrl.modem.model"
-                                        ></div>
+                                        <div class="oui-tile__description">
+                                            <span
+                                                data-ng-bind="$ctrl.modem.brandName"
+                                            ></span>
+                                            <span
+                                                data-ng-bind="$ctrl.modem.model"
+                                            ></span>
+                                        </div>
                                     </div>
                                 </div>
                             </li>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/xdsl-brand-modem`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-301
| License          | BSD 3-Clause

## Description

Display brand name adding to the model name for modem
