### PR TITLE
fix(hosting.multisite.logs): supress error for logs url

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/logs/hosting-multisite-logs.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/logs/hosting-multisite-logs.controller.js
@@ -67,12 +67,7 @@ angular.module('App').controller(
           }
         })
         .catch(() => {
-          this.Alerter.error(
-            this.$translate.instant(
-              'hosting_tab_DOMAINS_multisite_logs_generation_error',
-            ),
-            this.$scope.alerts.main,
-          );
+          domain.logUrl = null;
         })
         .finally(() => {
           domain.logsLoading = false;

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_de_DE.json
@@ -313,7 +313,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Suche...",
   "hosting_tab_DOMAINS_table_popover_restart": "Neu starten",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Erstellung des Links",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Bei der Erstellung des Zugangslinks zu den Logs ist ein Fehler aufgetreten.",
   "hosting_tab_DOMAINS_multisite_logs_link": "Zugang zu den Logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "Die Domain wurde erfolgreich neu gestartet: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Beim Neustart der Domain ist ein Fehler aufgetreten.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_en_GB.json
@@ -312,7 +312,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Searching...",
   "hosting_tab_DOMAINS_table_popover_restart": "Restart",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Generating the link",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "An error has occurred generating the access link to logs",
   "hosting_tab_DOMAINS_multisite_logs_link": "Access the logs ",
   "hosting_tab_DOMAINS_multisite_restart_done": "Your domain has been restarted: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "An error has occurred restarting your domain.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_es_ES.json
@@ -314,7 +314,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Buscar...",
   "hosting_tab_DOMAINS_table_popover_restart": "Reiniciar",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Generación del enlace",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Se ha producido un error al generar el enlace de acceso a los logs.",
   "hosting_tab_DOMAINS_multisite_logs_link": "Acceder a los logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "El multisitio se ha reinstalado correctamente: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Se ha producido un error al reinstalar el multisitio.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_es_US.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_es_US.json
@@ -284,7 +284,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Buscar...",
   "hosting_tab_DOMAINS_table_popover_restart": "Redémarrer",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Generar enlace",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Se ha producido un error al generar el enlace de acceso a los logs.",
   "hosting_tab_DOMAINS_multisite_logs_link": "Acceder a los logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "Le domaine a été redémarré avec succès : {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Une erreur est survenue lors du redémarrage du domaine.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_CA.json
@@ -314,7 +314,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Recherche...",
   "hosting_tab_DOMAINS_table_popover_restart": "Redémarrer",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Génération du lien",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Une erreur est survenue lors de la génération du lien d'accès aux logs",
   "hosting_tab_DOMAINS_multisite_logs_link": "Accéder aux logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "Le domaine a été redémarré avec succès : {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Une erreur est survenue lors du redémarrage du domaine.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_fr_FR.json
@@ -314,7 +314,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Recherche...",
   "hosting_tab_DOMAINS_table_popover_restart": "Redémarrer",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Génération du lien",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Une erreur est survenue lors de la génération du lien d'accès aux logs",
   "hosting_tab_DOMAINS_multisite_logs_link": "Accéder aux logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "Le domaine a été redémarré avec succès : {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Une erreur est survenue lors du redémarrage du domaine.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_it_IT.json
@@ -314,7 +314,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Ricerca in corso...",
   "hosting_tab_DOMAINS_table_popover_restart": "Riavvia",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Genera il link",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Si è verificato un errore durante la generazione del link di accesso ai log",
   "hosting_tab_DOMAINS_multisite_logs_link": "Accedi ai log",
   "hosting_tab_DOMAINS_multisite_restart_done": "Il dominio è stato riavviato correttamente: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Si è verificato un errore durante il riavvio del dominio.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_lt_LT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_lt_LT.json
@@ -295,7 +295,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Searching...",
   "hosting_tab_DOMAINS_table_popover_restart": "Restart",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Generating the link",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "An error has occurred generating the access link to logs",
   "hosting_tab_DOMAINS_multisite_logs_link": "Access the logs ",
   "hosting_tab_DOMAINS_multisite_restart_done": "Your domain has been restarted: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "An error has occurred restarting your domain.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_pl_PL.json
@@ -313,7 +313,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Wyszukiwanie...",
   "hosting_tab_DOMAINS_table_popover_restart": "Restart",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Generowanie linka",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Wystąpił błąd podczas generowania linku dostępowego do logów",
   "hosting_tab_DOMAINS_multisite_logs_link": "Dostęp do logów",
   "hosting_tab_DOMAINS_multisite_restart_done": "Domena została reaktywowana: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Wystąpił błąd podczas reaktywacji domeny.",

--- a/packages/manager/apps/web/client/app/hosting/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/hosting/translations/Messages_pt_PT.json
@@ -313,7 +313,6 @@
   "hosting_tab_DOMAINS_search_placeholder": "Buscando...",
   "hosting_tab_DOMAINS_table_popover_restart": "Reiniciar ",
   "hosting_tab_DOMAINS_multisite_logs_generation": "Geração do URL de download",
-  "hosting_tab_DOMAINS_multisite_logs_generation_error": "Ocorreu um erro na geração do link de acesso aos logs.",
   "hosting_tab_DOMAINS_multisite_logs_link": "Aceder aos logs",
   "hosting_tab_DOMAINS_multisite_restart_done": "O domínio foi reiniciado com êxito: {{t0}}",
   "hosting_tab_DOMAINS_multisite_restart_error": "Ocorreu um erro ao reiniciar o domínio.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-28376
| License          | BSD 3-Clause

## Description

We display the logs url only if the url is fetched successfully. But we do not have to alert the user, if there is an error while fetching the logsUrl (404 if not available), since this is being fetched in the background and an error gives does not give the user a good experience
