### PR TITLE
fix(telephony.line.management.terminate): add missing terminate info

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/terminate/telecom-telephony-line-management-terminate.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/terminate/telecom-telephony-line-management-terminate.html
@@ -33,6 +33,9 @@
                     <p
                         data-translate="telephony_group_line_terminate_info_4"
                     ></p>
+                    <p
+                        data-translate="telephony_group_line_terminate_info_5"
+                    ></p>
                     <div class="oui-box">
                         <address class="d-flex mb-0">
                             <i

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/terminate/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/terminate/translations/Messages_fr_FR.json
@@ -5,6 +5,7 @@
   "telephony_group_line_terminate_info_2": "Les demandes de résiliation seront prises en compte lors de votre prochaine facturation. Jusqu'à cette date, l'annulation de la demande restera possible.",
   "telephony_group_line_terminate_info_3": "Procédure de retour matériel : ",
   "telephony_group_line_terminate_info_4": "Vous nous retournez l'ancien matériel dans un délai de 15 jours après la résiliation effective de votre ligne. La caution vous est restituée sous 10 jours après réception de l'équipement.",
+  "telephony_group_line_terminate_info_5": "Vous recevrez par e-mail le bon de retour à joindre au matériel.",
   "telephony_group_line_terminate_back_address": "Adresse de retour : ",
   "telephony_group_line_terminate_address_name": "OVH SAS",
   "telephony_group_line_terminate_address_service": "Service Après Vente",


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5759
| License          | BSD 3-Clause

adding a text to inform the customer about a document to send with a resiliated phone
