### PR TITLE
fix(xdsl.tasks): add translated labels for task function

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/slots/task/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/slots/task/translations/Messages_fr_FR.json
@@ -31,5 +31,6 @@
   "telecom_task_function_regeneratePromoCode": "Régénération du code promotionel",
   "telecom_task_function_changePackOffer": "Changement d'offre",
   "telecom_task_function_packXdslAddressMove": "Déménagement",
-  "telecom_task_function_accessDiagnosticRun": "Diagnostic de la ligne"
+  "telecom_task_function_accessDiagnosticRun": "Diagnostic de la ligne",
+  "telecom_task_function_ToDoNothing": "Test OK, aucune action en attente"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `fix/xdsl-missing-translations`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-304
| License          | BSD 3-Clause

## Description

Add translated labels for tack function ToDoNothing.
This task is only displayed for test with UX user account (update all translation files for this reason).
