### PR TITLE
build(deps): bump @ovh-ux/manager-config to use latest

### DIFF
--- a/packages/manager/modules/at-internet-configuration/package.json
+++ b/packages/manager/modules/at-internet-configuration/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/manager-config": "^0.4.0"
+    "@ovh-ux/manager-config": "^1.1.1"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^9.0.0",

--- a/packages/manager/modules/notifications-sidebar/package.json
+++ b/packages/manager/modules/notifications-sidebar/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "@ovh-ux/manager-config": "^0.4.0",
+    "@ovh-ux/manager-config": "^1.1.1",
     "@ovh-ux/manager-core": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ng-at-internet": "^5.1.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Avoid to install `@ovh-ux/manager-config@^0.4.0` from package registry (using `^1.1.1` from https://github.com/ovh/manager/blob/master/packages/manager/modules/config/package.json)

## Context

In `yarn.lock`, when I `yarn install`: 

```shell
$ yarn install
...
[5/5] 🔨  Building fresh packages...
success Saved lockfile.

$ git diff 
diff --git a/yarn.lock b/yarn.lock
index e6d162bfc..bf7b141de 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,11 @@
   dependencies:
     "@types/node" ">= 8"

+"@ovh-ux/manager-config@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-config/-/manager-config-0.4.0.tgz#81171e361b8400870821632adddea7b46a240395"
+  integrity sha512-ZiLfkRNwCqnyQvYpN9Frx/WKXE9JEQhtkmoxIdhzDtkBjvuIHbC9uGH7rzh771xfuZcUPv8hmidwf0cjdpXCjQ==
+
 "@ovh-ux/ng-ovh-api-wrappers@^4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-api-wrappers/-/ng-ovh-api-wrappers-4.0.7.tgz#f07cff3c42ef1c9d1655e2300617528a7d8b2f4f"
(END)
```



