### PR TITLE
fix(deps): update @novnc/novnc package

### DIFF
--- a/packages/manager/modules/vps/package.json
+++ b/packages/manager/modules/vps/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@novnc/novnc": "git+https://github.com/ovh-ux/noVNC.git#build/websock_base64",
+    "@novnc/novnc": "ovh-ux/noVNC#build/websock_base64_dist",
     "@ovh-ux/ufrontend": "^1.0.0",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "flag-icon-css": "~0.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,9 +2798,9 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@novnc/novnc@git+https://github.com/ovh-ux/noVNC.git#build/websock_base64":
+"@novnc/novnc@ovh-ux/noVNC#build/websock_base64_dist":
   version "1.1.0"
-  resolved "git+https://github.com/ovh-ux/noVNC.git#3563337b3dfacc7d4d22e299e79464253359b7a8"
+  resolved "https://codeload.github.com/ovh-ux/noVNC/tar.gz/f10500ef3c47069625472791c8cac305475a12a3"
 
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"
@@ -10562,7 +10562,7 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flatpickr@^4.6.3:
+flatpickr@4.6.3, flatpickr@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
   integrity sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ==


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w03`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

ea2fa19 - fix(deps): update @novnc/novnc package

remove extra prepare hooks that can crash when installing the project.

### :link: Related

See: https://github.com/ovh-ux/noVNC/branches

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
