### PR TITLE
fix(xdsl.move): fix the move out date calendar to start to date + 1

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/move-eligibility.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/move-eligibility.controller.js
@@ -9,7 +9,9 @@ export default class MoveEligibilityCtrl {
 
   $onInit() {
     this.displayEligibility = false;
-    this.minDate = moment().format('YYYY-MM-DD');
+    this.minDate = moment()
+      .add(1, 'day')
+      .format('YYYY-MM-DD');
     this.maxDate = moment()
       .add(30, 'day')
       .format('YYYY-MM-DD');


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-324
| License          | BSD 3-Clause

## Description

Set the start date into the calendar component, for move out date, to today date + 1 day, to start to the day after.
