### PR TITLE
fix(vps): add missing isUpfront flag to configuration tile

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -102,6 +102,7 @@ export default /* @ngInject */ ($stateProvider) => {
         );
         return {
           currentPlan: tile.currentPlan,
+          isUpfront: tile.isUpfront,
           upgrades: tile.getAvailableUpgrades(),
           model: {
             memory: tile.currentPlan,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-29523
| License          | BSD 3-Clause

## Description

Set correct wording for VPS upfront on  RAM & Storage upgrade

ref: DTRSD-29523

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
