### PR TITLE
fix: multisite logs url

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/logs/hosting-multisite-logs.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/logs/hosting-multisite-logs.controller.js
@@ -1,14 +1,23 @@
-import isString from 'lodash/isString';
-
 angular.module('App').controller(
   'HostingTabDomainsMultisiteLogs',
   class HostingTabDomainsMultisiteLogs {
-    constructor($scope, $stateParams, $translate, Alerter, Hosting, constants) {
+    constructor(
+      $q,
+      $scope,
+      $stateParams,
+      $translate,
+      Alerter,
+      Hosting,
+      HostingStatistics,
+      constants,
+    ) {
+      this.$q = $q;
       this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
       this.Alerter = Alerter;
       this.Hosting = Hosting;
+      this.HostingStatistics = HostingStatistics;
       this.constants = constants;
     }
 
@@ -17,7 +26,7 @@ angular.module('App').controller(
         const domain = this.$scope.domains.list.results[
           elm['0'].dataset.domainIndex
         ];
-        if (!domain.logUrlGenerated) {
+        if (!domain.logUrlGenerated && !domain.logsLoading) {
           this.generateLogHref(domain);
         }
       });
@@ -25,28 +34,40 @@ angular.module('App').controller(
 
     /* eslint-disable no-param-reassign */
     generateLogHref(domain) {
-      domain.logUrlGenerated = true;
-      if (isString(domain.ownLog) && !domain.ownLogToken) {
-        domain.logsLoading = true;
-        this.Hosting.getUserLogsToken(this.$stateParams.productId, {
-          params: { attachedDomain: domain.name, remoteCheck: true },
+      domain.logsLoading = true;
+      this.$q
+        .all({
+          ownLogs: this.HostingStatistics.getLogs(
+            this.$stateParams.productId,
+            domain.name,
+          ),
+          userLogsToken: this.Hosting.getUserLogsToken(
+            this.$stateParams.productId,
+            {
+              params: {
+                attachedDomain: domain.name,
+                remoteCheck: true,
+              },
+            },
+          ),
         })
-          .then((result) => {
-            domain.logUrl = `${this.$scope.logs.logs}?token=${result}`;
-          })
-          .catch(() => {
-            this.Alerter.error(
-              this.$translate.instant(
-                'hosting_tab_DOMAINS_multisite_logs_generation_error',
-              ),
-              this.$scope.alerts.main,
-            );
-          })
-          .finally(() => {
-            domain.logsLoading = false;
-          });
-      }
-      return false;
+        .then(({ ownLogs, userLogsToken }) => {
+          if (ownLogs.logs) {
+            domain.logUrl = `${ownLogs.logs}?token=${userLogsToken}`;
+            domain.logUrlGenerated = true;
+          }
+        })
+        .catch(() => {
+          this.Alerter.error(
+            this.$translate.instant(
+              'hosting_tab_DOMAINS_multisite_logs_generation_error',
+            ),
+            this.$scope.alerts.main,
+          );
+        })
+        .finally(() => {
+          domain.logsLoading = false;
+        });
     }
     /* eslint-enable no-param-reassign */
   },

--- a/packages/manager/apps/web/client/app/hosting/popover/multisite.html
+++ b/packages/manager/apps/web/client/app/hosting/popover/multisite.html
@@ -12,12 +12,13 @@
         data-ng-controller="HostingTabDomainsMultisiteLogs"
         data-ng-if="!!domain.ownLog"
     >
-        <span data-ng-if="domain.logsLoading">
+        <span data-ng-if="domain.logsLoading || !domain.logUrl">
             <span
                 class="text-muted"
                 data-translate="hosting_tab_DOMAINS_multisite_logs_link"
             ></span>
-            <oui-spinner data-size="s"></oui-spinner>
+            <oui-spinner data-size="s" data-ng-if="domain.logsLoading">
+            </oui-spinner>
         </span>
         <a
             class="btn btn-link"

--- a/packages/manager/apps/web/client/app/hosting/statistics/hosting-statistics.service.js
+++ b/packages/manager/apps/web/client/app/hosting/statistics/hosting-statistics.service.js
@@ -13,11 +13,13 @@ angular.module('services').service(
       this.OvhHttp = OvhHttp;
     }
 
-    getLogs(serviceName) {
+    getLogs(serviceName, attachedDomain) {
+      const fqdn = attachedDomain || serviceName;
+
       return this.$http
         .get(`/hosting/web/${serviceName}/ownLogs`, {
           params: {
-            fqdn: serviceName,
+            fqdn,
           },
         })
         .then(({ data }) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-16672
| License          | BSD 3-Clause

## Description

When accessing separated logs of a multisite domain, the logs url generated was the main domain one.
This fix the issue by calling the right API that generate the right logs url.

## Reference
- DTRSD-16672