### PR TITLE
build: only provide esm target for private packages

### DIFF
--- a/packages/manager/modules/account-sidebar/package.json
+++ b/packages/manager/modules/account-sidebar/package.json
@@ -10,9 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/account-sidebar.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/account-sidebar/rollup.config.js
+++ b/packages/manager/modules/account-sidebar/rollup.config.js
@@ -15,4 +15,4 @@ const config = rollupConfig(
   },
 );
 
-export default [config.es({})];
+export default [config.es()];

--- a/packages/manager/modules/account-sidebar/rollup.config.js
+++ b/packages/manager/modules/account-sidebar/rollup.config.js
@@ -15,19 +15,4 @@ const config = rollupConfig(
   },
 );
 
-const outputs = [config.es({})];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs({}));
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es({})];

--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -19,9 +19,7 @@
     "directory": "packages/manager/modules/banner"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/banner.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/banner/rollup.config.js
+++ b/packages/manager/modules/banner/rollup.config.js
@@ -15,19 +15,4 @@ const config = rollupConfig(
   },
 );
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/manager/modules/cloud-styles"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/cloud-styles.js",
+  "main": "./dist/esm/index.js",
   "scripts": {
     "build": "rollup -c --environment BUILD:production",
     "dev": "rollup -c --environment BUILD:development",

--- a/packages/manager/modules/cloud-styles/rollup.config.js
+++ b/packages/manager/modules/cloud-styles/rollup.config.js
@@ -15,11 +15,4 @@ const config = rollupConfig(
   },
 );
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(config.umd());
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -20,9 +20,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/ng-ovh-cloud-universe-components.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/cloud-universe-components/rollup.config.js
+++ b/packages/manager/modules/cloud-universe-components/rollup.config.js
@@ -15,14 +15,4 @@ const config = rollupConfig(
   },
 );
 
-export default [
-  config.cjs(),
-  config.umd({
-    output: {
-      globals: {
-        angular: 'angular',
-        d3: 'd3',
-      },
-    },
-  }),
-];
+export default [config.es()];

--- a/packages/manager/modules/config/package.json
+++ b/packages/manager/modules/config/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/manager/modules/config"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/config.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/config/rollup.config.js
+++ b/packages/manager/modules/config/rollup.config.js
@@ -4,11 +4,4 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(config.umd());
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/manager/modules/core"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/core.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/core/rollup.config.js
+++ b/packages/manager/modules/core/rollup.config.js
@@ -4,21 +4,4 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          '@ovh-ux/ng-ovh-http': 'ngOvhHttp',
-          '@ovh-ux/ng-ovh-sso-auth': 'ngOvhSsoAuth',
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -19,9 +19,7 @@
     "directory": "packages/manager/modules/enterprise-cloud-database"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/enterprise-cloud-database.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/enterprise-cloud-database/rollup.config.js
+++ b/packages/manager/modules/enterprise-cloud-database/rollup.config.js
@@ -4,19 +4,4 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/manager/components/navbar"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/welcome.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/navbar/rollup.config.js
+++ b/packages/manager/modules/navbar/rollup.config.js
@@ -15,7 +15,7 @@ const config = rollupConfig(
   },
 );
 
-const outputs = [
+export default [
   config.es({
     output: {
       globals: {
@@ -24,27 +24,3 @@ const outputs = [
     },
   }),
 ];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(
-    config.cjs({
-      output: {
-        globals: {
-          Tour: 'Tour',
-        },
-      },
-    }),
-  );
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-          Tour: 'Tour',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;

--- a/packages/manager/modules/ng-layout-helpers/package.json
+++ b/packages/manager/modules/ng-layout-helpers/package.json
@@ -10,9 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/ng-layout-helpers.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/ng-layout-helpers/rollup.config.js
+++ b/packages/manager/modules/ng-layout-helpers/rollup.config.js
@@ -4,19 +4,4 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/preloader/package.json
+++ b/packages/manager/modules/preloader/package.json
@@ -10,9 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/preloader.js",
+  "main": "./dist/esm/index.js",
   "scripts": {
     "build": "rollup -c --environment BUILD:production",
     "dev": "rollup -c --environment BUILD:development",

--- a/packages/manager/modules/preloader/rollup.config.js
+++ b/packages/manager/modules/preloader/rollup.config.js
@@ -4,17 +4,10 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [
+export default [
   config.es({
     output: {
       sourcemap: false,
     },
   }),
 ];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(config.umd());
-}
-
-export default outputs;

--- a/packages/manager/modules/request-tagger/package.json
+++ b/packages/manager/modules/request-tagger/package.json
@@ -19,9 +19,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/request-tagger.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/request-tagger/rollup.config.js
+++ b/packages/manager/modules/request-tagger/rollup.config.js
@@ -4,19 +4,4 @@ const config = rollupConfig({
   input: './src/index.js',
 });
 
-const outputs = [config.es()];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -13,9 +13,7 @@
     "directory": "packages/manager/modules/server-sidebar"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/server-sidebar.js",
+  "main": "./dist/esm/index.js",
   "files": [
     "dist"
   ],

--- a/packages/manager/modules/server-sidebar/rollup.config.js
+++ b/packages/manager/modules/server-sidebar/rollup.config.js
@@ -15,19 +15,4 @@ const config = rollupConfig(
   },
 );
 
-const outputs = [config.es()];
-
-// if (process.env.BUILD === 'production') {
-outputs.push(config.cjs());
-outputs.push(
-  config.umd({
-    output: {
-      globals: {
-        angular: 'angular',
-      },
-    },
-  }),
-);
-// }
-
-export default outputs;
+export default [config.es()];

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -10,9 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/umd/sign-up.js",
+  "main": "./dist/esm/index.js",
   "scripts": {
     "build": "rollup -c --environment BUILD:production",
     "dev": "rollup -c --environment BUILD:development",

--- a/packages/manager/modules/sign-up/rollup.config.js
+++ b/packages/manager/modules/sign-up/rollup.config.js
@@ -4,25 +4,10 @@ const config = rollupConfig({
   input: 'src/index.js',
 });
 
-const outputs = [
+export default [
   config.es({
     output: {
       sourcemap: false,
     },
   }),
 ];
-
-if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
-  outputs.push(
-    config.umd({
-      output: {
-        globals: {
-          angular: 'angular',
-        },
-      },
-    }),
-  );
-}
-
-export default outputs;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

There is no need in providing multiple targets for private monorepo packages. It slows down the build time.
