### PR TITLE
fix(list): import missing dependency

### DIFF
--- a/packages/manager/modules/ng-layout-helpers/src/list/index.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/index.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import '@ovh-ux/ui-kit';
+import '@ovh-ux/ng-ovh-api-wrappers';
 
 import ListLayoutCtrl from './list-layout.controller';
 import component from './list-layout.component';
@@ -7,7 +8,9 @@ import utils from './list-layout.utils';
 
 const moduleName = 'ovhManagerListLayout';
 
-angular.module(moduleName, ['oui']).component('managerListLayout', component);
+angular
+  .module(moduleName, ['oui', 'ngOvhApiWrappers'])
+  .component('managerListLayout', component);
 
 export default {
   ...utils,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/solarsteein`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

Import ng-ovh-api-wrappers as it is needed by the angular module 
