### PR TITLE
fix(private-database.order.clouddb): display options after init

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
@@ -9,6 +9,7 @@
 
     <oui-stepper
         data-current-index="$ctrl.currentIndex"
+        data-on-init="$ctrl.initializeCustomizationOptions()"
         data-on-finish="$ctrl.validateCheckout()"
     >
         <oui-step-form
@@ -39,7 +40,6 @@
 
         <oui-step-form
             data-header="{{:: 'private_database_order_clouddb_customization' | translate }}"
-            data-on-focus="$ctrl.initializeCustomizationOptions()"
             data-editable="!$ctrl.loadingDurations && !$ctrl.loadingCheckout && !$ctrl.hasValidatedCheckout"
             data-navigation="false"
             data-disabled="$ctrl.hasValidatedCheckout"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-17483
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

363c217 - fix(private-database.order.clouddb): display options after init

Use `on-init` on the `oui-stepper` instead of using `on-focus`.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
