### PR TITLE
fix(deps): upgrade ovh-api-services to v11.0.1

### DIFF
--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -59,7 +59,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -47,7 +47,7 @@
     "angular-translate-loader-pluggable": "^1.3.1",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "regenerator-runtime": "^0.13.7",
     "whatwg-fetch": "^3.0.0"
   },

--- a/packages/manager/apps/cloud/package.json
+++ b/packages/manager/apps/cloud/package.json
@@ -115,7 +115,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-list-view": "ovh-ux/ovh-angular-list-view#^0.1.5",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-common-style": "ovh-ux/ovh-common-style#^3.2.2",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/dbaas-logs/package.json
+++ b/packages/manager/apps/dbaas-logs/package.json
@@ -59,7 +59,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -136,7 +136,7 @@
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.14",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -57,7 +57,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -69,7 +69,7 @@
     "lodash-es": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -62,7 +62,7 @@
     "jquery": "^2.1.3",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -56,7 +56,7 @@
     "core-js": "^3.6.5",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -42,7 +42,7 @@
     "core-js": "^3.6.5",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "regenerator-runtime": "^0.13.7"

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -61,7 +61,7 @@
     "jquery-ui": "^1.12.1",
     "matchmedia-ng": "^1.0.8",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -81,7 +81,7 @@
     "matchmedia-ng": "^1.0.8",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-common-style": "^5.0.0",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -57,7 +57,7 @@
     "moment": "^2.24.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ngstrap": "^4.0.2",
     "regenerator-runtime": "^0.13.7",
     "validator-js": "^0.2.1"

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -42,7 +42,7 @@
     "font-awesome": "~4.7.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -50,7 +50,7 @@
     "jsplumb": "^2.12.0",
     "lodash": "^4.17.15",
     "ng-csv": "^0.3.6",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -47,7 +47,7 @@
     "jsplumb": "^2.12.0",
     "ng-csv": "^0.3.6",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ngstrap": "^4.0.2",
     "ovh-ui-kit-bs": "^4.2.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -130,7 +130,7 @@
     "ngSmoothScroll": "d-oliveros/angular-smooth-scroll#~1.7.1",
     "oclazyload": "^1.1.0",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -52,7 +52,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",
     "ui-select": "^0.19.8"

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -51,7 +51,7 @@
     "d3": "~3.5.13",
     "flatpickr": "^4.6.3",
     "jquery": "^2.1.3",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -67,7 +67,7 @@
     "jsurl": "0.1.5",
     "moment": "^2.24.0",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.15",
     "messenger": "HubSpot/messenger#~1.4.1",
     "oclazyload": "^1.1.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "popper.js": "^1.16.1",
     "regenerator-runtime": "^0.13.7",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -111,7 +111,7 @@
     "ng-slide-down": "TheRusskiy/ng-slide-down#^1.0.0",
     "oclazyload": "^1.1.0",
     "office-ui-fabric-core": "^11.0.0",
-    "ovh-api-services": "^11.0.0",
+    "ovh-api-services": "^11.0.1",
     "ovh-manager-webfont": "^1.2.0",
     "ovh-ui-kit-bs": "^4.2.0",
     "popper.js": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15870,10 +15870,10 @@ ovh-angular-responsive-tabs@^4.0.0:
   resolved "https://registry.yarnpkg.com/ovh-angular-responsive-tabs/-/ovh-angular-responsive-tabs-4.0.0.tgz#85b66d7032612c3ed1a14cb29f83d1331b50c1df"
   integrity sha1-hbZtcDJhLD7RoUyyn4PRMxtQwd8=
 
-ovh-api-services@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-11.0.0.tgz#1425de29c8102d848296c41e2ae54224d04dca20"
-  integrity sha512-ffPIFDdHXkiH7CYJ3l4tDF4vAsmpT2r3+o6FCo16XxTFN428ZlTcusI1KbIpvsZkHIuj5sZB0G9CvLj5BBoUXg==
+ovh-api-services@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-11.0.1.tgz#9ab9174a57bf3e41a28c005d88c3751a6d4de09e"
+  integrity sha512-VBdbujFTgYyJ5uy9V1ojN71dMpphVw6ohr8bmPcy5KDFx2trWMFzDDts6hzOeEHbzccUQLDrKWMLMQc6pjqpqg==
   dependencies:
     lodash "^4.17.20"
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

215295d - fix(deps): upgrade ovh-api-services to v11.0.1

uses: `$ yarn upgrade-interactive --latest ovh-api-services`
- ovh-api-services@11.0.1

### :link: Related

- ovh-ux/ovh-api-services#317

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

