### PR TITLE
perf: remove unused ckeditor import

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -54,7 +54,6 @@ import 'script-loader!matchmedia-ng/matchmedia-ng.js';
 import 'angular-aria';
 import 'script-loader!chart.js/dist/Chart.min.js';
 import 'ovh-angular-responsive-tabs';
-import 'ckeditor';
 import 'script-loader!messenger/build/js/messenger.min.js';
 import 'script-loader!filesize/lib/filesize.js';
 import 'script-loader!angular-websocket/dist/angular-websocket';

--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -38,7 +38,6 @@ import 'angular-translate-loader-partial';
 import 'angular-translate-loader-static-files';
 import 'ng-slide-down';
 import 'script-loader!matchmedia-ng/matchmedia-ng.js';
-import 'ckeditor';
 import 'ovh-api-services';
 import 'script-loader!clipboard/dist/clipboard.min.js';
 import 'script-loader!bootstrap-tour/build/js/bootstrap-tour-standalone.min.js';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          |
| License          | BSD 3-Clause

## Description

ck-editor is already imported using script tag in html template
the import is not necessary

tested on staging, ckeditor looks ok

gains un-gzipped :
- web bundle size reduced from 2.45Mb to 1.8Mb
- dedicated bundle size reduced 3.38Mb to 2.8Mb
