### PR TITLE
feat(provider): add ovhSubsidiary param in logout url

### DIFF
--- a/packages/components/ng-ovh-sso-auth/src/provider.js
+++ b/packages/components/ng-ovh-sso-auth/src/provider.js
@@ -398,6 +398,7 @@ export default function() {
       if (!deferredObj.logout) {
         deferredObj.logout = $q.defer();
         isLogged = false;
+        const self = this;
 
         // redirect to logout page
         $timeout(() => {
@@ -410,6 +411,15 @@ export default function() {
             logoutUrl += `${
               logoutUrl.indexOf('?') > -1 ? '&' : '?'
             }from=${encodeURIComponent(document.referrer)}`;
+          }
+          if (
+            logoutUrl.indexOf('ovhSubsidiary') === -1 &&
+            self.user &&
+            self.user.ovhSubsidiary
+          ) {
+            logoutUrl += `${
+              logoutUrl.indexOf('?') > -1 ? '&' : '?'
+            }ovhSubsidiary=${self.user.ovhSubsidiary}`;
           }
           $window.location.assign(logoutUrl);
         });

--- a/packages/components/ng-ovh-sso-auth/src/provider.js
+++ b/packages/components/ng-ovh-sso-auth/src/provider.js
@@ -398,7 +398,6 @@ export default function() {
       if (!deferredObj.logout) {
         deferredObj.logout = $q.defer();
         isLogged = false;
-        const self = this;
 
         // redirect to logout page
         $timeout(() => {
@@ -413,13 +412,13 @@ export default function() {
             }from=${encodeURIComponent(document.referrer)}`;
           }
           if (
-            logoutUrl.indexOf('ovhSubsidiary') === -1 &&
-            self.user &&
-            self.user.ovhSubsidiary
+            !logoutUrl.includes('ovhSubsidiary') &&
+            this.user &&
+            this.user.ovhSubsidiary
           ) {
             logoutUrl += `${
               logoutUrl.indexOf('?') > -1 ? '&' : '?'
-            }ovhSubsidiary=${self.user.ovhSubsidiary}`;
+            }ovhSubsidiary=${this.user.ovhSubsidiary}`;
           }
           $window.location.assign(logoutUrl);
         });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-5023
| License          | BSD 3-Clause

## Description

Add ovhSubsidiary in logout URL in order to avoid old account creation form to be displayed.