### PR TITLE
build: prevent error ENOTDIR when starting application

### DIFF
--- a/scripts/start-application.js
+++ b/scripts/start-application.js
@@ -37,23 +37,23 @@ const applicationsWorkspace = 'packages/manager/apps';
  * @return {Array} Applications' list.
  */
 const choices = () =>
-  readdirSync(applicationsWorkspace, {
-    withFileTypes: true,
-  }).map((application) => {
-    const data = readFileSync(
-      `${applicationsWorkspace}/${application.name}/package.json`,
-      'utf8',
-    );
-    const { name } = JSON.parse(data);
-    // Skip scoped package name.
-    // `@ovh-ux/foo` => `foo`.
-    const [, formatedName] = name.split('/');
+  readdirSync(applicationsWorkspace, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map(({ name: application }) => {
+      const data = readFileSync(
+        `${applicationsWorkspace}/${application}/package.json`,
+        'utf8',
+      );
+      const { name } = JSON.parse(data);
+      // Skip scoped package name.
+      // `@ovh-ux/foo` => `foo`.
+      const [, formatedName] = name.split('/');
 
-    return {
-      name: formatedName,
-      value: name,
-    };
-  });
+      return {
+        name: formatedName,
+        value: name,
+      };
+    });
 
 /**
  * Ask for both packageName and region to start the corresponding application.


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :construction_worker: Build

build: prevent error ENOTDIR when starting application

Some OSes stores custom attribute in a specific files like `.DS_Store`.

```sh
(node:88679) UnhandledPromiseRejectionWarning: Error: ENOTDIR: not a directory, open 'packages/manager/apps/.DS_Store/package.json'
```
### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

cc @marie-j 