### PR TITLE
fix(components.catalog-items): avoid duplicate track by keys

### DIFF
--- a/packages/manager/modules/hub/src/components/catalog-items/template.html
+++ b/packages/manager/modules/hub/src/components/catalog-items/template.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div
             class="col-md-6 col-xl-4 mb-3"
-            data-ng-repeat="product in products track by product.productName"
+            data-ng-repeat="product in products track by (product.category + '_' + product.productName)"
         >
             <ovh-manager-hub-tile
                 heading="{{:: product.name }}"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-5865
| License          | BSD 3-Clause

## Description

Avoid duplicate track by keys in catalog-items ng-repeat once the catalog with duplicate items are prodded (required for essentials)
