### PR TITLE
fix(public-cloud): block storage page is not loading

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/blocks.service.js
@@ -1,6 +1,9 @@
 import find from 'lodash/find';
 import filter from 'lodash/filter';
 import get from 'lodash/get';
+import head from 'lodash/head';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
 import reduce from 'lodash/reduce';
 import round from 'lodash/round';
@@ -48,7 +51,12 @@ export default class PciProjectStorageBlockService {
         const instanceIds = uniq(
           reduce(
             volumes,
-            (instanceAcc, volume) => [...instanceAcc, ...volume.attachedTo],
+            (instanceAcc, volume) => {
+              if(isArray(volume.attachedTo) && !isEmpty(head(volume.attachedTo))) {
+                return [...instanceAcc, ...volume.attachedTo];
+              }
+              return [...instanceAcc];
+            },
             [],
           ),
         );


### PR DESCRIPTION
customer is not able to see his block storages. The page is not loading.

closes #DTRSD-17760

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-17760
| License          | BSD 3-Clause

## Description

Customer has volumes that are attached to empty ("") instanceID. I am not sure how is this possible. This creates an issue because we try to get instance details of instanceID (empty string). I have ignored these kinds of volumes. 
