### PR TITLE
refactor(new): rename ovhFeatureFlipping to ovhPciFeatureFlipping

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/components/feature-flipping/index.js
+++ b/packages/manager/modules/pci/src/projects/new/components/feature-flipping/index.js
@@ -8,6 +8,6 @@ import provider from './provider';
 
 const moduleName = 'pciProjectNewFeatureFlipping';
 
-angular.module(moduleName, []).provider('ovhFeatureFlipping', provider);
+angular.module(moduleName, []).provider('ovhPciFeatureFlipping', provider);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/new/config/routing.js
+++ b/packages/manager/modules/pci/src/projects/new/config/routing.js
@@ -7,8 +7,8 @@ export default /* @ngInject */ ($stateProvider) => {
       '': component.name,
 
       'banner@pci.projects.new.config': {
-        componentProvider: /* @ngInject */ (ovhFeatureFlipping) =>
-          ovhFeatureFlipping.isFeatureActive('pci.onboarding.new.banner')
+        componentProvider: /* @ngInject */ (ovhPciFeatureFlipping) =>
+          ovhPciFeatureFlipping.isFeatureActive('pci.onboarding.new.banner')
             ? 'pciProjectNewConfigBanner'
             : null,
       },

--- a/packages/manager/modules/pci/src/projects/new/index.js
+++ b/packages/manager/modules/pci/src/projects/new/index.js
@@ -7,8 +7,8 @@ const moduleName = 'ovhManagerPciProjectsNewLazyLoading';
 
 angular
   .module(moduleName, ['ui.router', 'oc.lazyLoad', featureFlippling])
-  .config((ovhFeatureFlippingProvider) => {
-    ovhFeatureFlippingProvider.addFeatures([
+  .config((ovhPciFeatureFlippingProvider) => {
+    ovhPciFeatureFlippingProvider.addFeatures([
       {
         key: 'pci.onboarding.new',
         name: 'New PCI onboarding',
@@ -26,7 +26,7 @@ angular
     ]);
   })
   .config(
-    /* @ngInject */ ($stateProvider, ovhFeatureFlippingProvider) => {
+    /* @ngInject */ ($stateProvider, ovhPciFeatureFlippingProvider) => {
       $stateProvider.state('pci.projects.new.**', {
         url: '/new',
         lazyLoad: ($transition$) => {
@@ -34,7 +34,7 @@ angular
           let loadPromise;
 
           if (
-            ovhFeatureFlippingProvider.isFeatureActive('pci.onboarding.new')
+            ovhPciFeatureFlippingProvider.isFeatureActive('pci.onboarding.new')
           ) {
             loadPromise = import('./module');
           } else {


### PR DESCRIPTION
Changes required to enable the following module `@ovh-ux/ng-ovh-feature-flipping`

See: https://github.com/ovh/manager/blob/master/packages/components/ng-ovh-feature-flipping/src/index.js#L7

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` for hotfix / `develop` for bug fixes <!-- target branch -->
| Bug fix?         | yes/no
| New feature?     | yes/no
| Breaking change? | yes/no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

<!-- Write a brief description of the changes introduced by this PR -->
