### PR TITLE
fix(billing): billing auto renew page is not loading

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/autoRenew/agreements/popup-agreement/popup-agreement.module.js
+++ b/packages/manager/apps/dedicated/client/app/billing/autoRenew/agreements/popup-agreement/popup-agreement.module.js
@@ -7,7 +7,7 @@ import '@ovh-ux/ui-kit';
 import component from './popup-agreement.component';
 import routing from './popup-agreement.routes';
 
-const moduleName = 'ovhManagerBillingAutorenewActivation';
+const moduleName = 'ovhManagerBillingAutorenewPopupAgreement';
 
 angular
   .module(moduleName, [
@@ -18,6 +18,6 @@ angular
     atInternet,
   ])
   .config(routing)
-  .component('billingAutorenewActivation', component);
+  .component('billingAutorenewPopupAgreement', component);
 
 export default moduleName;

--- a/packages/manager/apps/dedicated/client/app/billing/autoRenew/agreements/popup-agreement/popup-agreement.routes.js
+++ b/packages/manager/apps/dedicated/client/app/billing/autoRenew/agreements/popup-agreement/popup-agreement.routes.js
@@ -7,7 +7,7 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/popup-agreement',
       views: {
         modal: {
-          component: 'billingAutorenewActivation',
+          component: 'billingAutorenewPopupAgreement',
         },
       },
       params: {


### PR DESCRIPTION
closes #DTRSD-21243

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-21243
| License          | BSD 3-Clause

## Description

The billing auto-renew page is not loading because two modules, including auto-renew, had the same module name. "popup-agreement" module used the same name as the auto-renew module. May a copy-paste mistake. I have changed the module name.
