### PR TITLE
fix(hosting): add `track by` to ensure that "More" tab will always be displayed

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/hosting.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/hosting.controller.js
@@ -506,6 +506,12 @@ export default class {
             },
           ]);
         }
+      })
+      .catch(() => {
+        this.Alerter.error(
+          this.$translate.instant('hosting_tab_generic_error'),
+          this.$scope.alerts.page,
+        );
       });
   }
 

--- a/packages/manager/apps/web/client/app/hosting/hosting.html
+++ b/packages/manager/apps/web/client/app/hosting/hosting.html
@@ -149,7 +149,7 @@
         <oui-header-tabs>
             <oui-header-tabs-item
                 data-ng-if="$ctrl.tabs"
-                data-ng-repeat="tab in $ctrl.tabs"
+                data-ng-repeat="tab in $ctrl.tabs track by $index"
                 data-href="{{:: $ctrl.$state.href('app.hosting', { 'tab': tab }) }}"
                 data-active="$ctrl.selectedTab === tab"
                 data-on-click="$ctrl.setSelectedTab(tab)"

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
@@ -252,6 +252,7 @@
   "hosting_dashboard_local_seo_visibility_check": "Vérifiez votre référencement local",
   "hosting_dashboard_local_seo_activating": "Activation en cours",
   "hosting_dashboard_local_seo_inactive": "Inactif",
+  "hosting_tab_generic_error": "Une erreur est survenue lors de la récupération des informations.",
   "hosting_tab_CRON": "Cron",
   "hosting_tab_CRON_guide_help": "Besoin d'aide pour configurer vos tâches planifiées ?",
   "hosting_guide_help": "Consultez nos guides en ligne.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-22804
| License          | BSD 3-Clause

## Description

issue :
the "More" tab content depends on some async call ; depending on the duration of those calls if it takes too long the menu is not displayed in the manager because the ngRepeat does not detect array manipulation changes

adding "track by" ensure the "More" tab will always be displayed