### PR TITLE
perf: remove unused intl-tel-input dependency

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -39,8 +39,6 @@ import 'script-loader!randexp/build/randexp.min';
 import 'script-loader!ui-select/dist/select.min.js';
 import 'angular-resource';
 import 'script-loader!jsurl/lib/jsurl.js';
-import 'script-loader!intl-tel-input/build/js/intlTelInput.min.js';
-import 'script-loader!intl-tel-input/lib/libphonenumber/build/utils.js';
 import 'script-loader!international-phone-number/releases/international-phone-number.min.js';
 import 'script-loader!qrcode.js/lib/qrcode.js';
 import 'angular-qr';

--- a/packages/manager/apps/dedicated/client/app/css/source.less
+++ b/packages/manager/apps/dedicated/client/app/css/source.less
@@ -5,7 +5,6 @@
 @import (less) 'ovh-manager-webfont/dist/css/ovh-font.css';
 @import (less) 'animate.css/animate.min.css';
 @import (less) 'ui-select/dist/select.min.css';
-@import (less) 'intl-tel-input/build/css/intlTelInput.css';
 @import 'less/utils/variables';
 @import 'less/utils/function';
 @import 'less/utils/elements';

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -122,7 +122,6 @@
     "flatpickr": "^4.6.3",
     "font-awesome": "~4.7.0",
     "international-phone-number": "mareczek/international-phone-number#^0.0.16",
-    "intl-tel-input": "~5.1.0",
     "ipaddr.js": "^1.6.0",
     "jquery": "^2.1.3",
     "jquery.cookie": "^1.4.1",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

Remove unused dependecy

Un-gzipped gains around 280Kb, from 3.38Mb to 3.1Mb bundle size