### PR TITLE
feat(cloud-connect): remove regions config and let feature flipping

### DIFF
--- a/packages/manager/modules/cloud-connect/src/cloud-connect.constants.js
+++ b/packages/manager/modules/cloud-connect/src/cloud-connect.constants.js
@@ -1,6 +1,10 @@
 export const GUIDELINK = {
-  EN: 'https://docs.ovh.com/gb/en/ovhcloud-connect/',
+  GB: 'https://docs.ovh.com/gb/en/ovhcloud-connect/',
   FR: 'https://docs.ovh.com/fr/ovhcloud-connect/',
+  CA: 'https://docs.ovh.com/ca/fr/ovhcloud-connect/',
+  ASIA: 'https://docs.ovh.com/asia/en/ovhcloud-connect/',
+  AU: 'https://docs.ovh.com/au/en/ovhcloud-connect/',
+  SG: 'https://docs.ovh.com/sg/en/ovhcloud-connect/',
 };
 
 export const POP_MAP = {

--- a/packages/manager/modules/cloud-connect/src/cloud-connect.routing.js
+++ b/packages/manager/modules/cloud-connect/src/cloud-connect.routing.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import { GUIDELINK } from './cloud-connect.constants';
 
 export default /* @ngInject */ ($stateProvider) => {
@@ -7,7 +6,8 @@ export default /* @ngInject */ ($stateProvider) => {
     component: 'cloudConnect',
     resolve: {
       user: /* @ngInject */ (OvhApiMe) => OvhApiMe.v6().get().$promise,
-      guideUrl: /* @ngInject */ (user) => get(GUIDELINK, user.ovhSubsidiary),
+      guideUrl: /* @ngInject */ (user) =>
+        GUIDELINK[user.ovhSubsidiary] || GUIDELINK.GB,
     },
   });
 };

--- a/packages/manager/modules/server-sidebar/src/sidebar.constants.js
+++ b/packages/manager/modules/server-sidebar/src/sidebar.constants.js
@@ -354,7 +354,6 @@ export const DEDICATED_NETWORK_CONFIG = {
           state: 'cloud-connect.details',
           stateParams: ['ovhCloudConnectId'],
           app: [DEDICATED],
-          regions: ['EU'],
           namespace: [undefined, HPC_NAMESPACE],
         },
       ],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6020
| License          | BSD 3-Clause

## Description

Remove regions configuration in server sidebar in order to let feature flipping managing ovh-cloud-connect feature.