### PR TITLE
fix(telephony.service.voicemail): replace aapi call with autocomplete

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/default.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/default.controller.js
@@ -1,10 +1,8 @@
 import filter from 'lodash/filter';
-import flatten from 'lodash/flatten';
 import get from 'lodash/get';
-import map from 'lodash/map';
 
 export default /* @ngInject */ function TelecomTelephonyServiceVoicemailDefaultCtrl(
-  $scope,
+  $http,
   $stateParams,
   $q,
   $timeout,
@@ -16,22 +14,6 @@ export default /* @ngInject */ function TelecomTelephonyServiceVoicemailDefaultC
   TucToast,
 ) {
   const self = this;
-
-  function fetchLines() {
-    return OvhApiTelephony.Line()
-      .Aapi()
-      .get()
-      .$promise.then((result) =>
-        filter(flatten(map(result, 'lines')), { serviceType: 'line' }),
-      );
-  }
-
-  function fetchFax() {
-    return OvhApiTelephony.Fax()
-      .Aapi()
-      .getServices()
-      .$promise.then((result) => filter(result, { type: 'FAX' }));
-  }
 
   function fetchOptions() {
     return OvhApiTelephony.Line()
@@ -51,22 +33,33 @@ export default /* @ngInject */ function TelecomTelephonyServiceVoicemailDefaultC
     };
 
     self.loading = true;
-    return $q
-      .all({
-        lines: fetchLines(),
-        fax: fetchFax(),
-        options: fetchOptions(),
-      })
-      .then((result) => {
-        self.numbers = result.lines.concat(result.fax);
-        self.options = result.options;
-        self.defaultVoicemail = self.options.defaultVoicemail;
+    return fetchOptions()
+      .then((options) => {
+        self.options = options;
+        self.defaultVoicemail = options.defaultVoicemail;
       })
       .catch((err) => new TucToastError(err))
       .finally(() => {
         self.loading = false;
       });
   }
+
+  self.onDefaultVoicemailChange = function onDefaultVoicemailChange() {
+    self.success = false;
+    if (self.options.defaultVoicemail.length < 5) {
+      return $q.when();
+    }
+
+    return $http
+      .get('/telephony/searchServices', {
+        params: {
+          axiom: self.options.defaultVoicemail,
+        },
+      })
+      .then(({ data }) => {
+        self.numbers = data;
+      });
+  };
 
   self.saveDefaultVoicemail = function saveDefaultVoicemail() {
     self.saving = true;

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/default.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/default.html
@@ -19,16 +19,17 @@
                         data-translate="telephony_line_answer_default_voicemail_label"
                     >
                     </label>
-                    <select
+                    <input
                         id="default"
                         name="default"
-                        class="form-control"
-                        required
+                        class="oui-input"
                         data-ng-model="DefaultVoicemailCtrl.options.defaultVoicemail"
-                        data-ng-change="DefaultVoicemailCtrl.success = false"
-                        data-ng-options="number.serviceName as DefaultVoicemailCtrl.formatNumber(number) for number in DefaultVoicemailCtrl.numbers | orderBy: ['description', 'label', 'serviceName']"
-                    >
-                    </select>
+                        type="text"
+                        oui-autocomplete="DefaultVoicemailCtrl.numbers"
+                        oui-autocomplete-property="domain"
+                        data-ng-change="DefaultVoicemailCtrl.onDefaultVoicemailChange()"
+                        placeholder="{{:: 'telephony_line_answer_default_voicemail_search' | translate }}"
+                    />
                 </div>
                 <div class="form-group mt-4">
                     <hr />

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_en_GB.json
@@ -1,0 +1,3 @@
+{
+  "telephony_line_answer_default_voicemail_search": "Search for a service"
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_es_ES.json
@@ -1,0 +1,3 @@
+{
+  "telephony_line_answer_default_voicemail_search": "Buscar un servicio"
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_fr_CA.json
@@ -1,0 +1,11 @@
+{
+  "telephony_line_answer_default_voicemail_title": "Messagerie par défaut",
+  "telephony_line_answer_default_voicemail_config": "Configuration actuelle",
+  "telephony_line_answer_default_voicemail_change": "Appliquer",
+  "telephony_line_answer_default_voicemail_label": "Utiliser la messagerie du&nbsp;:",
+  "telephony_line_answer_default_voicemail_bulk_all_success": "La messagerie par défaut a bien été appliquée aux services sélectionnés.",
+  "telephony_line_answer_default_voicemail_bulk_some_success": "La messagerie par défaut a bien été appliquée à {{ count }} des services sélectionnés.",
+  "telephony_line_answer_default_voicemail_bulk_error": "La messagerie par défaut n'a pas pu être appliquée au(x) service(s) suivant(s) :",
+  "telephony_line_answer_default_voicemail_bulk_on_error": "Oups ! Une erreur est survenue lors de l'application de la messagerie par défaut.",
+  "telephony_line_answer_default_voicemail_search": "Rechercher un service"
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/default/translations/Messages_fr_FR.json
@@ -6,5 +6,6 @@
   "telephony_line_answer_default_voicemail_bulk_all_success": "La messagerie par défaut a bien été appliquée aux services sélectionnés.",
   "telephony_line_answer_default_voicemail_bulk_some_success": "La messagerie par défaut a bien été appliquée à {{ count }} des services sélectionnés.",
   "telephony_line_answer_default_voicemail_bulk_error": "La messagerie par défaut n'a pas pu être appliquée au(x) service(s) suivant(s) :",
-  "telephony_line_answer_default_voicemail_bulk_on_error": "Oups ! Une erreur est survenue lors de l'application de la messagerie par défaut."
+  "telephony_line_answer_default_voicemail_bulk_on_error": "Oups ! Une erreur est survenue lors de l'application de la messagerie par défaut.",
+  "telephony_line_answer_default_voicemail_search": "Rechercher un service"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-22218
| License          | BSD 3-Clause

## Description

2API timeout due to multiple calls and huge amount of data to fetch/return
This will also improve performances for large account as we avoid building a huge amount of options in a select

## Related 

- [x] TRANS-29069

## TODOs
- [x] Check that 2API is no longer used to remove or replace left calls
