### PR TITLE
Fix/regenerator runtime

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -64,6 +64,7 @@
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "validator": "^11.1.0",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/carrier-sip/src/index.js
+++ b/packages/manager/apps/carrier-sip/src/index.js
@@ -4,6 +4,7 @@ import 'script-loader!moment/min/moment-with-locales.min';
 /* eslint-enable import/no-webpack-loader-syntax */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -43,6 +43,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "ovh-api-services": "^10.1.0",
+    "regenerator-runtime": "^0.13.7",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/manager/apps/cloud/client/app/app.module.js
+++ b/packages/manager/apps/cloud/client/app/app.module.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'script-loader!jquery';
 import 'angular';
 import 'angular-animate';

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -120,6 +120,7 @@
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "uri.js": "medialize/URI.js#~1.15.0",
     "validator-js": "chriso/validator.js#~3.37.0",

--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'script-loader!moment/min/moment.min.js';
 import 'script-loader!es6-shim/es6-shim.min.js';
 import 'script-loader!components-jqueryui/ui/minified/version.js';

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -145,6 +145,7 @@
     "qrcode.js": "janantala/qrcode.js#~1.0.x",
     "randexp": "fent/randexp.js#~0.4.0",
     "raphael": "^2.2.8",
+    "regenerator-runtime": "^0.13.7",
     "u2f-api-polyfill": "^0.4.3",
     "ui-select": "^0.19.8",
     "urijs": "^1.19.1",

--- a/packages/manager/apps/enterprise-cloud-database/index.js
+++ b/packages/manager/apps/enterprise-cloud-database/index.js
@@ -9,6 +9,7 @@ import 'script-loader!messenger/build/js/messenger-theme-flat.js';
 /* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import '@uirouter/angularjs';

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -50,6 +50,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "zxcvbn": "^4.4.2"
   },

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -61,6 +61,7 @@
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/freefax/src/index.js
+++ b/packages/manager/apps/freefax/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -72,6 +72,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "whatwg-fetch": "^3.0.0"
   },

--- a/packages/manager/apps/hub/src/index.js
+++ b/packages/manager/apps/hub/src/index.js
@@ -1,6 +1,7 @@
 import 'script-loader!jquery'; // eslint-disable-line
 import 'whatwg-fetch';
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import { attach as attachPreloader } from '@ovh-ux/manager-preloader';
 import { bootstrapApplication } from '@ovh-ux/manager-core';
 import { MANAGER_URLS } from '@ovh-ux/manager-core/src/manager-core.constants';

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -65,6 +65,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/iplb/src/index.js
+++ b/packages/manager/apps/iplb/src/index.js
@@ -5,6 +5,7 @@ import 'script-loader!chart.js/dist/Chart.min.js';
 /* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import { Environment } from '@ovh-ux/manager-config';
 

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -59,6 +59,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/nasha/src/index.js
+++ b/packages/manager/apps/nasha/src/index.js
@@ -4,6 +4,7 @@ import 'script-loader!jquery';
 import 'script-loader!moment/min/moment.min.js';
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import 'ovh-ui-kit-bs/dist/css/oui-bs3.css';
 import '@ovh-ux/ui-kit/dist/css/oui.css';

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -42,6 +42,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/order-tracking/src/index.js
+++ b/packages/manager/apps/order-tracking/src/index.js
@@ -6,6 +6,7 @@ import ssoAuth from '@ovh-ux/ng-ovh-sso-auth';
 import ngOvhOrderTracking from '@ovh-ux/ng-ovh-order-tracking';
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import '@ovh-ux/ui-kit/dist/css/oui.css';
 import 'ovh-ui-kit-bs/dist/css/oui-bs3.css';

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -49,7 +49,8 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^10.1.0",
     "ovh-manager-webfont": "^1.2.0",
-    "ovh-ui-kit-bs": "^4.2.0"
+    "ovh-ui-kit-bs": "^4.2.0",
+    "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.0.8",

--- a/packages/manager/apps/overthebox/src/index.js
+++ b/packages/manager/apps/overthebox/src/index.js
@@ -3,6 +3,7 @@ import 'script-loader!lodash'; // eslint-disable-line
 import 'script-loader!moment/min/moment.min.js'; // eslint-disable-line
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';

--- a/packages/manager/apps/pci/index.js
+++ b/packages/manager/apps/pci/index.js
@@ -11,6 +11,7 @@ import 'script-loader!angular-ui-validate/dist/validate.js';
 /* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import '@ovh-ux/manager-pci';
 

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -60,6 +60,7 @@
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -86,6 +86,7 @@
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "tweetnacl-util": "^0.15.0",
     "ui-select": "^0.19.8",
     "whatwg-fetch": "^3.0.0"

--- a/packages/manager/apps/public-cloud/src/app.module.js
+++ b/packages/manager/apps/public-cloud/src/app.module.js
@@ -3,6 +3,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 /* eslint-disable import/no-webpack-loader-syntax, import/extensions */
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import angular from 'angular';
 import ngAnimate from 'angular-animate';
 import uiRouter, { RejectType } from '@uirouter/angularjs';

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -57,6 +57,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^10.1.0",
     "ovh-ngstrap": "^4.0.2",
+    "regenerator-runtime": "^0.13.7",
     "validator-js": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/manager/apps/sms/src/index.js
+++ b/packages/manager/apps/sms/src/index.js
@@ -5,6 +5,7 @@ import 'script-loader!moment/min/moment.min';
 /* eslint-enable import/no-webpack-loader-syntax */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 

--- a/packages/manager/apps/support/index.js
+++ b/packages/manager/apps/support/index.js
@@ -9,6 +9,7 @@ import 'script-loader!moment/min/moment-with-locales.min.js';
 /* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import { state } from './index.routing';
 

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -45,6 +45,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -55,6 +55,7 @@
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/telecom-dashboard/src/index.js
+++ b/packages/manager/apps/telecom-dashboard/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import telecomDashboard from '@ovh-ux/manager-telecom-dashboard';
 

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -52,6 +52,7 @@
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/telecom-task/src/index.js
+++ b/packages/manager/apps/telecom-task/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!lodash'; // eslint-disable-line
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import ovhManagerTelecomTask from '@ovh-ux/manager-telecom-task';

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -138,6 +138,7 @@
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8",
     "urijs": "^1.18.0",
     "validator": "^11.1.0",

--- a/packages/manager/apps/telecom/src/app/app.module.js
+++ b/packages/manager/apps/telecom/src/app/app.module.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'angular';
 import 'angular-animate';
 import 'angular-aria';

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -54,6 +54,7 @@
     "oclazyload": "^1.1.0",
     "ovh-api-services": "^10.1.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/veeam-cloud-connect/src/index.js
+++ b/packages/manager/apps/veeam-cloud-connect/src/index.js
@@ -2,6 +2,7 @@ import 'script-loader!jquery'; // eslint-disable-line
 import 'script-loader!moment/min/moment-with-locales.min'; // eslint-disable-line
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import ovhManagerCore from '@ovh-ux/manager-core';

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -54,6 +54,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/veeam-enterprise/src/index.js
+++ b/packages/manager/apps/veeam-enterprise/src/index.js
@@ -4,6 +4,7 @@ import 'script-loader!moment/min/moment-with-locales.min';
 /* eslint-enable import/no-webpack-loader-syntax */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -70,6 +70,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/vps/src/index.js
+++ b/packages/manager/apps/vps/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/extensions, import/no-webpack-loader-syntax */
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'script-loader!jquery';
 import 'script-loader!moment/min/moment-with-locales.min';
 import 'script-loader!jsurl/lib/jsurl';

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -55,6 +55,7 @@
     "ovh-api-services": "^10.1.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"
   },
   "devDependencies": {

--- a/packages/manager/apps/vrack/src/index.js
+++ b/packages/manager/apps/vrack/src/index.js
@@ -9,6 +9,7 @@ import 'script-loader!messenger/build/js/messenger-theme-flat.js';
 /* eslint-enable import/no-webpack-loader-syntax, import/extensions */
 
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 import angular from 'angular';
 import ovhManagerVrack from '@ovh-ux/manager-vrack';

--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */
 import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'script-loader!moment/min/moment.min.js';
 import 'jquery-ui/ui/core.js';
 import 'jquery-ui/ui/widget.js';

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -121,6 +121,7 @@
     "properties": "latest",
     "punycode": "^1.4.1",
     "raven-js": "^3.27.1",
+    "regenerator-runtime": "^0.13.7",
     "request": "^2.51.0",
     "ui-select": "^0.19.8",
     "urijs": "^1.19.1",

--- a/packages/manager/tools/webpack-config/package.json
+++ b/packages/manager/tools/webpack-config/package.json
@@ -36,7 +36,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.10.1",
     "@babel/plugin-proposal-private-methods": "^7.10.1",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.10.3",
     "@ovh-ux/component-rollup-config": "^7.2.0",
     "@ovh-ux/manager-webpack-dev-server": "^2.7.0",

--- a/packages/manager/tools/webpack-config/src/webpack.common.ts
+++ b/packages/manager/tools/webpack-config/src/webpack.common.ts
@@ -21,7 +21,7 @@ const cacheLoader = {
 
 // The common webpack configuration
 
-export = (opts) => {
+export = opts => {
   const lessLoaderOptions = {
     sourceMap: true,
     plugins: [
@@ -79,10 +79,14 @@ export = (opts) => {
     ],
 
     resolve: {
-      modules: ['./node_modules', path.resolve('./node_modules')],
+      modules: [
+        './node_modules',
+        path.resolve('./node_modules'),
+      ],
     },
 
     resolveLoader: {
+
       // webpack module resolution paths
       modules: [
         './node_modules', // #1 check in module's relative node_module directory
@@ -92,6 +96,7 @@ export = (opts) => {
 
     module: {
       rules: [
+
         // load HTML files as string (raw-loader)
         {
           test: /\.html$/,
@@ -198,7 +203,6 @@ export = (opts) => {
                   require.resolve('@babel/plugin-proposal-private-methods'), // private methods
                   require.resolve('@babel/plugin-syntax-dynamic-import'), // dynamic es6 imports
                   require.resolve('babel-plugin-angularjs-annotate'), // ng annotate
-                  require.resolve('@babel/plugin-transform-runtime'),
                 ],
                 shouldPrintComment: (val) => !/@ngInject/.test(val),
               },
@@ -215,10 +219,7 @@ export = (opts) => {
           use: [
             cacheLoader,
             {
-              loader: path.resolve(
-                __dirname,
-                './loaders/translation-ui-router.js',
-              ),
+              loader: path.resolve(__dirname, './loaders/translation-ui-router.js'),
               options: {
                 subdirectory: 'translations',
                 filtering: false,
@@ -235,10 +236,7 @@ export = (opts) => {
           use: [
             cacheLoader,
             {
-              loader: path.resolve(
-                __dirname,
-                './loaders/translation-inject.js',
-              ),
+              loader: path.resolve(__dirname, './loaders/translation-inject.js'),
               options: {
                 filtering: false,
               },
@@ -253,6 +251,7 @@ export = (opts) => {
       runtimeChunk: 'single',
       // bundle spliting configuration
       splitChunks: {
+
         // vendors bundle containing node_modules source code
         cacheGroups: {
           bower: {
@@ -277,6 +276,7 @@ export = (opts) => {
           },
         },
       },
+
     }, // \optimization
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,11 +440,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz#aac45cccf8bc1873b99a85f34bceef3beb5d3244"
   integrity sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==
 
-"@babel/helper-plugin-utils@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
-  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-
 "@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
@@ -1321,16 +1316,6 @@
   integrity sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
-
-"@babel/plugin-transform-runtime@^7.11.5":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz#f108bc8e0cf33c37da031c097d1df470b3a293fc"
-  integrity sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    resolve "^1.8.1"
-    semver "^5.5.1"
 
 "@babel/plugin-transform-runtime@^7.4.0":
   version "7.7.6"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

As mentionned in https://github.com/webpack/webpack/issues/4817, the use of `@babel/plugin-transform-runtime` can cause issue
Here in our case default exports not found for manager cloud : 
`
@ovh-ux/manager-cloud: "export 'default' (imported as 'ngOvhBrowserAlert') was not found in '@ovh-ux/ng-ovh-browser-alert'
@ovh-ux/manager-cloud:  warning  in /Users/mjones/Desktop/manager/packages/manager/modules/core/dist/esm/index.js
@ovh-ux/manager-cloud: "export 'default' (imported as 'ngOvhHttp') was not found in '@ovh-ux/ng-ovh-http'
@ovh-ux/manager-cloud:  warning  in ./client/app/app.js
` 
