### PR TITLE
fix(sidebar.constant): rename entry menu label for quota

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
@@ -202,7 +202,7 @@ export const MENU = [
         options: {
           state: 'pci.projects.project.quota',
         },
-        title: 'Quota and Localisation',
+        title: 'Quota and Regions',
       },
       {
         id: 'ssh-keys',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w01`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-18335
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

87a9992 - fix(sidebar.constant): rename entry menu label for quota

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
