### PR TITLE
fix(url-loader): disable es modules for url-loader

### DIFF
--- a/packages/manager/tools/webpack-config/src/webpack.common.ts
+++ b/packages/manager/tools/webpack-config/src/webpack.common.ts
@@ -109,6 +109,7 @@ export = opts => {
           loader: 'url-loader',
           options: {
             limit: 10000,
+            esModule: false,
           },
         },
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-24651
| License          | BSD 3-Clause

## Description

Fix svg paths in css (flag-icons in PCI instance creation).

Following the bump of `url-loader` from `^1.1.1` to `^4.1.1`, `url-loader@4` introduces a BC by adding & enabling `esModules` option by default (https://github.com/webpack-contrib/url-loader/tree/v4.1.1#esmodule)


