### PR TITLE
Feat/sms campaign hlr templates

### DIFF
--- a/packages/manager/modules/sms/src/sms/sms/hlr/index.js
+++ b/packages/manager/modules/sms/src/sms/sms/hlr/index.js
@@ -14,6 +14,10 @@ angular.module(moduleName, []).config(($stateProvider) => {
         controllerAs: 'SmsHlrCtrl',
       },
     },
+    resolve: {
+      goBack: /* @ngInject */ ($state, $transition$) => () =>
+        $state.go($transition$.from().name || '^'),
+    },
     translations: {
       value: ['../../dashboard', '.'],
       format: 'json',

--- a/packages/manager/modules/sms/src/sms/sms/hlr/telecom-sms-sms-hlr.controller.js
+++ b/packages/manager/modules/sms/src/sms/sms/hlr/telecom-sms-sms-hlr.controller.js
@@ -9,6 +9,7 @@ export default class {
     $stateParams,
     $q,
     $translate,
+    goBack,
     OvhApiSms,
     TucSmsMediator,
     tucValidator,
@@ -24,6 +25,7 @@ export default class {
         hlr: OvhApiSms.Hlr().v6(),
       },
     };
+    this.goBack = goBack;
     this.TucSmsMediator = TucSmsMediator;
     this.validator = tucValidator;
     this.TucToast = TucToast;

--- a/packages/manager/modules/sms/src/sms/sms/hlr/telecom-sms-sms-hlr.html
+++ b/packages/manager/modules/sms/src/sms/sms/hlr/telecom-sms-sms-hlr.html
@@ -1,11 +1,8 @@
 <section class="telecom-sms-sms-hlr">
     <header>
-        <tuc-section-back-link
-            data-tuc-section-back-link-to-state="sms.service.sms"
-            data-tuc-section-back-link-title="{{ 'sms_section_back_link' | translate }}"
-        >
-        </tuc-section-back-link>
-        <h1 data-translate="sms_sms_hlr_title"></h1>
+        <oui-back-button on-click="SmsHlrCtrl.goBack()">
+            <span data-translate="sms_sms_hlr_title"></span>
+        </oui-back-button>
     </header>
 
     <div class="telecom-section-content">

--- a/packages/manager/modules/sms/src/sms/sms/templates/index.js
+++ b/packages/manager/modules/sms/src/sms/sms/templates/index.js
@@ -15,6 +15,10 @@ angular.module(moduleName, []).config(($stateProvider) => {
         controllerAs: '$ctrl',
       },
     },
+    resolve: {
+      goBack: /* @ngInject */ ($state, $transition$) => () =>
+        $state.go($transition$.from().name || '^'),
+    },
     translations: { value: ['.'], format: 'json' },
   });
 });

--- a/packages/manager/modules/sms/src/sms/sms/templates/telecom-sms-sms-templates.controller.js
+++ b/packages/manager/modules/sms/src/sms/sms/templates/telecom-sms-sms-templates.controller.js
@@ -17,6 +17,7 @@ export default class {
     $translate,
     $stateParams,
     $uibModal,
+    goBack,
     OvhApiSms,
     TucSmsMediator,
     TucToast,
@@ -31,6 +32,7 @@ export default class {
         templates: OvhApiSms.Templates().v6(),
       },
     };
+    this.goBack = goBack;
     this.TucSmsMediator = TucSmsMediator;
     this.TucToast = TucToast;
     this.TucToastError = TucToastError;

--- a/packages/manager/modules/sms/src/sms/sms/templates/telecom-sms-sms-templates.html
+++ b/packages/manager/modules/sms/src/sms/sms/templates/telecom-sms-sms-templates.html
@@ -1,11 +1,8 @@
 <section class="telecom-sms-sms-templates">
     <header>
-        <tuc-section-back-link
-            data-tuc-section-back-link-to-state="sms.service.sms"
-            data-tuc-section-back-link-title="{{ 'sms_section_back_link' | translate }}"
-        >
-        </tuc-section-back-link>
-        <h1 data-translate="sms_sms_templates_title"></h1>
+        <oui-back-button on-click="$ctrl.goBack()">
+            <span data-translate="sms_sms_templates_title"></span>
+        </oui-back-button>
     </header>
 
     <!-- LOADING -->


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/sms-campaign`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-5201
| License          | BSD 3-Clause

## Description

Set go back method to be used through campaign portal, for HLR and templates page
