### PR TITLE
fix(email-domain): always show responders button

### DIFF
--- a/packages/manager/apps/web/client/app/email-domain/email/account/email-domain-email-account.html
+++ b/packages/manager/apps/web/client/app/email-domain/email/account/email-domain-email-account.html
@@ -344,7 +344,6 @@
                 type="button"
                 data-translate="email_tab_responders_management_heading"
                 data-ng-click="ctrlEmailDomainEmail.selectSubView('respondersView')"
-                data-ng-if="ctrlEmailDomainEmail.quotas.account > 0"
             ></button>
             <button
                 class="btn btn-block btn-default text-wrap"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | non
| Breaking change? | no
| Tickets          | Fix #DTRSD-17442
| License          | BSD 3-Clause

## Description

Enable responders management without any restrictions

ref: DTRSD-17442

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>
