### PR TITLE
perf: remove unused angular-flash-alert dependency

### DIFF
--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -83,7 +83,6 @@ angular
       'directives',
       ngQAllSettled,
       'ngMessages',
-      'ngFlash',
       'vs-repeat',
       'xeditable',
       ngAtInternet,

--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -20,7 +20,6 @@ import 'script-loader!flatpickr/dist/flatpickr.min.js';
 import '@ovh-ux/ui-kit';
 import 'script-loader!jquery.scrollto/jquery.scrollTo.min.js';
 import 'script-loader!angular-dynamic-locale/dist/tmhDynamicLocale.js';
-import 'angular-flash-alert';
 import 'script-loader!jquery.cookie/jquery.cookie.js';
 import 'bootstrap';
 import 'angular-ui-bootstrap';

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -71,7 +71,6 @@
     "angular-aria": "^1.6.0",
     "angular-cookies": "^1.6.0",
     "angular-dynamic-locale": "^0.1.27",
-    "angular-flash-alert": "^2.3.0",
     "angular-i18n": "^1.6.0",
     "angular-messages": "^1.6.0",
     "angular-resource": "^1.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,7 +3837,7 @@ angular-dynamic-locale@^0.1.0, angular-dynamic-locale@^0.1.27, angular-dynamic-l
   dependencies:
     "@types/angular" "^1.6.25"
 
-angular-flash-alert@2.5.0, angular-flash-alert@^2.3.0:
+angular-flash-alert@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/angular-flash-alert/-/angular-flash-alert-2.5.0.tgz#321d4908d9acf847aa8a219cc7f6e95a502e71d4"
   integrity sha512-O/uqA66qtGsOA232+enzJNH4wH9v6ywcClRPf2C+T7xE/MxRRovOc959mcX9mIqNwncwPPc8quWol36R9fm1ow==


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

remove unused angular-flash-alert dep from web