### PR TITLE
fix(notifications-sidebar): catch notifications errors

### DIFF
--- a/packages/manager/modules/notifications-sidebar/src/controller.js
+++ b/packages/manager/modules/notifications-sidebar/src/controller.js
@@ -158,6 +158,6 @@ export default class NotificationsCtrl {
           this.NavbarNotifications.constructor.convertToSubLink(notification),
         ),
       )
-      .catch(() => undefined);
+      .catch(() => []);
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2020-w38`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix
| License          | BSD 3-Clause

## Description

Avoid `Cannot read property 'forEach' of undefined` error if notifications API call fails.