### PR TITLE
hotfix(kube): wrong create button name in new node pool page

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/translations/Messages_en_GB.json
@@ -6,7 +6,7 @@
   "kube_list_cluster_manage": "Manage cluster",
   "kube_list_cluster_create": "Create a Kubernetes cluster",
   "kube_list_error": "An error has occurred loading your clusters.",
-  "kube_common_save": "Back up",
+  "kube_common_save": "Save",
   "kube_common_cancel": "Cancel",
   "kube_common_delete": "Delete",
   "kube_common_node_pool_title": "Configure your node pool",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/translations/Messages_lt_LT.json
@@ -6,7 +6,7 @@
   "kube_list_cluster_manage": "Manage cluster",
   "kube_list_cluster_create": "Create a Kubernetes cluster",
   "kube_list_error": "An error has occurred loading your clusters.",
-  "kube_common_save": "Back up",
+  "kube_common_save": "Save",
   "kube_common_cancel": "Cancel",
   "kube_common_delete": "Delete",
   "kube_common_node_pool_title": "Configure your node pool",


### PR DESCRIPTION
closes #MANAGER-5800

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | Fix #MANAGER-5800
| License          | BSD 3-Clause

## Description

The submit button name in the create node pool page has invalid text in the English language. Its current value is "Back up". It should be "Save". I have changed it to "Save". The button text in other languages looks good.
