### PR TITLE
fix(locale): add missing cs_CZ entry

### DIFF
--- a/packages/manager/modules/config/src/environment/environment.service.js
+++ b/packages/manager/modules/config/src/environment/environment.service.js
@@ -24,7 +24,11 @@ export default class EnvironmentService {
   }
 
   setUserLocale(userLocale) {
-    const locale = findAvailableLocale(userLocale, this.getRegion());
+    // TODO(@antleblanc): Remove it on February 4th, 2021.
+    const locale =
+      userLocale === 'cs_CZ'
+        ? userLocale
+        : findAvailableLocale(userLocale, this.getRegion());
     saveUserLocale(locale);
     this.userLocale = locale;
   }

--- a/packages/manager/modules/config/src/index.js
+++ b/packages/manager/modules/config/src/index.js
@@ -6,7 +6,10 @@ import {
   findLanguage as _findLanguage,
 } from './locale';
 
-import { LANGUAGES as _LANGUAGES } from './locale/locale.constants';
+import {
+  LANGUAGES as _LANGUAGES,
+  localeStorageKey as _localeStorageKey,
+} from './locale/locale.constants';
 
 export const Environment = _Environment;
 
@@ -14,6 +17,7 @@ export const convertLanguageFromOVHToBCP47 = _convertLanguageFromOVHToBCP47;
 export const detectUserLocale = _detectUserLocale;
 export const findLanguage = _findLanguage;
 export const LANGUAGES = _LANGUAGES;
+export const localeStorageKey = _localeStorageKey;
 
 export default {
   convertLanguageFromOVHToBCP47,
@@ -21,4 +25,5 @@ export default {
   detectUserLocale,
   findLanguage,
   LANGUAGES,
+  localeStorageKey, // TODO(@antleblanc): Remove it on February 4th, 2021.
 };

--- a/packages/manager/modules/config/src/locale/index.js
+++ b/packages/manager/modules/config/src/locale/index.js
@@ -52,7 +52,7 @@ export const findAvailableLocale = (userLocale, region) => {
   // Since following locales has been removed from the language menu picker
   // from the navbar we want to avoid to redirect customer to the default one
   // which is `fr_FR` by design.
-  if (['fi', 'nl'].includes(language)) {
+  if (['cs', 'nl'].includes(language)) {
     return findAvailableLocale('en_GB');
   }
   return findLanguage(language, country);

--- a/packages/manager/modules/config/src/locale/locale.constants.js
+++ b/packages/manager/modules/config/src/locale/locale.constants.js
@@ -36,6 +36,14 @@ export const LANGUAGES = {
       name: 'Português',
       key: 'pt_PT',
     },
+    {
+      name: 'Suomi',
+      key: 'fi_FI',
+    },
+    {
+      name: 'Česky',
+      key: 'cs_CZ',
+    },
   ],
   defaultLoc: 'fr_FR',
   fallback: 'fr_FR',

--- a/packages/manager/modules/navbar/src/language-menu/controller.js
+++ b/packages/manager/modules/navbar/src/language-menu/controller.js
@@ -6,7 +6,11 @@ import map from 'lodash/map';
 import union from 'lodash/union';
 import words from 'lodash/words';
 
-import { Environment, LANGUAGES } from '@ovh-ux/manager-config';
+import {
+  Environment,
+  LANGUAGES,
+  localeStorageKey,
+} from '@ovh-ux/manager-config';
 
 import { LANG_PATTERN } from './constants';
 
@@ -33,6 +37,11 @@ export default class {
   }
 
   getCurrentLang() {
+    // TODO(@antleblanc): Remove it on February 4th, 2021.
+    if (localStorage[localeStorageKey] === 'cs_CZ') {
+      return this.availableLangs.find(({ key }) => key === 'cs_CZ');
+    }
+
     return this.availableLangs.find(
       ({ key }) => key === Environment.getUserLocale(),
     );


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-5648
| License          | BSD 3-Clause

## Description

### Module: @ovh-ux/manager-config

#### :bug: Bug Fixes

d9be19c - fix(locale): add missing cs_CZ entry
293b588 - fix: export localeStorageKey constant as default
5cdf0c2 - fix(environment.service): temporarily fallback for cs_CZ language

### Module: @ovh-ux/manager-navbar

#### :bug: Bug Fixes

ddc504e - fix(language.menu): temporarily force display of cs_CZ language


### :link: Relates

#3795
