### PR TITLE
feat(dedicated): add  advices tile

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
@@ -880,6 +880,14 @@
                 user="$ctrl.user"
             ></dedicated-server-dashboard-advanced-features>
         </div>
+        <!-- Advices -->
+        <div class="col-md-4" data-ng-if="!$ctrl.server.isExpired">
+            <ovh-advices
+                service-type="dedicated-server"
+                service-name="{{ ::$ctrl.server.name }}"
+            >
+            </ovh-advices>
+        </div>
     </div>
 
     <!-- QUOTA -->

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/index.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/index.js
@@ -5,6 +5,7 @@ import '@ovh-ux/ng-translate-async-loader';
 import '@uirouter/angularjs';
 import 'angular-translate';
 import '@ovh-ux/ui-kit';
+import ovhManagerAdvices from '@ovh-ux/manager-advices';
 
 import advancedFeatures from './advanced-features';
 
@@ -20,6 +21,7 @@ angular
     'oui',
     'pascalprecht.translate',
     'ui.router',
+    ovhManagerAdvices,
   ])
   .component('dedicatedServerDashboard', component)
   .config(routing)

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ovh-ux/manager-account-migration": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-account-sidebar": "^2.0.0 || ^3.0.0",
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-at-internet-configuration": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-banner": "^1.1.3",
     "@ovh-ux/manager-beta-preference": "^1.0.0",


### PR DESCRIPTION
show guaranteed bandwidth and burst capacity reached advices on dedicated server dashboard

ref #MANAGER-6070 #MANAGER-6071

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/upsell-crosssell
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-6070 #MANAGER-6071
| License          | BSD 3-Clause

## Description

Show below dedicated server advices on advices tile
1. Guaranteed bandwidth advice
2. Burst capacity reached advice