### PR TITLE
fix(template): duplicate links

### DIFF
--- a/packages/manager/modules/account-sidebar/src/template.html
+++ b/packages/manager/modules/account-sidebar/src/template.html
@@ -30,7 +30,7 @@
             data-navi-id="account-sidebar-usefulLinks-block"
         >
             <h3 data-translate="hub_links_title"></h3>
-            <div data-ng-repeat="link in $ctrl.links track by $index">
+            <div data-ng-repeat="link in $ctrl.links">
                 <span
                     class="manager-hub-user-panel_divider"
                     data-ng-if="link.href || link.action"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-27784
| License          | BSD 3-Clause

## Description

since links array is modified dynamically here : https://github.com/ovh/manager/blob/master/packages/manager/modules/account-sidebar/src/controller.js#L24

the array indexes doesn't match anymore and track by $index results in a broken display (in this case, missing travaux link and duplicate create ticket link)

removing track by index fixes the issue