### PR TITLE
feat(registry): add static sync command

### DIFF
--- a/packages/manager/tools/registry/README.md
+++ b/packages/manager/tools/registry/README.md
@@ -102,14 +102,15 @@ manager-registry static --help
 Usage: manager-registry-static [options] [command]
 
 Options:
-  -V, --version                      output the version number
-  -h, --help                         output usage information
+  -V, --version                                   output the version number
+  -h, --help                                      output usage information
 
 Commands:
-  generate-manifests <registryPath>  Generate manifest for static registry
-  serve <registryPath>               Serve a static registry
-  add <registryPath> <fragmentPath>  Add a fragment in static registry
-  help [cmd]                         display help for [cmd]
+  generate-manifests <registryPath>               Generate manifest for static registry
+  serve <registryPath>                            Serve a static registry
+  add <registryPath> <fragmentPath>               Add a fragment in static registry
+  sync <sourceRegistryPath> <targetRegistryPath>  Sync two registry folders
+  help [cmd]                                      display help for [cmd]
 
 ```
 
@@ -196,6 +197,27 @@ $ manager-registry static add ./path/to/static/registry ./path/to/fragment/dist
 Fragment "fragment@1.0.O" already exists in ./path/to/static/registry
 ```
 
+##### Sync registry
+
+> Sync two registry directories (will add missing fragment from source to target directory)
+
+```sh
+$ manager-registry static sync --help
+Usage: manager-registry-static-sync [options] <sourceRegistryPath> <targetRegistryPath>
+
+Options:
+  -V, --version  output the version number
+  -h, --help     output usage information
+```
+
+*Example*
+
+Sync a static registry with an another existing static registry
+
+```sh
+$ manager-registry static sync ./path/to/static/registry ./path/to/another/static/registry
+Fragment "fragment@1.0.O" added in registry ./path/to/another/static/registry
+```
 
 ## Related
 

--- a/packages/manager/tools/registry/bin/manager-registry-static-sync.js
+++ b/packages/manager/tools/registry/bin/manager-registry-static-sync.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const program = require('commander');
+const pkg = require('../package.json');
+
+const syncStaticRegistry = require('../src/syncStaticRegistry');
+
+program
+  .version(pkg.version)
+  .arguments('<sourceRegistryPath> <targetRegistryPath>')
+  .action((sourceRegistryPath, targetRegistryPath) => {
+    syncStaticRegistry(
+      path.resolve(sourceRegistryPath),
+      path.resolve(targetRegistryPath),
+    );
+  })
+  .parse(process.argv);

--- a/packages/manager/tools/registry/bin/manager-registry-static.js
+++ b/packages/manager/tools/registry/bin/manager-registry-static.js
@@ -14,4 +14,8 @@ program
     'add <registryPath> <fragmentPath>',
     'Add a fragment in static registry',
   )
+  .command(
+    'sync <sourceRegistryPath> <targetRegistryPath>',
+    'Sync two registry directories',
+  )
   .parse(process.argv);

--- a/packages/manager/tools/registry/package.json
+++ b/packages/manager/tools/registry/package.json
@@ -19,8 +19,10 @@
     "manager-registry": "bin/manager-registry.js",
     "manager-registry-dev": "bin/manager-registry-dev.js",
     "manager-registry-static": "bin/manager-registry-static.js",
+    "manager-registry-static-add": "bin/manager-registry-static-add.js",
     "manager-registry-static-generate-manifests": "bin/manager-registry-static-generate-manifests.js",
-    "manager-registry-static-serve": "bin/manager-registry-static-serve.js"
+    "manager-registry-static-serve": "bin/manager-registry-static-serve.js",
+    "manager-registry-static-sync": "bin/manager-registry-static-sync.js"
   },
   "dependencies": {
     "axios": "^0.19.2",

--- a/packages/manager/tools/registry/src/syncStaticRegistry.js
+++ b/packages/manager/tools/registry/src/syncStaticRegistry.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+const path = require('path');
+const staticStorage = require('./storage/static-storage');
+
+const addFragmentStatic = require('./addFragmentStatic');
+
+const parseInfos = (infos) =>
+  infos.reduce(
+    (results, { name, versions }) => [
+      ...results,
+      ...versions.map((version) => ({ name, version })),
+    ],
+    [],
+  );
+
+const getMissingFragmentsVersion = (sourceInfos, targetInfos) => {
+  const source = parseInfos(sourceInfos);
+  const target = parseInfos(targetInfos);
+
+  return source.filter(
+    ({ name, version }) =>
+      !target.find(
+        ({ name: targetName, version: targetVersion }) =>
+          name === targetName && version === targetVersion,
+      ),
+  );
+};
+
+module.exports = (sourceRegistryPath, targetRegistryPath) => {
+  return Promise.all([
+    staticStorage.readInfos(sourceRegistryPath),
+    staticStorage.readInfos(targetRegistryPath),
+  ]).then(([sourceInfos, targetInfos]) => {
+    const diff = getMissingFragmentsVersion(sourceInfos, targetInfos);
+
+    if (diff.length > 0) {
+      return Promise.all(
+        diff.map(({ name, version }) =>
+          addFragmentStatic(
+            targetRegistryPath,
+            path.resolve(sourceRegistryPath, name, version),
+          ),
+        ),
+      );
+    }
+
+    console.log('No fragment to sync');
+    return Promise.resolve();
+  });
+};
+
+/* eslint-enable no-console */


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

> Sync two registry directories (will add missing fragment from source to target directory)

```sh
$ manager-registry static sync --help
Usage: manager-registry-static-sync [options] <sourceRegistryPath> <targetRegistryPath>

Options:
  -V, --version  output the version number
  -h, --help     output usage information
```

*Example*

Sync a static registry with an another existant static registry

```sh
$ manager-registry static sync ./path/to/static/registry ./path/to/another/static/registry
Fragment "fragment@1.0.O" added in registry ./path/to/another/static/registry
```


