### PR TITLE
Replace API calls using user from environment

### DIFF
--- a/packages/manager/modules/account-sidebar/package.json
+++ b/packages/manager/modules/account-sidebar/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-config": "^2.0.1",
     "@ovh-ux/manager-core": "^10.0.0 || ^11.0.0",
     "@ovh-ux/ng-at-internet": "^5.3.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",

--- a/packages/manager/modules/account-sidebar/src/controller.js
+++ b/packages/manager/modules/account-sidebar/src/controller.js
@@ -1,20 +1,13 @@
+import { Environment } from '@ovh-ux/manager-config';
 import constants from './constants';
 
 export default class OvhManagerAccountSidebarCtrl {
   /* @ngInject */
-  constructor(
-    $q,
-    $rootScope,
-    $translate,
-    atInternet,
-    OvhApiMe,
-    RedirectionService,
-  ) {
+  constructor($q, $rootScope, $translate, atInternet, RedirectionService) {
     this.$q = $q;
     this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.atInternet = atInternet;
-    this.OvhApiMe = OvhApiMe;
     this.RedirectionService = RedirectionService;
 
     this.$rootScope.$on('ovh::sidebar::toggle', () => {
@@ -28,15 +21,14 @@ export default class OvhManagerAccountSidebarCtrl {
   }
 
   $onInit() {
-    return this.$q
-      .when(this.me ? this.me : this.OvhApiMe.v6().get().$promise)
-      .then((me) => {
-        this.me = me;
-        this.hasChatbot = constants.CHATBOT_SUBSIDIARIES.includes(
-          me.ovhSubsidiary,
-        );
-      })
-      .then(() => this.$translate.refresh())
+    if (!this.me) {
+      this.me = Environment.getUser();
+    }
+    this.hasChatbot = constants.CHATBOT_SUBSIDIARIES.includes(
+      this.me.ovhSubsidiary,
+    );
+    return this.$translate
+      .refresh()
       .then(() => this.getLinks())
       .then((links) => {
         this.links = links;

--- a/packages/manager/modules/core/src/session/session.service.js
+++ b/packages/manager/modules/core/src/session/session.service.js
@@ -1,51 +1,24 @@
+import { Environment } from '@ovh-ux/manager-config';
 import { User } from '@ovh-ux/manager-models';
 
 export default class SessionService {
   /* @ngInject */
-
-  constructor($q, $http) {
-    this.$http = $http;
+  constructor($q) {
     this.$q = $q;
-
-    this.user = null;
-    this.userPromise = null;
-    this.userPromiseRunning = false;
-  }
-
-  getMe() {
-    return this.$http.get('/me').then(({ data }) => data);
-  }
-
-  getUserCertificates() {
-    return this.$http.get('/me/certificates').then(({ data }) => data);
   }
 
   getUser() {
-    if (!this.userPromiseRunning && this.user === null) {
-      this.userPromiseRunning = true;
-
-      this.userPromise = this.$q.when('start').then(() =>
-        this.$q
-          .all({
-            me: this.getMe(),
-            certificates: this.getUserCertificates(),
-          })
-          .then(({ me, certificates }) => {
-            this.userPromiseRunning = false;
-            this.user = new User(
-              {
-                ...me,
-                firstName: me.firstname,
-                lastName: me.name,
-                billingCountry: me.country,
-                customerCode: me.customerCode,
-              },
-              certificates,
-            );
-          }),
-      );
-    }
-
-    return this.userPromise.then(() => this.user);
+    const user = Environment.getUser();
+    return this.$q.resolve(
+      new User(
+        {
+          ...user,
+          firstName: user.firstname,
+          lastName: user.name,
+          billingCountry: user.country,
+        },
+        user.certificates,
+      ),
+    );
   }
 }

--- a/packages/manager/modules/navbar/src/service.js
+++ b/packages/manager/modules/navbar/src/service.js
@@ -1,26 +1,21 @@
 import { User } from '@ovh-ux/manager-models';
+import { Environment } from '@ovh-ux/manager-config';
 
 export default class {
   /* @ngInject */
-  constructor($q, OvhApiMe, OvhApiUniverses) {
+  constructor($q, OvhApiUniverses) {
     this.$q = $q;
-    this.OvhApiMe = OvhApiMe;
     this.OvhApiUniverses = OvhApiUniverses;
   }
 
   getUser() {
-    return this.$q
-      .all({
-        user: this.OvhApiMe.v6().get().$promise,
-        certificates: this.OvhApiMe.v6().certificates().$promise,
-      })
-      .then(({ user, certificates }) => new User(user, certificates));
+    return this.$q.resolve(
+      new User(Environment.getUser(), Environment.getUser().certificates),
+    );
   }
 
   getSupportLevel() {
-    return this.OvhApiMe.v6()
-      .supportLevel()
-      .$promise.catch(() => Promise.resolve(null));
+    return this.$q.resolve(Environment.getUser().supportLevel);
   }
 
   getUniverses(version) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/user-env`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Replace following API calls 
* `/me`
* `/me/certificates` 
* `/me/supportLevel` 
* `/auth/details` 

 in 

* `@ovh-ux/manager-navbar`
* `@ovh-ux/manager-account-sidebar`
* `@ovh-ux/manager-core` 

using `Environment.getUser()` from `@ovh-ux/manager-config`


