### PR TITLE
fix(deps): add missing @ovh-ux/manager-ng-layout-helpers dependency

### DIFF
--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -22,6 +22,7 @@
     "@ovh-ux/manager-config": "^0.4.0",
     "@ovh-ux/manager-core": "^9.0.0 || ^10.0.0",
     "@ovh-ux/manager-freefax": "^6.0.0 || ^7.0.0",
+    "@ovh-ux/manager-ng-layout-helpers": "^1.1.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.0",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ovh-ux/manager-config": "^0.4.0",
     "@ovh-ux/manager-core": "^9.0.0 || ^10.0.0",
+    "@ovh-ux/manager-ng-layout-helpers": "^1.1.0",
     "@ovh-ux/manager-overthebox": "^5.0.0 || ^6.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.7",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ovh-ux/manager-config": "^0.4.0",
     "@ovh-ux/manager-core": "^9.0.0 || ^10.0.0",
+    "@ovh-ux/manager-ng-layout-helpers": "^1.1.0",
     "@ovh-ux/manager-sms": "^8.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-at-internet": "^5.0.1",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

It solve the following issue reported across freefax, sms and overthebox application:

```sh
@ovh-ux/manager-freefax-app: ERROR in /home/foo/bar/ovh/manager/packages/manager/modules/freefax/src/freefaxes.routing.js
@ovh-ux/manager-freefax-app: Module not found: Error: Can't resolve '@ovh-ux/manager-ng-layout-helpers' in '/home/foo/bar/ovh/manager/packages/manager/modules/freefax/src'
@ovh-ux/manager-freefax-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/freefax/src/freefaxes.routing.js 7:0-69 10:20-36 12:12-28 17:7-23
@ovh-ux/manager-freefax-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/freefax/src/freefax.module.js
@ovh-ux/manager-freefax-app:  @ /home/foo/bar/ovh/manager/packages/manager/modules/freefax/src/index.js
@ovh-ux/manager-freefax-app:  @ ./src/index.js
```

### :construction_worker: Build

e8db5f9 - fix(deps): add missing @ovh-ux/manager-ng-layout-helpers dependency

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>