### PR TITLE
fix(dedicated-cloud.datacenter.datastore): datastore order plancode

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.html
@@ -23,7 +23,7 @@
                 data-name="selectedOffer"
                 data-model="$ctrl.selectedOffer"
                 data-value="$row"
-                ><span data-ng-bind="$row.productName"></span>
+                ><span data-ng-bind="$row.planCode"></span>
             </oui-radio>
         </oui-datagrid-column>
         <oui-datagrid-column


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-5860
| License          | BSD 3-Clause

## Description

Display profile plancode instead of profile name
