### PR TITLE
fix(training/serving): change deployed or in progress into running

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/serving/namespace/models/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/serving/namespace/models/details/translations/Messages_en_GB.json
@@ -21,7 +21,7 @@
   "pci_projects_project_serving_namespace_models_version_status_built": "OK",
   "pci_projects_project_serving_namespace_models_version_status_build-error": "Error",
   "pci_projects_project_serving_namespace_models_version_status_deploying": "Deployment",
-  "pci_projects_project_serving_namespace_models_version_status_deployed": "Deployed",
+  "pci_projects_project_serving_namespace_models_version_status_deployed": "Running",
   "pci_projects_project_serving_namespace_models_version_status_rollback": "Cancellation",
   "pci_projects_project_serving_namespace_models_version_status_failed": "Failed",
   "pci_projects_project_serving_models_details_configuration_flavor_label": "Flavor",

--- a/packages/manager/modules/pci/src/projects/project/serving/namespace/models/details/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/serving/namespace/models/details/translations/Messages_lt_LT.json
@@ -21,7 +21,7 @@
   "pci_projects_project_serving_namespace_models_version_status_built": "OK",
   "pci_projects_project_serving_namespace_models_version_status_build-error": "Error",
   "pci_projects_project_serving_namespace_models_version_status_deploying": "Deployment",
-  "pci_projects_project_serving_namespace_models_version_status_deployed": "Deployed",
+  "pci_projects_project_serving_namespace_models_version_status_deployed": "Running",
   "pci_projects_project_serving_namespace_models_version_status_rollback": "Cancellation",
   "pci_projects_project_serving_namespace_models_version_status_failed": "Failed",
   "pci_projects_project_serving_models_details_configuration_flavor_label": "Flavor",

--- a/packages/manager/modules/pci/src/projects/project/serving/namespace/models/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/serving/namespace/models/translations/Messages_en_GB.json
@@ -18,7 +18,7 @@
   "pci_projects_project_serving_namespace_models_version_status_built": "OK",
   "pci_projects_project_serving_namespace_models_version_status_build-error": "Error",
   "pci_projects_project_serving_namespace_models_version_status_deploying": "Deployment",
-  "pci_projects_project_serving_namespace_models_version_status_deployed": "Deployed",
+  "pci_projects_project_serving_namespace_models_version_status_deployed": "Running",
   "pci_projects_project_serving_namespace_models_version_status_rollback": "Cancellation",
   "pci_projects_project_serving_namespace_models_version_status_failed": "Failed",
   "pci_projects_project_serving_namespace_models_url": "URL",

--- a/packages/manager/modules/pci/src/projects/project/serving/namespace/models/translations/Messages_lt_LT.json
+++ b/packages/manager/modules/pci/src/projects/project/serving/namespace/models/translations/Messages_lt_LT.json
@@ -18,7 +18,7 @@
   "pci_projects_project_serving_namespace_models_version_status_built": "OK",
   "pci_projects_project_serving_namespace_models_version_status_build-error": "Error",
   "pci_projects_project_serving_namespace_models_version_status_deploying": "Deployment",
-  "pci_projects_project_serving_namespace_models_version_status_deployed": "Deployed",
+  "pci_projects_project_serving_namespace_models_version_status_deployed": "Running",
   "pci_projects_project_serving_namespace_models_version_status_rollback": "Cancellation",
   "pci_projects_project_serving_namespace_models_version_status_failed": "Failed",
   "pci_projects_project_serving_namespace_models_url": "URL",

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/translations/Messages_en_GB.json
@@ -16,7 +16,7 @@
   "pci_projects_project_training_dashboard_active_jobs": "Active jobs",
   "pci_projects_project_training_dashboard_active_users": "AI Training users",
   "pci_projects_project_training_dashboard_users_managements": "User management",
-  "pci_projects_project_training_dashboard_jobs_list_none": "You have no jobs in progress right now",
+  "pci_projects_project_training_dashboard_jobs_list_none": "You have no jobs running right now",
   "pci_projects_project_training_dashboard_users_list_name": "Name",
   "pci_projects_project_training_dashboard_users_list_description": "Description",
   "pci_projects_project_training_dashboard_users_list_none": "You have not created any users with the role \"AI Training Operator\" and \"ObjectStore Operator\"",

--- a/packages/manager/modules/pci/src/projects/project/training/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/translations/Messages_en_GB.json
@@ -24,7 +24,7 @@
   "pci_projects_project_training_jobs_state_INTERRUPTING": "Interruption",
   "pci_projects_project_training_jobs_state_INTERRUPTED": "Interrupted",
   "pci_projects_project_training_jobs_state_DONE": "Terminated",
-  "pci_projects_project_training_jobs_state_RUNNING": "In progress",
+  "pci_projects_project_training_jobs_state_RUNNING": "Running",
   "pci_projects_project_training_jobs_state_OTHER": "Other",
   "pci_projects_project_training_jobs_info": "Details",
   "pci_projects_project_training_jobs_kill": "Stop",


### PR DESCRIPTION
Signed-off-by: Maël LE GAL <mael.le-gal@corp.ovh.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Typo?     | yes
| Breaking change? | no
| Tickets          | None
| License          | BSD 3-Clause

## Description

As a "non french" customer we need status == "RUNNING" when something is deployed in AI Training or ML Serving

Current name is not clear enough :
AI training : "in progress" ==> "running"
ML Serving : "Deployed" ==> "running"
