### PR TITLE
feat(sms): add sender supporting document upload

### DIFF
--- a/packages/manager/modules/sms/src/sms/senders/add/telecom-sms-senders-add.html
+++ b/packages/manager/modules/sms/src/sms/senders/add/telecom-sms-senders-add.html
@@ -152,6 +152,17 @@
                         </span>
                     </div>
 
+                    <oui-field
+                        data-label="{{:: 'sms_senders_add_sender_supporting_document' | translate }}"
+                        data-help-text="{{:: 'sms_senders_add_sender_supporting_document_help' | translate }}"
+                        data-size="xl"
+                    >
+                        <oui-file
+                            model="SmsSendersAddCtrl.sender.supportingDocument"
+                            accept=".jpeg, .jpg, .pdf, .png"
+                        ></oui-file>
+                    </oui-field>
+
                     <!-- Description -->
                     <div
                         class="form-group"

--- a/packages/manager/modules/sms/src/sms/senders/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sms/src/sms/senders/add/translations/Messages_fr_FR.json
@@ -17,6 +17,8 @@
   "sms_senders_add_sender_error_required": "Le champ \"expéditeur\" est obligatoire.",
   "sms_senders_add_sender_error_pattern": "Le champ \"expéditeur\" doit être composé uniquement de caractères alphabétiques.",
   "sms_senders_add_sender_error_maxlength": "Le champ \"expéditeur\" ne peut excéder les 11 caractères.",
+  "sms_senders_add_sender_supporting_document": "Pièce justificative",
+  "sms_senders_add_sender_supporting_document_help": "Nous vous demandons un justificatif dans le cadre de notre politique de sécurité. Il s’agit par défaut d’un papier en-tête de la société ou de la marque, incluant l’autorisation d’un reponsable avec signature et tampon de cette même société, d’un papier d’identité, ou extrait Kbis si ce n’est pas une marque déposée.",
   "sms_senders_add_sender_description_label": "Description : ",
   "sms_senders_add_sender_description_placeholder": "Description (facultatif)",
   "sms_senders_add_sender_description_error_maxlength": "Le champ \"description\" ne peut excéder les 40 caractères.",


### PR DESCRIPTION
ref: MANAGER-5201
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/sms-in-europe
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | #MANAGER-5201
| License          | BSD 3-Clause

## Description

Add feature to upload supporting document on sms sender add page
