### PR TITLE
build(deps): upgrade ovh-api-services to v9.49.0

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -58,7 +58,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -114,7 +114,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -133,7 +133,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -56,7 +56,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -64,7 +64,7 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",
     "whatwg-fetch": "^3.0.0"

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -61,7 +61,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -55,7 +55,7 @@
     "clipboard": "^2.0.4",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -38,7 +38,7 @@
     "clipboard": "^2.0.4",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -47,7 +47,7 @@
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8"
   },

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -54,7 +54,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -78,7 +78,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -54,7 +54,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -37,7 +37,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -49,7 +49,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.1.8",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -46,7 +46,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.1.8",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -129,7 +129,7 @@
     "ngSmoothScroll": "d-oliveros/angular-smooth-scroll#~1.7.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -51,7 +51,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -50,7 +50,7 @@
     "d3": "~3.5.13",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -67,7 +67,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -112,7 +112,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^9.47.0",
+    "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",
     "popper.js": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14585,10 +14585,10 @@ ovh-angular-responsive-tabs@^4.0.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-responsive-tabs/-/ovh-angular-responsive-tabs-4.0.0.tgz#85b66d7032612c3ed1a14cb29f83d1331b50c1df"
   integrity sha1-hbZtcDJhLD7RoUyyn4PRMxtQwd8=
 
-ovh-api-services@^9.47.0:
-  version "9.47.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.47.0.tgz#b95902c3a07eaf45a8175a897c836011c3d2477d"
-  integrity sha512-I684f3mo5kxIpjT1Ea5KT+VzE1l45CHzifUejEzI7F/r6OcZ21Q78GGNd5SXPuxItSGn2IIHNeRiBYT+WXAr6g==
+ovh-api-services@^9.49.0:
+  version "9.49.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-9.49.0.tgz#6ea9a980fe1d13bee902c638903bb7239782e19a"
+  integrity sha512-VXqwgeyYDGS8Kha3DSMCaUy2PZcsHWLvuZSrXU7pe9ee1/Z9FiXl5bgTTz3vcuSw+XYWf5sOWxpuVi/5iFvYJw==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

c383ccc - build(deps): upgrade ovh-api-services to v9.49.0

uses: `$ yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@9.49.0

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>