### PR TITLE
ci(workflow): add gh-pages actions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,26 @@
+name: GitHub Pages
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install
+        run: |
+          yarn --version
+          yarn install
+          yarn workspace @ovh-ux/manager-documentation run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/docs/.vuepress/dist
+          full_commit_message: 'docs: update documentation [skip ci]'


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-5867
| License          | BSD 3-Clause

## Description

### :green_heart: Continuous Integration

Based on `release` event, the VuePress documentation is automatically
updated and deploy with GitHub Pages.

9bd9f26 - ci(workflow): add gh-pages actions

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
