### PR TITLE
fix: allow to access sub dashboard states

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedCloud.module.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedCloud.module.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 
 import confirmTerminate from './confirm-terminate';
-import dashboard from './dashboard';
+import dashboard from './dashboard/dedicatedCloud-dashboard.module';
 import datacenter from './datacenter';
 import datacenters from './datacenters';
 import dedicatedCloudComponent from '../components/dedicated-cloud';

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.module.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.module.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 
 import confirmTerminate from './confirm-terminate';
-import dashboard from './dashboard';
+import dashboard from './dashboard/dashboard.module';
 import datacenter from './datacenter';
 import datacenters from './datacenters';
 import dedicatedCloudComponent from '../components/dedicated-cloud';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     |no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

This is due to dashboard url being empty
The parent is already lazyloaded and redirect to dashboard state so module will always be loaded when parent is required

Example to reproduce issue: 

Try to access https://www.ovh.com/manager/dedicated/#/configuration/dedicated_cloud/{serviceName}/associate-ip-bloc directly without loading anything in the dedicated cloud section first

I didn't find any issues mentioning this on ui router or oclazyload repositories yet
