### PR TITLE
Add applicationName and universe in Environment

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -5,6 +5,8 @@ import has from 'lodash/has';
 import uiRouter, { RejectType } from '@uirouter/angularjs';
 import isString from 'lodash/isString';
 
+import { Environment } from '@ovh-ux/manager-config';
+
 import { detach as detachPreloader } from '@ovh-ux/manager-preloader';
 import ovhManagerCore from '@ovh-ux/manager-core';
 import ngAtInternet from '@ovh-ux/ng-at-internet';
@@ -41,6 +43,7 @@ import ovhManagerBanner from '@ovh-ux/manager-banner';
 import ovhManagerNavbar from '@ovh-ux/manager-navbar';
 import ovhManagerServerSidebar from '@ovh-ux/manager-server-sidebar';
 import ovhNotificationsSidebar from '@ovh-ux/manager-notifications-sidebar';
+import ngOvhFeatureFlipping from '@ovh-ux/ng-ovh-feature-flipping';
 
 import cloudUniverseComponents from '../cloudUniverseComponents';
 
@@ -106,6 +109,7 @@ angular
       ngOvhJqueryUiDraggable,
       ngOvhJqueryUiDroppable,
       ngOvhSlider,
+      ngOvhFeatureFlipping,
       ngTailLogs,
       'matchmedia-ng',
       'angular-websocket',
@@ -192,6 +196,13 @@ angular
   .config(
     /* @ngInject */ (CucConfigProvider, coreConfigProvider) => {
       CucConfigProvider.setRegion(coreConfigProvider.getRegion());
+    },
+  )
+  .config(
+    /* @ngInject */ (ovhFeatureFlippingProvider) => {
+      ovhFeatureFlippingProvider.setApplicationName(
+        Environment.getApplicationName(),
+      );
     },
   )
   .run(

--- a/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
+++ b/packages/manager/apps/cloud/client/app/common/cloud-main-controller.controller.js
@@ -23,6 +23,13 @@ class CloudMainController {
   $onInit() {
     this.expiringProject = null;
 
+    this.navbarOptions = {
+      toggle: {
+        event: 'sidebar:loaded',
+      },
+      universe: Environment.getUniverse(),
+    };
+
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
     const unregisterListener = this.$scope.$on('app:started', () => {

--- a/packages/manager/apps/cloud/client/app/index.js
+++ b/packages/manager/apps/cloud/client/app/index.js
@@ -6,7 +6,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('cloud').then(({ region }) => {
   import(`./config-${region}`)
     .catch(() => {})
     .then(() => import('./app.module'))

--- a/packages/manager/apps/cloud/client/index.html
+++ b/packages/manager/apps/cloud/client/index.html
@@ -41,12 +41,7 @@
             <!-- /Skip to main content -->
 
             <ovh-manager-navbar
-                data-navbar-options="{
-                    toggle: {
-                        event: 'sidebar:loaded'
-                    },
-                    universe: 'server'
-                }"
+                data-navbar-options="$ctrl.navbarOptions"
                 data-universe-click="$ctrl.openSidebar()"
             >
             </ovh-manager-navbar>

--- a/packages/manager/apps/dedicated/client/app/app.js
+++ b/packages/manager/apps/dedicated/client/app/app.js
@@ -362,7 +362,9 @@ angular
   )
   .config(
     /* @ngInject */ (ovhFeatureFlippingProvider) => {
-      ovhFeatureFlippingProvider.setApplicationName('dedicated');
+      ovhFeatureFlippingProvider.setApplicationName(
+        Environment.getApplicationName(),
+      );
     },
   );
 

--- a/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
@@ -19,6 +19,7 @@ angular.module('App').controller(
       this.$scope.$on('switchUniverse', (event, universe) => {
         this.sidebarNamespace = universe === 'server' ? undefined : 'hpc';
         this.navbarOptions.universe = universe;
+        Environment.setUniverse(universe);
       });
 
       this.currentLanguage = Environment.getUserLanguage();

--- a/packages/manager/apps/dedicated/client/app/index.js
+++ b/packages/manager/apps/dedicated/client/app/index.js
@@ -6,7 +6,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('dedicated').then(({ region }) => {
   import(`./config-${region}`)
     .catch(() => {})
     .then(() => import('./app.module'))

--- a/packages/manager/apps/hub/src/app.module.js
+++ b/packages/manager/apps/hub/src/app.module.js
@@ -68,7 +68,9 @@ angular
   )
   .config(
     /* @ngInject */ (ovhFeatureFlippingProvider) => {
-      ovhFeatureFlippingProvider.setApplicationName('hub');
+      ovhFeatureFlippingProvider.setApplicationName(
+        Environment.getApplicationName(),
+      );
     },
   )
   .config(routing)

--- a/packages/manager/apps/hub/src/controller.js
+++ b/packages/manager/apps/hub/src/controller.js
@@ -11,6 +11,13 @@ export default class HubController {
   }
 
   $onInit() {
+    this.navbarOptions = {
+      universe: Environment.getUniverse(),
+      version: 'beta',
+      toggle: {
+        event: 'sidebar:loaded',
+      },
+    };
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
     const unregisterListener = this.$scope.$on('app:started', () => {

--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -33,13 +33,7 @@
         </div>
         <!-- /Skip to main content -->
         <ovh-manager-navbar
-            data-navbar-options="{
-                universe: 'hub',
-                version: 'beta',
-                toggle: {
-                    event: 'sidebar:loaded',
-                },
-            }"
+            data-navbar-options="$ctrl.navbarOptions"
             data-sidebar-expand="true"
             data-sidebar-links="{}"
         >

--- a/packages/manager/apps/hub/src/index.js
+++ b/packages/manager/apps/hub/src/index.js
@@ -10,7 +10,7 @@ import { BILLING_REDIRECTIONS } from './constants';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('hub').then(({ region }) => {
   BILLING_REDIRECTIONS.forEach((redirectionRegex) => {
     const hash = window.location.hash.replace('#', '');
     if (redirectionRegex.test(hash)) {

--- a/packages/manager/apps/public-cloud/src/app.module.js
+++ b/packages/manager/apps/public-cloud/src/app.module.js
@@ -81,7 +81,9 @@ angular
   )
   .config(
     /* @ngInject */ (ovhFeatureFlippingProvider) => {
-      ovhFeatureFlippingProvider.setApplicationName('public-cloud');
+      ovhFeatureFlippingProvider.setApplicationName(
+        Environment.getApplicationName(),
+      );
     },
   )
   .config(routing)

--- a/packages/manager/apps/public-cloud/src/index.js
+++ b/packages/manager/apps/public-cloud/src/index.js
@@ -6,7 +6,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('public-cloud').then(({ region }) => {
   import(`./config-${region}`)
     .catch(() => {})
     .then(() => import('./app.module'))

--- a/packages/manager/apps/public-cloud/src/navbar.config.js
+++ b/packages/manager/apps/public-cloud/src/navbar.config.js
@@ -1,6 +1,8 @@
+import { Environment } from '@ovh-ux/manager-config';
+
 export default {
   toggle: {
     event: 'sidebar:loaded',
   },
-  universe: 'public-cloud',
+  universe: Environment.getUniverse(),
 };

--- a/packages/manager/apps/telecom/src/app/app.controller.js
+++ b/packages/manager/apps/telecom/src/app/app.controller.js
@@ -25,6 +25,12 @@ export default class TelecomAppCtrl {
   }
 
   $onInit() {
+    this.navbarOptions = {
+      toggle: {
+        event: 'sidebar:loaded',
+      },
+      universe: Environment.getUniverse(),
+    };
     this.currentLanguage = Environment.getUserLanguage();
     this.user = Environment.getUser();
 

--- a/packages/manager/apps/telecom/src/app/app.js
+++ b/packages/manager/apps/telecom/src/app/app.js
@@ -164,7 +164,9 @@ angular
     LineDiagnosticsProvider.setPathPrefix('/xdsl/{serviceName}');
   })
   .config((ovhFeatureFlippingProvider) => {
-    ovhFeatureFlippingProvider.setApplicationName('telecom');
+    ovhFeatureFlippingProvider.setApplicationName(
+      Environment.getApplicationName(),
+    );
   })
   .run(
     /* @ngInject */ ($translate) => {

--- a/packages/manager/apps/telecom/src/app/index.js
+++ b/packages/manager/apps/telecom/src/app/index.js
@@ -6,7 +6,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('telecom').then(({ region }) => {
   import(`./config-${region}`)
     .catch(() => {})
     .then(() => import('./app.module'))

--- a/packages/manager/apps/telecom/src/index.html
+++ b/packages/manager/apps/telecom/src/index.html
@@ -40,12 +40,7 @@
                 <!-- /Skip to main content -->
                 <div data-ui-view="navbar">
                     <ovh-manager-navbar
-                        data-navbar-options="{
-                            toggle: {
-                                event: 'sidebar:loaded'
-                            },
-                            universe: 'telecom'
-                        }"
+                        data-navbar-options="$ctrl.navbarOptions"
                         data-universe-click="$ctrl.openSidebar()"
                         data-global-search-link="{{ $ctrl.globalSearchLink }}"
                     >

--- a/packages/manager/apps/web/client/app/app.js
+++ b/packages/manager/apps/web/client/app/app.js
@@ -245,7 +245,9 @@ angular
   ])
   .config(
     /* @ngInject */ (ovhFeatureFlippingProvider) => {
-      ovhFeatureFlippingProvider.setApplicationName('web');
+      ovhFeatureFlippingProvider.setApplicationName(
+        Environment.getApplicationName(),
+      );
     },
   )
   .config([

--- a/packages/manager/apps/web/client/app/components/webApp.controller.js
+++ b/packages/manager/apps/web/client/app/components/webApp.controller.js
@@ -13,6 +13,13 @@ export default class WebAppCtrl {
   }
 
   $onInit() {
+    this.navbarOptions = {
+      toggle: {
+        event: 'sidebar:loaded',
+      },
+      universe: Environment.getUniverse(),
+    };
+
     this.$scope.$watch(
       () => this.$translate.instant('global_app_title'),
       () => {

--- a/packages/manager/apps/web/client/app/index.html
+++ b/packages/manager/apps/web/client/app/index.html
@@ -32,12 +32,7 @@
             <!-- /Skip to main content -->
             <div>
                 <ovh-manager-navbar
-                    data-navbar-options="{
-                      toggle: {
-                        event: 'sidebar:loaded'
-                      },
-                      universe: 'web',
-                    }"
+                    data-navbar-options="$ctrl.navbarOptions"
                     data-universe-click="$ctrl.openSidebar()"
                 >
                 </ovh-manager-navbar>

--- a/packages/manager/apps/web/client/app/index.js
+++ b/packages/manager/apps/web/client/app/index.js
@@ -6,7 +6,7 @@ import { Environment } from '@ovh-ux/manager-config';
 
 attachPreloader(Environment.getUserLanguage());
 
-bootstrapApplication().then(({ region }) => {
+bootstrapApplication('web').then(({ region }) => {
   import(`./config-${region}`)
     .catch(() => {})
     .then(() => import('./app.module'))

--- a/packages/manager/modules/config/src/environment/environment.service.js
+++ b/packages/manager/modules/config/src/environment/environment.service.js
@@ -11,6 +11,8 @@ export default class EnvironmentService {
     this.userLocale = findAvailableLocale(detectUserLocale(), this.region);
     this.version = null;
     this.user = {};
+    this.applicationName = '';
+    this.universe = '';
     this.applicationURLs = {};
   }
 
@@ -57,6 +59,22 @@ export default class EnvironmentService {
 
   getVersion() {
     return this.version;
+  }
+
+  setApplicationName(name) {
+    this.applicationName = name;
+  }
+
+  getApplicationName() {
+    return this.applicationName;
+  }
+
+  setUniverse(universe) {
+    this.universe = universe;
+  }
+
+  getUniverse() {
+    return this.universe;
   }
 
   setApplicationURLs(applicationURLs) {

--- a/packages/manager/modules/config/src/index.js
+++ b/packages/manager/modules/config/src/index.js
@@ -26,8 +26,15 @@ export const findLanguage = _findLanguage;
 export const LANGUAGES = _LANGUAGES;
 export const localeStorageKey = _localeStorageKey;
 
-export const fetchConfiguration = () => {
-  return fetch('/engine/2api/configuration', {
+export const fetchConfiguration = (applicationName) => {
+  let configurationURL = '/engine/2api/configuration';
+  if (applicationName) {
+    _Environment.setApplicationName(applicationName);
+    configurationURL = `${configurationURL}?app=${encodeURIComponent(
+      applicationName,
+    )}`;
+  }
+  return fetch(configurationURL, {
     headers: {
       'Content-Type': 'application/json;charset=utf-8',
       Accept: 'application/json',
@@ -48,6 +55,7 @@ export const fetchConfiguration = () => {
       _Environment.setRegion(config.region);
       _Environment.setUser(config.user);
       _Environment.setApplicationURLs(config.applicationURLs);
+      _Environment.setUniverse(config.universe);
       return config;
     })
     .catch(() => ({

--- a/packages/manager/modules/core/src/index.js
+++ b/packages/manager/modules/core/src/index.js
@@ -246,4 +246,5 @@ angular
 
 export default moduleName;
 
-export const bootstrapApplication = () => fetchConfiguration();
+export const bootstrapApplication = (applicationName) =>
+  fetchConfiguration(applicationName);


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Will replace https://github.com/ovh/manager/pull/4138 ?

-  add `applicationName` (`setApplicationName`/`getApplicationName`) and `universe` (`setUniverse`/`getUniverse`) in `Environment`
- define `applicationName` at bootstrap
- get universe from `/configuration` response


### Applications
- define `applicationName` and refactor to use `Environment.getApplicationName()` && `Environment.getUniverse()`

- [x] `@ovh-ux/manager-hup-app` (`hub`)
- [x] `@ovh-ux/manager-dedicated` (`dedicated`)
- [x] `@ovh-ux/manager-public-cloud` (`public-cloud`)
- [x] `@ovh-ux/manager-cloud` (`cloud`)
- [x] `@ovh-ux/manager-telecom` (`telecom`)
- [x] `@ovh-ux/manager-web` (`web`)




