### PR TITLE
fix(telephony.alias.ccs.time-condition): display right message error

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/timeCondition/telecom-telephony-alias-configuration-time-condition-easy-hunting.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/timeCondition/telecom-telephony-alias-configuration-time-condition-easy-hunting.controller.js
@@ -206,7 +206,7 @@ angular.module('managerApp').controller(
         .catch((error) => {
           this.number.feature.timeCondition.stopEdition(true).startEdition();
           this.TucToast.error(
-            `${this.$trnaslate.instant(
+            `${this.$translate.instant(
               'telephony_alias_config_contactCenterSolution_timeCondition_update_error',
             )} ${get(error, 'data.message', error.message)}`,
           );


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | sentry-26270
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

152a529  - fix(telephony.alias.ccs.time-condition): display right message error

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>