### PR TITLE
fix(autorenew): add serviceType parameter

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/autoRenew/actions/cancel-resiliation/cancel-resiliation.routing.js
+++ b/packages/manager/apps/dedicated/client/app/billing/autoRenew/actions/cancel-resiliation/cancel-resiliation.routing.js
@@ -1,6 +1,6 @@
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.account.billing.autorenew.cancelResiliation', {
-    url: '/cancel-resiliation?serviceId',
+    url: '/cancel-resiliation?serviceId&serviceType',
     views: {
       modal: {
         component: 'billingAutorenewCancelResiliation',
@@ -16,8 +16,10 @@ export default /* @ngInject */ ($stateProvider) => {
       },
       serviceId: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceId,
-      service: /* @ngInject */ (BillingAutoRenew, serviceId) =>
-        BillingAutoRenew.getService(serviceId),
+      serviceType: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceType,
+      service: /* @ngInject */ (BillingAutoRenew, serviceId, serviceType) =>
+        BillingAutoRenew.getService(serviceId, serviceType),
     },
   });
 };

--- a/packages/manager/apps/dedicated/client/app/billing/autoRenew/actions/update/update.routing.js
+++ b/packages/manager/apps/dedicated/client/app/billing/autoRenew/actions/update/update.routing.js
@@ -1,6 +1,6 @@
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.account.billing.autorenew.update', {
-    url: '/update?serviceId',
+    url: '/update?serviceId&serviceType',
     component: 'billingAutorenewUpdate',
     translations: { value: ['.'], format: 'json' },
     resolve: {
@@ -12,8 +12,10 @@ export default /* @ngInject */ ($stateProvider) => {
       goBack: /* @ngInject */ (goToAutorenew) => goToAutorenew,
       serviceId: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceId,
-      service: /* @ngInject */ (BillingAutoRenew, serviceId) =>
-        BillingAutoRenew.getService(serviceId),
+      serviceType: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceType,
+      service: /* @ngInject */ (BillingAutoRenew, serviceId, serviceType) =>
+        BillingAutoRenew.getService(serviceId, serviceType),
       /* @ngInject */
       updateRenew: (BillingAutoRenew) => (service, agreements) =>
         BillingAutoRenew.updateRenew(service, agreements),

--- a/packages/manager/apps/dedicated/client/app/billing/autoRenew/autorenew.service.js
+++ b/packages/manager/apps/dedicated/client/app/billing/autoRenew/autorenew.service.js
@@ -1,3 +1,4 @@
+import find from 'lodash/find';
 import head from 'lodash/head';
 import map from 'lodash/map';
 import pick from 'lodash/pick';
@@ -74,14 +75,25 @@ export default class {
     }).$promise;
   }
 
-  getService(serviceId) {
+  /**
+   * add optional serviceType parameter to filter service result
+   * (some services might have the same serviceId but a different
+   *  serviceType : domain and email-domain)
+   */
+  getService(serviceId, serviceType) {
     return this.OvhApiBillingAutorenewServices.Aapi()
       .query({
         search: serviceId,
       })
-      .$promise.then(
-        (services) => new BillingService(head(services.list.results)),
-      );
+      .$promise.then((services) => {
+        if (serviceType) {
+          return find(services.list.results, {
+            serviceType,
+          });
+        }
+        return head(services.list.results);
+      })
+      .then((service) => new BillingService(service));
   }
 
   getServicesTypes(services) {

--- a/packages/manager/modules/billing/src/components/services-actions/services-actions.controller.js
+++ b/packages/manager/modules/billing/src/components/services-actions/services-actions.controller.js
@@ -14,8 +14,8 @@ export default class ServicesActionsCtrl {
   $onInit() {
     this.warningLink = `${this.autorenewLink}/warn-nic?nic=${this.service.contactBilling}`;
     this.billingLink = this.RedirectionService.getURL('billing');
-    this.updateLink = `${this.autorenewLink}/update?serviceId=${this.service.serviceId}`;
-    this.cancelResiliationLink = `${this.autorenewLink}/cancel-resiliation?serviceId=${this.service.serviceId}`;
+    this.updateLink = `${this.autorenewLink}/update?serviceId=${this.service.serviceId}&serviceType=${this.service.serviceType}`;
+    this.cancelResiliationLink = `${this.autorenewLink}/cancel-resiliation?serviceId=${this.service.serviceId}&serviceType=${this.service.serviceType}`;
 
     switch (this.service.serviceType) {
       case SERVICE_TYPE.EXCHANGE:


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-18366
| License          | BSD 3-Clause

## Description

Some services have the same serviceId but a different serviceType (example : domain and email-domain).
The wrong service was passed because the first result from api is taken without checking if the serviceType was correct.
I added a filter on the serviceType to ensure the service is the correct one.