### PR TITLE
feat(dedicated.cloud-connect): display cloud-connect service for canada too

### DIFF
--- a/packages/manager/modules/server-sidebar/src/sidebar.constants.js
+++ b/packages/manager/modules/server-sidebar/src/sidebar.constants.js
@@ -346,7 +346,6 @@ export const DEDICATED_NETWORK_CONFIG = {
     },
     {
       id: 'cloud_connect',
-      feature: 'cloud-connect',
       loadOnState: 'cloud-connect',
       types: [
         {
@@ -354,12 +353,12 @@ export const DEDICATED_NETWORK_CONFIG = {
           state: 'cloud-connect.details',
           stateParams: ['ovhCloudConnectId'],
           app: [DEDICATED],
-          regions: ['EU'],
           namespace: [undefined, HPC_NAMESPACE],
         },
       ],
       icon: 'oui-icon oui-icon-line-communicating_concept',
       app: [DEDICATED],
+      regions: ['EU', 'CA'],
       namespace: [undefined, HPC_NAMESPACE],
     },
   ],


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-350
| License          | BSD 3-Clause

## Description

Display Cloud Connect service into left menu into Canadian Manager too
