### PR TITLE
fix(dedicated-cloud.upgrade): switch datastore from hourly to monthly

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_de_DE.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Es wird ein neuer Tab geöffnet, und Sie werden automatisch auf das Zahlungsinterface weitergeleitet.",
   "ovhManagerPccResourceUpgrade_validateButton": "Bestätigen",
   "ovhManagerPccResourceUpgrade_cancelButton": "Abbrechen",
-  "dedicatedCloud_order_loading_error": "Beim Laden der Informationen ist ein Fehler aufgetreten."
+  "dedicatedCloud_order_loading_error": "Beim Laden der Informationen ist ein Fehler aufgetreten.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "Die Option {{ planCode }} ist nicht verfügbar."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_en_GB.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "A new tab will open and you will automatically be redirected to the payment interface.",
   "ovhManagerPccResourceUpgrade_validateButton": "Confirm",
   "ovhManagerPccResourceUpgrade_cancelButton": "Cancel",
-  "dedicatedCloud_order_loading_error": "An error has occurred loading information."
+  "dedicatedCloud_order_loading_error": "An error has occurred loading information.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "The {{ planCode }} option is not available."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_es_ES.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Se abrirá una nueva pestaña y el sistema le redirigirá automáticamente a la interfaz de pago de OVH.",
   "ovhManagerPccResourceUpgrade_validateButton": "Aceptar",
   "ovhManagerPccResourceUpgrade_cancelButton": "Cancelar",
-  "dedicatedCloud_order_loading_error": "Se ha producido un error al cargar la información."
+  "dedicatedCloud_order_loading_error": "Se ha producido un error al cargar la información.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "La opción {{ planCode }} no está disponible."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_fr_CA.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Un nouvel onglet s'ouvrira et vous serez automatiquement redirigé vers l'interface de paiement.",
   "ovhManagerPccResourceUpgrade_validateButton": "Valider",
   "ovhManagerPccResourceUpgrade_cancelButton": "Annuler",
-  "dedicatedCloud_order_loading_error": "Une erreur est survenue lors du chargement des informations."
+  "dedicatedCloud_order_loading_error": "Une erreur est survenue lors du chargement des informations.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "L'option {{ planCode }} n'est pas disponible."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_fr_FR.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Un nouvel onglet s'ouvrira et vous serez automatiquement redirigé vers l'interface de paiement.",
   "ovhManagerPccResourceUpgrade_validateButton": "Valider",
   "ovhManagerPccResourceUpgrade_cancelButton": "Annuler",
-  "dedicatedCloud_order_loading_error": "Une erreur est survenue lors du chargement des informations."
+  "dedicatedCloud_order_loading_error": "Une erreur est survenue lors du chargement des informations.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "L'option {{ planCode }} n'est pas disponible."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_it_IT.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Si aprirà una nuova scheda e verrai reindirizzato automaticamente verso l'interfaccia di pagamento.",
   "ovhManagerPccResourceUpgrade_validateButton": "Conferma",
   "ovhManagerPccResourceUpgrade_cancelButton": "Annulla",
-  "dedicatedCloud_order_loading_error": "Si è verificato un errore durante il caricamento delle informazioni."
+  "dedicatedCloud_order_loading_error": "Si è verificato un errore durante il caricamento delle informazioni.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "L'opzione {{ planCode }} non è disponibile."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_pl_PL.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Otworzy się nowa zakładka i zostaniesz automatycznie przekierowany do strony z płatnościami.",
   "ovhManagerPccResourceUpgrade_validateButton": "Zatwierdź",
   "ovhManagerPccResourceUpgrade_cancelButton": "Anuluj",
-  "dedicatedCloud_order_loading_error": "Wystąpił błąd podczas pobierania informacji."
+  "dedicatedCloud_order_loading_error": "Wystąpił błąd podczas pobierania informacji.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "Opcja {{planCode}} jest niedostępna."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/translations/Messages_pt_PT.json
@@ -10,5 +10,6 @@
   "ovhManagerPccResourceUpgrade_willOpenNewTabAndRedirect": "Será aberto um novo separador e será automaticamente reencaminhado para a interface de pagamentos.",
   "ovhManagerPccResourceUpgrade_validateButton": "Validar",
   "ovhManagerPccResourceUpgrade_cancelButton": "Cancelar",
-  "dedicatedCloud_order_loading_error": "Erro ao carregar a informação."
+  "dedicatedCloud_order_loading_error": "Erro ao carregar a informação.",
+  "ovhManagerPccResourceUpgrade_plan_not_found": "A opção {{ planCode }} não está disponível."
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/upgrade.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/upgrade.controller.js
@@ -20,7 +20,7 @@ export default class {
     this.bindings = {
       isLoading: false,
     };
-
+    this.optionPlanCode = null;
     return this.fetchInitialData();
   }
 
@@ -70,6 +70,8 @@ export default class {
   fetchServiceOptionPlanCode(target) {
     const targetPlanCode = target.profileCode || target.profile || null;
     const targetFamily = this.type;
+    this.optionPlanCode = targetPlanCode;
+
     return this.$http
       .get(`/order/cartServiceOption/privateCloud/${this.productId}`)
       .then((data) => get(data, 'data'))
@@ -77,7 +79,7 @@ export default class {
         find(
           options,
           ({ planCode, family }) =>
-            planCode.startsWith(targetPlanCode) && family === targetFamily,
+            planCode === targetPlanCode && family === targetFamily,
         ),
       )
       .then(({ planCode }) => planCode);
@@ -153,6 +155,14 @@ export default class {
   }
 
   placeOrder() {
+    if (!this.plan) {
+      return this.goBack(
+        this.$translate.instant('ovhManagerPccResourceUpgrade_plan_not_found', {
+          planCode: this.optionPlanCode,
+        }),
+        'danger',
+      );
+    }
     const stringifiedExpressParameters = JSURL.stringify([
       {
         productId: ORDER_PARAMETERS.productId,
@@ -179,6 +189,6 @@ export default class {
     window.location = `${this.expressURL}review?products=${stringifiedExpressParameters}`;
     window.target = '_blank';
 
-    this.goBack();
+    return this.goBack();
   }
 }


### PR DESCRIPTION
use exact plan code while getting plan details from datastore service options

ref #DTRSD-23106

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-23106
| License          | BSD 3-Clause

## Description

Use exact plan code while getting plan details from datastore service options
