### PR TITLE
fix(plugins.uirouter): check if item key is defined

### DIFF
--- a/packages/manager/tools/component-rollup-config/src/plugins/translation-ui-router.ts
+++ b/packages/manager/tools/component-rollup-config/src/plugins/translation-ui-router.ts
@@ -51,7 +51,7 @@ export = (opts: any = {}) => {
               props.filter(
                 (item) =>
                   item &&
-                  item.key.name === 'translations' &&
+                  item.key?.name === 'translations' &&
                   item.type === 'Property',
               )[0];
 


### PR DESCRIPTION
Signed-off-by: Marie JONES <marie.jones@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          |`develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

Check if item is defined as this can cause issue when introducing spread operator in state declaration
