### PR TITLE
fix(sso): avoid region config error

### DIFF
--- a/packages/manager/tools/dev-server-config/src/sso/index.js
+++ b/packages/manager/tools/dev-server-config/src/sso/index.js
@@ -27,7 +27,7 @@ module.exports = class Sso {
   config;
 
   constructor(region) {
-    this.config = CONFIG.ssoAuth[region];
+    this.config = CONFIG.ssoAuth[region.toLowerCase()];
   }
 
   login(req, res) {


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Avoid `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'devLoginUrl' of undefined` error if region is upper case.

