### PR TITLE
Hotfixes release

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.js
+++ b/packages/manager/apps/dedicated/client/app/app.js
@@ -2,6 +2,7 @@ import { Environment } from '@ovh-ux/manager-config';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import set from 'lodash/set';
+import values from 'lodash/values';
 import isString from 'lodash/isString';
 import ngAtInternet from '@ovh-ux/ng-at-internet';
 import ngAtInternetUiRouterPlugin from '@ovh-ux/ng-at-internet-ui-router-plugin';
@@ -56,7 +57,6 @@ import dedicatedCloudTerminate from './dedicatedCloud/terminate/terminate.module
 import dedicatedCloudDashboard from './dedicatedCloud/dashboard';
 import dedicatedUniverseComponents from './dedicatedUniverseComponents';
 import errorPage from './error';
-import ovhManagerPccDashboard from './dedicatedCloud/dashboard';
 import ovhManagerPccResourceUpgrade from './dedicatedCloud/resource/upgrade';
 
 import dedicatedServer from './dedicated/server';
@@ -127,7 +127,6 @@ angular
       'ovh-angular-responsive-tabs',
       'ovh-api-services',
       ovhManagerAtInternetConfiguration,
-      ovhManagerPccDashboard,
       ovhManagerIplb,
       ovhManagerPccResourceUpgrade,
       ovhManagerServerSidebar,
@@ -219,10 +218,28 @@ angular
     ssoAuthentication.login().then(() => User.getUser());
   })
   .run(
-    /* @ngInject */ ($rootScope, $state, $transitions, coreConfig) => {
+    /* @ngInject */ (
+      $location,
+      $rootScope,
+      $state,
+      $transitions,
+      coreConfig,
+    ) => {
       $rootScope.$on('$locationChangeStart', () => {
         // eslint-disable-next-line no-param-reassign
         delete $rootScope.isLeftMenuVisible;
+      });
+
+      // if query params contains unescaped '<' value then
+      // clear query params to avoid html injection
+      $transitions.onBefore({}, () => {
+        let invalidParams = false;
+        values($location.search()).forEach((param) => {
+          invalidParams = invalidParams || /</.test(param);
+        });
+        if (invalidParams) {
+          $location.search('');
+        }
       });
 
       // manage restriction on billing section for enterprise account

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/server.service.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/server.service.js
@@ -5,6 +5,7 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 import head from 'lodash/head';
 import indexOf from 'lodash/indexOf';
+import includes from 'lodash/includes';
 import map from 'lodash/map';
 import parseInt from 'lodash/parseInt';
 import set from 'lodash/set';
@@ -2139,9 +2140,10 @@ export default class ServerF {
   getSms(productId) {
     let promises = [];
 
-    if (this.coreConfig.getRegion() === 'CA') {
+    if (includes(['CA', 'US'], this.coreConfig.getRegion())) {
       return this.$q.when([]);
     }
+
     return this.get(productId, '', {
       proxypass: true,
       urlPath: this.path.sms,

--- a/packages/manager/apps/web/client/app/domain/zone/activate/activate.controller.js
+++ b/packages/manager/apps/web/client/app/domain/zone/activate/activate.controller.js
@@ -87,7 +87,7 @@ export default class DomainDnsZoneActivateController {
   checkoutOrderCart(autoPayWithPreferredPaymentMethod, cartId, isOptionFree) {
     this.checkoutLoading = true;
     this.DomainDnsZoneActivateService.checkoutOrderCart(
-      isOptionFree || autoPayWithPreferredPaymentMethod,
+      autoPayWithPreferredPaymentMethod,
       cartId,
     )
       .then((order) => {

--- a/packages/manager/modules/at-internet-configuration/package.json
+++ b/packages/manager/modules/at-internet-configuration/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/manager-config": "^0.4.0"
+    "@ovh-ux/manager-config": "^1.1.1"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^9.0.0",

--- a/packages/manager/modules/at-internet-configuration/src/index.js
+++ b/packages/manager/modules/at-internet-configuration/src/index.js
@@ -47,20 +47,24 @@ angular
       const cookie = $cookies.get(USER_ID);
       const tag = atInternet.getTag();
       if (trackingEnabled) {
-        if (cookie) {
-          tag.clientSideUserId.set(cookie);
-        } else {
-          const value = tag.clientSideUserId.get();
-          tag.clientSideUserId.store();
+        try {
+          if (cookie) {
+            tag.clientSideUserId.set(cookie);
+          } else {
+            const value = tag.clientSideUserId.get();
+            tag.clientSideUserId.store();
 
-          const element = document.getElementById('manager-tms-iframe');
+            const element = document.getElementById('manager-tms-iframe');
 
-          if (element) {
-            element.contentWindow.postMessage({
-              id: 'ClientUserId',
-              value,
-            });
+            if (element) {
+              element.contentWindow.postMessage({
+                id: 'ClientUserId',
+                value,
+              });
+            }
           }
+        } catch (e) {
+          // nothing to do.
         }
       }
     },

--- a/packages/manager/modules/at-internet-configuration/src/index.js
+++ b/packages/manager/modules/at-internet-configuration/src/index.js
@@ -33,9 +33,9 @@ angular
       atInternetUiRouterPluginProvider.addStateNameFilter((routeName) => {
         let route = routeName || '';
         atInternetConfigurationProvider.stateRules.forEach((rule) => {
-          route.replace(rule.pattern, rule.replacement);
+          route = route.replace(rule.pattern, rule.replacement);
         });
-        route = routeName.replace(/\./g, '::');
+        route = route.replace(/\./g, '::');
         return atInternetConfigurationProvider.prefix
           ? `${atInternetConfigurationProvider.prefix}::${route}`
           : route;

--- a/packages/manager/modules/notifications-sidebar/package.json
+++ b/packages/manager/modules/notifications-sidebar/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "@ovh-ux/manager-config": "^0.4.0",
+    "@ovh-ux/manager-config": "^1.1.1",
     "@ovh-ux/manager-core": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ng-at-internet": "^5.1.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",


### PR DESCRIPTION
## Web

### :bug: Bug Fixes

e8f79ea - fix(domain.zone.activate): only autopay depending on payment method (#3569)

## Dedicated

### :bug: Bug Fixes

- [x] DTRSD-11881 - fix(dedicated): escape query params (#3604)
- [x] MANAGER-5632 - fix(dedicated.server): no sms monitoring in US (#3605)

---

## Transversal

### :arrow_up: Upgrade

399fc8a - build(deps): bump @ovh-ux/manager-config to use latest (#3603)

### Module: @ovh-ux/manager-at-internet-configuration

dd658a7 - fix(at-internet): prevents errors if clientSideUserId is not available (#3608)
b62d029  - fix: assign new value for route replacement (#3582)
