### PR TITLE
feat(move.offers): order offers, first ftth then xdsl

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -32,7 +32,7 @@ export default class PackMoveOffersCtrl {
       })
       .then(() => {
         if (this.eligibilityReferenceFiber) {
-          this.offers = [...this.listOffers, ...this.listOffersFiber];
+          this.offers = [...this.listOffersFiber, ...this.listOffers];
         } else {
           this.offers = [...this.listOffers];
         }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-348
| License          | BSD 3-Clause

## Description

Reorder offers for pack, display first FTTH offers and xDSL offers
