### PR TITLE
fix(overthebox.remote): update poller when tab switching before result

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.controller.js
+++ b/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.controller.js
@@ -173,8 +173,7 @@ export default class OverTheBoxRemoteCtrl {
    * @param {Date} when Date to compare
    * @return {Boolean}
    */
-  // eslint-disable-next-line class-methods-use-this
-  isInFuture(when) {
+  static isInFuture(when) {
     return !when || moment(when).isAfter(new Date());
   }
 
@@ -183,8 +182,7 @@ export default class OverTheBoxRemoteCtrl {
    * @param remote
    * @returns {string}
    */
-  // eslint-disable-next-line class-methods-use-this
-  getSshConnectionHelp(remote) {
+  static getSshConnectionHelp(remote) {
     return remote && remote.connectionInfos && remote.connectionInfos.ip
       ? `ssh -p ${remote.connectionInfos.port} root@${remote.connectionInfos.ip}`
       : '';
@@ -195,8 +193,7 @@ export default class OverTheBoxRemoteCtrl {
    * @param remote
    * @returns {string}
    */
-  // eslint-disable-next-line class-methods-use-this
-  getHttpConnectionHelp(remote) {
+  static getHttpConnectionHelp(remote) {
     return remote && remote.connectionInfos && remote.connectionInfos.port
       ? `https://${remote.connectionInfos.ip}:${remote.connectionInfos.port}/`
       : '';

--- a/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.controller.js
+++ b/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.controller.js
@@ -86,7 +86,9 @@ export default class OverTheBoxRemoteCtrl {
           (remotes) => {
             this.remotes = remotes;
           },
-          this.TucToastError,
+          () => {
+            this.remotes = [];
+          },
           (remotes) => {
             this.remotes = remotes;
           },

--- a/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.html
+++ b/packages/manager/modules/overthebox/src/overthebox/remote/overTheBox-remote.html
@@ -161,13 +161,13 @@
                                     >
                                         <pre
                                             data-ng-if="remote.exposedPort===22"
-                                            data-ng-bind="$ctrl.getSshConnectionHelp(remote)"
+                                            data-ng-bind="$ctrl.constructor.getSshConnectionHelp(remote)"
                                         ></pre>
                                         <a
                                             data-ng-if="remote.exposedPort===443"
-                                            href="{{$ctrl.getHttpConnectionHelp(remote)}}"
+                                            href="{{$ctrl.constructor.getHttpConnectionHelp(remote)}}"
                                             target="_blank"
-                                            data-ng-bind="$ctrl.getHttpConnectionHelp(remote)"
+                                            data-ng-bind="$ctrl.constructor.getHttpConnectionHelp(remote)"
                                         ></a>
                                         <span
                                             data-ng-if="(remote.exposedPort!==443) && (remote.exposedPort!==22)"
@@ -304,7 +304,7 @@
                                     data-datepicker-options="$ctrl.datepickerOptions"
                                     data-ng-model="$ctrl.newRemote.expirationDate"
                                     data-ng-focus="$ctrl.openDatePicker($event)"
-                                    data-ui-validate="{date: '$ctrl.validator.isDate($value) || !$value', future: '$ctrl.isInFuture($value)'}"
+                                    data-ui-validate="{date: '$ctrl.validator.isDate($value) || !$value', future: '$ctrl.constructor.isInFuture($value)'}"
                                     data-ng-disabled="$ctrl.adding"
                                     data-is-open="$ctrl.pickerOpened"
                                     data-show-button-bar="false"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-369
| License          | BSD 3-Clause

## Description

When tab switching before result for the poller call, not display error message which is not necessary here.
