### PR TITLE
fix(cloud-connect): avoid unwanted errors in lock and unlock

### DIFF
--- a/packages/manager/modules/cloud-connect/src/details/overview/edit-description/template.html
+++ b/packages/manager/modules/cloud-connect/src/details/overview/edit-description/template.html
@@ -7,7 +7,6 @@
     <oui-modal
         data-on-dismiss="$ctrl.goBack()"
         data-primary-label="{{:: 'cloud_connect_common_confirm' | translate}}"
-        data-primary-action="$ctrl.confirm()"
         data-secondary-action="$ctrl.goBack()"
         data-secondary-label="{{:: 'cloud_connect_common_cancel' | translate}}"
         data-loading="$ctrl.isLoading"

--- a/packages/manager/modules/cloud-connect/src/details/overview/lock-port/lock-port.controller.js
+++ b/packages/manager/modules/cloud-connect/src/details/overview/lock-port/lock-port.controller.js
@@ -2,7 +2,8 @@ import get from 'lodash/get';
 
 export default class LockPortCtrl {
   /* @ngInject */
-  constructor($translate, cloudConnectService) {
+  constructor($q, $translate, cloudConnectService) {
+    this.$q = $q;
     this.$translate = $translate;
     this.cloudConnectService = cloudConnectService;
   }
@@ -16,11 +17,11 @@ export default class LockPortCtrl {
       'cloud-connect::overview::lock-port::confirm',
     );
     this.isLoading = true;
-    this.cloudConnectService
+    return this.cloudConnectService
       .lockInterface(this.cloudConnect.id, this.interfaceId)
       .then((task) => {
         this.interface.setDisabling(true);
-        this.goBack(
+        return this.goBack(
           {
             textHtml: this.$translate.instant(
               'cloud_connect_pop_block_port_success',
@@ -34,7 +35,7 @@ export default class LockPortCtrl {
           false,
         ).then(() => {
           if (task) {
-            this.cloudConnectService
+            return this.cloudConnectService
               .checkTaskStatus(this.cloudConnect.id, task.id)
               .finally(() => {
                 const cloudConnectInterface = this.cloudConnect.getInterface(
@@ -43,6 +44,7 @@ export default class LockPortCtrl {
                 cloudConnectInterface.disable();
               });
           }
+          return this.$q.resolve();
         });
       })
       .catch((error) =>

--- a/packages/manager/modules/cloud-connect/src/details/overview/overview.routing.js
+++ b/packages/manager/modules/cloud-connect/src/details/overview/overview.routing.js
@@ -80,9 +80,9 @@ export default /* @ngInject */ ($stateProvider) => {
           ovhCloudConnectId: cloudConnect.id,
         }),
       goToCloudConnectPage: /* @ngInject */ (
+        $q,
         $state,
         $translate,
-        $timeout,
         CucCloudMessage,
         CucControllerHelper,
         cloudConnectId,
@@ -90,9 +90,8 @@ export default /* @ngInject */ ($stateProvider) => {
       ) => (message = false, type = 'success', reload = false, vrackId) => {
         const state = 'cloud-connect.details.overview';
 
-        let promise = null;
-        $timeout(function() {
-          promise = $state.go(
+        return $state
+          .go(
             state,
             {
               ovhCloudConnectId: cloudConnectId,
@@ -100,14 +99,14 @@ export default /* @ngInject */ ($stateProvider) => {
             {
               reload,
             },
-          );
-          promise.then(() => {
+          )
+          .then(() => {
             if (message) {
               CucCloudMessage[type](message, state);
               CucControllerHelper.scrollPageToTop();
             }
             if (vrackId) {
-              cloudConnectService
+              return cloudConnectService
                 .getVrackAssociatedCloudConnect(vrackId)
                 .then((res) => {
                   if (res) {
@@ -120,9 +119,8 @@ export default /* @ngInject */ ($stateProvider) => {
                   }
                 });
             }
+            return $q.resolve();
           });
-        });
-        return promise;
       },
     },
   });

--- a/packages/manager/modules/cloud-connect/src/details/overview/unlock-port/unlock-port.controller.js
+++ b/packages/manager/modules/cloud-connect/src/details/overview/unlock-port/unlock-port.controller.js
@@ -2,7 +2,8 @@ import get from 'lodash/get';
 
 export default class UnlockPortCtrl {
   /* @ngInject */
-  constructor($translate, cloudConnectService) {
+  constructor($q, $translate, cloudConnectService) {
+    this.$q = $q;
     this.$translate = $translate;
     this.cloudConnectService = cloudConnectService;
   }
@@ -16,11 +17,11 @@ export default class UnlockPortCtrl {
       'cloud-connect::overview::unlock-port::confirm',
     );
     this.isLoading = true;
-    this.cloudConnectService
+    return this.cloudConnectService
       .unlockInterface(this.cloudConnect.id, this.interfaceId)
       .then((task) => {
         this.interface.setEnabling(true);
-        this.goBack(
+        return this.goBack(
           {
             textHtml: this.$translate.instant(
               'cloud_connect_pop_unblock_port_success',
@@ -34,7 +35,7 @@ export default class UnlockPortCtrl {
           false,
         ).then(() => {
           if (task) {
-            this.cloudConnectService
+            return this.cloudConnectService
               .checkTaskStatus(this.cloudConnect.id, task.id)
               .finally(() => {
                 const cloudConnectInterface = this.cloudConnect.getInterface(
@@ -43,6 +44,7 @@ export default class UnlockPortCtrl {
                 cloudConnectInterface.enable();
               });
           }
+          return this.$q.resolve();
         });
       })
       .catch((error) =>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/ovh-cloud-connect`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-5674
| License          | BSD 3-Clause

## Description

Fix `goToCloudConnectPage` resolve and promises chaining to avoid errors like `Unable to unblock port: Cannot read property 'then' of null` or `Unable to unblock port: e.goBack(...) is null`
