### PR TITLE
fix(dedicated): private cloud guide urls

### DIFF
--- a/packages/manager/apps/dedicated/client/app/config/constants.config.js
+++ b/packages/manager/apps/dedicated/client/app/config/constants.config.js
@@ -1166,7 +1166,7 @@ const constants = {
           nsx:
             'https://us.ovhcloud.com/products/hosted-private-cloud/vmware-nsx',
           vrops:
-            'https://us.ovhcloud.com/products/hosted-private-cloud/vmware-vrealize-operations',
+            'https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/vrops/',
         },
         presentations: {
           home: 'https://us.ovhcloud.com/products/hosted-private-cloud/',
@@ -1175,7 +1175,7 @@ const constants = {
           veeam:
             'https://us.ovhcloud.com/products/hosted-private-cloud/managed-veeam-backup',
           vrops:
-            'https://us.ovhcloud.com/products/hosted-private-cloud/vmware-vrealize-operations',
+            'https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/vrops/',
         },
         vpsCloud: 'https://www.ovh.com/ca/en/vps/vps-cloud.xml',
         dedicatedIpmi:

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/dashboard/tiles/options/models/bindings/bindings.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/dashboard/tiles/options/models/bindings/bindings.js
@@ -187,7 +187,7 @@ export default class {
           status === ACTIVATION_STATUS.disabled &&
           ServicePackOptionService.getPresentationUrl(
             option.name,
-            this.model.currentUser,
+            this.model.currentUser.ovhSubsidiary,
           ),
         status,
       };
@@ -281,7 +281,7 @@ export default class {
         exists: !currentlyHasCertification,
         url: ServicePackOptionService.getPresentationUrl(
           'home',
-          this.model.currentUser,
+          this.model.currentUser.ovhSubsidiary,
         ),
       },
       status: exists && status,


### PR DESCRIPTION
vrops guide url takes to wrong page in US

closes #MANAGER-5495

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-5495
| License          | BSD 3-Clause

## Description

vrops guide link takes to the wrong page (French page) in the US. Use below link
https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/vrops/
