### PR TITLE
fix(web.domain): handle unavailable capabilities

### DIFF
--- a/packages/manager/apps/web/client/app/domain/domain.routing.js
+++ b/packages/manager/apps/web/client/app/domain/domain.routing.js
@@ -23,7 +23,9 @@ const commonResolves = {
       .then((options) => options.data.zone),
   zoneCapabilities: /* @ngInject */ (DNSZoneService, zoneOption) =>
     zoneOption
-      ? DNSZoneService.getCapabilities(zoneOption.serviceName)
+      ? DNSZoneService.getCapabilities(zoneOption.serviceName).catch(() => ({
+          dynHost: false,
+        }))
       : { dynHost: false },
 };
 


### PR DESCRIPTION
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `hotfix-2020-08-21` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix # DTRSD-18305
| License          | BSD 3-Clause

## Description

Prevent domain zone page to fall in error if /zone/capabilities returns 404 for a given domain zone
