### PR TITLE
feat(voip.billing-account): add alert for suspended billing account

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billingAccount.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billingAccount.routing.js
@@ -96,6 +96,10 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href('telecom.telephony.billingAccount.guides', {
           billingAccount: billingAccountId,
         }),
+      billingDepositLink: /* @ngInject */ ($state, billingAccountId) =>
+        $state.href('telecom.telephony.billingAccount.billing.deposit', {
+          billingAccount: billingAccountId,
+        }),
       breadcrumb: /* @ngInject */ (billingAccount) => billingAccount,
     },
     translations: { value: ['..', '.', './dashboard'], format: 'json' },

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.controller.js
@@ -14,6 +14,7 @@ export default /* @ngInject */ function TelecomTelephonyBillingAccountDashboardC
   $q,
   $window,
   $timeout,
+  billingDepositLink,
   TelephonyMediator,
   OvhApiTelephony,
   TucToastError,
@@ -22,10 +23,15 @@ export default /* @ngInject */ function TelecomTelephonyBillingAccountDashboardC
   const self = this;
 
   function isExpired() {
-    if (self.group) {
-      return self.group.status === 'expired';
-    }
-    return true;
+    return self.group ? self.group.status === 'expired' : false;
+  }
+
+  function isClosed() {
+    return self.group ? self.group.status === 'closed' : false;
+  }
+
+  function shouldIncreaseDeposit() {
+    return self.group ? self.group.shouldIncreaseDeposit() : false;
   }
 
   function getGroup() {
@@ -264,6 +270,10 @@ export default /* @ngInject */ function TelecomTelephonyBillingAccountDashboardC
       });
   }
 
+  this.isGroupSuspended = function isGroupSuspended() {
+    return (isExpired() || isClosed()) && shouldIncreaseDeposit();
+  };
+
   /*= =====================================
     =            INITIALIZATION            =
     ====================================== */
@@ -286,6 +296,8 @@ export default /* @ngInject */ function TelecomTelephonyBillingAccountDashboardC
             orderBy: "",
             orderDesc: true */,
     };
+
+    self.billingDepositLink = billingDepositLink;
 
     getGroup().then(() => {
       self.actions = [

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.html
@@ -3,6 +3,21 @@
         <oui-spinner></oui-spinner>
     </div>
 
+    <!-- supended group alert -->
+    <oui-message
+        data-ng-if="!DashboardCtrl.loading.init && DashboardCtrl.isGroupSuspended()"
+        data-type="warning"
+        data-dismissable
+    >
+        <span data-translate="telephony_group_billing_dashboard_suspended_info">
+        </span>
+        <a
+            data-translate="telephony_group_billing_dashboard_suspended_info_link"
+            data-ng-href="{{ DashboardCtrl.billingDepositLink }}"
+        >
+        </a>
+    </oui-message>
+
     <tuc-toast-message></tuc-toast-message>
 
     <div

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_de_DE.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Réception du colis",
   "telephony_group_billing_dashboard_no_phone": "Ligne nue",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Anrufe"
+  "telephony_group_billing_dashboard_calls": "Anrufe",
+  "telephony_group_billing_dashboard_suspended_info": "Diese Gruppe ist derzeit ausgesetzt.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Klicken Sie hier, um Ihr Garantiedepot zu erhöhen."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_en_GB.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Réception du colis",
   "telephony_group_billing_dashboard_no_phone": "Ligne nue",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Calls"
+  "telephony_group_billing_dashboard_calls": "Calls",
+  "telephony_group_billing_dashboard_suspended_info": "This group is currently suspended.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Click here to increase your balance."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_es_ES.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Recepción de paquetes",
   "telephony_group_billing_dashboard_no_phone": "Naked line",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Llamadas"
+  "telephony_group_billing_dashboard_calls": "Llamadas",
+  "telephony_group_billing_dashboard_suspended_info": "Este grupo está actualmente suspendido.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Haga clic aquí para aumentar el depósito de garantía."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_fr_CA.json
@@ -13,7 +13,7 @@
   "telephony_group_billing_dashboard_line": "Ligne",
   "telephony_group_billing_dashboard_aliases": "Numéros",
   "telephony_group_billing_dashboard_alias": "Numéro",
-  "telephony_group_billing_dashboard_fax": "Télécopieur",
+  "telephony_group_billing_dashboard_fax": "Fax",
   "telephony_group_billing_dashboard_mac": "Adresse MAC",
   "telephony_group_billing_dashboard_status": "État",
   "telephony_group_billing_dashboard_status_closed": "Fermé",
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Réception du colis",
   "telephony_group_billing_dashboard_no_phone": "Ligne nue",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Appels"
+  "telephony_group_billing_dashboard_calls": "Appels",
+  "telephony_group_billing_dashboard_suspended_info": "Ce groupe est actuellement suspendu.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Cliquez ici pour augmenter votre dépôt de garantie."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_fr_FR.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Réception du colis",
   "telephony_group_billing_dashboard_no_phone": "Ligne nue",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Appels"
+  "telephony_group_billing_dashboard_calls": "Appels",
+  "telephony_group_billing_dashboard_suspended_info": "Ce groupe est actuellement suspendu.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Cliquez ici pour augmenter votre dépôt de garantie."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_it_IT.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Ricezione del pacco",
   "telephony_group_billing_dashboard_no_phone": "Linea naked",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Chiamate"
+  "telephony_group_billing_dashboard_calls": "Chiamate",
+  "telephony_group_billing_dashboard_suspended_info": "Questo gruppo è attualmente sospeso.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Clicca qui per aumentare il tuo deposito cauzionale."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/translations/Messages_pl_PL.json
@@ -36,5 +36,7 @@
   "telephony_group_billing_dashboard_RMA_status_received": "Réception du colis",
   "telephony_group_billing_dashboard_no_phone": "Ligne nue",
   "telephony_group_billing_dashboard_RMA_title": "RMA",
-  "telephony_group_billing_dashboard_calls": "Połączenia"
+  "telephony_group_billing_dashboard_calls": "Połączenia",
+  "telephony_group_billing_dashboard_suspended_info": "Grupa ta jest obecnie zawieszona.",
+  "telephony_group_billing_dashboard_suspended_info_link": "Kliknij tutaj, aby zwiększyć wysokość kaucji."
 }

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/group.factory.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/group.factory.js
@@ -100,6 +100,10 @@ export default /* @ngInject */ (
     return allServices;
   };
 
+  TelephonyGroup.prototype.shouldIncreaseDeposit = function shouldIncreaseDeposit() {
+    return this.currentOutplan.value >= this.allowedOutplan.value;
+  };
+
   /* ----------  API CALLS  ----------*/
 
   TelephonyGroup.prototype.save = function save() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6222
| License          | BSD 3-Clause

## Description

Add an info message when billing account is suspended.

### :flags: Translations

- [x] TRANS-32688

Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>