### PR TITLE
hotfix(dedicated): ips are not listing

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
@@ -285,7 +285,7 @@
 
                 <tbody
                     data-ng-if="ipsList.length"
-                    data-ng-repeat="ipBlock in ipsList track by ipBlock.ipBlock"
+                    data-ng-repeat="ipBlock in ipsList track by $index"
                 >
                     <tr
                         data-ng-show="ipBlock.refreshing || ipBlock.reverseDelegationsRefresh"


### PR DESCRIPTION
public cloud IPs are not listing in Manage IP page

closes #DTRSD-17970

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-17970
| License          | BSD 3-Clause

## Description

IP object has no unique field. Field "ipBlock" was used in track by. This is not a unique field and customers had two IPs with the same IP block. Because of this, the UI was failing. I used $index for track by.
