### PR TITLE
perf: exclude bundled js modules from babel

### DIFF
--- a/packages/manager/tools/webpack-config/src/webpack.common.ts
+++ b/packages/manager/tools/webpack-config/src/webpack.common.ts
@@ -21,7 +21,7 @@ const cacheLoader = {
 
 // The common webpack configuration
 
-export = opts => {
+export = (opts) => {
   const lessLoaderOptions = {
     sourceMap: true,
     plugins: [
@@ -37,6 +37,11 @@ export = opts => {
   if ('lessJavascriptEnabled' in opts) {
     set(lessLoaderOptions, 'javascriptEnabled', opts.lessJavascriptEnabled);
   }
+
+  const jsExclude = [
+    /\/node_modules/, // vendors
+    /\/dist/, // bundled files
+  ];
 
   return {
     plugins: [
@@ -79,14 +84,10 @@ export = opts => {
     ],
 
     resolve: {
-      modules: [
-        './node_modules',
-        path.resolve('./node_modules'),
-      ],
+      modules: ['./node_modules', path.resolve('./node_modules')],
     },
 
     resolveLoader: {
-
       // webpack module resolution paths
       modules: [
         './node_modules', // #1 check in module's relative node_module directory
@@ -96,7 +97,6 @@ export = opts => {
 
     module: {
       rules: [
-
         // load HTML files as string (raw-loader)
         {
           test: /\.html$/,
@@ -188,7 +188,7 @@ export = opts => {
         // load JS files
         {
           test: /\.js$/,
-          exclude: /node_modules(?!\/ovh-module)/, // we don't want babel to process vendors files
+          exclude: jsExclude,
           use: [
             cacheLoader,
             {
@@ -214,12 +214,15 @@ export = opts => {
         // given proper ui-router state 'translations' property
         {
           test: /\.js$/,
-          exclude: /node_modules(?!\/ovh-module)/,
+          exclude: jsExclude,
           enforce: 'pre',
           use: [
             cacheLoader,
             {
-              loader: path.resolve(__dirname, './loaders/translation-ui-router.js'),
+              loader: path.resolve(
+                __dirname,
+                './loaders/translation-ui-router.js',
+              ),
               options: {
                 subdirectory: 'translations',
                 filtering: false,
@@ -231,12 +234,15 @@ export = opts => {
         // inject translation with @ngTranslationsInject comment
         {
           test: /\.js$/,
-          exclude: /node_modules(?!\/ovh-module)/,
+          exclude: jsExclude,
           enforce: 'pre',
           use: [
             cacheLoader,
             {
-              loader: path.resolve(__dirname, './loaders/translation-inject.js'),
+              loader: path.resolve(
+                __dirname,
+                './loaders/translation-inject.js',
+              ),
               options: {
                 filtering: false,
               },
@@ -251,7 +257,6 @@ export = opts => {
       runtimeChunk: 'single',
       // bundle spliting configuration
       splitChunks: {
-
         // vendors bundle containing node_modules source code
         cacheGroups: {
           bower: {
@@ -276,7 +281,6 @@ export = opts => {
           },
         },
       },
-
     }, // \optimization
   };
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

babel & translation injection is processed twice for our modules built with rollup (first with rollup, then again with webpack)
ignoring them in webpack decrease the build time sightly (note: rollup & webpack is using the same babel config)

quick benchmark :
local build of manager dedicated without cache
before : 2m37
after : 2m12 (-16%)

also on CI the last two build tooks around 11min30 which looks in the "low range" of our build time (13-15min is more common) (sounds promising but it varies so much that it might be luck, more data is needed to see accurately the gains)