### PR TITLE
fix(new): get newSupportTicketLink service asynchronously

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/routing.js
+++ b/packages/manager/modules/pci/src/projects/new/routing.js
@@ -27,7 +27,7 @@ export default /* @ngInject */ ($stateProvider) => {
       const eligibilityPromise = transition.injector().getAsync('eligibility');
       const newSupportTicketLink = transition
         .injector()
-        .get('newSupportTicketLink');
+        .getAsync('newSupportTicketLink');
       return Promise.all([
         translatePromise,
         windowPromise,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-21027
| License          | BSD 3-Clause

## Description

When accessing to the state `pci.projects.new` we got the following error message:
```txt
message: "Resolvable async .get() not complete:\"newSupportTicketLink\""
```

### :ambulance: Hotfix

44aed30 - fix(new): get newSupportTicketLink service asynchronously

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
