### PR TITLE
hotfix(web-email): not possible to create mx plan email account

### DIFF
--- a/packages/manager/modules/emailpro/src/account/emailpro-account.controller.js
+++ b/packages/manager/modules/emailpro/src/account/emailpro-account.controller.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 import set from 'lodash/set';
@@ -254,6 +255,7 @@ export default /* @ngInject */ (
       primaryEmailAddress: newConfiguredAccount,
     })
       .then((account) => {
+        $scope.accountIds = $scope.accountIds.slice(1);
         set(account, 'completeDomain', {
           name: account.domain,
           displayName: punycode.toUnicode(account.domain),
@@ -264,12 +266,15 @@ export default /* @ngInject */ (
           account,
         );
       })
-      .catch((err) =>
+      .catch((err) => {
         $scope.setMessage(
           $translate.instant('emailpro_tab_ACCOUNTS_error_message'),
-          err,
-        ),
-      )
+          {
+            ...err,
+            type: err.type || 'error',
+          },
+        );
+      })
       .finally(() => {
         $scope.loadingNewConfiguredAccount = false;
       });


### PR DESCRIPTION
ref #DTRSD-24203

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-24203
| License          | BSD 3-Clause

## Description

Issue: Not possible to create more than one mx plan email accounts. 
Fix: Remove account from new account options once the account is created. If not the same account is used again which breaks the API.
