### PR TITLE
fix(deps): add missing @ovh-ux/manager-ng-layout-helpers deps

### DIFF
--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -29,6 +29,7 @@
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-error-page": "^1.0.0 || ^2.0.0",
     "@ovh-ux/manager-navbar": "^4.0.0 || ^5.0.0",
+    "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-notifications-sidebar": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-pci": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | noe
| License          | BSD 3-Clause

## Description

Module `@ovh-ux/manager-pci` defines `@ovh-ux/manager-ng-layout-helpers` as a peerDependency.
see: https://github.com/ovh/manager/blob/develop/packages/manager/modules/pci/package.json#L37

### :bug: Bug Fixes

f386cc8 - fix(deps): add missing @ovh-ux/manager-ng-layout-helpers deps

### :link: Related

#3846

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

/cc @mohammed-zahaf 

