### PR TITLE
fix(deps): add missing dependency

### DIFF
--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -84,6 +84,7 @@
     "@ovh-ux/ng-q-allsettled": "^2.0.1",
     "@ovh-ux/ng-tail-logs": "^2.0.4",
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",
+    "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.3",
     "@ovh-ux/ng-ui-router-layout": "^4.0.2",
     "@ovh-ux/ng-ui-router-line-progress": "^1.2.4",
     "@ovh-ux/ufrontend": "^1.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

74d0643 - fix(deps): add missing dependency

uses: `yarn workspace @ovh-ux/manager-dedicated add @ovh-ux/ng-ui-router-breadcrumb`

### :link: Related

- #4103

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>