### PR TITLE
fix(pack.move): set missing building from address eligibility test

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.controller.js
@@ -185,6 +185,7 @@ export default class {
         this.fiber,
         'address',
         ELIGIBILITY_LINE_STATUS.create,
+        building,
       );
       this.displayResult = true;
       this.displaySearchResult = true;
@@ -263,6 +264,7 @@ export default class {
                 this.fiber,
                 'address',
                 ELIGIBILITY_LINE_STATUS.create,
+                building,
               );
               this.displayResult = true;
               this.displaySearchResult = true;


### PR DESCRIPTION
Signed-off-by: Stephanie Moallic <stephanie.moallic@corp.ovh.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-321
| License          | BSD 3-Clause

## Description

Set the missing building for pack move from eligibility by address test
