### PR TITLE
fix(domain.dashboard.webhosting-enable): display error message info

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/domain-enable-web-hosting.controller.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/domain-enable-web-hosting.controller.js
@@ -60,7 +60,7 @@ export default class EnableWebHostingOrderCtrl {
           this.$translate.instant(
             'domain_configuration_enable_web_hosting_checkout_error',
             {
-              message: error.message,
+              message: get(error, 'data.message', error.message),
             },
           ),
         ),
@@ -97,7 +97,7 @@ export default class EnableWebHostingOrderCtrl {
           this.$translate.instant(
             'domain_configuration_enable_web_hosting_checkout_error',
             {
-              message: get(error, 'message'),
+              message: get(error, 'data.message', error.message),
             },
           ),
         ),


### PR DESCRIPTION
error message not shown when a error occures during web hosting email activation

ref #DTRSD-25748

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-25748
| License          | BSD 3-Clause

## Description

API error message not shown on UI.
