### PR TITLE
fix(cloud.logs): bump ovh-api-services, business wording

### DIFF
--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/streams/home/logs-streams-home.controller.js
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/streams/home/logs-streams-home.controller.js
@@ -143,13 +143,6 @@ class LogsStreamsHomeCtrl {
       .flat();
   }
 
-  storageInfo(stream) {
-    if (stream.info.isEditable && stream.info.currentStorage !== -1) {
-      return this.bytesFilter(stream.info.currentStorage, 2, true);
-    }
-    return ' - ';
-  }
-
   findRetention(stream) {
     return find(
       this.retentions,

--- a/packages/manager/apps/cloud/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/detail/streams/home/logs-streams-home.html
@@ -63,8 +63,10 @@
         >
             <span
                 class="oui-badge oui-badge_info"
-                data-ng-bind="ctrl.storageInfo($row)"
+                data-ng-if="$row.info.isEditable"
+                data-ng-bind="($row.info.currentStorage | bytes:2:true)"
             ></span>
+            <span data-ng-if="!$row.info.isEditable"> - </span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title="::'logs_streams_col_archives' | translate"

--- a/packages/manager/apps/cloud/client/app/dbaas/logs/translations/Messages_en_GB.json
+++ b/packages/manager/apps/cloud/client/app/dbaas/logs/translations/Messages_en_GB.json
@@ -120,7 +120,7 @@
   "logs_home_offer": "Solution ",
   "logs_home_data_volume": "Data volume",
   "logs_home_cluster": "Access point",
-  "logs_home_service": "Logs Data Platform service",
+  "logs_home_service": "Logs Data Platform username",
   "logs_home_start_date": "Creation date",
   "logs_home_number_of_documents": "Number of documents",
   "logs_home_no_usage_data": "No data available",
@@ -168,7 +168,7 @@
   "logs_streams_col_notifications": "Alerts",
   "logs_streams_col_indexing": "Indexation",
   "logs_streams_enabled": "Active",
-  "logs_streams_disabled": "On break",
+  "logs_streams_disabled": "Stopped",
   "logs_streams_no_streams": "No data streams",
   "logs_streams_col_shared": "Shared data stream",
   "logs_streams_manage_alerts": "Manage alerts",
@@ -477,8 +477,8 @@
   "logs_index_modal_suffix": "Suffix",
   "logs_index_suffix_description": "Only lower-case letters from a to z, numbers and the characters '-' and '_' are permitted.",
   "logs_index_modal_description": "Description",
-  "logs_index_modal_nb_shard": "Number of partitions",
-  "logs_index_modal_nb_shard_help": "A partition has a capacity of 25GB, and its unit price is {{t0}} ex. VAT/month. The price per GB stored is {{t1}} ex. VAT/month.",
+  "logs_index_modal_nb_shard": "Number of shards",
+  "logs_index_modal_nb_shard_help": "A shard has a capacity of 25GB, and its unit price is {{t0}} ex. VAT/month. The price per GB stored is {{t1}} ex. VAT/month.",
   "logs_index_modal_notification": "Notification",
   "logs_index_modal_checkbox": "Notify me by email when the index reaches a critical size.",
   "logs_index_edit_error": "An error has occurred modifying the '{{name}}' index: {{message}}",
@@ -668,7 +668,7 @@
   "logs_role_empty_selected_kibana": "No instances selected",
   "logs_roles_add_kibana_error": "An error has occurred adding the Kibana instance to the '{{tokenName}}' permission: {{message}}",
   "logs_streams_col_retention": "Retention",
-  "streams_45_days": " days",
+  "streams_45_days": "45 days",
   "inputs_nb_instance": "Instances",
-  "logs_index_col_nb_shard": "Partitions"
+  "logs_index_col_nb_shard": "Shards"
 }

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -113,7 +113,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-api-services": "^9.50.0",
+    "ovh-api-services": "^10.0.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.8",


### PR DESCRIPTION
Hello,

This PR includes following changes on LDP Manager:

- Bump ovh-api-services to the last release
- Improve the way we display stream storage
- Fix en_GB translation with common business words (e.g. in Elasticsearch world we speak about `shard`, not `partition` (like in french); it's better to say `Stopped` for indexation than `On break`; reuse `service` keyword is confusing when we talk about `username`). 

As always, thanks for your time on this.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@ovhcloud.com>
