### PR TITLE
fix(dedicated): cpanel license upgrade

### DIFF
--- a/packages/manager/apps/dedicated/client/app/license/license.service.js
+++ b/packages/manager/apps/dedicated/client/app/license/license.service.js
@@ -162,6 +162,9 @@ angular.module('Module.license').service('License', [
             }
             break;
           case 'CPANEL':
+            if (hasOption(data.options, 'version')) {
+              opts.version = data.options.version.value;
+            }
             break;
           case 'VIRTUOZZO':
             if (hasOption(data.options, 'containerNumber')) {

--- a/packages/manager/apps/dedicated/client/app/license/upgrade/CPANEL.html
+++ b/packages/manager/apps/dedicated/client/app/license/upgrade/CPANEL.html
@@ -1,0 +1,18 @@
+<div class="control-group">
+    <label
+        for="optionVersion"
+        class="control-label"
+        data-translate="license_order_step2_version"
+    >
+    </label>
+    <select
+        class="form-control"
+        id="optionVersion"
+        name="optionVersion"
+        data-ng-options="optionVersion as (('license_designation_' + license.type + '_version_' + optionVersion.value) | ducTranslateAlt: optionVersion.value) for optionVersion in getOptionVersions()"
+        data-ng-model="selected.options['CPANEL'].version"
+    >
+        <option value="" data-translate="license_upgrade_common_no_change">
+        </option>
+    </select>
+</div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-17392
| License          | BSD 3-Clause

## Description

Add upgrade option for cpanel license. Seems like this option alone is broken for license upgrade

### :flags: Translations

- [ ] _to be defined_
