### PR TITLE
Fix/dtrsd 17982

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/domain-enable-web-hosting.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/domain-enable-web-hosting.html
@@ -83,11 +83,13 @@
             valid="$ctrl.contractsValidated"
             submit-text="{{:: 'domain_configuration_enable_web_hosting_activate' | translate }}"
             on-cancel="$ctrl.goBack()"
+            prevent-next
         >
             <ovh-contracts-summary
                 name="agreeContracts"
                 items="$ctrl.checkout.contracts"
                 model="$ctrl.contractsValidated"
+                required
             >
             </ovh-contracts-summary>
         </oui-step-form>

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/enable.component.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/enable.component.js
@@ -4,7 +4,6 @@ import template from './domain-enable-web-hosting.html';
 export default {
   bindings: {
     addOption: '<',
-    defaultPaymentMethod: '<',
     domainName: '<',
     getCheckout: '<',
     goBack: '<',

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/routing.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/routing.js
@@ -3,8 +3,6 @@ const commonResolves = {
     WucOrderCartService.createNewCart(user.ovhSubsidiary).then((cart) =>
       WucOrderCartService.assignCart(cart.cartId).then(() => cart),
     ),
-  defaultPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
-    ovhPaymentMethod.getDefaultPaymentMethod(),
   addOption: /* @ngInject */ (cart, domainName, WebhostingEnableService) => (
     item,
     offer,
@@ -20,13 +18,9 @@ const commonResolves = {
 
   getCheckout: /* @ngInject */ (cart, WucOrderCartService) => () =>
     WucOrderCartService.getCheckoutInformations(cart.cartId),
-  order: /* @ngInject */ (
-    cart,
-    defaultPaymentMethod,
-    WucOrderCartService,
-  ) => () =>
+  order: /* @ngInject */ (cart, WucOrderCartService) => () =>
     WucOrderCartService.checkoutCart(cart.cartId, {
-      autoPayWithPreferredPaymentMethod: !!defaultPaymentMethod,
+      autoPayWithPreferredPaymentMethod: true,
       waiveRetractationPeriod: true,
     }),
   goBack: /* @ngInject */ (goToDashboard) => goToDashboard,

--- a/packages/manager/apps/web/client/app/domain/zone/activate/activate.component.js
+++ b/packages/manager/apps/web/client/app/domain/zone/activate/activate.component.js
@@ -3,7 +3,6 @@ import template from './activate.html';
 
 export default {
   bindings: {
-    autoPayWithPreferredPaymentMethod: '<',
     goBack: '<',
     serviceName: '<',
     serviceOption: '<',

--- a/packages/manager/apps/web/client/app/domain/zone/activate/activate.controller.js
+++ b/packages/manager/apps/web/client/app/domain/zone/activate/activate.controller.js
@@ -1,9 +1,7 @@
 import filter from 'lodash/filter';
 import get from 'lodash/get';
 
-import {
-  pricingConstants,
-} from '@ovh-ux/manager-product-offers';
+import { pricingConstants } from '@ovh-ux/manager-product-offers';
 
 export default class DomainDnsZoneActivateController {
   /* @ngInject */
@@ -62,13 +60,15 @@ export default class DomainDnsZoneActivateController {
             'app.domain.product.zoneactivate',
           ),
         )
-        .finally(() => (this.checkoutLoading = false));
+        .finally(() => {
+          this.checkoutLoading = false;
+        });
     }
   }
 
   checkout() {
     this.checkoutOrderCart(
-      this.autoPayWithPreferredPaymentMethod,
+      !!this.defaultPaymentMethod,
       this.cartId,
       this.price.value === 0,
     );
@@ -77,7 +77,7 @@ export default class DomainDnsZoneActivateController {
   checkoutOrderCart(autoPayWithPreferredPaymentMethod, cartId, isOptionFree) {
     this.checkoutLoading = true;
     this.DomainDnsZoneActivateService.checkoutOrderCart(
-      autoPayWithPreferredPaymentMethod,
+      isOptionFree || autoPayWithPreferredPaymentMethod,
       cartId,
     )
       .then((order) => {
@@ -117,7 +117,7 @@ export default class DomainDnsZoneActivateController {
         this.serviceOption,
         price,
       ).then((finalCart) => {
-        return { ...finalCart, cartId: cart.cartId }
+        return { ...finalCart, cartId: cart.cartId };
       }),
     );
   }

--- a/packages/manager/apps/web/client/app/domain/zone/activate/activate.routing.js
+++ b/packages/manager/apps/web/client/app/domain/zone/activate/activate.routing.js
@@ -1,7 +1,4 @@
 const commonResolves = {
-  autoPayWithPreferredPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
-    ovhPaymentMethod.hasDefaultPaymentMethod(),
-
   serviceName: /* @ngInject */ ($transition$) =>
     $transition$.params().productId,
 

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
@@ -32,7 +32,7 @@ export default /* @ngInject */ ($stateProvider) => {
       ) => async (autoPayWithPreferredPaymentMethod, cartId) => {
         try {
           const order = await HostingCdnOrderService.checkoutOrderCart(
-            autoPayWithPreferredPaymentMethod,
+            isOptionFree || autoPayWithPreferredPaymentMethod,
             cartId,
           );
 

--- a/packages/manager/modules/web-universe-components/src/order-cart/order-cart.constants.js
+++ b/packages/manager/modules/web-universe-components/src/order-cart/order-cart.constants.js
@@ -1,5 +1,0 @@
-export const FIDELITY_ACCOUNT = 'fidelityAccount';
-
-export default {
-  FIDELITY_ACCOUNT,
-};

--- a/packages/manager/modules/web-universe-components/src/order-cart/order-cart.service.js
+++ b/packages/manager/modules/web-universe-components/src/order-cart/order-cart.service.js
@@ -1,5 +1,3 @@
-import { FIDELITY_ACCOUNT } from './order-cart.constants';
-
 /**
  * Cart order management service, based on API /order/cart
  * It is, for the moment, aimed to handle order of product, or existing product
@@ -212,19 +210,6 @@ export default class OrderCartService {
           ...checkout,
         },
       ).$promise;
-
-    if (order.prices.withTax.value === 0) {
-      await this.OvhApiMe.Order()
-        .v6()
-        .payRegisteredPaymentMean(
-          {
-            orderId: order.orderId,
-          },
-          {
-            paymentMean: FIDELITY_ACCOUNT,
-          },
-        ).$promise;
-    }
 
     return order;
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-17982
| License          | BSD 3-Clause

## Description

Remove call to /me/order/{orderId}/payWithRegisteredPaymentMean that was done when order price equals.
This call is useless, all cart option with free pricing must be checked out with flag 'autoPayWithPreferredPaymentMethod' ste to true.