### PR TITLE
fix(overthebox.details): fix restart button

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -23,7 +23,7 @@
         </oui-dropdown>
         <oui-button
             data-disabled="!$ctrl.availableAction.reboot"
-            data-on-click="ctrl.LaunchAction('reboot')"
+            data-on-click="$ctrl.LaunchAction('reboot')"
         >
             <span data-translate="overTheBox_action_reboot_label"></span>
         </oui-button>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-368
| License          | BSD 3-Clause

## Description

Fix the restart button on the OverTheBox detail tab which does nothing whenyou click.
<!-- Write a brief description of the changes introduced by this PR -->
