### PR TITLE
fix(mxplan): remove domain add for mxplan

### DIFF
--- a/packages/manager/modules/emailpro/src/domain/emailpro-domain.html
+++ b/packages/manager/modules/emailpro/src/domain/emailpro-domain.html
@@ -106,22 +106,26 @@
                         <tr>
                             <td class="text-center" colspan="6">
                                 <div data-ng-if="!search.value">
-                                    <span
-                                        data-translate="{{:: exchange.isMXPlan
-                                        ? 'emailpro-mxplan_tab_domain_no_domains_1'
-                                        : 'emailpro_tab_domain_no_domains_1'
-                                    }}"
-                                    ></span>
-                                    <button
-                                        class="btn btn-link p-0"
-                                        type="button"
-                                        style="font-size:inherit"
-                                        data-translate="emailpro_tab_domain_no_domains_2"
-                                        data-ng-click="setAction('emailpro/domain/add/emailpro-domain-add')"
-                                    ></button>
-                                    <span
-                                        data-translate="emailpro_tab_domain_no_domains_3"
-                                    ></span>
+                                    <div data-ng-if="canAddDomain">
+                                        <span
+                                            data-translate="emailpro_tab_domain_no_domains_1"
+                                        ></span>
+                                        <button
+                                            class="btn btn-link p-0"
+                                            type="button"
+                                            style="font-size:inherit"
+                                            data-translate="emailpro_tab_domain_no_domains_2"
+                                            data-ng-click="setAction('emailpro/domain/add/emailpro-domain-add')"
+                                        ></button>
+                                        <span
+                                            data-translate="emailpro_tab_domain_no_domains_3"
+                                        ></span>
+                                    </div>
+                                    <div data-ng-if="!canAddDomain">
+                                        <span
+                                            data-translate="emailpro-mxplan_tab_domain_no_domains"
+                                        ></span>
+                                    </div>
                                 </div>
                                 <span
                                     data-translate="emailpro_tab_domain_table_empty_search"

--- a/packages/manager/modules/emailpro/src/emailpro.controller.js
+++ b/packages/manager/modules/emailpro/src/emailpro.controller.js
@@ -182,7 +182,11 @@ export default /* @ngInject */ function EmailProCtrl(
           loadPtrv6Tooltip($scope.exchange);
         }
 
-        if (!$scope.exchange.domainsNumber && initialLoad) {
+        if (
+          !$scope.exchange.domainsNumber &&
+          !$scope.exchange.isMXPlan &&
+          initialLoad
+        ) {
           initialLoad = false;
           $timeout(() => {
             $scope.setAction('emailpro/domain/add/emailpro-domain-add', {

--- a/packages/manager/modules/emailpro/src/translations/Messages_de_DE.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_de_DE.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "Die Stornierung der E-Mail Pro Dienstleistung \"{0}\" ist für das Ablaufdatum festgelegt. <br /><br />Sind Sie sicher, dass Sie die Stornierung abbrechen möchten? Die Dienstleistung wird danach automatisch verlängert.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "Die Kündigung des MX Plan E-Mail-Dienstes „{0}\" ist für das Ablaufdatum programmiert. <br /><br />Sind Sie sicher, dass Sie die Kündigung stornieren möchten? Der Dient wird anschließend automatisch verlängert.",
   "emailpro_tab_domain_no_domains_1": "Eine Domain hinzufügen, um E-Mail Pro Accounts einzurichten. Klicken Sie",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Fügen Sie eine Domain hinzu, um MX Plan Accounts zu erstellen. Klicken Sie",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Wenn Sie den nicht-autoritativen Modus (Exchange + ein anderes E-Mail-System) mit einem System verwenden, dass nicht bei OVH gehostet wird:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Wenn Sie den nicht-autoritativen Modus (MX Plan E-Mail + anderes E-Mail-System) mit einem System verwenden, das nicht bei OVH gehostet wird:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Wenn Sie den autoritativen Modus (nur Exchange) oder den nicht-autoritativen Modus mit einem E-Mail-System verwenden (Webhosting E-Mail), das bei OVH gehostet wird:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailinglisten",
   "emailpro_tab_REDIRECTION": "Weiterleitungen",
   "emailpro_navigation_more": "Mehr",
-  "emailpro_tab_INFORMATIONS_server": "Server"
+  "emailpro_tab_INFORMATIONS_server": "Server",
+  "emailpro-mxplan_tab_domain_no_domains": "Keine Ergebnisse gefunden"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_en_GB.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_en_GB.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "The \"{0}\" Email Pro service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "The \"{0}\" MX Plan email service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro_tab_domain_no_domains_1": "Add a domain to create Email Pro accounts. Click",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Add a domain to create MX Plan accounts. Click",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (Exchange + another email service) with an email service that is not hosted by OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (MX Plan email + another email service) with an email service that is not hosted by OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "If you use authoritative (Exchange only) or non-authoritative mode with an email service (hosted email) hosted by OVH:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailing-lists",
   "emailpro_tab_REDIRECTION": "Redirections",
   "emailpro_navigation_more": "More",
-  "emailpro_tab_INFORMATIONS_server": "Server"
+  "emailpro_tab_INFORMATIONS_server": "Server",
+  "emailpro-mxplan_tab_domain_no_domains": "No results found"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_es_ES.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_es_ES.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "La baja del servicio Email Pro «{0}» está programada para su fecha de expiración. <br /><br />¿Seguro que quiere cancelar dicha baja? Si continúa, el servicio pasará a renovación automática.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "La baja del servicio MX Plan «{0}» está programada para su fecha de expiración. <br /><br />¿Seguro que quiere cancelar dicha baja? Si continúa, el servicio pasará a renovación automática.",
   "emailpro_tab_domain_no_domains_1": "Añada un dominio para crear cuentas Email Pro. Haga clic",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Añada un dominio para crear cuentas MX Plan. Haga clic",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Si utiliza el modo no autoritario (Exchange + otro servicio de correo) con una solución de correo no alojada en OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Si utiliza el modo no autoritario (MX Plan + otro servicio de correo) con una solución de correo no alojada en OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Si utiliza el modo autoritario (solo Exchange) o no autoritario con una solución de correo alojada en OVH (correo en alojamiento compartido):",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Listas de correo",
   "emailpro_tab_REDIRECTION": "Redirecciones",
   "emailpro_navigation_more": "Más",
-  "emailpro_tab_INFORMATIONS_server": "Servidor"
+  "emailpro_tab_INFORMATIONS_server": "Servidor",
+  "emailpro-mxplan_tab_domain_no_domains": "No se han encontrado resultados"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_es_US.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_es_US.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "La cancelación del servicio Email Pro «{0}» está programada en su fecha de expiración. <br /><br />¿Está seguro(a) de que desea cancelar esta operación? Si continúa, el servicio pasará a renovación automática.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "La résiliation du service E-mail MX Plan \"{0}\" est programmée à la date d'expiration. <br /><br />Etes-vous sûr(e) de vouloir annuler cette résiliation ? Le service passera alors en renouvellement automatique.",
   "emailpro_tab_domain_no_domains_1": "Añada un dominio para crear cuentas Email Pro. Haga clic",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Ajoutez un domaine afin de créer des comptes MX Plan. Cliquez",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Si utiliza el modo no autoritario (Exchange + otro servicio de correo) con un servicio de correo no alojado por OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Si vous utilisez le mode non autoritatif (E-mail MX Plan + autre système de messagerie) avec un système de messagerie non hébergé par OVH :",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Si utiliza el modo autoritario (solo Exchange) o no autoritario con un servicio de correo (correo compartido) alojado por OVH:",
@@ -847,5 +846,6 @@
   "email_tab_modal_delete_redirection_heading": "Va a eliminar la redirección:",
   "email_tab_modal_delete_redirection_accounts": "<strong>{0}</strong> hacia <strong>{1}</strong>",
   "emails_common_continue_question": "¿Desea continuar?",
-  "emails_common_account_name_conditions": "Atención, el nombre de la cuenta debe cumplir los siguientes criterios: <br/>- mínimo {0} caracteres,<br/>- máximo {1} caracteres,<br/>- sin espacios,<br/>- sin caracteres acentuados,<br/>- sin caracteres especiales, excepto «.», «-» y «_»."
+  "emails_common_account_name_conditions": "Atención, el nombre de la cuenta debe cumplir los siguientes criterios: <br/>- mínimo {0} caracteres,<br/>- máximo {1} caracteres,<br/>- sin espacios,<br/>- sin caracteres acentuados,<br/>- sin caracteres especiales, excepto «.», «-» y «_».",
+  "emailpro-mxplan_tab_domain_no_domains": "No se han encontrado resultados."
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_fi_FI.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "The \"{0}\" Email Pro service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "The \"{0}\" MX Plan email service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro_tab_domain_no_domains_1": "Add a domain to create Email Pro accounts. Click",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Add a domain to create MX Plan accounts. Click",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (Exchange + another email service) with an email service that is not hosted by OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (MX Plan email + another email service) with an email service that is not hosted by OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "If you use authoritative (Exchange only) or non-authoritative mode with an email service (hosted email) hosted by OVH:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailing-lists",
   "emailpro_tab_REDIRECTION": "Redirections",
   "emailpro_navigation_more": "More",
-  "emailpro_tab_INFORMATIONS_server": "Server"
+  "emailpro_tab_INFORMATIONS_server": "Server",
+  "emailpro-mxplan_tab_domain_no_domains": "No results found"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_fr_CA.json
@@ -40,7 +40,6 @@
   "emailpro_resilitation_cancel_action_intro": "La résiliation du service E-mail Pro \"{0}\" est programmée à la date d'expiration. <br /><br />Etes-vous sûr(e) de vouloir annuler cette résiliation ? Le service passera alors en renouvellement automatique.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "La résiliation du service E-mail MX Plan \"{0}\" est programmée à la date d'expiration. <br /><br />Etes-vous sûr(e) de vouloir annuler cette résiliation ? Le service passera alors en renouvellement automatique.",
   "emailpro_tab_domain_no_domains_1": "Ajoutez un domaine afin de créer des comptes E-mail Pro. Cliquez",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Ajoutez un domaine afin de créer des comptes MX Plan. Cliquez",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Si vous utilisez le mode non-autoritatif (Exchange + autre système de messagerie) avec un système de messagerie non hébergé par OVH :",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Si vous utilisez le mode non autoritatif (E-mail MX Plan + autre système de messagerie) avec un système de messagerie non hébergé par OVH :",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Si vous utilisez le mode autoritatif (Exchange uniquement) ou non-autoritatif avec un système de messagerie hébergé (e-mail mutualisé) par OVH :",
@@ -855,5 +854,6 @@
   "email_tab_modal_delete_redirection_heading": "Vous allez supprimer la redirection :",
   "email_tab_modal_delete_redirection_accounts": "<strong>{0}</strong> vers <strong>{1}</strong>",
   "emails_common_continue_question": "Voulez-vous continuer ?",
-  "emails_common_account_name_conditions": "Attention, le nom du compte doit respecter les conditions suivantes : <br/>- Minimum {0} caractères<br/>- Maximum {1} caractères<br/>- Aucun espace<br/>- Aucun caractère accentué<br/>- Aucun caractère spécial à l'exception de ., - et _."
+  "emails_common_account_name_conditions": "Attention, le nom du compte doit respecter les conditions suivantes : <br/>- Minimum {0} caractères<br/>- Maximum {1} caractères<br/>- Aucun espace<br/>- Aucun caractère accentué<br/>- Aucun caractère spécial à l'exception de ., - et _.",
+  "emailpro-mxplan_tab_domain_no_domains": "Aucun résultat trouvé"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_fr_FR.json
@@ -40,7 +40,6 @@
   "emailpro_resilitation_cancel_action_intro": "La résiliation du service E-mail Pro \"{0}\" est programmée à la date d'expiration. <br /><br />Etes-vous sûr(e) de vouloir annuler cette résiliation ? Le service passera alors en renouvellement automatique.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "La résiliation du service E-mail MX Plan \"{0}\" est programmée à la date d'expiration. <br /><br />Etes-vous sûr(e) de vouloir annuler cette résiliation ? Le service passera alors en renouvellement automatique.",
   "emailpro_tab_domain_no_domains_1": "Ajoutez un domaine afin de créer des comptes E-mail Pro. Cliquez",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Ajoutez un domaine afin de créer des comptes MX Plan. Cliquez",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Si vous utilisez le mode non-autoritatif (Exchange + autre système de messagerie) avec un système de messagerie non hébergé par OVH :",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Si vous utilisez le mode non autoritatif (E-mail MX Plan + autre système de messagerie) avec un système de messagerie non hébergé par OVH :",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Si vous utilisez le mode autoritatif (Exchange uniquement) ou non-autoritatif avec un système de messagerie hébergé (e-mail mutualisé) par OVH :",
@@ -855,5 +854,6 @@
   "email_tab_modal_delete_redirection_heading": "Vous allez supprimer la redirection :",
   "email_tab_modal_delete_redirection_accounts": "<strong>{0}</strong> vers <strong>{1}</strong>",
   "emails_common_continue_question": "Voulez-vous continuer ?",
-  "emails_common_account_name_conditions": "Attention, le nom du compte doit respecter les conditions suivantes : <br/>- Minimum {0} caractères<br/>- Maximum {1} caractères<br/>- Aucun espace<br/>- Aucun caractère accentué<br/>- Aucun caractère spécial à l'exception de ., - et _."
+  "emails_common_account_name_conditions": "Attention, le nom du compte doit respecter les conditions suivantes : <br/>- Minimum {0} caractères<br/>- Maximum {1} caractères<br/>- Aucun espace<br/>- Aucun caractère accentué<br/>- Aucun caractère spécial à l'exception de ., - et _.",
+  "emailpro-mxplan_tab_domain_no_domains": "Aucun résultat trouvé"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_it_IT.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_it_IT.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "La disattivazione del servizio Email Pro \"{0}\" è pianificata alla data di scadenza. <br /><br />Se annulli questa operazione, il servizio tornerà in rinnovo automatico. Vuoi continuare? ",
   "emailpro-mxplan_resilitation_cancel_action_intro": "La disattivazione del servizio MX Plan \"{0}\" è pianificata alla data di scadenza. <br /><br />Se annulli questa operazione, il servizio tornerà in rinnovo automatico. Vuoi continuare? ",
   "emailpro_tab_domain_no_domains_1": "Per creare uno o più account Email Pro, aggiungi un dominio. Clicca",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Per creare uno o più account MX Plan, aggiungi un dominio. Clicca",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Se utilizzi la modalità non autoritativa (Exchange + altro sistema di posta) con un servizio di posta non ospitato in OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Se utilizzi la modalità non autoritativa (MX Plan + altro sistema di posta) con un servizio di posta non ospitato in OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Se utilizzi la modalità autoritativa (solo Exchange) o non autoritativa con un servizio di posta ospitato in OVH:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailing list",
   "emailpro_tab_REDIRECTION": "Reindirizzamenti",
   "emailpro_navigation_more": "Più",
-  "emailpro_tab_INFORMATIONS_server": "Server"
+  "emailpro_tab_INFORMATIONS_server": "Server",
+  "emailpro-mxplan_tab_domain_no_domains": "Nessun risultato trovato"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_lt_LT.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "The \"{0}\" Email Pro service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "The \"{0}\" MX Plan email service is scheduled to close on the expiry date. <br /><br />Are you sure you want to undo this cancellation? The service will then switch to automatic renewal.",
   "emailpro_tab_domain_no_domains_1": "Add a domain to create Email Pro accounts. Click",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Add a domain to create MX Plan accounts. Click",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (Exchange + another email service) with an email service that is not hosted by OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "If you are using non-authoritative mode (MX Plan email + another email service) with an email service that is not hosted by OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "If you use authoritative (Exchange only) or non-authoritative mode with an email service (hosted email) hosted by OVH:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailing-lists",
   "emailpro_tab_REDIRECTION": "Redirections",
   "emailpro_navigation_more": "More",
-  "emailpro_tab_INFORMATIONS_server": "Server"
+  "emailpro_tab_INFORMATIONS_server": "Server",
+  "emailpro-mxplan_tab_domain_no_domains": "No results found"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_pl_PL.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "Zakończenie usługi E-mail Pro \"{0}\" jest zaplanowane na dzień wygaśnięcia. <br /><br />Czy chcesz anulować zakończenie usługi?  Włączone wówczas zostanie automatyczne odnawianie usługi.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "Zakończenie usługi E-mail MX Plan \"{0}\" jest zaplanowane na dzień wygaśnięcia.  <br /><br />Czy chcesz anulować zakończenie usługi?  Włączone wówczas zostanie automatyczne odnawianie usługi.",
   "emailpro_tab_domain_no_domains_1": "Dodaj domenę, aby tworzyć konta E-mail Pro.  Kliknij",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Dodaj domenę, aby utworzyć konta MX Plan. Kliknij",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Jeśli korzystasz z trybu nieautorytatywnego (Exchange + inny system poczty elektronicznej) z systemem poczty elektronicznej nieobsługiwanej przez OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Jeśli używasz trybu autorytatywnego (E-mail MX Plan + inny system poczty elektronicznej) z systemem poczty elektronicznej nie hostowanym przez OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Jeśli korzystasz z trybu autorytatywnego (wyłącznie Exchange) lub nieautorytatywnego z systemem poczty elektronicznej obługiwanym przez OVH (e-mail na hostingu):",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Listy mailingowe",
   "emailpro_tab_REDIRECTION": "Przekierowania",
   "emailpro_navigation_more": "Więcej",
-  "emailpro_tab_INFORMATIONS_server": "Serwer"
+  "emailpro_tab_INFORMATIONS_server": "Serwer",
+  "emailpro-mxplan_tab_domain_no_domains": "Brak wyników"
 }

--- a/packages/manager/modules/emailpro/src/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/emailpro/src/translations/Messages_pt_PT.json
@@ -34,7 +34,6 @@
   "emailpro_resilitation_cancel_action_intro": "O cancelamento do serviço E-mail Pro \"{0}\" está programado para o final do período de subscrição. <br /><br />Tem a certeza que deseja anular este cancelamento? O serviço passará para renovação automática.",
   "emailpro-mxplan_resilitation_cancel_action_intro": "A rescisão do serviço E-mail Pro \"{0}\" está programado para a data de expiração. <br /><br />Tem a certeza de que quer anular esta rescisão? O serviço passará para renovação automática.",
   "emailpro_tab_domain_no_domains_1": "Adicione um domínio para poder criar contas de E-mail Pro. Clique",
-  "emailpro-mxplan_tab_domain_no_domains_1": "Adicione um domínio para criar contas MX Plan. Clique",
   "emailpro_tab_domain_diagnostic_mx_no_antispam": "Se usar o modo não-autoritário (Exchange + outro sistema de e-mail) com um sistema de e-mail não alojado na OVH:",
   "emailpro-mxplan_tab_domain_diagnostic_mx_no_antispam": "Se utilizar o modo autoritário (E-mail MX Plan + outro sistema de correio) com um sistema de mensagens não alojado pela OVH:",
   "emailpro_tab_domain_diagnostic_mx_antispam": "Se usar o modo autoritário (só com Exchange) ou não autoritário com um sistema de e-mail alojado na OVH:",
@@ -855,5 +854,6 @@
   "emailpro_tab_MAILING_LIST": "Mailing lists",
   "emailpro_tab_REDIRECTION": "Reencaminhamentos",
   "emailpro_navigation_more": "Mais",
-  "emailpro_tab_INFORMATIONS_server": "Servidor"
+  "emailpro_tab_INFORMATIONS_server": "Servidor",
+  "emailpro-mxplan_tab_domain_no_domains": "Não foram encontrados resultados para os termos pesquisados"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-17182
| License          | BSD 3-Clause

## Description

Remove the possibility to add a domain to a MXPlan.

The added `emailpro-mxplan_tab_domain_no_domains` translation is a copy of existing translation (`emailpro_tab_domain_add_step1_domain_none`).

