### PR TITLE
fix(network): open when loading vrack or cloud-connect

### DIFF
--- a/packages/manager/modules/server-sidebar/src/sidebar.constants.js
+++ b/packages/manager/modules/server-sidebar/src/sidebar.constants.js
@@ -285,6 +285,7 @@ export const DEDICATED_NETWORK_CONFIG = {
   app: [DEDICATED],
   regions: ['EU', 'CA', 'US'],
   icon: 'oui-icon oui-icon-bandwidth_concept',
+  loadOnState: ['vrack', 'cloud-connect'],
   children: [
     {
       id: 'vrack',


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/ovh-cloud-connect`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Open `network` sidebar item when reaching a `vrack` or `cloud-connect` service.



