### PR TITLE
fix(instance): add link to vrack on instance creation

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.component.js
@@ -18,6 +18,7 @@ export default {
     prices: '<',
     quotaLink: '<',
     regionsLink: '<',
+    addPrivateNetworksLink: '<',
     selectedCategory: '@?',
   },
   controller,

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -314,7 +314,6 @@
         <oui-field
             data-ng-if="!$ctrl.disablePrivateNetworks"
             data-label="{{ :: 'pci_projects_project_instances_add_privateNetwork_label' | translate }}"
-            data-size="xl"
         >
             <oui-select
                 data-name="privateNetwork"
@@ -325,7 +324,17 @@
                 data-searchable
             >
             </oui-select>
+            <p>
+                <span
+                    data-translate="pci_projects_project_instances_add_privateNetwork_description"
+                ></span>
+                <a
+                    data-ng-href="{{:: $ctrl.addPrivateNetworksLink }}"
+                    data-translate="pci_projects_project_instances_add_privateNetwork_add"
+                ></a>
+            </p>
         </oui-field>
+
         <div data-ng-if="$ctrl.automatedBackup.available">
             <oui-checkbox
                 class="mb-4"

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
@@ -50,9 +50,13 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href('pci.projects.project.quota', {
           projectId,
         }),
-
       regionsLink: /* @ngInject */ ($state, projectId) =>
         $state.href('pci.projects.project.regions', {
+          projectId,
+        }),
+
+      addPrivateNetworksLink: /* @ngInject */ ($state, projectId) =>
+        $state.href('pci.projects.project.privateNetwork', {
           projectId,
         }),
 

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Gewählter Standort: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Die nicht verfügbaren Standorte anzeigen",
   "pci_project_instances_instance_add_choose_model": "Modell wechseln",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Empfohlen"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Empfohlen",
+  "pci_projects_project_instances_add_privateNetwork_description": "Die Public Cloud Instanzen verfügen standardmäßig über ein öffentliches Netzwerk. Sie können ihnen ein privates Netzwerk hinzufügen. ",
+  "pci_projects_project_instances_add_privateNetwork_add": "Privates Netzwerk erstellen"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Region chosen: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Show unavailable regions",
   "pci_project_instances_instance_add_choose_model": "Change model",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
+  "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Localización elegida: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Mostrar las localizaciones no disponibles",
   "pci_project_instances_instance_add_choose_model": "Cambiar de modelo",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
+  "pci_projects_project_instances_add_privateNetwork_description": "Por defecto las instancias Public Cloud disponen de una red pública, pero es posible añadir una red privada.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Crear una red privada"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Region chosen: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Show unavailable regions",
   "pci_project_instances_instance_add_choose_model": "Change model",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
+  "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
@@ -33,6 +33,8 @@
   "pci_projects_project_instances_add_script_add_label": "Ajouter",
   "pci_projects_project_instances_add_privateNetwork_label": "Réseau privé attaché",
   "pci_projects_project_instances_add_privateNetwork_none": "Aucun",
+  "pci_projects_project_instances_add_privateNetwork_description": "Par défaut les instances Public Cloud possèdent un réseau public, vous pouvez ajouter un réseau privé.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Créer un réseau privé",
 
   "pci_projects_project_instances_add_automated_backup_label": "Sauvegarde automatisée des instances",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommandé",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
@@ -33,6 +33,8 @@
   "pci_projects_project_instances_add_script_add_label": "Ajouter",
   "pci_projects_project_instances_add_privateNetwork_label": "Réseau privé attaché",
   "pci_projects_project_instances_add_privateNetwork_none": "Aucun",
+  "pci_projects_project_instances_add_privateNetwork_description": "Par défaut les instances Public Cloud possèdent un réseau public, vous pouvez ajouter un réseau privé.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Créer un réseau privé",
 
   "pci_projects_project_instances_add_automated_backup_label": "Sauvegarde automatisée des instances",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommandé",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Localizzazione scelta: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Mostra le localizzazioni non disponibili",
   "pci_project_instances_instance_add_choose_model": "Cambia modello",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Consigliato"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Consigliato",
+  "pci_projects_project_instances_add_privateNetwork_description": "Di default le istanze Public Cloud dispongono  di una rete pubblica, ma è possibile aggiungere anche una rete privata.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Crea una rete privata"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Region chosen: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Show unavailable regions",
   "pci_project_instances_instance_add_choose_model": "Change model",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
+  "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Wybrana lokalizacja: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Wyświetl niedostępne lokalizacje",
   "pci_project_instances_instance_add_choose_model": "Zmień model",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Zalecane"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Zalecane",
+  "pci_projects_project_instances_add_privateNetwork_description": "Instancje Public Cloud połączone są domyślnie w ramach sieci publicznej, możesz dodać sieć prywatną.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Utwórz prywatną sieć"
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
@@ -44,5 +44,7 @@
   "pci_projects_project_instances_add_region_selected_title": "Localização escolhida: {{location}}",
   "pci_projects_project_instances_add_region_display_nonavailable": "Mostrar as localizações indisponíveis",
   "pci_project_instances_instance_add_choose_model": "Mudar de modelo",
-  "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado"
+  "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
+  "pci_projects_project_instances_add_privateNetwork_description": "Por predefinição, as instâncias Public Cloud possuem uma rede pública. Pode adicionar uma rede privada.",
+  "pci_projects_project_instances_add_privateNetwork_add": "Criar uma rede privada"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-2697
| License          | BSD 3-Clause

## Description

Add a link to Private Network on instance creation

### :bookmark: TODO

- [x] TRANS-27221