### PR TITLE
fix: remove duplicates import of ngOvhFeatureFlipping

### DIFF
--- a/packages/manager/apps/cloud/client/app/app.js
+++ b/packages/manager/apps/cloud/client/app/app.js
@@ -44,7 +44,6 @@ import ovhManagerBanner from '@ovh-ux/manager-banner';
 import ovhManagerNavbar from '@ovh-ux/manager-navbar';
 import ovhManagerServerSidebar from '@ovh-ux/manager-server-sidebar';
 import ovhNotificationsSidebar from '@ovh-ux/manager-notifications-sidebar';
-import ngOvhFeatureFlipping from '@ovh-ux/ng-ovh-feature-flipping';
 
 import cloudUniverseComponents from '../cloudUniverseComponents';
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

be03133 - fix: remove duplicates import of ngOvhFeatureFlipping

Fix following error message:
```sh
SyntaxError: Identifier 'ngOvhFeatureFlipping' has already been declared
```

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>