### PR TITLE
fix(pack.xdsl.access): remove disabled for ftth pack

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
@@ -289,7 +289,6 @@
 
                                             <button
                                                 class="oui-button oui-button_secondary oui-button_icon-right oui-button_block"
-                                                data-ng-disabled="access.xdsl.isFiber"
                                                 data-ui-sref="telecom.packs.pack.move"
                                                 role="button"
                                             >


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-333
| License          | BSD 3-Clause

## Description

Unable button move for FTTH offer
