### PR TITLE
fix(vrack): filter services expired

### DIFF
--- a/packages/manager/modules/vrack/src/vrack.constant.js
+++ b/packages/manager/modules/vrack/src/vrack.constant.js
@@ -28,7 +28,13 @@ export const VRACK_URLS = {
 
 export const POLLING_INTERVAL = 500;
 
+export const STATUS = {
+  ok: 'ok',
+  delivered: 'delivered',
+};
+
 export default {
   POLLING_INTERVAL,
+  STATUS,
   VRACK_URLS,
 };


### PR DESCRIPTION
ref: DTRSD-22888
Signed-off-by: Jérémy De-Cesare <jeremy.de-cesare@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-22888
| License          | BSD 3-Clause

## Description

Filter expired services for vRack configuration
(Based on additional information returned by 2API vrack-allowed-services endpoint)
