### PR TITLE
fix(components.support): prevent ngRepeat:dupes error

### DIFF
--- a/packages/manager/modules/hub/src/components/support/template.html
+++ b/packages/manager/modules/hub/src/components/support/template.html
@@ -20,10 +20,11 @@
             class="oui-table-responsive"
         >
             <table class="oui-table">
-                <tbody>
+                <tbody
+                    data-ng-if="$ctrl.tickets.length > 0 && !$ctrl.isLoading"
+                >
                     <tr
                         class="oui-table__row"
-                        data-ng-if="!$ctrl.isLoading"
                         data-ng-repeat="ticket in $ctrl.tickets track by ticket.ticketId"
                         data-navi-id="{{:: 'helpBlock-' + ticket.serviceName }}"
                     >
@@ -55,11 +56,9 @@
                             </a>
                         </td>
                     </tr>
-                    <tr
-                        class="oui-table__row"
-                        data-ng-if="$ctrl.isLoading"
-                        data-ng-repeat="loader in [1,2]"
-                    >
+                </tbody>
+                <tbody data-ng-if="$ctrl.isLoading">
+                    <tr class="oui-table__row" data-ng-repeat="loader in [1,2]">
                         <td
                             data-ng-repeat="skeleton in [1,2]"
                             class="oui-table__cell"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

9aa0204 - fix(components.support): prevent ngRepeat:dupes error 

Fix following console error message when having an empty tickets' list.

Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed.
Use 'track by' expression to specify unique keys.
Repeater: ticket in $ctrl.tickets track by ticket.ticketId, Duplicate key: undefined, Duplicate value: []

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
