### PR TITLE
fix(registry.static.add): detect invalid fragment manifest

### DIFF
--- a/packages/manager/tools/registry/src/addFragmentStatic.js
+++ b/packages/manager/tools/registry/src/addFragmentStatic.js
@@ -19,28 +19,33 @@ module.exports = (rootPath, fragmentPath) =>
     getFragmentManifest(fragmentPath),
   ]).then(([infos, fragmentManifest]) => {
     const { name, version } = fragmentManifest;
-    const fragmentExists = infos.find(
-      (info) => info.name === name && info.versions.includes(version),
-    );
 
-    if (fragmentExists) {
-      console.log(
-        `Fragment "${name}@${version}" already exists in ${rootPath}`,
-      );
+    if (!name || !version) {
+      console.log(`Invalid manifest in ${fragmentPath}`);
     } else {
-      util
-        .promisify(fse.copy)(
-          fragmentPath,
-          path.resolve(rootPath, name, version),
-          {
-            dereference: true,
-          },
-        )
-        .then(() => {
-          console.log(
-            `Fragment "${name}@${version}" added in registry ${rootPath}`,
-          );
-        });
+      const fragmentExists = infos.find(
+        (info) => info.name === name && info.versions.includes(version),
+      );
+
+      if (fragmentExists) {
+        console.log(
+          `Fragment "${name}@${version}" already exists in ${rootPath}`,
+        );
+      } else {
+        util
+          .promisify(fse.copy)(
+            fragmentPath,
+            path.resolve(rootPath, name, version),
+            {
+              dereference: true,
+            },
+          )
+          .then(() => {
+            console.log(
+              `Fragment "${name}@${version}" added in registry ${rootPath}`,
+            );
+          });
+      }
     }
   });
 /* eslint-enable no-console */


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `ufrontend`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Avoid trying to copy a fragment dist folder into a static registry if the fragment manifest is invalid (malformed, missing `name` and `version` info or file doesn't exists)



