### PR TITLE
Fix/manager 5486

### DIFF
--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavor.class.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavor.class.js
@@ -5,6 +5,7 @@ import {
   FLEX_TYPE,
   LEGACY_FLAVORS,
   SSD_DISK_TYPES,
+  CATEGORIES,
 } from './flavors-list.constants';
 
 export default class Flavors {
@@ -46,5 +47,9 @@ export default class Flavors {
 
   hasOsType(os) {
     return this.osType === os;
+  }
+
+  isType(title) {
+    return get(find(CATEGORIES, { title }), 'pattern').test(this.type);
   }
 }

--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.constants.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.constants.js
@@ -60,6 +60,7 @@ export const CPU_FREQUENCY = {
 };
 
 export default {
+  CATEGORIES,
   CPU_FREQUENCY,
   DEFAULT_OS,
   FLEX_TYPE,

--- a/packages/manager/modules/pci/src/components/project/instance/instance.class.js
+++ b/packages/manager/modules/pci/src/components/project/instance/instance.class.js
@@ -5,6 +5,7 @@ import includes from 'lodash/includes';
 import isObject from 'lodash/isObject';
 
 import { CAPABILITIES } from './instance.constants';
+import Flavor from '../flavors-list/flavor.class';
 
 export default class Instance {
   constructor(resource) {
@@ -182,5 +183,9 @@ export default class Instance {
 
   canBeHardRebooted() {
     return ['ACTIVE', 'SHUTOFF'].includes(this.status);
+  }
+
+  isFlavorType(type) {
+    return new Flavor(this.flavor || {}).isType(type);
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -369,6 +369,14 @@
                 data-is-customizable="false"
             >
             </pci-projects-project-workflow-schedule>
+            <oui-message
+                data-ng-if="$ctrl.automatedBackup.selected && $ctrl.flavor.isType('IOPS')"
+                type="warning"
+            >
+                <p
+                    data-translate="pci_projects_project_instances_add_instance_is_iops"
+                ></p>
+            </oui-message>
         </div>
     </oui-step-form>
 

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Modell wechseln",
   "pci_projects_project_instances_add_automated_backup_recommended": "Empfohlen",
   "pci_projects_project_instances_add_privateNetwork_description": "Die Public Cloud Instanzen verfügen standardmäßig über ein öffentliches Netzwerk. Sie können ihnen ein privates Netzwerk hinzufügen. ",
-  "pci_projects_project_instances_add_privateNetwork_add": "Privates Netzwerk erstellen"
+  "pci_projects_project_instances_add_privateNetwork_add": "Privates Netzwerk erstellen",
+  "pci_projects_project_instances_add_instance_is_iops": "Das automatische Backup wird nur für die Daten auf der lokalen Festplatte Ihrer Instanz ausgeführt. Die Daten auf den NVMe-Festplatten werden nicht gesichert."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Change model",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
   "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network",
+  "pci_projects_project_instances_add_instance_is_iops": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Cambiar de modelo",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
   "pci_projects_project_instances_add_privateNetwork_description": "Por defecto las instancias Public Cloud disponen de una red pública, pero es posible añadir una red privada.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Crear una red privada"
+  "pci_projects_project_instances_add_privateNetwork_add": "Crear una red privada",
+  "pci_projects_project_instances_add_instance_is_iops": "La copia de seguridad automática solo se aplica a los datos del disco local de su instancia. No se realizarán copias de seguridad de los datos de los discos NVMe."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fi_FI.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Change model",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
   "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network",
+  "pci_projects_project_instances_add_instance_is_iops": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
@@ -18,6 +18,7 @@
   "pci_projects_project_instances_add_image_title": "Sélectionnez une image",
   "pci_projects_project_instances_add_image_not_available": "Ces images sont disponibles sur d'autre modèles.",
 
+  "pci_projects_project_instances_add_instance_is_iops": "La sauvegarde automatique s’applique strictement aux données du disque local de votre instance. Les données des disques NVMe ne seront pas sauvegardées.",
   "pci_projects_project_instances_add_instance_title": "Configurez votre instance",
   "pci_projects_project_instances_add_numInstances_label": "Nombre d'instances à créer",
   "pci_projects_project_instances_add_numInstances_help": "Votre quota actuel vous permet de créer simultanéement jusqu'à {{ num }} instance(s) de type {{ flavor }} pour la region de {{ region }}.",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
@@ -18,6 +18,7 @@
   "pci_projects_project_instances_add_image_title": "Sélectionnez une image",
   "pci_projects_project_instances_add_image_not_available": "Ces images sont disponibles sur d'autre modèles.",
 
+  "pci_projects_project_instances_add_instance_is_iops": "La sauvegarde automatique s’applique strictement aux données du disque local de votre instance. Les données des disques NVMe ne seront pas sauvegardées.",
   "pci_projects_project_instances_add_instance_title": "Configurez votre instance",
   "pci_projects_project_instances_add_numInstances_label": "Nombre d'instances à créer",
   "pci_projects_project_instances_add_numInstances_help": "Votre quota actuel vous permet de créer simultanéement jusqu'à {{ num }} instance(s) de type {{ flavor }} pour la region de {{ region }}.",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Cambia modello",
   "pci_projects_project_instances_add_automated_backup_recommended": "Consigliato",
   "pci_projects_project_instances_add_privateNetwork_description": "Di default le istanze Public Cloud dispongono  di una rete pubblica, ma è possibile aggiungere anche una rete privata.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Crea una rete privata"
+  "pci_projects_project_instances_add_privateNetwork_add": "Crea una rete privata",
+  "pci_projects_project_instances_add_instance_is_iops": "Il backup automatico viene eseguito esclusivamente per i dati del disco locale della tua istanza. I dati dei dischi NVMe non saranno copiati."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_lt_LT.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Change model",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
   "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network"
+  "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network",
+  "pci_projects_project_instances_add_instance_is_iops": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Zmień model",
   "pci_projects_project_instances_add_automated_backup_recommended": "Zalecane",
   "pci_projects_project_instances_add_privateNetwork_description": "Instancje Public Cloud połączone są domyślnie w ramach sieci publicznej, możesz dodać sieć prywatną.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Utwórz prywatną sieć"
+  "pci_projects_project_instances_add_privateNetwork_add": "Utwórz prywatną sieć",
+  "pci_projects_project_instances_add_instance_is_iops": "Usługa automatyczne kopie zapasowe ma zastosowanie wyłącznie w odniesieniu do danych znajdujących się na dysku lokalnym Twojej instancji. Nie będą tworzone kopie zapasowe danych znajdujących się na dyskach NVMe."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
@@ -46,5 +46,6 @@
   "pci_project_instances_instance_add_choose_model": "Mudar de modelo",
   "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
   "pci_projects_project_instances_add_privateNetwork_description": "Por predefinição, as instâncias Public Cloud possuem uma rede pública. Pode adicionar uma rede privada.",
-  "pci_projects_project_instances_add_privateNetwork_add": "Criar uma rede privada"
+  "pci_projects_project_instances_add_privateNetwork_add": "Criar uma rede privada",
+  "pci_projects_project_instances_add_instance_is_iops": "O backup automático aplica-se estritamente aos dados do disco local da sua instância. Os dados dos discos NVMe não serão guardados."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/resources/resources.html
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/resources/resources.html
@@ -71,3 +71,11 @@
     >
     </oui-select-picker>
 </div>
+<oui-message
+    data-ng-if="$ctrl.selectedResource.isFlavorType('IOPS')"
+    type="warning"
+>
+    <p
+        data-translate="pci_projects_project_workflow_instance_status_IS_IOPS"
+    ></p>
+</oui-message>

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_de_DE.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Instance Backup wird erstellt",
   "pci_projects_project_workflow_instance_status_RESUMING": "Wird fortgesetzt",
   "pci_workflow_create_price_monthly": "{{ price }} ohne MWSt./Monat/GB",
-  "pci_workflow_create_monthly_backup_price": "Jede Sicherung wird in Rechnung gestellt: {{ price }} ohne MWSt./Monat/GB"
+  "pci_workflow_create_monthly_backup_price": "Jede Sicherung wird in Rechnung gestellt: {{ price }} ohne MWSt./Monat/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "Das automatische Backup wird nur für die Daten auf der lokalen Festplatte Ihrer Instanz ausgeführt. Die Daten auf den NVMe-Festplatten werden nicht gesichert."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_en_GB.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Backup instance creation",
   "pci_projects_project_workflow_instance_status_RESUMING": "Recovering",
   "pci_workflow_create_price_monthly": "{{ price }} ex. VAT/month/GB",
-  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB"
+  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_es_ES.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Creando backup",
   "pci_projects_project_workflow_instance_status_RESUMING": "Recuperando",
   "pci_workflow_create_price_monthly": "{{ price }}/mes + IVA por GB",
-  "pci_workflow_create_monthly_backup_price": "Cada backup tiene un precio de {{ price }}/mes + IVA por GB"
+  "pci_workflow_create_monthly_backup_price": "Cada backup tiene un precio de {{ price }}/mes + IVA por GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "La copia de seguridad automática solo se aplica a los datos del disco local de su instancia. No se realizarán copias de seguridad de los datos de los discos NVMe."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fi_FI.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fi_FI.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Backup instance creation",
   "pci_projects_project_workflow_instance_status_RESUMING": "Recovering",
   "pci_workflow_create_price_monthly": "{{ price }} ex. VAT/month/GB",
-  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB"
+  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fr_CA.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_RESCUING": "Redémarrage (rescue)",
   "pci_projects_project_workflow_instance_status_UNRESCUING": "Redémarrage",
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Création d'une instance backup",
-  "pci_projects_project_workflow_instance_status_RESUMING": "Reprise en cours"
+  "pci_projects_project_workflow_instance_status_RESUMING": "Reprise en cours",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "La sauvegarde automatique s’applique strictement aux données du disque local de votre instance. Les données des disques NVMe ne seront pas sauvegardées."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_fr_FR.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_RESCUING": "Redémarrage (rescue)",
   "pci_projects_project_workflow_instance_status_UNRESCUING": "Redémarrage",
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Création d'une instance backup",
-  "pci_projects_project_workflow_instance_status_RESUMING": "Reprise en cours"
+  "pci_projects_project_workflow_instance_status_RESUMING": "Reprise en cours",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "La sauvegarde automatique s’applique strictement aux données du disque local de votre instance. Les données des disques NVMe ne seront pas sauvegardées."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_it_IT.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Crea un Instance Backup",
   "pci_projects_project_workflow_instance_status_RESUMING": "Ripresa in corso...",
   "pci_workflow_create_price_monthly": "{{ price }} +IVA/mese/GB",
-  "pci_workflow_create_monthly_backup_price": "Ogni backup viene fatturato  {{ price }} +IVA/mese/GB"
+  "pci_workflow_create_monthly_backup_price": "Ogni backup viene fatturato  {{ price }} +IVA/mese/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "Il backup automatico viene eseguito esclusivamente per i dati del disco locale della tua istanza. I dati dei dischi NVMe non saranno copiati."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_lt_LT.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Backup instance creation",
   "pci_projects_project_workflow_instance_status_RESUMING": "Recovering",
   "pci_workflow_create_price_monthly": "{{ price }} ex. VAT/month/GB",
-  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB"
+  "pci_workflow_create_monthly_backup_price": "Each backup will be billed at: {{ price }} ex. VAT/month/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_pl_PL.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Tworzenie kopii instancji",
   "pci_projects_project_workflow_instance_status_RESUMING": "Trwa wznawianie",
   "pci_workflow_create_price_monthly": "{{ price }} netto/m-c/GB",
-  "pci_workflow_create_monthly_backup_price": "Każda kopia zapasowa będzie płatna w: {{ price }} netto/m-c/GB"
+  "pci_workflow_create_monthly_backup_price": "Każda kopia zapasowa będzie płatna w: {{ price }} netto/m-c/GB",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "Usługa automatyczne kopie zapasowe ma zastosowanie wyłącznie w odniesieniu do danych znajdujących się na dysku lokalnym Twojej instancji. Nie będą tworzone kopie zapasowe danych znajdujących się na dyskach NVMe."
 }

--- a/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/workflow/add/translations/Messages_pt_PT.json
@@ -75,5 +75,6 @@
   "pci_projects_project_workflow_instance_status_SNAPSHOTTING": "Criação de uma instância de backup",
   "pci_projects_project_workflow_instance_status_RESUMING": "Retoma em curso",
   "pci_workflow_create_price_monthly": "{{ price }}/mês por GB + IVA",
-  "pci_workflow_create_monthly_backup_price": "Cada backup será faturado: {{ price }}/mês por GB + IVA"
+  "pci_workflow_create_monthly_backup_price": "Cada backup será faturado: {{ price }}/mês por GB + IVA",
+  "pci_projects_project_workflow_instance_status_IS_IOPS": "O backup automático aplica-se estritamente aos dados do disco local da sua instância. Os dados dos discos NVMe não serão guardados."
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5486
| License          | BSD 3-Clause

## Description
Two warn messages and translation keys are added into:
```
     1 - instances -> Create an instance
           pci_projects_project_instances_add_instance_is_iops
```

```
     2 - workflow -> Create a schedule
          pci_projects_project_workflow_instance_status_IS_IOPS
```

### :bookmark: TODO

- [x] TRANS-27502