### PR TITLE
feat(registry): add possibility to filter dev fragments

### DIFF
--- a/packages/manager/tools/registry/README.md
+++ b/packages/manager/tools/registry/README.md
@@ -37,7 +37,7 @@ Commands:
 
 *Common Options*
 
-* `-V, --version` : Display version number
+* `-V, --version`: Display version number
 * `-h, --help`: Display help
 
 #### Dev
@@ -51,6 +51,7 @@ Usage: manager-registry-dev [options] <fragmentsPath>
 Options:
   -V, --version                          output the version number
   -p, --port <port>                      server port (default: 8888)
+  -e, --regexp <pattern>                 filter fragment pattern (default: [])
   --fallbackRegistry <fallbackRegistry>  Fallback server registry url
   -h, --help                             output usage information
 
@@ -58,8 +59,9 @@ Options:
 
 *Options*
 
-* `-p, --port <port>` : Server port (default: 8888)
-* `--fallbackRegistry <fallbackRegistry>` : Fallback server registry url
+* `-p, --port <port>`: Server port (default: 8888)
+* `-e, --regexp <pattern>`: Allows to filter fragments served (multiple allowed)
+* `--fallbackRegistry <fallbackRegistry>`: Fallback server registry url
 
 *Examples*
 
@@ -74,8 +76,21 @@ Serve: ./packages/manager/fragments - localhost:1234
 To serve fragments from dev environmment, and fallback missing fragments to another registry:
 ```sh
 $ manager-registry dev ./packages/manager/fragments --fallbackRegistry http://localhost:1234
-Serve: ./packages/manager/fragments  - localhost:8888
+Serve: ./packages/manager/fragments - localhost:8888
 Fallback registry: http://localhost:1234
+```
+
+
+To serve only the `navbar` fragment:
+```sh
+$ manager-registry dev ./packages/manager/fragments -e navbar
+Serve: ./packages/manager/fragments - localhost:8888
+```
+
+To serve only fragments with name following `*bar` and `!sidebar` patterns (e.g. `navbar`, `userbar`):
+```sh
+$ manager-registry dev ./packages/manager/fragments -e '*bar' -e '!sidebar'
+Serve: ./packages/manager/fragments - localhost:8888
 ```
 
 #### Static
@@ -114,7 +129,7 @@ Options:
 
 *Options*
 
-* `--fallbackRegistry <fallbackRegistry>` : Fallback server registry url
+* `--fallbackRegistry <fallbackRegistry>`: Fallback server registry url
 
 *Examples*
 

--- a/packages/manager/tools/registry/bin/manager-registry-dev.js
+++ b/packages/manager/tools/registry/bin/manager-registry-dev.js
@@ -6,10 +6,18 @@ const pkg = require('../package.json');
 
 const devServer = require('../src/dev');
 
+const collectFragment = (fragment, fragments) => [...fragments, fragment];
+
 program
   .version(pkg.version)
   .arguments('<fragmentsPath>')
   .option('-p, --port <port>', 'server port', 8888)
+  .option(
+    '-e, --regexp <pattern>',
+    'filter fragment pattern',
+    collectFragment,
+    [],
+  )
   .option(
     '--fallbackRegistry <fallbackRegistry>',
     'Fallback server registry url',
@@ -17,6 +25,7 @@ program
   .action((fragmentsPath, cmd) => {
     devServer(path.resolve(fragmentsPath), cmd.port, {
       fallbackRegistry: cmd.fallbackRegistry,
+      filters: cmd.regexp,
     });
   })
   .parse(process.argv);

--- a/packages/manager/tools/registry/package.json
+++ b/packages/manager/tools/registry/package.json
@@ -27,6 +27,7 @@
     "commander": "^4.0.0",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
+    "multimatch": "^4.0.0",
     "semver": "^7.3.2"
   },
   "engines": {

--- a/packages/manager/tools/registry/src/dev.js
+++ b/packages/manager/tools/registry/src/dev.js
@@ -6,6 +6,7 @@ const express = require('express');
 const manifestBuilder = require('./builder/manifest');
 const devStorage = require('./storage/dev-storage');
 const remoteStorage = require('./storage/remote-storage');
+const filterInfos = require('./storage/filter-infos');
 const mergeInfos = require('./storage/merge-infos');
 
 const {
@@ -13,12 +14,14 @@ const {
   FRAGMENT_DEFINITION_FILE,
 } = require('./storage/constants');
 
-module.exports = (rootPath, port = 8888, { fallbackRegistry }) => {
+module.exports = (rootPath, port = 8888, { fallbackRegistry, filters }) => {
   return Promise.all([
     devStorage.readInfos(rootPath),
     fallbackRegistry ? remoteStorage.readInfos(fallbackRegistry) : [],
   ])
-    .then(([devInfos, fallbackInfos]) => mergeInfos(fallbackInfos, devInfos))
+    .then(([devInfos, fallbackInfos]) =>
+      mergeInfos(fallbackInfos, filterInfos(devInfos, filters)),
+    )
     .then((infos) => {
       const app = express();
 

--- a/packages/manager/tools/registry/src/storage/filter-infos.js
+++ b/packages/manager/tools/registry/src/storage/filter-infos.js
@@ -1,0 +1,10 @@
+const multimatch = require('multimatch');
+
+module.exports = (infos, filters = []) => {
+  if (filters.length) {
+    return infos.filter((fragment) => {
+      return multimatch([fragment.name], filters)[0] === fragment.name;
+    });
+  }
+  return infos;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,7 +2732,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
   integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -3950,6 +3950,11 @@ array-differ@^2.0.3:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
   integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
 
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
+
 array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
@@ -4047,6 +4052,11 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+arrify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
 asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
@@ -13774,6 +13784,17 @@ multimatch@^3.0.0:
     array-differ "^2.0.3"
     array-union "^1.0.2"
     arrify "^1.0.1"
+    minimatch "^3.0.4"
+
+multimatch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
+  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
     minimatch "^3.0.4"
 
 multipipe@^0.1.2:


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `ufrontend`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix MANAGER-5350,
| License          | BSD 3-Clause

## Description

Add the possibility to filter fragments served through a dev registry. 
It will allow to launch a `dev registry` without needing to build all fragments.

```sh
manager-registry dev --help
Usage: manager-registry-dev [options] <fragmentsPath>

Options:
  -V, --version                          output the version number
  -p, --port <port>                      server port (default: 8888)
  -e, --regexp <pattern>                 filter fragment pattern (default: [])
  --fallbackRegistry <fallbackRegistry>  Fallback server registry url
  -h, --help                             output usage information

```

Example:
```sh
$ tree -L 1 ./packages/manager/fragments
packages/manager/fragments
├── navbar
├── sidebar
└── userbar
```

Serve only `navbar` fragment:
```sh
$ manager-registry dev ./packages/manager/fragments -e navbar
Serve: ./packages/manager/fragments  - localhost:8888
```

Serve fragments satisfying following patterns `*bar` & `!sidebar` (will serve `sidebar` and `userbar`):
```sh
$ manager-registry dev ./packages/manager/fragments -e '*bar' -e '!sidebar'
Serve: ./packages/manager/fragments  - localhost:8888
```
