### PR TITLE
docs: update links to rely on the new organization name [skip ci]

### DIFF
--- a/packages/components/ng-at-internet-ui-router-plugin/README.md
+++ b/packages/components/ng-at-internet-ui-router-plugin/README.md
@@ -19,7 +19,7 @@ import ngAtInternetUiRouterPlugin from '@ovh-ux/ng-at-internet-ui-router-plugin'
 angular.module('myApp', [ngAtInternetUiRouterPlugin]);
 ```
 
-Follow [at-internet installation](https://github.com/ovh-ux/ng-at-internet/blob/master/README.md)
+Follow [at-internet installation](https://github.com/ovh/manager/blob/master/packages/components/ng-at-internet/README.md)
 In your web page:
 
 ```html
@@ -32,7 +32,7 @@ In your web page:
 ## Examples
 
 Please see at-internet documentation:
-[link](https://github.com/ovh-ux/ng-at-internet/blob/master/README.md)
+[link](https://github.com/ovh/manager/blob/master/packages/components/ng-at-internet/README.md)
 
 Configuring the provider:
 
@@ -90,7 +90,7 @@ $ yarn test
 
 ## Related
 
-- [ng-at-internet](https://github.com/ovh-ux/ng-at-internet) - AT Internet tracking js library wrapper for AngularJS
+- [ng-at-internet](https://github.com/ovh/manager/tree/master/packages/components/ng-at-internet) - AT Internet tracking js library wrapper for AngularJS
 
 ## Contributing
 

--- a/packages/components/ng-at-internet/README.md
+++ b/packages/components/ng-at-internet/README.md
@@ -142,7 +142,7 @@ $ yarn test
 
 ## Related
 
-- [ng-at-internet-ui-router-plugin](https://github.com/ovh-ux/ng-at-internet-ui-router-plugin) - Plugin for AT Internet when using UI-Router
+- [ng-at-internet-ui-router-plugin](https://github.com/ovh/manager/tree/master/packages/components/ng-at-internet-ui-router-plugin) - Plugin for AT Internet when using UI-Router
 
 ## Contributing
 

--- a/packages/components/ng-ovh-actions-menu/README.md
+++ b/packages/components/ng-ovh-actions-menu/README.md
@@ -275,7 +275,7 @@ $ yarn test
 
 ## Related
 
-- [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover)
+- [ng-ovh-responsive-popover](https://github.com/ovh/manager/tree/master/packages/components/ng-ovh-responsive-popover)
 
 ## Contributing
 

--- a/packages/components/ng-ovh-actions-menu/src/index.js
+++ b/packages/components/ng-ovh-actions-menu/src/index.js
@@ -4,7 +4,7 @@
  * @name actionsMenu
  *
  *  @requires [pascalprecht.translate](https://github.com/angular-translate/angular-translate)
- *  @requires [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover)
+ *  @requires [ng-ovh-responsive-popover](https://github.com/ovh/manager/tree/master/packages/components/ng-ovh-responsive-popover)
  *
  * @description
  * _An actions menu gives the opportunity to group a set of actions available for a specific

--- a/packages/components/ng-ovh-actions-menu/src/item/index.js
+++ b/packages/components/ng-ovh-actions-menu/src/item/index.js
@@ -4,7 +4,7 @@
  * @name actionsMenu
  *
  *  @requires [pascalprecht.translate](https://github.com/angular-translate/angular-translate)
- *  @requires [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover)
+ *  @requires [ng-ovh-responsive-popover](https://github.com/ovh/manager/tree/master/packages/components/ng-ovh-responsive-popover)
  *
  * @description
  * _An actions menu gives the opportunity to group a set of actions available for a specific context

--- a/packages/components/ng-ovh-line-diagnostics/README.md
+++ b/packages/components/ng-ovh-line-diagnostics/README.md
@@ -26,7 +26,7 @@ $ yarn test
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-line-diagnostics/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-line-diagnostics/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/packages/components/ng-ovh-mondial-relay/README.md
+++ b/packages/components/ng-ovh-mondial-relay/README.md
@@ -27,7 +27,7 @@ $ yarn test
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-mondial-relay/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-mondial-relay/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/packages/components/ng-ovh-responsive-page-switcher/README.md
+++ b/packages/components/ng-ovh-responsive-page-switcher/README.md
@@ -41,7 +41,7 @@ yarn test
 * [matchmedia-ng](https://github.com/AnalogJ/matchmedia-ng)
 * [angular-animate](https://docs.angularjs.org/api/ngAnimate)
 
-__Note__ : `ng-ovh-responsive-page-switcher` is suitable with [ng-ovh-responsive-popover](https://github.com/ovh-ux/ng-ovh-responsive-popover).
+__Note__ : `ng-ovh-responsive-page-switcher` is suitable with [ng-ovh-responsive-popover](https://github.com/ovh/manager/tree/master/packages/components/ng-ovh-responsive-popover).
 
 ## Module Components
 
@@ -54,7 +54,7 @@ __Note__ : `ng-ovh-responsive-page-switcher` is suitable with [ng-ovh-responsive
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-responsive-page-switcher/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-responsive-page-switcher/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/packages/components/ng-ovh-sidebar-menu/README.md
+++ b/packages/components/ng-ovh-sidebar-menu/README.md
@@ -31,7 +31,7 @@ To know what is going on, click [here](./ROADMAP.md).
 
 ## Related
 
-- [ng-ovh-actions-menu](https://github.com/ovh-ux/ng-ovh-actions-menu) - Group a set of actions for a specific context under a single menu
+- [ng-ovh-actions-menu](https://github.com/ovh/manager/tree/master/packages/components/ng-ovh-actions-menu) - Group a set of actions for a specific context under a single menu
 - [ng-slide-down](https://github.com/TheRusskiy/ng-slide-down) - AngularJS directive for slide-down animation
 
 ## Contributing

--- a/packages/components/ng-ovh-timeline/README.md
+++ b/packages/components/ng-ovh-timeline/README.md
@@ -64,7 +64,7 @@ yarn test
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-timeline/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-timeline/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/packages/components/ng-ovh-toaster/README.md
+++ b/packages/components/ng-ovh-toaster/README.md
@@ -7,7 +7,7 @@
 ---
 
 <div align="center">
-:bookmark: `ovh-angular-toaster` is now deprecated. Please take a look at our <a href="https://github.com/ovh-ux/ovh-ui-kit" target="_blank">OVH UI Kit - Master UI Framework</a>. You can find more details <a href="http://master.ui-kit.ovh/#!/ovh-ui-kit/message" target="_blank">here</a>.
+:bookmark: `ovh-angular-toaster` is now deprecated. Please take a look at our <a href="https://github.com/ovh/ovh-ui-kit" target="_blank">OVH UI Kit - Master UI Framework</a>. You can find more details <a href="https://ovh.github.io/ovh-ui-kit/?path=/story/design-system-components-message-webcomponent--default" target="_blank">here</a>.
 </div>
 
 ---

--- a/packages/components/ng-ovh-ui-confirm-modal/README.md
+++ b/packages/components/ng-ovh-ui-confirm-modal/README.md
@@ -48,7 +48,7 @@ yarn test
 
 ## Contributing
 
-Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh-ux/ng-ovh-ui-confirm-modal/issues/new) or working on some of the [open issues](https://github.com/ovh-ux/ng-ovh-ui-confirm-modal/issues), our [contributing guide](CONTRIBUTING.md) will help get you started.
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
 
 ## License
 

--- a/packages/components/ng-ui-router-breadcrumb/package.json
+++ b/packages/components/ng-ui-router-breadcrumb/package.json
@@ -8,9 +8,9 @@
     "state",
     "ui-router"
   ],
-  "homepage": "https://github.com/ovh-ux/manager/tree/master/packages/components/ng-ui-router-breadcrumb#readme",
+  "homepage": "https://github.com/ovh/manager/tree/master/packages/components/ng-ui-router-breadcrumb#readme",
   "bugs": {
-    "url": "https://github.com/ovh-ux/manager/issues"
+    "url": "https://github.com/ovh/manager/issues"
   },
   "repository": {
     "type": "git",

--- a/packages/components/ng-ui-router-title/package.json
+++ b/packages/components/ng-ui-router-title/package.json
@@ -8,9 +8,9 @@
     "title",
     "ui-router"
   ],
-  "homepage": "https://github.com/ovh-ux/manager/tree/master/packages/components/ng-ui-router-breadcrumb#readme",
+  "homepage": "https://github.com/ovh/manager/tree/master/packages/components/ng-ui-router-title#readme",
   "bugs": {
-    "url": "https://github.com/ovh-ux/manager/issues"
+    "url": "https://github.com/ovh/manager/issues"
   },
   "repository": {
     "type": "git",

--- a/packages/manager/apps/cloud/README.md
+++ b/packages/manager/apps/cloud/README.md
@@ -45,9 +45,9 @@ yarn test
 
 ## Related
 
-* [Web Control Panel UI](https://github.com/ovh-ux/ovh-manager-web).
-* [Dedicated Control Panel UI](https://github.com/ovh-ux/ovh-manager-dedicated).
-* [Telecom Control Panel UI](https://github.com/ovh-ux/ovh-manager-telecom).
+* [Web Control Panel UI](https://github.com/ovh/manager/tree/master/packages/manager/apps/web).
+* [Dedicated Control Panel UI](https://github.com/ovh/manager/tree/master/packages/manager/apps/dedicated).
+* [Telecom Control Panel UI](https://github.com/ovh/manager/tree/master/packages/manager/apps/telecom).
 
 ## Contributing
 

--- a/packages/manager/apps/dedicated/README.md
+++ b/packages/manager/apps/dedicated/README.md
@@ -45,9 +45,9 @@ yarn test
 
 ## Related
 
-* [ovh-manager-web](https://github.com/ovh-ux/ovh-manager-web) - OVH Control Panel Web UI
-* [ovh-manager-cloud](https://github.com/ovh-ux/ovh-manager-cloud) - OVH Control Panel Cloud UI
-* [ovh-manager-telecom](https://github.com/ovh-ux/ovh-manager-telecom) - OVH Control Panel Telecom UI
+* [ovh-manager-web](https://github.com/ovh/manager/tree/master/packages/manager/apps/web) - OVH Control Panel Web UI
+* [ovh-manager-cloud](https://github.com/ovh/manager/tree/master/packages/manager/apps/cloud) - OVH Control Panel Cloud UI
+* [ovh-manager-telecom](https://github.com/ovh/manager/tree/master/packages/manager/apps/telecom) - OVH Control Panel Telecom UI
 
 ## Contributing
 

--- a/packages/manager/apps/telecom/README.md
+++ b/packages/manager/apps/telecom/README.md
@@ -45,9 +45,9 @@ yarn test
 
 ## Related
 
-* [ovh-manager-web](https://github.com/ovh-ux/ovh-manager-web) - OVH Control Panel Web UI
-* [ovh-manager-dedicated](https://github.com/ovh-ux/ovh-manager-dedicated) - OVH Control Panel Dedicated UI
-* [ovh-manager-cloud](https://github.com/ovh-ux/ovh-manager-cloud) - OVH Control Panel Cloud UI
+* [ovh-manager-web](https://github.com/ovh/manager/tree/master/packages/manager/apps/web) - OVH Control Panel Web UI
+* [ovh-manager-dedicated](https://github.com/ovh/manager/tree/master/packages/manager/apps/dedicated) - OVH Control Panel Dedicated UI
+* [ovh-manager-cloud](https://github.com/ovh/manager/tree/master/packages/manager/apps/cloud) - OVH Control Panel Cloud UI
 
 ## Contributing
 

--- a/packages/manager/apps/web/README.md
+++ b/packages/manager/apps/web/README.md
@@ -45,13 +45,13 @@ yarn test
 
 ## Related
 
-* [ovh-manager-dedicated](https://github.com/ovh-ux/ovh-manager-dedicated) - OVH Control Panel Dedicated UI
-* [ovh-manager-cloud](https://github.com/ovh-ux/ovh-manager-cloud) - OVH Control Panel Cloud UI
-* [ovh-manager-telecom](https://github.com/ovh-ux/ovh-manager-telecom) - OVH Control Panel Telecom UI
-* [ovh-module-emailpro](https://github.com/ovh-ux/ovh-module-emailpro) - Web Module Emailpro
-* [ovh-module-exchange](https://github.com/ovh-ux/ovh-module-exchange) - Web Module Exchange
-* [ovh-module-office](https://github.com/ovh-ux/ovh-module-office) - Web Module Office
-* [ovh-module-sharepoint](https://github.com/ovh-ux/ovh-module-sharepoint) - Web Module Sharepoint
+* [ovh-manager-dedicated](https://github.com/ovh/manager/tree/master/packages/manager/apps/dedicated) - OVH Control Panel Dedicated UI
+* [ovh-manager-cloud](https://github.com/ovh/manager/tree/master/packages/manager/apps/cloud) - OVH Control Panel Cloud UI
+* [ovh-manager-telecom](https://github.com/ovh/manager/tree/master/packages/manager/apps/telecom) - OVH Control Panel Telecom UI
+* [ovh-module-emailpro](https://github.com/ovh/manager/tree/master/packages/manager/modules/emailpro) - Web Module Emailpro
+* [ovh-module-exchange](https://github.com/ovh/manager/tree/master/packages/manager/modules/exchange) - Web Module Exchange
+* [ovh-module-office](https://github.com/ovh/manager/tree/master/packages/manager/modules/office) - Web Module Office
+* [ovh-module-sharepoint](https://github.com/ovh/manager/tree/master/packages/manager/modules/sharepoint) - Web Module Sharepoint
 
 ## Contributing
 

--- a/packages/manager/modules/carrier-sip/README.md
+++ b/packages/manager/modules/carrier-sip/README.md
@@ -23,7 +23,7 @@ angular.module('myApp', [ovhManagerCarrierSip]);
 
 ## Related
 
-* [manager-telecom](https://github.com/ovh-ux/manager/blob/master/packages/manager/apps/telecom/README.md) - OVH Control Panel Telecom UI.
+* [manager-telecom](https://github.com/ovh/manager/blob/master/packages/manager/apps/telecom/README.md) - OVH Control Panel Telecom UI.
 
 ## Contributing
 

--- a/packages/manager/modules/cloud-universe-components/README.md
+++ b/packages/manager/modules/cloud-universe-components/README.md
@@ -26,7 +26,7 @@ yarn test
 
 ## Related
 
-* [ovh-manager-cloud](https://github.com/ovh-ux/ovh-manager-cloud) - OVH Control Panel Cloud UI
+* [ovh-manager-cloud](https://github.com/ovh/manager/tree/master/packages/manager/apps/cloud) - OVH Control Panel Cloud UI
 
 ## Contributing
 

--- a/packages/manager/modules/telecom-universe-components/README.md
+++ b/packages/manager/modules/telecom-universe-components/README.md
@@ -4,7 +4,7 @@
 
 [![Downloads](https://badgen.net/npm/dt/@ovh-ux/ng-ovh-telecom-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-telecom-universe-components) [![Dependencies](https://badgen.net/david/dep/ovh-ux/ng-ovh-telecom-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-telecom-universe-components?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/ng-ovh-telecom-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-telecom-universe-components?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
 
-We extracted all the components of the [telecom control panel](https://github.com/ovh-ux/ovh-manager-telecom) in order to interconnect them
+We extracted all the components of the [telecom control panel](https://github.com/ovh/manager/tree/master/packages/manager/apps/telecom) in order to interconnect them
 both in our upcoming [monorepo](https://github.com/ovh/manager) but also in the current stack.
 
 At the end we are planning remove this repository and privilege the management of sources directly
@@ -32,7 +32,7 @@ yarn test
 
 ## Related
 
-* [ovh-manager-telecom](https://github.com/ovh-ux/ovh-manager-telecom) - OVH Control Panel Telecom UI
+* [ovh-manager-telecom](https://github.com/ovh/manager/tree/master/packages/manager/apps/telecom) - OVH Control Panel Telecom UI
 
 ## Contributing
 

--- a/packages/manager/modules/web-universe-components/README.md
+++ b/packages/manager/modules/web-universe-components/README.md
@@ -4,7 +4,7 @@
 
 [![Downloads](https://badgen.net/npm/dt/@ovh-ux/ng-ovh-web-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-web-universe-components) [![Dependencies](https://badgen.net/david/dep/ovh-ux/ng-ovh-web-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-web-universe-components?activeTab=dependencies) [![Dev Dependencies](https://badgen.net/david/dev/ovh-ux/ng-ovh-web-universe-components)](https://npmjs.com/package/@ovh-ux/ng-ovh-web-universe-components?activeTab=dependencies) [![Gitter](https://badgen.net/badge/gitter/ovh-ux/blue?icon=gitter)](https://gitter.im/ovh/ux)
 
-We extracted all the components of the [web control panel](https://github.com/ovh-ux/ovh-manager-web) in order to interconnect them
+We extracted all the components of the [web control panel](https://github.com/ovh/manager/tree/master/packages/manager/apps/web) in order to interconnect them
 both in our upcoming [monorepo](https://github.com/ovh/manager) but also in the current stack.
 
 At the end we are planning remove this repository and privilege the management of sources directly
@@ -32,7 +32,7 @@ yarn test
 
 ## Related
 
-* [ovh-manager-web](https://github.com/ovh-ux/ovh-manager-web) - OVH Control Panel Web UI
+* [ovh-manager-web](https://github.com/ovh/manager/tree/master/packages/manager/apps/web) - OVH Control Panel Web UI
 
 ## Contributing
 

--- a/packages/manager/tools/component-rollup-config/README.md
+++ b/packages/manager/tools/component-rollup-config/README.md
@@ -191,7 +191,7 @@ $ yarn test
 
 ## Related
 
-- [@ovh-ux/rollup-plugin-less-tilde-importer](https://github.com/ovh-ux/rollup-plugin-less-tilde-importer) - Rollup plugin to facilitate less imports with a ~ (tilde) prefix
+- [@ovh-ux/rollup-plugin-less-tilde-importer](https://github.com/ovh/rollup-plugin-less-tilde-importer) - Rollup plugin to facilitate less imports with a ~ (tilde) prefix
 
 ## Contributing
 

--- a/packages/manager/tools/dev-server-config/README.md
+++ b/packages/manager/tools/dev-server-config/README.md
@@ -12,7 +12,7 @@ yarn add @ovh-ux/manager-dev-server-config
 
 ## Related
 
-* [dev-server](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/dev-server) - OVHcloud manager dev server
+* [dev-server](https://github.com/ovh/manager/tree/master/packages/manager/tools/dev-server) - OVHcloud manager dev server
 
 ## Contributing
 

--- a/packages/manager/tools/dev-server/README.md
+++ b/packages/manager/tools/dev-server/README.md
@@ -95,7 +95,7 @@ Serve: ./packages/manager/apps/hub/dist - region: ca - localhost:1234
 
 ## Related
 
-* [manager-dev-server-config](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/dev-server-config) - OVHcloud manager shared dev server configuration
+* [manager-dev-server-config](https://github.com/ovh/manager/tree/master/packages/manager/tools/dev-server-config) - OVHcloud manager shared dev server configuration
 
 ## Contributing
 

--- a/packages/manager/tools/webpack-config/README.md
+++ b/packages/manager/tools/webpack-config/README.md
@@ -69,7 +69,7 @@ module.exports = merge(config, {
 
 ## Related
 
-* [manager-webpack-dev-server](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/webpack-dev-server) - OVH manager webpack development server configuration
+* [manager-webpack-dev-server](https://github.com/ovh/manager/tree/master/packages/manager/tools/webpack-dev-server) - OVH manager webpack development server configuration
 
 ## Contributing
 

--- a/packages/manager/tools/webpack-dev-server/README.md
+++ b/packages/manager/tools/webpack-dev-server/README.md
@@ -48,7 +48,7 @@ const env = {
 
 ## Related
 
-* [manager-webpack-config](https://github.com/ovh-ux/manager/tree/master/packages/manager/tools/webpack-config) - OVH manager shared webpack configuration
+* [manager-webpack-config](https://github.com/ovh/manager/tree/master/packages/manager/tools/webpack-config) - OVH manager shared webpack configuration
 
 ## Contributing
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :memo: Documentation

b4d4bae - docs: update links to rely on the new organization name [skip ci]

uses:
```sh
$ git grep "https://github.com/ovh-ux" -- './*' ':!*CHANGELOG.md'
```

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>

