### PR TITLE
build: skip ci when deploying docs github page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "lerna clean -y && yarn run clean:dist && rimraf node_modules",
     "clean:dist": "rimraf \"packages/**/dist?(-EU|-CA|-US)\"",
     "docs:build": "vuepress prebuild docs && vuepress build docs",
-    "docs:deploy": "yarn run docs:build && gh-pages -d docs/.vuepress/dist -m \"docs: update documentation\"",
+    "docs:deploy": "yarn run docs:build && gh-pages -d docs/.vuepress/dist -m \"docs: update documentation [skip ci]\"",
     "docs:dev": "vuepress prebuild docs && vuepress dev docs",
     "format": "run-p format:*",
     "format:css": "yarn run lint:css --fix",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :construction_worker: Build

0748e27 - build: skip ci when deploying docs github page

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
