### PR TITLE
fix(pci.sidebar): use small badges in sidebar

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.component.js
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.component.js
@@ -1,6 +1,5 @@
 import template from './sidebar.html';
 import controller from './sidebar.controller';
-import './sidebar.scss';
 
 export default {
   bindings: {

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.html
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.html
@@ -114,7 +114,7 @@
                                         ></span>
                                         <span
                                             data-ng-if="subitem.new"
-                                            class="oui-badge_beta oui-badge_new ml-2 oui-badge"
+                                            class="oui-badge oui-badge_s oui-badge_new ml-2"
                                             data-translate="cloud_sidebar_new_project"
                                         ></span>
                                     </a>

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.scss
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.scss
@@ -1,4 +1,0 @@
-.oui-badge.oui-badge_new {
-  background-color: #47fffa;
-  color: #00185e;
-}


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Following CX rules, the badge mini size should be used in the manager sidebar.




