### PR TITLE
Add chatbot support level & delay the initialization

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -218,6 +218,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
+++ b/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
@@ -4,6 +4,7 @@ class CloudMainController {
   constructor(
     $document,
     $interval,
+    $scope,
     $rootScope,
     $transitions,
     $translate,
@@ -11,10 +12,12 @@ class CloudMainController {
   ) {
     this.$document = $document;
     this.$interval = $interval;
+    this.$scope = $scope;
     this.$rootScope = $rootScope;
     this.$transitions = $transitions;
     this.$translate = $translate;
     this.CucProductsService = CucProductsService;
+    this.chatbotEnabled = false;
   }
 
   $onInit() {
@@ -22,6 +25,10 @@ class CloudMainController {
 
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+    const unregisterListener = this.$scope.$on('app:started', () => {
+      this.chatbotEnabled = true;
+      unregisterListener();
+    });
 
     this.$transitions.onStart({}, () => this.closeSidebar());
   }

--- a/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
+++ b/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
@@ -1,3 +1,5 @@
+import { Environment } from '@ovh-ux/manager-config';
+
 class CloudMainController {
   constructor(
     $document,
@@ -6,7 +8,6 @@ class CloudMainController {
     $transitions,
     $translate,
     CucProductsService,
-    SessionService,
   ) {
     this.$document = $document;
     this.$interval = $interval;
@@ -14,17 +15,13 @@ class CloudMainController {
     this.$transitions = $transitions;
     this.$translate = $translate;
     this.CucProductsService = CucProductsService;
-    this.SessionService = SessionService;
   }
 
   $onInit() {
     this.expiringProject = null;
 
-    [this.currentLanguage] = this.$translate.use().split('_');
-
-    this.SessionService.getUser().then((user) => {
-      this.user = user;
-    });
+    this.currentLanguage = Environment.getUserLanguage();
+    this.user = Environment.getUser();
 
     this.$transitions.onStart({}, () => this.closeSidebar());
   }

--- a/packages/manager/apps/cloud/client/index.html
+++ b/packages/manager/apps/cloud/client/index.html
@@ -92,6 +92,7 @@
                             data-ng-if="$ctrl.user.ovhSubsidiary"
                             data-language="{{$ctrl.currentLanguage}}"
                             data-country="{{$ctrl.user.ovhSubsidiary}}"
+                            data-support-level="{{$ctrl.user.supportLevel.level}}"
                         ></ovh-chatbot>
 
                         <div data-ui-view></div>

--- a/packages/manager/apps/cloud/client/index.html
+++ b/packages/manager/apps/cloud/client/index.html
@@ -89,7 +89,7 @@
                         <ovh-browser-alert></ovh-browser-alert>
                         <account-migration-notification></account-migration-notification>
                         <ovh-chatbot
-                            data-ng-if="$ctrl.user.ovhSubsidiary"
+                            data-ng-if="$ctrl.chatbotEnabled"
                             data-language="{{$ctrl.currentLanguage}}"
                             data-country="{{$ctrl.user.ovhSubsidiary}}"
                             data-support-level="{{$ctrl.user.supportLevel.level}}"

--- a/packages/manager/apps/dedicated/client/app/app.js
+++ b/packages/manager/apps/dedicated/client/app/app.js
@@ -350,6 +350,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
@@ -1,17 +1,17 @@
 import isString from 'lodash/isString';
 import set from 'lodash/set';
+import { Environment } from '@ovh-ux/manager-config';
 
 angular.module('App').controller(
   'SessionCtrl',
-  class {
+  class SessionCtrl {
     /* @ngInject */
-    constructor($document, $scope, $state, $transitions, $translate, User) {
+    constructor($document, $scope, $state, $transitions, $translate) {
       this.$document = $document;
       this.$scope = $scope;
       this.$state = $state;
       this.$transitions = $transitions;
       this.$translate = $translate;
-      this.User = User;
     }
 
     $onInit() {
@@ -20,7 +20,8 @@ angular.module('App').controller(
         this.navbarOptions.universe = universe;
       });
 
-      [this.currentLanguage] = this.$translate.use().split('_');
+      this.currentLanguage = Environment.getUserLanguage();
+      this.user = Environment.getUser();
 
       this.navbarOptions = {
         toggle: {
@@ -28,10 +29,6 @@ angular.module('App').controller(
         },
         universe: 'server',
       };
-
-      this.User.getUser().then((user) => {
-        this.user = user;
-      });
 
       set(this.$document, 'title', this.$translate.instant('global_app_title'));
 

--- a/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
@@ -12,6 +12,7 @@ angular.module('App').controller(
       this.$state = $state;
       this.$transitions = $transitions;
       this.$translate = $translate;
+      this.chatbotEnabled = false;
     }
 
     $onInit() {
@@ -22,6 +23,10 @@ angular.module('App').controller(
 
       this.currentLanguage = Environment.getUserLanguage();
       this.user = Environment.getUser();
+      const unregisterListener = this.$scope.$on('app:started', () => {
+        this.chatbotEnabled = true;
+        unregisterListener();
+      });
 
       this.navbarOptions = {
         toggle: {

--- a/packages/manager/apps/dedicated/client/app/index.html
+++ b/packages/manager/apps/dedicated/client/app/index.html
@@ -124,7 +124,7 @@
         </div>
 
         <ovh-chatbot
-            data-ng-if="$ctrl.user.ovhSubsidiary"
+            data-ng-if="$ctrl.chatbotEnabled"
             data-language="{{$ctrl.currentLanguage}}"
             data-country="{{$ctrl.user.ovhSubsidiary}}"
             data-support-level="{{$ctrl.user.supportLevel.level}}"

--- a/packages/manager/apps/dedicated/client/app/index.html
+++ b/packages/manager/apps/dedicated/client/app/index.html
@@ -127,6 +127,7 @@
             data-ng-if="$ctrl.user.ovhSubsidiary"
             data-language="{{$ctrl.currentLanguage}}"
             data-country="{{$ctrl.user.ovhSubsidiary}}"
+            data-support-level="{{$ctrl.user.supportLevel.level}}"
         ></ovh-chatbot>
 
         <div data-otrs-popup></div>

--- a/packages/manager/apps/hub/src/app.module.js
+++ b/packages/manager/apps/hub/src/app.module.js
@@ -115,6 +115,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/hub/src/controller.js
+++ b/packages/manager/apps/hub/src/controller.js
@@ -4,13 +4,19 @@ import { Environment } from '@ovh-ux/manager-config';
 
 export default class HubController {
   /* @ngInject */
-  constructor($document) {
+  constructor($document, $scope) {
     this.$document = $document;
+    this.$scope = $scope;
+    this.chatbotEnabled = false;
   }
 
   $onInit() {
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+    const unregisterListener = this.$scope.$on('app:started', () => {
+      this.chatbotEnabled = true;
+      unregisterListener();
+    });
   }
 
   /**

--- a/packages/manager/apps/hub/src/controller.js
+++ b/packages/manager/apps/hub/src/controller.js
@@ -1,19 +1,16 @@
 import { isString } from 'lodash-es';
 
+import { Environment } from '@ovh-ux/manager-config';
+
 export default class HubController {
   /* @ngInject */
-  constructor($document, $translate, SessionService) {
+  constructor($document) {
     this.$document = $document;
-    this.$translate = $translate;
-    this.SessionService = SessionService;
   }
 
   $onInit() {
-    [this.currentLanguage] = this.$translate.use().split('_');
-
-    this.SessionService.getUser().then((user) => {
-      this.user = user;
-    });
+    this.currentLanguage = Environment.getUserLanguage();
+    this.user = Environment.getUser();
   }
 
   /**

--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -74,6 +74,7 @@
             data-ng-if="$ctrl.user.ovhSubsidiary"
             data-language="{{$ctrl.currentLanguage}}"
             data-country="{{$ctrl.user.ovhSubsidiary}}"
+            data-support-level="{{$ctrl.user.supportLevel.level}}"
         ></ovh-chatbot>
     </body>
 </html>

--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -71,7 +71,7 @@
         </div>
 
         <ovh-chatbot
-            data-ng-if="$ctrl.user.ovhSubsidiary"
+            data-ng-if="$ctrl.chatbotEnabled"
             data-language="{{$ctrl.currentLanguage}}"
             data-country="{{$ctrl.user.ovhSubsidiary}}"
             data-support-level="{{$ctrl.user.supportLevel.level}}"

--- a/packages/manager/apps/public-cloud/src/app.module.js
+++ b/packages/manager/apps/public-cloud/src/app.module.js
@@ -129,6 +129,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/public-cloud/src/index.controller.js
+++ b/packages/manager/apps/public-cloud/src/index.controller.js
@@ -21,6 +21,8 @@ export default class PublicCloudController {
     this.publicCloud = publicCloud;
     this.navbarOptions = options;
 
+    this.chatbotEnabled = false;
+
     $scope.$on('oui-step-form.submit', (event, { form }) => {
       this.atInternet.trackClick({
         name: form.$name,
@@ -32,6 +34,11 @@ export default class PublicCloudController {
   $onInit() {
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+
+    const unregisterListener = this.$scope.$on('app:started', () => {
+      this.chatbotEnabled = true;
+      unregisterListener();
+    });
   }
 
   openSidebar() {

--- a/packages/manager/apps/public-cloud/src/index.controller.js
+++ b/packages/manager/apps/public-cloud/src/index.controller.js
@@ -1,3 +1,4 @@
+import { Environment } from '@ovh-ux/manager-config';
 import options from './navbar.config';
 
 export default class PublicCloudController {
@@ -6,22 +7,18 @@ export default class PublicCloudController {
     $scope,
     $state,
     $timeout,
-    $translate,
     $window,
     atInternet,
     ovhUserPref,
     publicCloud,
-    SessionService,
   ) {
     this.$scope = $scope;
     this.$state = $state;
     this.$timeout = $timeout;
-    this.$translate = $translate;
     this.$window = $window;
     this.atInternet = atInternet;
     this.ovhUserPref = ovhUserPref;
     this.publicCloud = publicCloud;
-    this.sessionService = SessionService;
     this.navbarOptions = options;
 
     $scope.$on('oui-step-form.submit', (event, { form }) => {
@@ -33,13 +30,8 @@ export default class PublicCloudController {
   }
 
   $onInit() {
-    [this.currentLanguage] = this.$translate.use().split('_');
-
-    this.$translate.refresh().then(() => {
-      this.sessionService.getUser().then((user) => {
-        this.user = user;
-      });
-    });
+    this.currentLanguage = Environment.getUserLanguage();
+    this.user = Environment.getUser();
   }
 
   openSidebar() {

--- a/packages/manager/apps/public-cloud/src/index.html
+++ b/packages/manager/apps/public-cloud/src/index.html
@@ -41,7 +41,7 @@
             </div>
 
             <ovh-chatbot
-                data-ng-if="$ctrl.user.ovhSubsidiary"
+                data-ng-if="$ctrl.chatbotEnabled"
                 data-language="{{$ctrl.currentLanguage}}"
                 data-country="{{$ctrl.user.ovhSubsidiary}}"
                 data-support-level="{{$ctrl.user.supportLevel.level}}"

--- a/packages/manager/apps/public-cloud/src/index.html
+++ b/packages/manager/apps/public-cloud/src/index.html
@@ -44,6 +44,7 @@
                 data-ng-if="$ctrl.user.ovhSubsidiary"
                 data-language="{{$ctrl.currentLanguage}}"
                 data-country="{{$ctrl.user.ovhSubsidiary}}"
+                data-support-level="{{$ctrl.user.supportLevel.level}}"
             ></ovh-chatbot>
 
             <public-cloud-dark-mode></public-cloud-dark-mode>

--- a/packages/manager/apps/telecom/src/app/app.controller.js
+++ b/packages/manager/apps/telecom/src/app/app.controller.js
@@ -1,3 +1,5 @@
+import { Environment } from '@ovh-ux/manager-config';
+
 export default class TelecomAppCtrl {
   /* @ngInject */
   constructor(
@@ -6,7 +8,6 @@ export default class TelecomAppCtrl {
     $transitions,
     $translate,
     betaPreferenceService,
-    SessionService,
     ovhUserPref,
   ) {
     this.displayFallbackMenu = false;
@@ -17,15 +18,11 @@ export default class TelecomAppCtrl {
     this.$state = $state;
     this.betaPreferenceService = betaPreferenceService;
     this.ovhUserPref = ovhUserPref;
-    this.SessionService = SessionService;
   }
 
   $onInit() {
-    [this.currentLanguage] = this.$translate.use().split('_');
-
-    this.SessionService.getUser().then((user) => {
-      this.user = user;
-    });
+    this.currentLanguage = Environment.getUserLanguage();
+    this.user = Environment.getUser();
 
     return this.betaPreferenceService.isBetaActive().then((beta) => {
       this.globalSearchLink = beta

--- a/packages/manager/apps/telecom/src/app/app.controller.js
+++ b/packages/manager/apps/telecom/src/app/app.controller.js
@@ -5,6 +5,7 @@ export default class TelecomAppCtrl {
   constructor(
     $q,
     $state,
+    $scope,
     $transitions,
     $translate,
     betaPreferenceService,
@@ -16,13 +17,21 @@ export default class TelecomAppCtrl {
     this.$q = $q;
     this.$translate = $translate;
     this.$state = $state;
+    this.$scope = $scope;
     this.betaPreferenceService = betaPreferenceService;
     this.ovhUserPref = ovhUserPref;
+
+    this.chatbotEnabled = false;
   }
 
   $onInit() {
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+
+    const unregisterListener = this.$scope.$on('app:started', () => {
+      this.chatbotEnabled = true;
+      unregisterListener();
+    });
 
     return this.betaPreferenceService.isBetaActive().then((beta) => {
       this.globalSearchLink = beta

--- a/packages/manager/apps/telecom/src/app/app.js
+++ b/packages/manager/apps/telecom/src/app/app.js
@@ -290,6 +290,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/telecom/src/index.html
+++ b/packages/manager/apps/telecom/src/index.html
@@ -88,7 +88,7 @@
                                     <ovh-browser-alert></ovh-browser-alert>
 
                                     <ovh-chatbot
-                                        data-ng-if="$ctrl.user.ovhSubsidiary"
+                                        data-ng-if="$ctrl.chatbotEnabled"
                                         data-language="{{$ctrl.currentLanguage}}"
                                         data-country="{{$ctrl.user.ovhSubsidiary}}"
                                         data-support-level="{{$ctrl.user.supportLevel.level}}"

--- a/packages/manager/apps/telecom/src/index.html
+++ b/packages/manager/apps/telecom/src/index.html
@@ -91,6 +91,7 @@
                                         data-ng-if="$ctrl.user.ovhSubsidiary"
                                         data-language="{{$ctrl.currentLanguage}}"
                                         data-country="{{$ctrl.user.ovhSubsidiary}}"
+                                        data-support-level="{{$ctrl.user.supportLevel.level}}"
                                     ></ovh-chatbot>
 
                                     <div data-ui-view></div>

--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -535,6 +535,7 @@ angular
     /* @ngInject */ ($rootScope, $transitions) => {
       const unregisterHook = $transitions.onSuccess({}, () => {
         detachPreloader();
+        $rootScope.$broadcast('app:started');
         unregisterHook();
       });
     },

--- a/packages/manager/apps/web/client/app/components/webApp.controller.js
+++ b/packages/manager/apps/web/client/app/components/webApp.controller.js
@@ -1,13 +1,13 @@
 import isString from 'lodash/isString';
+import { Environment } from '@ovh-ux/manager-config';
 
 export default class WebAppCtrl {
   /* @ngInject */
-  constructor($document, $rootScope, $scope, $timeout, $translate, User) {
+  constructor($document, $rootScope, $scope, $timeout, $translate) {
     this.$document = $document;
     this.$scope = $scope;
     this.$timeout = $timeout;
     this.$translate = $translate;
-    this.User = User;
     this.$rootScope = $rootScope;
     this.$onInit();
   }
@@ -24,11 +24,8 @@ export default class WebAppCtrl {
       this.isNavbarLoaded = true;
     });
 
-    [this.currentLanguage] = this.$translate.use().split('_');
-
-    this.User.getUser().then((user) => {
-      this.user = user;
-    });
+    this.currentLanguage = Environment.getUserLanguage();
+    this.user = Environment.getUser();
 
     // Scroll to anchor id
     this.$scope.scrollTo = (id) => {

--- a/packages/manager/apps/web/client/app/components/webApp.controller.js
+++ b/packages/manager/apps/web/client/app/components/webApp.controller.js
@@ -9,7 +9,7 @@ export default class WebAppCtrl {
     this.$timeout = $timeout;
     this.$translate = $translate;
     this.$rootScope = $rootScope;
-    this.$onInit();
+    this.chatbotEnabled = false;
   }
 
   $onInit() {
@@ -26,6 +26,10 @@ export default class WebAppCtrl {
 
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+    const unregisterListener = this.$scope.$on('app:started', () => {
+      this.chatbotEnabled = true;
+      unregisterListener();
+    });
 
     // Scroll to anchor id
     this.$scope.scrollTo = (id) => {

--- a/packages/manager/apps/web/client/app/index.html
+++ b/packages/manager/apps/web/client/app/index.html
@@ -80,6 +80,7 @@
                             data-universe="WEB"
                             data-language="{{$ctrl.currentLanguage}}"
                             data-country="{{$ctrl.user.ovhSubsidiary}}"
+                            data-support-level="{{$ctrl.user.supportLevel.level}}"
                         ></ovh-chatbot>
 
                         <div data-ui-view class="pb-5"></div>

--- a/packages/manager/apps/web/client/app/index.html
+++ b/packages/manager/apps/web/client/app/index.html
@@ -76,7 +76,7 @@
 
                         <!-- /Skip content target -->
                         <ovh-chatbot
-                            data-ng-if="$ctrl.user.ovhSubsidiary"
+                            data-ng-if="$ctrl.chatbotEnabled"
                             data-universe="WEB"
                             data-language="{{$ctrl.currentLanguage}}"
                             data-country="{{$ctrl.user.ovhSubsidiary}}"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/user-env`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-5302
| License          | BSD 3-Clause

## Description

Add `supportLevel` on the chatbot and delay the chatbot initialization on 

- `@ovh-ux/manager-hub-app`
- `@ovh-ux/manager-web`
- `@ovh-ux/manager-dedicated`
- `@ovh-ux/manager-cloud`
- `@ovh-ux/manager-public-cloud`
- `@ovh-ux/manager-telecom`

Based on https://github.com/ovh/manager/pull/4080

2 commits for each application : 
- `fix(chatbot): add support level`: to retrieve `supportLevel` and give it to the chatbot
- `perf(chatbot): delay the chatbot initialization`: to delay the chatbot initialization when the app is started (avoid to call chatbot API during the application bootstrap)



