### PR TITLE
fix(sidebar): order domain link for WS

### DIFF
--- a/packages/manager/modules/server-sidebar/src/order.constants.js
+++ b/packages/manager/modules/server-sidebar/src/order.constants.js
@@ -305,7 +305,7 @@ export const ORDER_URLS = {
       QC: 'https://ca.ovh.com/fr/order/domain',
       SG: 'https://ca.ovh.com/sg/order/domain',
       WE: 'https://us.ovh.com/us/order/domain',
-      WS: 'https://us.ovh.com/us/es/order/domain',
+      WS: 'https://us.ovh.com/es/order/domain',
     },
     orderHosting: {
       ASIA: 'https://www.ovh.com/asia/web-hosting/',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-17464
| License          | BSD 3-Clause

## Description

Fix order domain link for WS subsidiary.

ref: DTRSD-17464

Signed-off-by: cyril.biencourt <cyril.biencourt@ovhcloud.com>

