### PR TITLE
fix(pack.xdsl.modem): disable modem wifi config if remote config is disabled

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/pack-xdsl-modem-wifi.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/pack-xdsl-modem-wifi.html
@@ -3,7 +3,7 @@
         <div class="form-group service-item px-0">
             <a
                 class="service-button service-button-checkbox"
-                data-ng-disabled="!WifiCtrl.wifis.length || (WifiCtrl.wifis.length === 1 && (!WifiCtrl.mediator.capabilities.canChangeWLAN || WifiCtrl.mediator.tasks.changeModemConfigWLAN === true))"
+                data-ng-disabled="!WifiCtrl.mediator.info.managedByOvh || !WifiCtrl.wifis.length || (WifiCtrl.wifis.length === 1 && (!WifiCtrl.mediator.capabilities.canChangeWLAN || WifiCtrl.mediator.tasks.changeModemConfigWLAN === true))"
                 data-ui-sref="telecom.packs.pack.xdsl.line.modem.wifi"
             >
                 <div class="service-button-description">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-18862
| License          | BSD 3-Clause

## Description

disable wifi configuration if remote config is disabled
