### PR TITLE
feat(xdsl.modem): add acs backend config

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/index.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+
+import '@ovh-ux/ng-ovh-telecom-universe-components';
+
+import component from './modem-acsBackend.component';
+
+const moduleName = 'ovhManagerTelecomPackXdslModemACS';
+
+angular
+  .module(moduleName, ['ngOvhTelecomUniverseComponents'])
+  .component('modemAcsBackend', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.component.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.component.js
@@ -1,0 +1,10 @@
+import controller from './modem-acsBackend.controller';
+import template from './modem-acsBackend.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    serviceName: '<',
+  },
+};

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.controller.js
@@ -1,0 +1,81 @@
+import isEmpty from 'lodash/isEmpty';
+import set from 'lodash/set';
+
+export default class XdslModemAcsBackendCtrl {
+  /* @ngInject */
+  constructor($translate, OvhApiXdsl, TucPackXdslModemMediator, TucToast) {
+    this.$translate = $translate;
+    this.OvhApiXdsl = OvhApiXdsl;
+    this.mediator = TucPackXdslModemMediator;
+    this.TucToast = TucToast;
+  }
+
+  $onInit() {
+    return this.getAvailableAcsBackend();
+  }
+
+  getAvailableAcsBackend() {
+    return this.OvhApiXdsl.Modem()
+      .AvailableACSBackend()
+      .v6()
+      .get({ xdslId: this.serviceName })
+      .$promise.then((result) => {
+        this.availableAcsList = result;
+        this.acsBackendTmp = this.mediator.info.acsBackend;
+        this.acsBackend = this.acsBackendTmp;
+        return result;
+      })
+      .catch(() => {
+        this.availableAcsList = [this.mediator.info.acsBackend];
+      });
+  }
+
+  undo() {
+    set(this.mediator, 'info.acsBackend', !this.acsBackend);
+  }
+
+  changeAcsBackend() {
+    if (
+      isEmpty(this.serviceName) ||
+      !this.acsBackendTmp ||
+      !this.mediator.capabilities.canChangeACS
+    ) {
+      this.acsBackendTmp = this.acsBackend;
+      this.TucToast.error(
+        this.$translate.instant('xdsl_modem_acs_an_error_ocurred'),
+      );
+      return this.$q.reject();
+    }
+    this.loading = true;
+    return this.OvhApiXdsl.Modem()
+      .v6()
+      .update(
+        {
+          xdslId: this.serviceName,
+        },
+        {
+          acsBackend: this.acsBackendTmp,
+        },
+      )
+      .$promise.then((data) => {
+        this.mediator.disableCapabilities();
+        this.mediator.setTask('changeACSBackend');
+        this.acsBackend = this.acsBackendTmp;
+        this.TucToast.success(
+          this.$translate.instant('xdsl_modem_acs_backend_doing'),
+        );
+        return data;
+      })
+      .catch((err) => {
+        this.acsBackendTmp = this.acsBackend;
+        this.undo();
+        this.TucToast.error(
+          this.$translate.instant('xdsl_modem_acs_backend_an_error_ocurred'),
+        );
+        return this.$q.reject(err);
+      })
+      .finally(() => {
+        this.loading = false;
+      });
+  }
+}

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/modem-acsBackend.html
@@ -1,0 +1,27 @@
+<form name="acsBackendForm" data-ng-submit="$ctrl.changeAcsBackend()">
+    <div class="form-group">
+        <select
+            class="form-control"
+            name="configAcsBackend"
+            id="configAcsBackend"
+            data-ng-model="$ctrl.acsBackendTmp"
+            data-ng-options="acs for acs in $ctrl.availableAcsList"
+            data-ng-disabled="!$ctrl.mediator.capabilities.canChangeACS || $ctrl.mediator.tasks.changeACSBackend || $ctrl.loading"
+        >
+        </select>
+    </div>
+    <button
+        class="oui-button oui-button_primary mt-1"
+        type="submit"
+        data-ng-disabled="!$ctrl.mediator.capabilities.canChangeACS || $ctrl.acsBackend === $ctrl.acsBackendTmp"
+    >
+        <span data-ng-if="$ctrl.mediator.tasks.changeACSBackend">
+            <oui-spinner class="mr-2" data-size="s"> </oui-spinner>
+            <span data-translate="xdsl_modem_acs_backend_doing"></span>
+        </span>
+        <span
+            data-ng-if="!$ctrl.mediator.tasks.changeACSBackend"
+            data-translate="xdsl_modem_acs_backend_submit"
+        ></span>
+    </button>
+</form>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/acsBackend/translations/Messages_fr_FR.json
@@ -1,0 +1,6 @@
+{
+  "xdsl_modem_acs_backend_description": "La modification de la valeur du backend de l'ACS est réservée à un usage avancé.",
+  "xdsl_modem_acs_backend_doing": "Modification de la version du backend de l'ACS en cours",
+  "xdsl_modem_acs_backend_submit": "Valider",
+  "xdsl_modem_acs_an_error_ocurred": "Backend ACS : Une erreur est survenue !"
+}

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
@@ -5,11 +5,12 @@ import '@ovh-ux/ng-ovh-telecom-universe-components';
 import component from './pack-xdsl-modem.component';
 import { PACK_XDSL_MODEM } from './pack-xdsl-modem.constant';
 import routing from './pack-xdsl-modem.routing';
+import acsBackend from './acsBackend';
 
 const moduleName = 'ovhManagerTelecomPackXdslModem';
 
 angular
-  .module(moduleName, ['ngOvhTelecomUniverseComponents'])
+  .module(moduleName, ['ngOvhTelecomUniverseComponents', acsBackend])
   .component('packXdslModem', component)
   .config(routing)
   .constant('PACK_XDSL_MODEM', PACK_XDSL_MODEM)

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/pack-xdsl-modem.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/pack-xdsl-modem.html
@@ -204,6 +204,20 @@
                 </div>
             </section>
         </div>
+        <div
+            class="my-3"
+            data-ng-class="{ 'disabled' : !$ctrl.mediator.capabilities.canChangeACS || $ctrl.mediator.tasks.changeModemConfigACS }"
+        >
+            <label
+                data-oui-tooltip="{{:: 'xdsl_modem_acs_backend_description' | translate}}"
+                data-translate="xdsl_modem_acs_backend"
+                oui-tooltip-placement="top-start"
+            >
+            </label>
+            <modem-acs-backend
+                service-name="$ctrl.serviceName"
+            ></modem-acs-backend>
+        </div>
     </div>
 
     <div data-ui-view="serviceView"></div>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/translations/Messages_fr_FR.json
@@ -16,5 +16,6 @@
   "xdsl_model_access_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre pack.",
   "xdsl_model_task_error": "Oups ! Nous n'avons pas pu récupérer la pile de tâches en cours.",
   "xdsl_modem_modem_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre modem.",
-  "xdsl_modem_firmware": "Firmware"
+  "xdsl_modem_firmware": "Firmware",
+  "xdsl_modem_acs_backend": "Backend ACS"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-278
| License          | BSD 3-Clause

## Description

Add ACS backend configuration into modem tab
