### PR TITLE
fix(template): prevent repeater error message

### DIFF
--- a/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.html
+++ b/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.html
@@ -1,5 +1,5 @@
 <ul>
-    <li data-ng-repeat="element in $ctrl.breadcrumb track by element.name">
+    <li data-ng-repeat="element in $ctrl.breadcrumb track by $index">
         <a
             data-ng-if="element.url && !element.active && !$last"
             data-ng-href="{{ element.url }}"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | sentry-MANAGER-4H8W
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

87da4e3 - fix(template): prevent repeater error message

Error reported in the console:
```sh
ngRepeat:dupes: Duplicates in a repeater are not allowed.
Use 'track by' expression to specify unique keys.
Repeater: element in $ctrl.breadcrumb track by element.name,
```

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

