### PR TITLE
fix(vps): not able to order vps options

### DIFF
--- a/packages/manager/modules/vps/src/additional-disk/order/vps-order-additional-disk-order.controller.js
+++ b/packages/manager/modules/vps/src/additional-disk/order/vps-order-additional-disk-order.controller.js
@@ -57,12 +57,15 @@ export default class VpsOrderDiskCtrl {
       this.coreConfig.getRegion(),
       this.connectedUser.ovhSubsidiary,
     ]);
+    const priceOptions = find(this.model.disk.prices, {
+      duration: 'P1M',
+    });
     const expressParams = {
       productId: 'vps',
       serviceName: this.stateVps.name,
       planCode: this.model.disk.planCode,
-      duration: 'P1M',
-      pricingMode: 'default',
+      duration: priceOptions.duration,
+      pricingMode: priceOptions.pricingMode,
       quantity: 1,
     };
     expressOrderUrl = `${expressOrderUrl}?products=${JSURL.stringify([

--- a/packages/manager/modules/vps/src/backup-storage/order/vps-backup-storage-order.controller.js
+++ b/packages/manager/modules/vps/src/backup-storage/order/vps-backup-storage-order.controller.js
@@ -52,12 +52,15 @@ export default class VpsBackupStorageOrderCtrl {
       this.coreConfig.getRegion(),
       this.connectedUser.ovhSubsidiary,
     ]);
+    const priceOptions = find(this.ftpBackupOption.prices, {
+      duration: 'P1M',
+    });
     const expressParams = {
       productId: 'vps',
       serviceName: this.stateVps.name,
       planCode: this.ftpBackupOption.planCode,
-      duration: 'P1M',
-      pricingMode: 'default',
+      duration: priceOptions.duration,
+      pricingMode: priceOptions.pricingMode,
       quantity: 1,
     };
     expressOrderUrl = `${expressOrderUrl}?products=${JSURL.stringify([

--- a/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.controller.js
+++ b/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.controller.js
@@ -27,7 +27,7 @@ export default class VpsSnapshotOrderCtrl {
 
     // other attributes used in view
     this.snapshotOption = null;
-    this.getSnapshotMonthlyPrice = VpsSnapshotOrderCtrl.getSnapshotMonthlyPrice;
+    this.snapshotMonthlyPrice = null;
     this.hasInitError = false;
 
     this.loading = {
@@ -35,11 +35,8 @@ export default class VpsSnapshotOrderCtrl {
     };
   }
 
-  static getSnapshotMonthlyPrice(snapshot) {
-    const price = find(snapshot.prices, {
-      duration: 'P1M',
-    });
-    return get(price, 'price');
+  getSnapshotMonthlyPrice() {
+    return get(this.snapshotMonthlyPrice, 'price');
   }
 
   /* =============================
@@ -55,8 +52,8 @@ export default class VpsSnapshotOrderCtrl {
       productId: 'vps',
       serviceName: this.stateVps.name,
       planCode: this.snapshotOption.planCode,
-      duration: 'P1M',
-      pricingMode: 'default',
+      duration: this.snapshotMonthlyPrice.duration,
+      pricingMode: this.snapshotMonthlyPrice.pricingMode,
       quantity: 1,
     };
     expressOrderUrl = `${expressOrderUrl}?products=${JSURL.stringify([
@@ -109,7 +106,9 @@ export default class VpsSnapshotOrderCtrl {
             },
           });
         }
-
+        this.snapshotMonthlyPrice = find(this.snapshotOption.prices, {
+          duration: 'P1M',
+        });
         return this.snapshotOption;
       })
       .catch((error) => {

--- a/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.html
+++ b/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.html
@@ -20,7 +20,7 @@
                 >
                     <p
                         data-translate="vps_configuration_activate_snapshot_step1_alert"
-                        data-translate-values="{ amount: $ctrl.getSnapshotMonthlyPrice($ctrl.snapshotOption).text }"
+                        data-translate-values="{ amount: $ctrl.getSnapshotMonthlyPrice().text }"
                     ></p>
 
                     <p

--- a/packages/manager/modules/vps/src/veeam/order/vps-veeam-order.controller.js
+++ b/packages/manager/modules/vps/src/veeam/order/vps-veeam-order.controller.js
@@ -51,12 +51,15 @@ export default class VpsVeeamOrderCtrl {
       this.coreConfig.getRegion(),
       this.connectedUser.ovhSubsidiary,
     ]);
+    const priceOptions = find(this.veeamOption.prices, {
+      duration: 'P1M',
+    });
     const expressParams = {
       productId: 'vps',
       serviceName: this.stateVps.name,
       planCode: this.veeamOption.planCode,
-      duration: 'P1M',
-      pricingMode: 'default',
+      duration: priceOptions.duration,
+      pricingMode: priceOptions.pricingMode,
       quantity: 1,
     };
     expressOrderUrl = `${expressOrderUrl}?products=${JSURL.stringify([

--- a/packages/manager/modules/vps/src/windows/order/vps-windows-order.controller.js
+++ b/packages/manager/modules/vps/src/windows/order/vps-windows-order.controller.js
@@ -51,12 +51,15 @@ export default class VpsWindowsOrderCtrl {
       this.coreConfig.getRegion(),
       this.connectedUser.ovhSubsidiary,
     ]);
+    const priceOptions = find(this.windowsOption.prices, {
+      duration: 'P1M',
+    });
     const expressParams = {
       productId: 'vps',
       serviceName: this.stateVps.name,
       planCode: this.windowsOption.planCode,
-      duration: 'P1M',
-      pricingMode: 'default',
+      duration: priceOptions.duration,
+      pricingMode: priceOptions.pricingMode,
       quantity: 1,
     };
     expressOrderUrl = `${expressOrderUrl}?products=${JSURL.stringify([


### PR DESCRIPTION
not able to order vps options for vps which has non default payment method

closes #DTRSD-21356

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | Fix #DTRSD-21356
| License          | BSD 3-Clause

## Description

The manager is hardcoding default payment mode while ordering VPS options. Because of this option order for VPS which has non-default payment mode is failing. I have changed this to use the same payment mode that of VPS while ordering options.
