### PR TITLE
fix(config): prevent trigger when target state is the final one

### DIFF
--- a/packages/components/ng-ui-router-line-progress/src/ng-ui-router-line-progress.config.js
+++ b/packages/components/ng-ui-router-line-progress/src/ng-ui-router-line-progress.config.js
@@ -2,7 +2,11 @@ import NProgress from 'nprogress';
 
 export default /* @ngInject */ ($transitions) => {
   $transitions.onBefore({}, (transition) => {
-    if (!transition.ignored() && transition.from().name !== '') {
+    if (
+      !transition.ignored() &&
+      transition.from().name !== '' &&
+      transition.entering().length > 0
+    ) {
       NProgress.start();
     }
   });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

prevent trigger when target state is the final one. 
If not when trying to reaccess the same state through a resolve or with redirections, the line progress never ends 
