### PR TITLE
hotfix(payment-method): not able to add paypal payment method

### DIFF
--- a/packages/components/ng-ovh-payment-method/package.json
+++ b/packages/components/ng-ovh-payment-method/package.json
@@ -44,6 +44,7 @@
     "@ovh-ux/component-rollup-config": "^7.0.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-config": "^0.4.0 || ^1.0.0",
     "@ovh-ux/manager-core": "^10.0.0 || ^11.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.0",
     "@ovh-ux/ui-kit": "^4.1.12",

--- a/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/inContext/paypal/controller.js
@@ -1,10 +1,11 @@
 import { get, merge } from 'lodash-es';
 
+import { Environment } from '@ovh-ux/manager-config';
+
 export default class OvhPaymentMethodIntegrationInContextPaypalCtrl {
   /* @ngInject */
-  constructor($timeout, TranslateService) {
+  constructor($timeout) {
     this.$timeout = $timeout;
-    this.TranslateService = TranslateService;
   }
 
   /**
@@ -16,7 +17,7 @@ export default class OvhPaymentMethodIntegrationInContextPaypalCtrl {
     // call onIntegrationInitialized callback from parent controller to get render options
     const renderOptions = merge(
       {
-        locale: this.TranslateService.getUserLocale(),
+        locale: Environment.getUserLocale(),
       },
       this.inContextCtrl.integrationCtrl.onIntegrationInitialized(),
     );


### PR DESCRIPTION
no button is visible to add paypal payment method

closes #DTRSD-18423

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-18423 and #DTRSD-18442
| License          | BSD 3-Clause

## Description

the ovh-payment-method component was using deleted TranslateService to get the user locale. I have used Environment to get the user locale.
