### PR TITLE
fix(telephony.ccs.timecondition): prevent overflow hidden on dropdown

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/timeCondition/telecom-telephony-alias-configuration-time-condition.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/timeCondition/telecom-telephony-alias-configuration-time-condition.html
@@ -60,39 +60,33 @@
             data-translate="telephony_alias_config_contactCenterSolution_timeCondition_time_configuration_subtitle"
         ></p>
 
-        <div class="oui-button-group">
-            <oui-dropdown class="mr-3">
-                <oui-dropdown-trigger
-                    aria-label="{{:: 'common_actions' | translate }}"
-                    data-text="{{:: 'common_actions' | translate }}"
-                >
-                </oui-dropdown-trigger>
-                <oui-dropdown-content>
-                    <oui-dropdown-item
-                        data-on-click="$ctrl.exportConfiguration()"
-                    >
-                        <span
-                            data-translate="telephony_common_time_condition_export_configuration"
-                        ></span>
-                    </oui-dropdown-item>
-                    <oui-dropdown-item
-                        data-on-click="$ctrl.importConfiguration()"
-                    >
-                        <span
-                            data-translate="telephony_common_time_condition_import_configuration"
-                        ></span>
-                    </oui-dropdown-item>
-                </oui-dropdown-content>
-            </oui-dropdown>
-            <oui-button
-                data-variant="secondary"
-                data-on-click="$ctrl.manageScheduler()"
+        <oui-dropdown class="mr-3">
+            <oui-dropdown-trigger
+                aria-label="{{:: 'common_actions' | translate }}"
+                data-text="{{:: 'common_actions' | translate }}"
             >
-                <span
-                    data-translate="telephony_alias_config_contactCenterSolution_timeCondition_scheduler"
-                ></span>
-            </oui-button>
-        </div>
+            </oui-dropdown-trigger>
+            <oui-dropdown-content>
+                <oui-dropdown-item data-on-click="$ctrl.exportConfiguration()">
+                    <span
+                        data-translate="telephony_common_time_condition_export_configuration"
+                    ></span>
+                </oui-dropdown-item>
+                <oui-dropdown-item data-on-click="$ctrl.importConfiguration()">
+                    <span
+                        data-translate="telephony_common_time_condition_import_configuration"
+                    ></span>
+                </oui-dropdown-item>
+            </oui-dropdown-content>
+        </oui-dropdown>
+        <oui-button
+            data-variant="secondary"
+            data-on-click="$ctrl.manageScheduler()"
+        >
+            <span
+                data-translate="telephony_alias_config_contactCenterSolution_timeCondition_scheduler"
+            ></span>
+        </oui-button>
 
         <div class="my-5">
             <!-- CONDITIONS -->

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/telephony-scheduler.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/telephony-scheduler.less
@@ -66,7 +66,7 @@
 
 .telephony-scheduler-time-condition-slots {
   .telephony-time-condition-slot .legend-color.unavailable {
-    background-color: #bbbdbf;
+    background-color: white;
     border: 1px solid #999;
   }
 }

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/timeCondition/telephony-time-condition.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/timeCondition/telephony-time-condition.less
@@ -28,7 +28,7 @@
     }
 
     &.unavailable {
-      background-color: #bbbdbf;
+      background-color: white;
       border: solid 1px #999;
     }
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-21298
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

82efab8 - fix(telephony.ccs.timecondition): prevent overflow hidden on dropdown

Class `oui-button-group` causes issue to the dropdown element so it has
been removed.

9f2085d - fix(telephony): update color for both scheduler and timeCondition

The table body now turns into a white background color so to match
unavailable elements we use the same color (white).

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
