### PR TITLE
Fix PCC certificates visibility

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/dashboard/tiles/options/options.html
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/dashboard/tiles/options/options.html
@@ -116,7 +116,7 @@
         </oui-tile-definition>
 
         <oui-tile-definition
-            data-ng-if=":: $ctrl.bindings.options.certification.exists && $ctrl.canManagerSectorSpecificCompliance"
+            data-ng-if=":: $ctrl.bindings.options.certification.exists && $ctrl.canManageSectorSpecificCompliance"
             data-term="{{:: 'ovhManagerPccDashboardOptions_certification_term' | translate }}"
         >
             <oui-tile-description>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-21508
| License          | BSD 3-Clause

## Description

There was a typo on the variable being used in the html file, to control the visibility of the certificates. This has been fixed
