### PR TITLE
fix(dev-deps): remove extra @ovh-ux/ovh-ui-kit dependency

### DIFF
--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -80,7 +80,6 @@
   },
   "devDependencies": {
     "@ovh-ux/manager-webpack-config": "^3.3.0 || ^4.0.0",
-    "@ovh-ux/ui-kit": "^4.4.1",
     "glob": "^7.1.6",
     "lodash": "^4.17.15",
     "webpack-merge": "^4.2.2"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :arrow_up: Upgrade

66e3ace - fix(dev-deps): remove extra @ovh-ux/ovh-ui-kit dependency

prevent following console warning:

```sh
warning package.json: "dependencies" has dependency "@ovh-ux/ui-kit" with range "^4.4.3" that collides with a dependency in "devDependencies" of the same name with version "^4.4.1"
```

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
