### PR TITLE
fix(sms): display the full message in incoming sms popup

### DIFF
--- a/packages/manager/modules/sms/src/sms/sms/incoming/read/telecom-sms-sms-incoming-read.html
+++ b/packages/manager/modules/sms/src/sms/sms/incoming/read/telecom-sms-sms-incoming-read.html
@@ -50,7 +50,7 @@
             data-translate="sms_sms_incoming_read_label_message"
         ></dt>
         <dd
-            class="text-truncate"
+            class="word-break"
             data-ng-if="IncomingReadCtrl.incomingSms.message.length >= 25"
             data-ng-bind="IncomingReadCtrl.incomingSms.message"
         ></dd>

--- a/packages/manager/modules/sms/src/sms/sms/outgoing/read/telecom-sms-sms-outgoing-read.html
+++ b/packages/manager/modules/sms/src/sms/sms/outgoing/read/telecom-sms-sms-outgoing-read.html
@@ -103,7 +103,7 @@
             data-translate="sms_sms_outgoing_read_label_message"
         ></dt>
         <dd
-            class="text-truncate"
+            class="word-break"
             data-ng-if="OutgoingReadCtrl.outgoingSms.message.length >= 25"
             data-ng-bind="OutgoingReadCtrl.outgoingSms.message"
         ></dd>


### PR DESCRIPTION
ref: DTRSD-25819
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-25819
| License          | BSD 3-Clause

## Description

Display the whole message (In SMS > Incoming > Sms details)
