### PR TITLE
fix(notifications): remove unwanted ovhManagerNavbar dependency

### DIFF
--- a/packages/manager/modules/notifications-sidebar/src/controller.js
+++ b/packages/manager/modules/notifications-sidebar/src/controller.js
@@ -9,24 +9,20 @@ export default class NotificationsCtrl {
   constructor(
     $document,
     $element,
-    $q,
     $timeout,
     $rootScope,
     $translate,
     atInternet,
     NavbarNotifications,
-    ovhManagerNavbarMenuHeaderBuilder,
     ouiNavbarConfiguration,
   ) {
     this.$document = $document;
     this.$element = $element;
-    this.$q = $q;
     this.$timeout = $timeout;
     this.$rootScope = $rootScope;
     this.$translate = $translate;
     this.atInternet = atInternet;
     this.toggle = false;
-    this.NavbarBuilder = ovhManagerNavbarMenuHeaderBuilder;
     this.NavbarNotifications = NavbarNotifications;
     this.translations = ouiNavbarConfiguration.translations;
 
@@ -81,15 +77,9 @@ export default class NotificationsCtrl {
 
     return this.$translate
       .refresh()
-      .then(() =>
-        this.$q.all({
-          menuTitle: this.getMenuTitle(),
-          sublinks: this.getSublinks(),
-        }),
-      )
-      .then(({ menuTitle, sublinks }) => {
+      .then(() => this.getSublinks())
+      .then((sublinks) => {
         this.NavbarNotifications.setRefreshTime(sublinks);
-        this.menuTitle = menuTitle;
         if (sublinks.length > MAX_NOTIFICATIONS) {
           this.sublinks = sublinks.slice(0, MAX_NOTIFICATIONS);
         } else {
@@ -139,12 +129,6 @@ export default class NotificationsCtrl {
         );
         return notification;
       },
-    );
-  }
-
-  getMenuTitle() {
-    return this.NavbarBuilder.buildMenuHeader(
-      this.$translate.instant('navbar_notification_title'),
     );
   }
 

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_de_DE.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_de_DE.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Ihre Benachrichtigungen",
   "navbar_notification_new": "Neu"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_en_GB.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_en_GB.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Your notifications",
   "navbar_notification_new": "New"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_es_ES.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_es_ES.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Sus notificaciones",
   "navbar_notification_new": "Nuevo"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_fr_CA.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Vos notifications",
   "navbar_notification_new": "New"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_fr_FR.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Vos notifications",
   "navbar_notification_new": "New"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_it_IT.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_it_IT.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Le tue notifiche",
   "navbar_notification_new": "Nuovo"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_pl_PL.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "Powiadomienia",
   "navbar_notification_new": "Nowe"
 }

--- a/packages/manager/modules/notifications-sidebar/src/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/notifications-sidebar/src/translations/Messages_pt_PT.json
@@ -1,4 +1,3 @@
 {
-  "navbar_notification_title": "As suas notificações",
   "navbar_notification_new": "Novo"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Remove unused `ovhManagerNavbarMenuHeaderBuilder` usage (used but the result isn't).
`ovhManagerNavbarMenuHeaderBuilder` is exposed by `@ovh-ux/manager-navbar` (https://github.com/ovh/manager/blob/master/packages/manager/modules/navbar/src/navbar-menu-header/index.js#L11) which is not a dependency of `@ovh-ux/manager-notifications-sidebar`

