### PR TITLE
fix(deps): upgrade ovh-api-services to v11.0.0

### DIFF
--- a/packages/components/ng-ovh-contact/package.json
+++ b/packages/components/ng-ovh-contact/package.json
@@ -48,7 +48,7 @@
     "international-phone-number": "mareczek/international-phone-number#^0.0.16",
     "jquery": "~2.1",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.2.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ui-select": "^0.19.8"
   }

--- a/packages/components/ng-ovh-contacts/package.json
+++ b/packages/components/ng-ovh-contacts/package.json
@@ -52,7 +52,7 @@
     "bs4": "twbs/bootstrap#v4.0.0-beta",
     "flag-icon-css": "^3.2.1",
     "moment": "^2.20.1",
-    "ovh-api-services": "^9.0.0",
+    "ovh-api-services": "^11.0.0",
     "ui-select": "^0.19.8"
   }
 }

--- a/packages/components/ng-ovh-line-diagnostics/package.json
+++ b/packages/components/ng-ovh-line-diagnostics/package.json
@@ -51,6 +51,6 @@
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
-    "ovh-api-services": "^9.2.0"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/components/ng-ovh-mondial-relay/package.json
+++ b/packages/components/ng-ovh-mondial-relay/package.json
@@ -54,6 +54,6 @@
     "angular-leaflet-directive": "0.8.5",
     "angular-translate": "^2.18.1",
     "leaflet": "0.7.x",
-    "ovh-api-services": "^3.33.0"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/components/ng-ovh-order-tracking/package.json
+++ b/packages/components/ng-ovh-order-tracking/package.json
@@ -48,6 +48,6 @@
     "@ovh-ux/ui-kit": "^4.1.12",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/components/ng-ovh-otrs/package.json
+++ b/packages/components/ng-ovh-otrs/package.json
@@ -48,6 +48,6 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.7.0",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^3.15.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/components/ng-ovh-payment-method/package.json
+++ b/packages/components/ng-ovh-payment-method/package.json
@@ -51,6 +51,6 @@
     "angular": "^1.5.0",
     "angular-translate": "^2.17.0",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -58,7 +58,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -42,7 +42,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -115,7 +115,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -137,7 +137,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -56,7 +56,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -68,7 +68,7 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -61,7 +61,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -55,7 +55,7 @@
     "clipboard": "^2.0.4",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -38,7 +38,7 @@
     "clipboard": "^2.0.4",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0"
   },

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -54,7 +54,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -81,7 +81,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -54,7 +54,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ngstrap": "^4.0.2",
     "validator-js": "^0.2.1"
   },

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -41,7 +41,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -49,7 +49,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -46,7 +46,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -131,7 +131,7 @@
     "ngSmoothScroll": "d-oliveros/angular-smooth-scroll#~1.7.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -51,7 +51,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"
   },

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -50,7 +50,7 @@
     "d3": "~3.5.13",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -67,7 +67,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -114,7 +114,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^10.1.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/modules/account-migration/package.json
+++ b/packages/manager/modules/account-migration/package.json
@@ -41,6 +41,6 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/account-sidebar/package.json
+++ b/packages/manager/modules/account-sidebar/package.json
@@ -41,6 +41,6 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -44,6 +44,6 @@
     "@ovh-ux/ng-at-internet": "^5.3.0",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/carrier-sip/package.json
+++ b/packages/manager/modules/carrier-sip/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/ui-kit": "^4.1.12",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/cloud-connect/package.json
+++ b/packages/manager/modules/cloud-connect/package.json
@@ -25,6 +25,6 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -53,6 +53,6 @@
     "angular-translate": "^2.11.0",
     "angular-ui-bootstrap": "~1.3.3",
     "d3": "~3.5.13",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -33,6 +33,6 @@
     "moment": "^2.24.0",
     "ng-ckeditor": "^2.0.5",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -57,7 +57,7 @@
     "font-awesome": "4.7.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -32,6 +32,6 @@
     "moment": "^2.24.0",
     "ng-ckeditor": "^2.0.5",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -32,7 +32,7 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/hub/package.json
+++ b/packages/manager/modules/hub/package.json
@@ -34,6 +34,6 @@
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/iplb/package.json
+++ b/packages/manager/modules/iplb/package.json
@@ -34,7 +34,7 @@
     "chart.js": "chartjs/Chart.js#^2.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/nasha/package.json
+++ b/packages/manager/modules/nasha/package.json
@@ -27,7 +27,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -46,6 +46,6 @@
     "angular-translate": "^2.18.1",
     "bootstrap-tour": "^0.12.0",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/notifications-sidebar/package.json
+++ b/packages/manager/modules/notifications-sidebar/package.json
@@ -25,6 +25,6 @@
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -35,7 +35,7 @@
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.44.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -61,7 +61,7 @@
     "jquery-ui": "components/jqueryui#~1.11.2",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.41.0",
+    "ovh-api-services": "^11.0.0",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"

--- a/packages/manager/modules/product-offers/package.json
+++ b/packages/manager/modules/product-offers/package.json
@@ -28,6 +28,6 @@
     "angular-translate": "^2.18.2",
     "bootstrap": "^4.3.1",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -46,6 +46,6 @@
     "@ovh-ux/ui-kit": "^4.1.12",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -24,6 +24,6 @@
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1"
+    "ovh-api-services": "^11.0.0"
   }
 }

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -40,7 +40,7 @@
     "font-awesome": "4.7.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/support/package.json
+++ b/packages/manager/modules/support/package.json
@@ -29,7 +29,7 @@
     "font-awesome": "~4.7.0",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -28,7 +28,7 @@
     "angular-translate": "^2.18.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.14",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -28,7 +28,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "~1.3.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -35,7 +35,7 @@
     "jsplumb": "^2.11.2",
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ngstrap": "^4.0.2",
     "punycode": "^1.4.1",
     "validator": "^11.1.0",

--- a/packages/manager/modules/veeam-cloud-connect/package.json
+++ b/packages/manager/modules/veeam-cloud-connect/package.json
@@ -26,7 +26,7 @@
     "flag-icon-css": "~0.8.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/veeam-enterprise/package.json
+++ b/packages/manager/modules/veeam-enterprise/package.json
@@ -28,7 +28,7 @@
     "angular-ui-bootstrap": "1.3.3",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/vps/package.json
+++ b/packages/manager/modules/vps/package.json
@@ -40,7 +40,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }
 }

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -42,7 +42,7 @@
     "angular-ui-bootstrap": "~1.3.3",
     "font-awesome": "4.7.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.1.5"
   }

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -38,7 +38,7 @@
     "ipaddr.js": "^1.9.1",
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
-    "ovh-api-services": "^9.39.1",
+    "ovh-api-services": "^11.0.0",
     "punycode": "^1.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14850,10 +14850,10 @@ ovh-angular-responsive-tabs@^4.0.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-responsive-tabs/-/ovh-angular-responsive-tabs-4.0.0.tgz#85b66d7032612c3ed1a14cb29f83d1331b50c1df"
   integrity sha1-hbZtcDJhLD7RoUyyn4PRMxtQwd8=
 
-ovh-api-services@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-10.1.0.tgz#75d00f267b1398b681e2a84baf441089dedb6d6d"
-  integrity sha512-TMDRdm5Xo0B+JcQpqQnLKP0SDUXUUJ9HYFjVpIkCkESIc1kwpBxhDIjZD3eyzlw6N40Xbajj9KdYgfbpDb+Xww==
+ovh-api-services@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-11.0.0.tgz#1425de29c8102d848296c41e2ae54224d04dca20"
+  integrity sha512-ffPIFDdHXkiH7CYJ3l4tDF4vAsmpT2r3+o6FCo16XxTFN428ZlTcusI1KbIpvsZkHIuj5sZB0G9CvLj5BBoUXg==
   dependencies:
     lodash "^4.17.20"
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2020-w43`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

1a3fc5b - fix(deps): upgrade ovh-api-services to v11.0.0

uses: `$ yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@11.0.0

### :link: Relates

- https://github.com/ovh-ux/ovh-api-services/blob/master/CHANGELOG.md#1100-2020-10-16

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
