### PR TITLE
fix(xdsl.move): change label for move out date

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
@@ -53,7 +53,7 @@
   "pack_move_line_address_building": "Bâtiment:",
   "pack_move_line_address_residence": "Residence:",
   "pack_move_rio": "RIO",
-  "pack_move_eligibility_move_out_date": "Date de déménagement souhaitée",
+  "pack_move_eligibility_move_out_date": "Date de fermeture de l'accès actuel",
   "pack_move_eligibility_move_out_date_description": "La date doit être comprise entre aujourd'hui et 30 jours. La date par défaut sera celle dans 30 jours.",
   "pack_move_eligibility_address_more": "Plus de précisions",
   "pack_move_eligibility_number": "Numéro de téléphone",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-332
| License          | BSD 3-Clause

## Description

Change label for move out date which was confusing for some customers
