### PR TITLE
fix(provider): add trailing slash in order to avoid 301

### DIFF
--- a/packages/components/ng-ovh-sso-auth/src/provider.js
+++ b/packages/components/ng-ovh-sso-auth/src/provider.js
@@ -9,8 +9,8 @@ import { NIC_STATE_ENUM } from './constants';
  *
  */
 export default function() {
-  let loginUrl = 'https://www.ovh.com/auth';
-  let logoutUrl = 'https://www.ovh.com/auth?action=disconnect';
+  let loginUrl = 'https://www.ovh.com/auth/';
+  let logoutUrl = 'https://www.ovh.com/auth/?action=disconnect';
   let signUpUrl = 'https://www.ovh.com/auth/signup/new/';
   let userUrl = '/engine/api/me';
   let rules = [];


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #ECINT-2501
| License          | BSD 3-Clause

## Description

Add trailing slash to login url in order to avoir 301 redirection.

Signed-off-by: Cyril Biencourt <cyril.biencourt@corp.ovh.com>
