### PR TITLE
fix(dedicated): replace billing payments apiv7 calls with iceberg

### DIFF
--- a/packages/manager/modules/billing/src/main/payments/details/billing-payments-details.controller.js
+++ b/packages/manager/modules/billing/src/main/payments/details/billing-payments-details.controller.js
@@ -1,34 +1,41 @@
-export default /* @ngInject */ function BillingPaymentDetailsCtrl(
-  $q,
-  $state,
-  $stateParams,
-  $translate,
-  Alerter,
-  BillingPayments,
-) {
-  this.paymentId = $stateParams.id;
-  this.payment = {};
+export default class BillingPaymentDetailsCtrl {
+  /* @ngInject */
+  constructor($q, $state, $stateParams, $translate, Alerter, BillingPayments) {
+    this.$q = $q;
+    this.$state = $state;
+    this.$translate = $translate;
+    this.Alerter = Alerter;
+    this.BillingPayments = BillingPayments;
+    this.paymentId = $stateParams.id;
+    this.payment = {};
+  }
 
-  this.loadBills = ({ offset, pageSize }) =>
-    BillingPayments.getBillsIds($stateParams.id).then((ids) => ({
-      data: ids.slice(offset - 1, offset - 1 + pageSize).map((id) => ({ id })),
-      meta: {
-        totalCount: ids.length,
-      },
-    }));
-
-  this.loadDetails = ({ id }) =>
-    BillingPayments.getBillDetails($stateParams.id, id);
-
-  this.paymentsHref = () => $state.href('app.account.billing.main.payments');
-
-  this.$onInit = () =>
-    BillingPayments.getPayment($stateParams.id)
+  $onInit() {
+    return this.BillingPayments.getPayment(this.paymentId)
       .then((payment) => {
         this.payment = payment;
       })
       .catch((err) => {
-        Alerter.alertFromSWS($translate.instant('payments_error'), err.data);
-        return $q.reject(err);
+        this.Alerter.alertFromSWS(
+          this.$translate.instant('payments_error'),
+          err.data,
+        );
+        return this.$q.reject(err);
       });
+  }
+
+  loadBills({ offset, pageSize }) {
+    return this.BillingPayments.getBills(this.paymentId, {
+      offset,
+      pageSize,
+    });
+  }
+
+  loadDetails(bill) {
+    return this.BillingPayments.getBillDetails(this.paymentId, bill);
+  }
+
+  paymentsHref() {
+    return this.$state.href('app.account.billing.main.payments');
+  }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/kill-apiv7`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-5631
| License          | BSD 3-Clause

## Description

Replace billing payments calls (list & details) apiv7 calls with iceberg

I have also moved from `function` to `class`(with `@ngInject`) but don't refactor the modules/component lifecycles.


