### PR TITLE
refactor: use uikit header instead of responsive tabs

### DIFF
--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -46,7 +46,6 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-api-services": "^9.49.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8"

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -35,7 +35,6 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-angular-responsive-tabs": "^4.0.0",
     "ovh-api-services": "^9.44.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"

--- a/packages/manager/modules/overthebox/src/overthebox/overTheBox.html
+++ b/packages/manager/modules/overthebox/src/overthebox/overTheBox.html
@@ -14,50 +14,29 @@
             </div>
         </header>
 
-        <nav role="navigation">
-            <responsive-tabs>
-                <responsive-tab
-                    data-state="overTheBoxes.overTheBox.details"
-                    data-dropdown-title="{{ 'overTheBox_tabs_detail' | translate }}"
-                >
-                    <span data-translate="overTheBox_tabs_detail"></span>
-                </responsive-tab>
-                <responsive-tab
-                    data-state="overTheBoxes.overTheBox.remote"
-                    data-dropdown-title="{{ 'overTheBox_tabs_remote' | translate }}"
-                    disabled="OverTheBox.disabledRemote"
-                >
-                    <span data-translate="overTheBox_tabs_remote"></span>
-                </responsive-tab>
-                <responsive-tab
-                    data-state="overTheBoxes.overTheBox.tasks"
-                    data-dropdown-title="{{ 'overTheBox_tabs_tasks' | translate }}"
-                >
-                    <span data-translate="overTheBox_tabs_tasks"></span>
-                </responsive-tab>
-                <responsive-tab
-                    data-ui-sref="overTheBoxes.overTheBox.actions"
-                    data-dropdown-title="{{ 'overTheBox_tabs_actions' | translate }}"
-                >
-                    <span data-translate="overTheBox_tabs_actions"></span>
-                </responsive-tab>
-                <responsive-tab
-                    data-state="overTheBoxes.overTheBox.logs"
-                    data-dropdown-title="{{ 'overTheBox_tabs_logs' | translate }}"
-                >
-                    <span data-translate="overTheBox_tabs_logs"></span>
-                </responsive-tab>
-                <responsive-tab
-                    data-state="overTheBoxes.overTheBox.docs"
-                    data-dropdown-title="{{ 'overTheBox_tabs_docs' | translate }}"
-                >
-                    <span data-translate="overTheBox_tabs_docs"></span>
-                </responsive-tab>
-                <responsive-tab-more>
-                    <i class="fa fa-plus"></i>
-                </responsive-tab-more>
-            </responsive-tabs>
-        </nav>
+        <oui-header-tabs>
+            <oui-header-tabs-item data-state="overTheBoxes.overTheBox.details">
+                <span data-translate="overTheBox_tabs_detail"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item
+                data-state="overTheBoxes.overTheBox.remote"
+                disabled="OverTheBox.disabledRemote"
+            >
+                <span data-translate="overTheBox_tabs_remote"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item data-state="overTheBoxes.overTheBox.tasks">
+                <span data-translate="overTheBox_tabs_tasks"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item data-state="overTheBoxes.overTheBox.actions">
+                <span data-translate="overTheBox_tabs_actions"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item data-state="overTheBoxes.overTheBox.logs">
+                <span data-translate="overTheBox_tabs_logs"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item data-state="overTheBoxes.overTheBox.docs">
+                <span data-translate="overTheBox_tabs_docs"></span>
+            </oui-header-tabs-item>
+        </oui-header-tabs>
     </div>
     <!-- /.telecom-section-header -->
 

--- a/packages/manager/modules/overthebox/src/overthebox/overTheBox.module.js
+++ b/packages/manager/modules/overthebox/src/overthebox/overTheBox.module.js
@@ -7,7 +7,6 @@ import 'angularjs-scroll-glue';
 import '@ovh-ux/ng-ovh-telecom-universe-components';
 import '@ovh-ux/ng-ui-router-title';
 import '@ovh-ux/ng-tail-logs';
-import 'ovh-angular-responsive-tabs';
 import ngOvhUiConfirmModal from '@ovh-ux/ng-ovh-ui-confirm-modal';
 
 import constant from './overTheBox.constant';
@@ -30,7 +29,6 @@ const moduleName = 'OvhManagerOverTheBoxComponent';
 
 angular
   .module(moduleName, [
-    'ovh-angular-responsive-tabs',
     'ngTailLogs',
     'ngOvhTelecomUniverseComponents',
     'ngUiRouterTitle',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

use uikit header instead of responsive tabs
