### PR TITLE
Feat/flip chatbot

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -14,6 +14,7 @@ import ngOvhApiWrappers from '@ovh-ux/ng-ovh-api-wrappers';
 import ngOvhBrowserAlert from '@ovh-ux/ng-ovh-browser-alert';
 import ngOvhCheckboxTable from '@ovh-ux/ng-ovh-checkbox-table';
 import ngOvhDocUrl from '@ovh-ux/ng-ovh-doc-url';
+import ngOvhFeatureFlipping from '@ovh-ux/ng-ovh-feature-flipping';
 import ngOvhFormFlat from '@ovh-ux/ng-ovh-form-flat';
 import ngOvhJsplumb from '@ovh-ux/ng-ovh-jsplumb';
 import ngOvhResponsiveTabs from '@ovh-ux/ng-ovh-responsive-tabs';
@@ -71,6 +72,7 @@ angular
       ngOvhBrowserAlert,
       ngOvhCheckboxTable,
       ngOvhDocUrl,
+      ngOvhFeatureFlipping,
       ngOvhFormFlat,
       ngOvhSsoAuth,
       ngOvhSsoAuthModalPlugin,
@@ -223,6 +225,11 @@ angular
       });
     },
   )
-  .run(/* @ngTranslationsInject:json ./common/translations */);
+  .run(/* @ngTranslationsInject:json ./common/translations */)
+  .config(
+    /* @ngInject */ (ovhFeatureFlippingProvider) => {
+      ovhFeatureFlippingProvider.setApplicationName('cloud');
+    },
+  );
 
 export default moduleName;

--- a/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
+++ b/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
@@ -9,6 +9,7 @@ class CloudMainController {
     $transitions,
     $translate,
     CucProductsService,
+    ovhFeatureFlipping,
   ) {
     this.$document = $document;
     this.$interval = $interval;
@@ -17,6 +18,7 @@ class CloudMainController {
     this.$transitions = $transitions;
     this.$translate = $translate;
     this.CucProductsService = CucProductsService;
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
     this.chatbotEnabled = false;
   }
 
@@ -26,7 +28,20 @@ class CloudMainController {
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
     const unregisterListener = this.$scope.$on('app:started', () => {
-      this.chatbotEnabled = true;
+      const CHATBOT_FEATURE = 'chatbot';
+      this.ovhFeatureFlipping
+        .checkFeatureAvailability(CHATBOT_FEATURE)
+        .then((featureAvailability) => {
+          this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+            CHATBOT_FEATURE,
+          );
+          if (this.chatbotEnabled) {
+            this.$rootScope.$broadcast(
+              'ovh-chatbot:enable',
+              this.chatbotEnabled,
+            );
+          }
+        });
       unregisterListener();
     });
 

--- a/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
@@ -6,12 +6,22 @@ angular.module('App').controller(
   'SessionCtrl',
   class SessionCtrl {
     /* @ngInject */
-    constructor($document, $scope, $state, $transitions, $translate) {
+    constructor(
+      $document,
+      $rootScope,
+      $scope,
+      $state,
+      $transitions,
+      $translate,
+      ovhFeatureFlipping,
+    ) {
       this.$document = $document;
+      this.$rootScope = $rootScope;
       this.$scope = $scope;
       this.$state = $state;
       this.$transitions = $transitions;
       this.$translate = $translate;
+      this.ovhFeatureFlipping = ovhFeatureFlipping;
       this.chatbotEnabled = false;
     }
 
@@ -24,7 +34,20 @@ angular.module('App').controller(
       this.currentLanguage = Environment.getUserLanguage();
       this.user = Environment.getUser();
       const unregisterListener = this.$scope.$on('app:started', () => {
-        this.chatbotEnabled = true;
+        const CHATBOT_FEATURE = 'chatbot';
+        this.ovhFeatureFlipping
+          .checkFeatureAvailability(CHATBOT_FEATURE)
+          .then((featureAvailability) => {
+            this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+              CHATBOT_FEATURE,
+            );
+            if (this.chatbotEnabled) {
+              this.$rootScope.$broadcast(
+                'ovh-chatbot:enable',
+                this.chatbotEnabled,
+              );
+            }
+          });
         unregisterListener();
       });
 

--- a/packages/manager/apps/hub/src/controller.js
+++ b/packages/manager/apps/hub/src/controller.js
@@ -4,17 +4,32 @@ import { Environment } from '@ovh-ux/manager-config';
 
 export default class HubController {
   /* @ngInject */
-  constructor($document, $scope) {
+  constructor($document, $scope, $rootScope, ovhFeatureFlipping) {
     this.$document = $document;
     this.$scope = $scope;
+    this.$rootScope = $rootScope;
     this.chatbotEnabled = false;
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
   }
 
   $onInit() {
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
     const unregisterListener = this.$scope.$on('app:started', () => {
-      this.chatbotEnabled = true;
+      const CHATBOT_FEATURE = 'chatbot';
+      this.ovhFeatureFlipping
+        .checkFeatureAvailability(CHATBOT_FEATURE)
+        .then((featureAvailability) => {
+          this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+            CHATBOT_FEATURE,
+          );
+          if (this.chatbotEnabled) {
+            this.$rootScope.$broadcast(
+              'ovh-chatbot:enable',
+              this.chatbotEnabled,
+            );
+          }
+        });
       unregisterListener();
     });
   }

--- a/packages/manager/apps/public-cloud/src/index.controller.js
+++ b/packages/manager/apps/public-cloud/src/index.controller.js
@@ -4,6 +4,7 @@ import options from './navbar.config';
 export default class PublicCloudController {
   /* @ngInject */
   constructor(
+    $rootScope,
     $scope,
     $state,
     $timeout,
@@ -11,7 +12,9 @@ export default class PublicCloudController {
     atInternet,
     ovhUserPref,
     publicCloud,
+    ovhFeatureFlipping,
   ) {
+    this.$rootScope = $rootScope;
     this.$scope = $scope;
     this.$state = $state;
     this.$timeout = $timeout;
@@ -19,6 +22,7 @@ export default class PublicCloudController {
     this.atInternet = atInternet;
     this.ovhUserPref = ovhUserPref;
     this.publicCloud = publicCloud;
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
     this.navbarOptions = options;
 
     this.chatbotEnabled = false;
@@ -36,7 +40,20 @@ export default class PublicCloudController {
     this.user = Environment.getUser();
 
     const unregisterListener = this.$scope.$on('app:started', () => {
-      this.chatbotEnabled = true;
+      const CHATBOT_FEATURE = 'chatbot';
+      this.ovhFeatureFlipping
+        .checkFeatureAvailability(CHATBOT_FEATURE)
+        .then((featureAvailability) => {
+          this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+            CHATBOT_FEATURE,
+          );
+          if (this.chatbotEnabled) {
+            this.$rootScope.$broadcast(
+              'ovh-chatbot:enable',
+              this.chatbotEnabled,
+            );
+          }
+        });
       unregisterListener();
     });
   }

--- a/packages/manager/apps/telecom/src/app/app.controller.js
+++ b/packages/manager/apps/telecom/src/app/app.controller.js
@@ -5,11 +5,13 @@ export default class TelecomAppCtrl {
   constructor(
     $q,
     $state,
+    $rootScope,
     $scope,
     $transitions,
     $translate,
     betaPreferenceService,
     ovhUserPref,
+    ovhFeatureFlipping,
   ) {
     this.displayFallbackMenu = false;
     $transitions.onStart({}, () => this.closeSidebar());
@@ -17,9 +19,11 @@ export default class TelecomAppCtrl {
     this.$q = $q;
     this.$translate = $translate;
     this.$state = $state;
+    this.$rootScope = $rootScope;
     this.$scope = $scope;
     this.betaPreferenceService = betaPreferenceService;
     this.ovhUserPref = ovhUserPref;
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
 
     this.chatbotEnabled = false;
   }
@@ -29,7 +33,20 @@ export default class TelecomAppCtrl {
     this.user = Environment.getUser();
 
     const unregisterListener = this.$scope.$on('app:started', () => {
-      this.chatbotEnabled = true;
+      const CHATBOT_FEATURE = 'chatbot';
+      this.ovhFeatureFlipping
+        .checkFeatureAvailability(CHATBOT_FEATURE)
+        .then((featureAvailability) => {
+          this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+            CHATBOT_FEATURE,
+          );
+          if (this.chatbotEnabled) {
+            this.$rootScope.$broadcast(
+              'ovh-chatbot:enable',
+              this.chatbotEnabled,
+            );
+          }
+        });
       unregisterListener();
     });
 

--- a/packages/manager/apps/web/client/app/components/webApp.controller.js
+++ b/packages/manager/apps/web/client/app/components/webApp.controller.js
@@ -3,13 +3,21 @@ import { Environment } from '@ovh-ux/manager-config';
 
 export default class WebAppCtrl {
   /* @ngInject */
-  constructor($document, $rootScope, $scope, $timeout, $translate) {
+  constructor(
+    $document,
+    $rootScope,
+    $scope,
+    $timeout,
+    $translate,
+    ovhFeatureFlipping,
+  ) {
     this.$document = $document;
     this.$scope = $scope;
     this.$timeout = $timeout;
     this.$translate = $translate;
     this.$rootScope = $rootScope;
     this.chatbotEnabled = false;
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
   }
 
   $onInit() {
@@ -26,8 +34,22 @@ export default class WebAppCtrl {
 
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
+
     const unregisterListener = this.$scope.$on('app:started', () => {
-      this.chatbotEnabled = true;
+      const CHATBOT_FEATURE = 'chatbot';
+      this.ovhFeatureFlipping
+        .checkFeatureAvailability(CHATBOT_FEATURE)
+        .then((featureAvailability) => {
+          this.chatbotEnabled = featureAvailability.isFeatureAvailable(
+            CHATBOT_FEATURE,
+          );
+          if (this.chatbotEnabled) {
+            this.$rootScope.$broadcast(
+              'ovh-chatbot:enable',
+              this.chatbotEnabled,
+            );
+          }
+        });
       unregisterListener();
     });
 

--- a/packages/manager/modules/account-sidebar/src/constants.js
+++ b/packages/manager/modules/account-sidebar/src/constants.js
@@ -1,3 +1,0 @@
-export default {
-  CHATBOT_SUBSIDIARIES: ['FR', 'PL'],
-};

--- a/packages/manager/modules/account-sidebar/src/controller.js
+++ b/packages/manager/modules/account-sidebar/src/controller.js
@@ -1,5 +1,4 @@
 import { Environment } from '@ovh-ux/manager-config';
-import constants from './constants';
 
 export default class OvhManagerAccountSidebarCtrl {
   /* @ngInject */
@@ -18,15 +17,20 @@ export default class OvhManagerAccountSidebarCtrl {
       this.isSidebarVisible = false;
       this.sidebarExpand = false;
     });
+
+    const unregisterListener = this.$rootScope.$on('ovh-chatbot:enable', () => {
+      this.hasChatbot = true;
+      this.links = this.getLinks();
+      unregisterListener();
+    });
   }
 
   $onInit() {
     if (!this.me) {
       this.me = Environment.getUser();
     }
-    this.hasChatbot = constants.CHATBOT_SUBSIDIARIES.includes(
-      this.me.ovhSubsidiary,
-    );
+
+    this.hasChatbot = false;
     return this.$translate
       .refresh()
       .then(() => this.getLinks())


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix MANAGER-6021
| License          | BSD 3-Clause

## Description

Use feature-flipping to detect if chatbot is available or not.
Broadcast a `ovh-chatbot:enable` when the `chatbot` feature is available.
Update `@ovh-ux/manager-account-sidebar` to display or not the chatbot link.

Done in 
- [x] `@ovh-ux/manager-cloud`
- [x] `@ovh-ux/manager-dedicated`
- [x] `@ovh-ux/manager-hub-app`
- [x] `@ovh-ux/manager-public-cloud`
- [x] `@ovh-ux/manager-telecom`
- [x] `@ovh-ux/manager-web`

## Related 

feature-availability#42



