### PR TITLE
fix(move.buildingdetails): rename building reference to reference

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
@@ -45,7 +45,7 @@ export default class MoveBuildingDetailsCtrl {
 
     this.OvhApiConnectivityEligibilitySearch.v6()
       .pollerBuildingDetails(this.$scope, {
-        building: this.building.buildingReference,
+        building: this.building.reference,
       })
       .then((buildingDetails) => {
         if (has(buildingDetails, 'result.stairs')) {
@@ -62,7 +62,7 @@ export default class MoveBuildingDetailsCtrl {
   }
 
   nextStep() {
-    this.selectedOffer.buildingReference = this.model.selectedBuilding.buildingReference;
+    this.selectedOffer.buildingReference = this.model.selectedBuilding.reference;
     this.selectedOffer.stair = this.model.selectedStair.stair.value;
     this.selectedOffer.floor = this.model.selectedFloor.value;
     this.selectedOffer.pto = [


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-373
| License          | BSD 3-Clause

## Description

Use reference instead of buildingReference which is not defined.
