### PR TITLE
feat(emails): sort alphabetically and save page pref

### DIFF
--- a/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.controller.js
+++ b/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.controller.js
@@ -1,84 +1,116 @@
 import map from 'lodash/map';
 
-angular.module('App').controller(
-  'EmailDomainEmailRedirectionCtrl',
-  class EmailDomainEmailRedirectionCtrl {
-    /**
-     * Constructor
-     * @param $scope
-     * @param $stateParams
-     * @param $q
-     * @param $translate
-     * @param Alerter
-     * @param WucEmails
-     */
-    constructor($scope, $stateParams, $q, $translate, Alerter, WucEmails) {
-      this.$scope = $scope;
-      this.$stateParams = $stateParams;
-      this.$q = $q;
-      this.$translate = $translate;
-      this.Alerter = Alerter;
-      this.WucEmails = WucEmails;
-    }
+angular
+  .module('App')
+  .constant('PAGE_SIZE_STORAGE_KEY', 'REDIRECTION_EMAILS_PAGINATION')
+  .controller(
+    'EmailDomainEmailRedirectionCtrl',
+    class EmailDomainEmailRedirectionCtrl {
+      /**
+       * Constructor
+       * @param $scope
+       * @param $stateParams
+       * @param $q
+       * @param $translate
+       * @param $window
+       * @param Alerter
+       * @param WucEmails
+       * @param PAGE_SIZE_STORAGE_KEY
+       */
+      constructor(
+        $scope,
+        $stateParams,
+        $q,
+        $translate,
+        $window,
+        Alerter,
+        WucEmails,
+        PAGE_SIZE_STORAGE_KEY,
+      ) {
+        this.$scope = $scope;
+        this.$stateParams = $stateParams;
+        this.$q = $q;
+        this.$translate = $translate;
+        this.$window = $window;
+        this.Alerter = Alerter;
+        this.WucEmails = WucEmails;
+        this.$scope.PAGE_SIZE_STORAGE_KEY = PAGE_SIZE_STORAGE_KEY;
+      }
 
-    $onInit() {
-      this.loading = {
-        exportCSV: false,
-        redirections: false,
-      };
-      this.redirectionsDetails = [];
+      $onInit() {
+        this.loading = {
+          exportCSV: false,
+          redirections: false,
+        };
+        this.redirectionsDetails = [];
+        this.pageSize = this.fetchPageSizePreference();
 
-      this.$scope.$on('hosting.tabs.emails.redirections.refresh', () =>
-        this.refreshTableRedirections(),
-      );
+        this.$scope.$on('hosting.tabs.emails.redirections.refresh', () =>
+          this.refreshTableRedirections(),
+        );
 
-      this.refreshTableRedirections();
-    }
+        this.refreshTableRedirections();
+      }
 
-    getDatasToExport() {
-      this.loading.exportCSV = true;
+      getDatasToExport() {
+        this.loading.exportCSV = true;
 
-      const dataToExport = [
-        [
-          this.$translate.instant('emails_common_from'),
-          this.$translate.instant('emails_common_to'),
-        ],
-      ];
+        const dataToExport = [
+          [
+            this.$translate.instant('emails_common_from'),
+            this.$translate.instant('emails_common_to'),
+          ],
+        ];
 
-      return this.$q
-        .all(
-          map(this.redirections, ({ id }) =>
-            this.WucEmails.getRedirection(this.$stateParams.productId, id),
-          ),
-        )
-        .then((data) => dataToExport.concat(map(data, (d) => [d.from, d.to])))
-        .finally(() => {
-          this.loading.exportCSV = false;
-        });
-    }
+        return this.$q
+          .all(
+            map(this.redirections, ({ id }) =>
+              this.WucEmails.getRedirection(this.$stateParams.productId, id),
+            ),
+          )
+          .then((data) => dataToExport.concat(map(data, (d) => [d.from, d.to])))
+          .finally(() => {
+            this.loading.exportCSV = false;
+          });
+      }
 
-    refreshTableRedirections() {
-      this.loading.redirections = true;
-      this.redirections = null;
+      refreshTableRedirections() {
+        this.loading.redirections = true;
+        this.redirections = null;
 
-      return this.WucEmails.getRedirections(this.$stateParams.productId)
-        .then((data) => {
-          this.redirections = data.map((id) => ({ id }));
-        })
-        .catch((err) =>
-          this.Alerter.alertFromSWS(
-            this.$translate.instant('email_tab_table_redirections_error'),
-            err,
-            this.$scope.alerts.main,
-          ),
-        )
-        .finally(() => {
-          this.loading.redirections = false;
-        });
-    }
+        return this.WucEmails.getRedirections(this.$stateParams.productId)
+          .then((data) => {
+            this.redirections = data.map((id) => ({ id }));
+          })
+          .catch((err) =>
+            this.Alerter.alertFromSWS(
+              this.$translate.instant('email_tab_table_redirections_error'),
+              err,
+              this.$scope.alerts.main,
+            ),
+          )
+          .finally(() => {
+            this.loading.redirections = false;
+          });
+      }
 
-    transformItem({ id }) {
-      return this.WucEmails.getRedirection(this.$stateParams.productId, id);
-    }
-  },
-);
+      transformItem({ id }) {
+        return this.WucEmails.getRedirection(this.$stateParams.productId, id);
+      }
+
+      fetchPageSizePreference() {
+        return this.$window.localStorage.getItem(
+          this.$scope.PAGE_SIZE_STORAGE_KEY,
+        );
+      }
+
+      savePageSizePreference(newPageSize) {
+        if (!localStorage) return;
+
+        this.$window.localStorage.setItem(
+          this.$scope.PAGE_SIZE_STORAGE_KEY,
+          newPageSize.pageSize,
+        );
+      }
+    },
+  );

--- a/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.controller.js
+++ b/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.controller.js
@@ -34,7 +34,7 @@ angular
         this.$window = $window;
         this.Alerter = Alerter;
         this.WucEmails = WucEmails;
-        this.$scope.PAGE_SIZE_STORAGE_KEY = PAGE_SIZE_STORAGE_KEY;
+        this.PAGE_SIZE_STORAGE_KEY = PAGE_SIZE_STORAGE_KEY;
       }
 
       $onInit() {
@@ -99,16 +99,14 @@ angular
       }
 
       fetchPageSizePreference() {
-        return this.$window.localStorage.getItem(
-          this.$scope.PAGE_SIZE_STORAGE_KEY,
-        );
+        return this.$window.localStorage.getItem(this.PAGE_SIZE_STORAGE_KEY);
       }
 
       savePageSizePreference(newPageSize) {
         if (!localStorage) return;
 
         this.$window.localStorage.setItem(
-          this.$scope.PAGE_SIZE_STORAGE_KEY,
+          this.PAGE_SIZE_STORAGE_KEY,
           newPageSize.pageSize,
         );
       }

--- a/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.html
+++ b/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.html
@@ -41,10 +41,13 @@
             <oui-datagrid
                 data-rows="ctrlEmailDomainEmailRedirection.redirections"
                 data-row-loader="ctrlEmailDomainEmailRedirection.transformItem($row)"
+                data-page-size="{{ ctrlEmailDomainEmailRedirection.pageSize }}"
+                data-on-page-change="ctrlEmailDomainEmailRedirection.savePageSizePreference($pagination)"
             >
                 <oui-datagrid-column
                     data-title="'emails_common_from' | translate"
                     data-property="from"
+                    sortable="asc"
                 ></oui-datagrid-column>
                 <oui-datagrid-column
                     data-title="'emails_common_to' | translate"

--- a/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.html
+++ b/packages/manager/apps/web/client/app/email-domain/email/redirection/email-domain-email-redirection.html
@@ -47,7 +47,7 @@
                 <oui-datagrid-column
                     data-title="'emails_common_from' | translate"
                     data-property="from"
-                    sortable="asc"
+                    data-sortable
                 ></oui-datagrid-column>
                 <oui-datagrid-column
                     data-title="'emails_common_to' | translate"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #3566, MANAGER-6337
| License          | BSD 3-Clause

## Description

Sorted alphabetically email redirections and kept user preference of pagination in memory as asked  in the Issue #3566.
