### PR TITLE
perf: lazy load angular-qr dependency

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/user.module.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/user.module.js
@@ -8,7 +8,6 @@ import supportLevel from './support-level/support-level.module';
 
 angular
   .module('UserAccount', [
-    'ja.qr',
     'ngOvhUtils',
     'ovhSignupApp',
     advanced,

--- a/packages/manager/apps/dedicated/client/app/account/user/user.routes.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/user.routes.js
@@ -20,6 +20,10 @@ angular.module('UserAccount').config(
       },
       redirectTo: `${name}.method`,
       resolve: {
+        angularQr: /* @ngInject */ ($ocLazyLoad) =>
+          import('angular-qr').then((module) =>
+            $ocLazyLoad.inject(module.default || module),
+          ),
         schema: /* @ngInject */ (OvhApiMe) => OvhApiMe.v6().schema().$promise,
         supportLevel: /* @ngInject */ (OvhApiMe, schema) =>
           schema.models[API_MODEL_SUPPORT_LEVEL]

--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -42,8 +42,6 @@ import 'script-loader!jsurl/lib/jsurl.js';
 import 'script-loader!intl-tel-input/build/js/intlTelInput.min.js';
 import 'script-loader!intl-tel-input/lib/libphonenumber/build/utils.js';
 import 'script-loader!international-phone-number/releases/international-phone-number.min.js';
-import 'script-loader!qrcode.js/lib/qrcode.js';
-import 'angular-qr';
 import 'script-loader!u2f-api-polyfill/u2f-api-polyfill.js';
 import 'ovh-api-services';
 import 'angular-translate';

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -144,7 +144,6 @@
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "punycode": "^1.4.1",
-    "qrcode.js": "janantala/qrcode.js#~1.0.x",
     "randexp": "fent/randexp.js#~0.4.0",
     "raphael": "^2.2.8",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16546,10 +16546,6 @@ qrcode-terminal@^0.10.0:
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz#a76a48e2610a18f97fa3a2bd532b682acff86c53"
   integrity sha1-p2pI4mEKGPl/o6K9UytoKs/4bFM=
 
-qrcode.js@janantala/qrcode.js#~1.0.x:
-  version "1.0.2"
-  resolved "https://codeload.github.com/janantala/qrcode.js/tar.gz/2c20b467901740e6e32308b100d2df1125d4f6ac"
-
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

angular-qr was imported for the whole application, now it's lazy loaded only in the module using it
remove unused dependency qrcode.js

un-gzipped gains : 50Kb on dedicated