### PR TITLE
feat(pack.move): set only fiber offers for user who is already fibered

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -29,8 +29,7 @@ export default class PackMoveOffersCtrl {
 
     this.PROMO_DISPLAY = PROMO_DISPLAY;
 
-    this.$q
-      .all([this.getOptions()])
+    this.getOptions()
       .then(() => {
         if (
           (this.currentOffer.isFTTH && !this.eligibilityReferenceFiber) ||
@@ -47,14 +46,14 @@ export default class PackMoveOffersCtrl {
       .then(() => {
         if (this.currentOffer.isFTTH && this.eligibilityReferenceFiber) {
           // For FTTH customer eligible to fiber, display fiber offers ONLY
-          this.offers = [...this.listOffersFiber];
+          this.offers = this.listOffersFiber;
         } else if (
           this.eligibilityReferenceFiber &&
           !this.currentOffer.isFTTH
         ) {
           this.offers = [...this.listOffersFiber, ...this.listOffers];
         } else {
-          this.offers = [...this.listOffers];
+          this.offers = this.listOffers;
         }
       })
       .finally(() => {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -31,10 +31,7 @@ export default class PackMoveOffersCtrl {
 
     this.getOptions()
       .then(() => {
-        if (
-          (this.currentOffer.isFTTH && !this.eligibilityReferenceFiber) ||
-          !this.currentOffer.isFTTH
-        ) {
+        if (!this.currentOffer.isFTTH || !this.eligibilityReferenceFiber) {
           // Retrieve copper offers for xDSL customer or FTTH customer not eligible to fiber
           return this.getCopperOffers();
         }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -30,12 +30,28 @@ export default class PackMoveOffersCtrl {
     this.PROMO_DISPLAY = PROMO_DISPLAY;
 
     this.$q
-      .all([this.getOptions(), this.getCopperOffers()])
+      .all([this.getOptions()])
+      .then(() => {
+        if (
+          (this.currentOffer.isFTTH && !this.eligibilityReferenceFiber) ||
+          !this.currentOffer.isFTTH
+        ) {
+          // Retrieve copper offers for xDSL customer or FTTH customer not eligible to fiber
+          return this.getCopperOffers();
+        }
+        return null;
+      })
       .then(() => {
         return this.getFiberOffers();
       })
       .then(() => {
-        if (this.eligibilityReferenceFiber) {
+        if (this.currentOffer.isFTTH && this.eligibilityReferenceFiber) {
+          // For FTTH customer eligible to fiber, display fiber offers ONLY
+          this.offers = [...this.listOffersFiber];
+        } else if (
+          this.eligibilityReferenceFiber &&
+          !this.currentOffer.isFTTH
+        ) {
           this.offers = [...this.listOffersFiber, ...this.listOffers];
         } else {
           this.offers = [...this.listOffers];

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/pack-move.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/pack-move.controller.js
@@ -225,6 +225,9 @@ export default class PackMoveCtrl {
         this.offer.current.offerDescription = data.offerDescription;
         this.offer.current.offerPrice = data.offerPrice;
         this.offer.current.isLegacy = data.capabilities.isLegacyOffer;
+        this.offer.current.isFTTH = data.offerDescription.includes(
+          OFFER_TYPE.ftth,
+        );
       })
       .catch((error) => new this.TucToastError(error));
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-375
| License          | BSD 3-Clause

## Description

For fiber customer who want to move, if the new address is available to fiber, the offers list displayed contains ONLY fiber offer.
