### PR TITLE
fix(pack.xdsl.line): avoid to duplicate serviceName in url

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/pack-xdsl.routing.js
@@ -26,7 +26,7 @@ export default /* @ngInject */ ($stateProvider) => {
   });
 
   $stateProvider.state('telecom.packs.pack.xdsl.line', {
-    url: '/xdsl/:serviceName/lines/:number',
+    url: '/lines/:number',
     views: {
       '@telecom.packs': 'packXdsl',
       'xdslView@telecom.packs.pack.xdsl.line': 'packXdslAccess',


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Url should be `/pack/:packName/xdsl/:serviceName/lines/:number` instead of `/pack/:packName/xdsl/:serviceName/xdsl/:serviceName/lines/:number` (duplication of `/xdsl/:serviceName`)


