### PR TITLE
fix(web): remove upgrade for emails with parent

### DIFF
--- a/packages/manager/apps/web/client/app/email-domain/general-informations/email-domain-general-informations.controller.js
+++ b/packages/manager/apps/web/client/app/email-domain/general-informations/email-domain-general-informations.controller.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import set from 'lodash/set';
 
 angular.module('App').controller(
@@ -6,6 +7,7 @@ angular.module('App').controller(
     /* @ngInject */
     constructor(
       $q,
+      $http,
       $scope,
       $state,
       $stateParams,
@@ -18,6 +20,7 @@ angular.module('App').controller(
       WucEmails,
     ) {
       this.$q = $q;
+      this.$http = $http;
       this.$scope = $scope;
       this.$state = $state;
       this.$stateParams = $stateParams;
@@ -46,7 +49,11 @@ angular.module('App').controller(
 
       this.$scope.$on('domain.dashboard.refresh', () => this.loadDomain());
       return this.$q
-        .all([this.loadDomain(), this.loadQuotas(), this.loadServiceInfos()])
+        .all([
+          this.loadDomain(),
+          this.loadQuotas(),
+          this.loadServiceInfos().then(() => this.loadServiceDetails()),
+        ])
         .then(() => this.loadUrls());
     }
 
@@ -77,6 +84,25 @@ angular.module('App').controller(
         })
         .finally(() => {
           this.loading.domain = false;
+        });
+    }
+
+    loadServiceDetails() {
+      this.loading.serviceDetails = true;
+      return this.$http
+        .get(`/services/${get(this, 'serviceInfos.serviceId', '')}`)
+        .then((response) => {
+          this.serviceDetails = response.data;
+        })
+        .catch((err) => {
+          this.Alerter.alertFromSWS(
+            this.$translate.instant('email_tab_table_accounts_error'),
+            err,
+            this.$scope.alerts.main,
+          );
+        })
+        .finally(() => {
+          this.loading.serviceDetails = false;
         });
     }
 

--- a/packages/manager/apps/web/client/app/email-domain/general-informations/email-domain-general-informations.html
+++ b/packages/manager/apps/web/client/app/email-domain/general-informations/email-domain-general-informations.html
@@ -88,14 +88,18 @@
         <div class="col-sm-4 mb-5">
             <oui-tile
                 data-heading="{{ ::'common_plan' | translate }}"
-                data-loading="ctrlTabGeneralInformations.loading.domain || ctrlTabGeneralInformations.loading.serviceInfos || ctrlTabGeneralInformations.loading.urls"
+                data-loading="ctrlTabGeneralInformations.loading.domain || ctrlTabGeneralInformations.loading.serviceInfos || ctrlTabGeneralInformations.loading.urls || ctrlTabGeneralInformations.loading.serviceDetails"
                 class="h-100"
             >
                 <oui-tile-definition
                     data-term="{{ ::'email_tab_domain_offer' | translate }}"
                     data-description="{{ ::ctrlTabGeneralInformations.domain.offer || '-' }}"
                 >
-                    <oui-action-menu data-compact data-placement="end">
+                    <oui-action-menu
+                        data-compact
+                        data-placement="end"
+                        data-ng-if="!ctrlTabGeneralInformations.serviceDetails.parentServiceId"
+                    >
                         <oui-action-menu-item
                             data-on-click="ctrlTabGeneralInformations.goToUpgrade()"
                         >


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-18841
| License          | BSD 3-Clause

## Description

Allow email upgrade only if it is not a part of another service (no parent service)
