### PR TITLE
fix(pack.migration): initialize selected building first

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/buildings/pack-migration-buildings.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/buildings/pack-migration-buildings.controller.js
@@ -10,6 +10,9 @@ export default class TelecomPackMigrationBuildingsCtrl {
   }
 
   selectBuilding(building) {
+    // initialize selected building
+    this.TucPackMigrationProcess.setSelectedBuilding(building);
+
     // check if the building name is empty to set a name to display in the select component
     this.process.selectedBuilding.name =
       building.name === ''
@@ -17,7 +20,6 @@ export default class TelecomPackMigrationBuildingsCtrl {
             'telecom_pack_migration_building_details_unknown',
           )
         : building.name;
-    this.TucPackMigrationProcess.setSelectedBuilding(building);
 
     // Display offers
     this.process.currentStep = 'offers';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | UXCT-364
| License          | BSD 3-Clause

## Description

Initialize selected building first, then update name of selected building if is empty
