### PR TITLE
fix(deps): force flatpickr version to 4.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "test:e2e:firefox:headless": "rimraf ./reports && testcafe firefox:headless",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
+  "resolutions": {
+    "flatpickr": "4.6.3"
+  },
   "devDependencies": {
     "@commitlint/cli": "^8.3.3",
     "@commitlint/config-angular": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9801,10 +9801,10 @@ flat@^4.1.0:
   dependencies:
     is-buffer "~2.0.3"
 
-flatpickr@^4.6.3:
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.6.tgz#34d2ad80adfa34254e62583a34264d472f1038d6"
-  integrity sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A==
+flatpickr@4.6.3, flatpickr@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
+  integrity sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ==
 
 flatted@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-22372
| License          | BSD 3-Clause

## Description

hotfix time selection everywhere oui-calendar is used
(because of incompatibility with flatpickr 4.6.6 : https://github.com/flatpickr/flatpickr/commit/d224d9ec9a868f4542add23a30c99d6f4ee54dcf)

until oui-kit & oui-calendar is patched
