### PR TITLE
fix(server): show bandwidth plans irrespective of capacity

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.controller.js
@@ -1,5 +1,4 @@
 import find from 'lodash/find';
-import get from 'lodash/get';
 
 export default class {
   /* @ngInject */
@@ -13,13 +12,6 @@ export default class {
     this.model = {};
     this.plans = null;
     this.isLoading = false;
-    this.existingBandwidth = get(this, 'specifications.vrack.bandwidth.value');
-
-    if (!this.existingBandwidth) {
-      this.plans = [];
-      this.isLoading = false;
-      return;
-    }
 
     this.steps = [
       {
@@ -29,13 +21,9 @@ export default class {
           this.isLoading = true;
           return this.Server.getBareMetalPrivateBandwidthOptions(
             this.serverName,
-            this.existingBandwidth,
           )
             .then((plans) => {
-              this.plans = this.Server.getValidBandwidthPlans(
-                plans,
-                this.existingBandwidth,
-              );
+              this.plans = this.Server.getValidBandwidthPlans(plans);
             })
             .catch((error) => {
               this.goBack().then(() =>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.html
@@ -32,7 +32,7 @@
             <p data-translate="select_bandwidth_vrack_type_label"></p>
             <div data-ng-repeat="plan in $ctrl.plans track by $index">
                 <div class="row">
-                    <div class="col-md-9 pr-0">
+                    <div class="col-md-9 pr-0 pb-2">
                         <oui-radio
                             data-name="bandwidth-plan"
                             data-model="$ctrl.model.plan"

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
@@ -1,5 +1,4 @@
 import find from 'lodash/find';
-import get from 'lodash/get';
 
 export default class {
   /* @ngInject */
@@ -14,10 +13,6 @@ export default class {
     this.model = {};
     this.plans = null;
     this.isLoading = false;
-    this.existingBandwidth = get(
-      this,
-      'specifications.bandwidth.OvhToInternet.value',
-    );
 
     this.steps = [
       {
@@ -25,15 +20,9 @@ export default class {
         isLoading: () => this.isLoading,
         load: () => {
           this.isLoading = true;
-          return this.Server.getBareMetalPublicBandwidthOptions(
-            this.serverName,
-            this.existingBandwidth,
-          )
+          return this.Server.getBareMetalPublicBandwidthOptions(this.serverName)
             .then((plans) => {
-              this.plans = this.Server.getValidBandwidthPlans(
-                plans,
-                this.existingBandwidth,
-              );
+              this.plans = this.Server.getValidBandwidthPlans(plans);
             })
             .catch((error) => {
               this.goBack().then(() =>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.html
@@ -32,7 +32,7 @@
             <p data-translate="select_bandwidth_type_label"></p>
             <div data-ng-repeat="plan in $ctrl.plans track by $index">
                 <div class="row">
-                    <div class="col-md-9 pr-0">
+                    <div class="col-md-9 pr-0 pb-2">
                         <oui-radio
                             data-name="bandwidth-plan"
                             data-model="$ctrl.model.plan"

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/server.service.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/server.service.js
@@ -1,4 +1,3 @@
-import assign from 'lodash/assign';
 import camelCase from 'lodash/camelCase';
 import compact from 'lodash/compact';
 import filter from 'lodash/filter';
@@ -1496,7 +1495,7 @@ export default class ServerF {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  getValidBandwidthPlans(plans, existingBandwidth) {
+  getValidBandwidthPlans(plans) {
     const list = map(plans, (plan) => {
       // Not to include already included plans (existing plan)
       if (!plan.planCode.includes('included')) {
@@ -1504,11 +1503,10 @@ export default class ServerF {
         const bandwidth = parseInt(
           head(filter(plan.productName.split('-'), (ele) => /^\d+$/.test(ele))),
         );
-        assign(plan, { bandwidth });
-
-        if (bandwidth !== existingBandwidth) {
-          return plan;
-        }
+        return {
+          ...plan,
+          bandwidth,
+        };
       }
       return null;
     });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-6230
| License          | BSD 3-Clause

## Description

Manager filters bandwidth plans to remove plans with current bandwidth capacity. This is wrong because there can be different bandwidth plans with the same bandwidth capacity. For example, there are two plans, guaranteed and ultimate, with 1Gbps capacity. Bandwidth plans can not be filtered only based on current capacity. As of now, there is no API to know the current bandwidth plan to remove it from the plan's list. There is a change request on PU to enable this. For now, its better to show all plans.


Required for up-sell cross-sell