### PR TITLE
fix(dedicated-server): ip monitoring management

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.component.js
@@ -13,4 +13,7 @@ export default {
   },
   controller,
   template,
+  require: {
+    dedicatedServer: '^dedicatedServer',
+  },
 };

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.controller.js
@@ -29,7 +29,7 @@ export default class Monitoring {
       smsNotifications: false,
     };
 
-    this.$scope.$on('server.monitoring.reload', this.refreshTableMonitoring);
+    this.$scope.$on('server.monitoring.reload', () => this.refreshTableMonitoring());
 
     return this.refreshTableMonitoring();
   }
@@ -67,6 +67,8 @@ export default class Monitoring {
   refreshTableMonitoring() {
     this.loaders.monitorings = true;
     this.monitoringServicesIds = [];
+    this.editMode = null;
+    this.addMode = null;
 
     this.Server.getServiceMonitoringIds(this.$stateParams.productId)
       .then((monitoringIds) => {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.html
@@ -464,7 +464,7 @@
         >
             <!-- monitoring services -->
             <tr
-                data-ng-repeat="monitoring in $ctrl.monitoringServices track by monitoring.monitoringId"
+                data-ng-repeat="monitoring in $ctrl.monitoringServices track by $index"
             >
                 <!-- Read Mode  -->
                 <td
@@ -573,7 +573,7 @@
                         type="button"
                         class="btn btn-link"
                         title="{{ 'server_tab_MONITORING_table_action_delete' | translate }}"
-                        data-ng-click="setAction('monitoring/delete/dedicated-server-monitoring-delete', monitoring)"
+                        data-ng-click="$ctrl.dedicatedServer.$scope.setAction('monitoring/delete/dedicated-server-monitoring-delete', monitoring)"
                     >
                         <span
                             class="oui-icon oui-icon-trash_concept"
@@ -724,7 +724,7 @@
                                             data-ng-click="$ctrl.editMode = null"
                                         >
                                             <span
-                                                class="oui-icon oui-icon-error"
+                                                class="oui-icon oui-icon-close"
                                                 aria-hidden="true"
                                             ></span>
                                         </button>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/monitoring/monitoring.routing.js
@@ -1,4 +1,5 @@
 import filter from 'lodash/filter';
+import flatten from 'lodash/flatten';
 import includes from 'lodash/includes';
 import map from 'lodash/map';
 
@@ -19,11 +20,11 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.go('app.dedicated.server.dashboard'),
       ips: /* @ngInject */ ($stateParams, IpRange, Server) =>
         Server.listIps($stateParams.productId).then((ips) =>
-          map(
+        flatten(map(
             filter(ips, (ip) => !includes(ip, ':')),
             (ip) => IpRange.getRangeForIpv4Block(ip),
           ),
-        ),
+        )),
       languageEnum: /* @ngInject */ (models) =>
         models.data.models['dedicated.server.AlertLanguageEnum'].enum,
       monitoringIntervalEnum: /* @ngInject */ (models) =>


### PR DESCRIPTION
not able to add, edit and delete ips for monitoring

closes #DTRSD-19171

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-19171
| License          | BSD 3-Clause

## Description

API accepts ip address to create new ip monitoring. Manager was sending an array of ip's. I have fixed this issue. Also made a few more changes to fix edit and delete.
