### PR TITLE
fix(snapshot.order): get offer by capacity instead of duration

### DIFF
--- a/packages/manager/modules/vps/src/snapshot/order/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/vps/src/snapshot/order/translations/Messages_fr_FR.json
@@ -5,7 +5,7 @@
   "vps_configuration_activate_snapshot_step1_id": "Afin de confirmer votre demande, veuillez accepter les conditions d'utilisation et cliquer sur le bouton \"Suivant\" ci-dessous.",
   "vps_configuration_activate_snapshot_step1_contracts": "Je reconnais avoir bien pris connaissance des éléments suivants :",
   "vps_configuration_activate_snapshot_step1_info": "Pour le premier paiement, vous serez facturé au prorata du nombre de jours restant avant la date de renouvellement de votre VPS.",
-  "vps_configuration_activate_snapshot_step1_alert": "Cette option sera facturée au tarif mensuel de <strong>{{ amount }} HT</strong>.",
+  "vps_configuration_activate_snapshot_step1_alert": "Cette option sera facturée au tarif de <strong>{{ amount }} HT</strong>.",
   "vps_configuration_activate_snapshot_step1_description": "L'option Snapshot vous permet de créer un point de restauration. C'est un instantané de votre configuration pouvant être restauré en cas de besoin.",
   "vps_configuration_activate_snapshot_step1_instruction": "Veuillez cliquer sur le bouton \"Suivant\" afin de poursuivre l'activation de l'option Snapshot.",
   "vps_configuration_activate_snapshot_step2_id": "Afin de confirmer votre demande, veuillez procéder au règlement en cliquant sur le bouton \"Commander\" ci-dessous.",

--- a/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.controller.js
+++ b/packages/manager/modules/vps/src/snapshot/order/vps-snapshot-order.controller.js
@@ -106,9 +106,10 @@ export default class VpsSnapshotOrderCtrl {
             },
           });
         }
-        this.snapshotMonthlyPrice = find(this.snapshotOption.prices, {
-          duration: 'P1M',
-        });
+        this.snapshotMonthlyPrice = find(
+          this.snapshotOption.prices,
+          ({ capacities }) => capacities.includes('renew'),
+        );
         return this.snapshotOption;
       })
       .catch((error) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-21898
| License          | BSD 3-Clause

## Description

VPS snapshot order : get offer by capacity instead of duration 