### PR TITLE
fix(domain.zone): allow zone deletion attached to web hosting

### DIFF
--- a/packages/manager/apps/web/client/app/domain/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/domain/translations/Messages_fr_FR.json
@@ -615,7 +615,6 @@
   "domain_configuration_zonedns_reset_type_MX_title": "Adresse de votre serveur mail",
   "domain_configuration_zonedns_reset_type_A_title": "Adresse IP de votre hébergement",
   "domain_configuration_zonedns_delete_all_question": "Voulez-vous supprimer la zone DNS?",
-  "domain_configuration_zonedns_delete_all_blocked": "Votre zone DNS ne peut être supprimée car elle est actuellement liée à un hébergement Web.",
   "domain_configuration_zonedns_delete_all_warning": "Attention ! Cela supprimera définitivement tous les enregistrements DNS existants.",
   "domain_configuration_zonedns_delete_all_success": "La suppression de la zone DNS a été lancée, veuillez consulter la boite email du NIC administrateur de la zone DNS et suivre les instructions afin de finaliser la demande.",
   "domain_configuration_zonedns_delete_all_error": "Une erreur est survenue lors de la suppression de la zone DNS.",

--- a/packages/manager/apps/web/client/app/domain/zone/delete-all/domain-zone-delete-all.controller.js
+++ b/packages/manager/apps/web/client/app/domain/zone/delete-all/domain-zone-delete-all.controller.js
@@ -1,38 +1,17 @@
-import get from 'lodash/get';
-
 angular.module('App').controller(
   'DomainZoneDeleteAllCtrl',
   class DomainZoneDeleteAllCtrl {
-    constructor($scope, $translate, Alerter, Domain, Hosting) {
+    constructor($scope, $translate, Alerter, Domain) {
       this.$scope = $scope;
       this.$translate = $translate;
       this.alerter = Alerter;
       this.domainService = Domain;
-      this.hostingService = Hosting;
     }
 
     $onInit() {
       this.domain = this.$scope.currentActionData;
-      this.canDeleteAllZone = false;
-      this.loading = true;
+      this.loading = false;
       this.$scope.deleteAllZone = () => this.deleteAllZone();
-
-      this.checkAllZoneCanBeDelete(this.domain.name);
-    }
-
-    checkAllZoneCanBeDelete(name) {
-      this.loading = true;
-      return this.hostingService
-        .getHosting(name)
-        .then(() => {
-          this.canDeleteAllZone = false;
-        })
-        .catch((err) => {
-          this.canDeleteAllZone = get(err, 'status') === 404;
-        })
-        .finally(() => {
-          this.loading = false;
-        });
     }
 
     deleteAllZone() {

--- a/packages/manager/apps/web/client/app/domain/zone/delete-all/domain-zone-delete-all.html
+++ b/packages/manager/apps/web/client/app/domain/zone/delete-all/domain-zone-delete-all.html
@@ -5,30 +5,18 @@
         data-wizard-on-finish="deleteAllZone"
         data-wizard-title="'domain_tab_ZONE_default_delete_all' | translate"
     >
-        <div
-            data-wizard-step
-            data-wizard-step-valid="!ctrl.loading && ctrl.canDeleteAllZone"
-        >
+        <div data-wizard-step data-wizard-step-valid="!ctrl.loading">
             <oui-spinner data-ng-if="ctrl.loading"></oui-spinner>
 
             <div data-ng-if="!ctrl.loading">
+                <p
+                    data-translate="domain_configuration_zonedns_delete_all_question"
+                ></p>
                 <div
-                    class="alert alert-warning"
+                    class="alert alert-warning mt-5"
                     role="alert"
-                    data-translate="domain_configuration_zonedns_delete_all_blocked"
-                    data-ng-if="!ctrl.canDeleteAllZone"
+                    data-translate="domain_configuration_zonedns_delete_all_warning"
                 ></div>
-
-                <div data-ng-if="ctrl.canDeleteAllZone">
-                    <p
-                        data-translate="domain_configuration_zonedns_delete_all_question"
-                    ></p>
-                    <div
-                        class="alert alert-warning mt-5"
-                        role="alert"
-                        data-translate="domain_configuration_zonedns_delete_all_warning"
-                    ></div>
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-25221
| License          | BSD 3-Clause

## Description

Allow domain zone deletion attached to web hosting

ref: DTRSD-25221

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>

