### PR TITLE
fix(web.privatedb): hide order ram button in oom modal if not possible

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/oom/private-database-oom.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/oom/private-database-oom.controller.js
@@ -4,16 +4,26 @@ import findIndex from 'lodash/findIndex';
 angular.module('App').controller(
   'PrivateDatabaseOomCtrl',
   class PrivateDatabaseOomCtrl {
-    constructor($scope, $q, $stateParams, $translate, Alerter, OomService) {
+    constructor(
+      $scope,
+      $q,
+      $stateParams,
+      $translate,
+      Alerter,
+      OomService,
+      PrivateDatabase,
+    ) {
       this.$scope = $scope;
       this.$q = $q;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
       this.Alerter = Alerter;
       this.oomService = OomService;
+      this.privateDatabaseService = PrivateDatabase;
     }
 
     $onInit() {
+      this.isLoading = true;
       this.productId = this.$stateParams.productId;
 
       this.NB_DAY_OOM = 7;
@@ -39,6 +49,15 @@ angular.module('App').controller(
       this.$scope.orderMoreRam = () => this.orderMoreRam();
 
       this.getOom();
+
+      return this.privateDatabaseService
+        .canOrderRam(this.productId)
+        .then((canOrderRam) => {
+          this.canOrderRam = canOrderRam;
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
     }
 
     getOom() {

--- a/packages/manager/apps/web/client/app/private-database/oom/private-database-oom.html
+++ b/packages/manager/apps/web/client/app/private-database/oom/private-database-oom.html
@@ -5,10 +5,13 @@
         data-wizard-on-finish="orderMoreRam"
         data-wizard-confirm-button-text="'privateDatabase_modale_oom_confirm_button' | translate"
         data-wizard-cancel-button-text="'privateDatabase_modale_oom_close_button' | translate"
-        data-wizard-hide-confirm-button="oomCtrl.database.oom.realList.length >= oomCtrl.database.oom.nbOomError"
+        data-wizard-hide-confirm-button="oomCtrl.database.oom.realList.length >= oomCtrl.database.oom.nbOomError || !oomCtrl.canOrderRam"
         data-wizard-title="'privateDatabase_modale_oom_title' | translate"
     >
-        <div data-wizard-step>
+        <div class="text-center" data-ng-if="oomCtrl.isLoading">
+            <oui-spinner></oui-spinner>
+        </div>
+        <div data-wizard-step data-ng-if="!oomCtrl.isLoading">
             <p
                 data-ng-bind-html="'privateDatabase_modale_oom_info' | translate: { t0: oomCtrl.NB_DAY_OOM, t1: oomCtrl.NB_MAX_OOM }"
             ></p>
@@ -47,7 +50,7 @@
                 class="alert alert-info mt-3"
                 role="alert"
                 data-ng-bind-html="'privateDatabase_modale_oom_info_order' | translate: { t0: oomCtrl.displayType[oomCtrl.database.offer].value }"
-                data-ng-if="oomCtrl.database.oom.realList.length >= oomCtrl.database.oom.nbOomError"
+                data-ng-if="oomCtrl.database.oom.realList.length >= oomCtrl.database.oom.nbOomError && oomCtrl.canOrderRam"
             ></div>
         </div>
     </div>


### PR DESCRIPTION
ref: DTRSD-22286
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-22286
| License          | BSD 3-Clause

## Description
Disabling button to order RAM in "out of memory" information modal
