### PR TITLE
feat: redirect to instance edition when reinstalling a deprecated image

### DIFF
--- a/packages/manager/modules/pci/src/components/project/image/image.constants.js
+++ b/packages/manager/modules/pci/src/components/project/image/image.constants.js
@@ -1,0 +1,7 @@
+export const IMAGE_STATUS = {
+  DEPRECATED: 'deprecated',
+};
+
+export default {
+  IMAGE_STATUS,
+};

--- a/packages/manager/modules/pci/src/components/project/images-list/images-list.component.js
+++ b/packages/manager/modules/pci/src/components/project/images-list/images-list.component.js
@@ -5,6 +5,7 @@ export default {
   controller,
   template,
   bindings: {
+    instance: '<',
     displaySelectedImage: '<',
     flavorType: '<?',
     isImageCompatible: '=?',

--- a/packages/manager/modules/pci/src/components/project/images-list/images-list.controller.js
+++ b/packages/manager/modules/pci/src/components/project/images-list/images-list.controller.js
@@ -108,23 +108,28 @@ export default class ImagesListController {
 
   findDefaultImage() {
     if (this.defaultImageId) {
-      find(this.os, (osList, osType) => {
-        find(osList, (osSubList, osName) => {
-          find(osSubList, (os) => {
-            const region = find(os.regions, {
-              region: this.region,
-              id: this.defaultImageId,
-            });
-            if (region) {
-              this.selectedTab = osType;
-              this.distribution = osName;
-              this.image = os;
+      // To cover case where image is deprecated
+      if (this.instance.isDeprecatedImage()) {
+        this.selectedTab = this.instance.image.type;
+      } else {
+        find(this.os, (osList, osType) => {
+          find(osList, (osSubList, osName) => {
+            find(osSubList, (os) => {
+              const region = find(os.regions, {
+                region: this.region,
+                id: this.defaultImageId,
+              });
+              if (region) {
+                this.selectedTab = osType;
+                this.distribution = osName;
+                this.image = os;
 
-              this.onImageChange(os);
-            }
+                this.onImageChange(os);
+              }
+            });
           });
         });
-      });
+      }
 
       if (!this.image) {
         find(this.apps, (app) => {

--- a/packages/manager/modules/pci/src/components/project/instance/instance.class.js
+++ b/packages/manager/modules/pci/src/components/project/instance/instance.class.js
@@ -6,6 +6,7 @@ import isObject from 'lodash/isObject';
 
 import { CAPABILITIES } from './instance.constants';
 import Flavor from '../flavors-list/flavor.class';
+import { IMAGE_STATUS } from '../image/image.constants';
 
 export default class Instance {
   constructor(resource) {
@@ -169,6 +170,10 @@ export default class Instance {
 
   isApplicationImage() {
     return includes(get(this, 'image.tags', []), 'application');
+  }
+
+  isDeprecatedImage() {
+    return this.image?.status === IMAGE_STATUS.DEPRECATED;
   }
 
   getDefaultIp() {

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
@@ -3,6 +3,7 @@ import reduce from 'lodash/reduce';
 import { PATTERN } from '../../../../../components/project/instance/name/constants';
 import Flavor from '../../../../../components/project/flavors-list/flavor.class';
 import Instance from '../../../../../components/project/instance/instance.class';
+import { EDIT_PAGE_SECTIONS } from '../instance.constants';
 
 export default class PciInstanceEditController {
   /* @ngInject */
@@ -16,6 +17,7 @@ export default class PciInstanceEditController {
     this.CucCloudMessage = CucCloudMessage;
     this.CucRegionService = CucRegionService;
     this.PciProjectsProjectInstanceService = PciProjectsProjectInstanceService;
+    this.EDIT_PAGE_SECTIONS = EDIT_PAGE_SECTIONS;
   }
 
   $onInit() {

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.html
@@ -97,7 +97,10 @@
         </fieldset>
     </form>
 
-    <div class="mt-4 pt-4 border-top">
+    <div
+        id="{{::$ctrl.EDIT_PAGE_SECTIONS.IMAGES}}"
+        class="mt-4 pt-4 border-top"
+    >
         <form
             novalidate
             name="$ctrl.editImageForm"
@@ -109,6 +112,7 @@
                     data-size="auto"
                 >
                     <pci-project-images-list
+                        data-instance="$ctrl.editInstance"
                         data-flavor-type="$ctrl.instance.flavor.type"
                         data-os-types="[$ctrl.instance.flavor.osType]"
                         data-region="$ctrl.instance.region"
@@ -154,7 +158,10 @@
         </form>
     </div>
 
-    <div class="mt-4 pt-4 border-top">
+    <div
+        id="{{::$ctrl.EDIT_PAGE_SECTIONS.FLAVORS}}"
+        class="mt-4 pt-4 border-top"
+    >
         <form
             novalidate
             name="$ctrl.resizeInstanceForm"
@@ -227,7 +234,10 @@
         </form>
     </div>
 
-    <div class="mt-4 pt-4 border-top">
+    <div
+        id="{{::$ctrl.EDIT_PAGE_SECTIONS.BILLING_PERIOD}}"
+        class="mt-4 pt-4 border-top"
+    >
         <form
             novalidate
             name="$ctrl.activateMonthlyBillingForm"

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/instance.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/instance.constants.js
@@ -1,0 +1,9 @@
+export const EDIT_PAGE_SECTIONS = {
+  IMAGES: 'imagesSection',
+  FLAVORS: 'flavorsSection',
+  BILLING_PERIOD: 'billingPeriodSection',
+};
+
+export default {
+  EDIT_PAGE_SECTIONS,
+};

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.component.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.component.js
@@ -5,6 +5,7 @@ export default {
   controller,
   template,
   bindings: {
+    editInstance: '<',
     goBack: '<',
     instance: '<',
     projectId: '<',

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.controller.js
@@ -1,8 +1,17 @@
 import get from 'lodash/get';
+import { EDIT_PAGE_SECTIONS } from '../instance.constants';
 
 export default class PciInstanceReinstallController {
   /* @ngInject */
-  constructor($translate, CucCloudMessage, PciProjectsProjectInstanceService) {
+  constructor(
+    $anchorScroll,
+    $location,
+    $translate,
+    CucCloudMessage,
+    PciProjectsProjectInstanceService,
+  ) {
+    this.$anchorScroll = $anchorScroll;
+    this.$location = $location;
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
     this.PciProjectsProjectInstanceService = PciProjectsProjectInstanceService;
@@ -43,5 +52,17 @@ export default class PciInstanceReinstallController {
       .finally(() => {
         this.isLoading = false;
       });
+  }
+
+  /**
+   * This function is used in case where customer image is deprecated
+   * To allow him to choose and install new image
+   * @returns {Promise}
+   */
+  goToEditAnInstance() {
+    return this.editInstance(this.instance).then(() => {
+      this.$location.hash(EDIT_PAGE_SECTIONS.IMAGES);
+      this.$anchorScroll();
+    });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/reinstall.html
@@ -1,6 +1,6 @@
 <oui-modal
     data-heading="{{ 'pci_projects_project_instances_instance_reinstall_title' | translate }}"
-    data-primary-action="$ctrl.reinstallInstance()"
+    data-primary-action="$ctrl.instance.isDeprecatedImage() ? $ctrl.goToEditAnInstance() : $ctrl.reinstallInstance()"
     data-primary-label="{{:: 'pci_projects_project_instances_instance_reinstall_submit_label' | translate }}"
     data-primary-disabled="$ctrl.isLoading"
     data-secondary-action="$ctrl.goBack()"
@@ -8,14 +8,33 @@
     data-on-dismiss="$ctrl.goBack()"
     data-loading="$ctrl.isLoading"
 >
-    <p
-        data-translate="pci_projects_project_instances_instance_reinstall_content"
-        data-translate-values="{ instance: $ctrl.instance.name }"
-    ></p>
+    <!--Reinstall image-->
+    <div data-ng-if="!$ctrl.instance.isDeprecatedImage()">
+        <p
+            data-translate="pci_projects_project_instances_instance_reinstall_content"
+            data-translate-values="{ instance: $ctrl.instance.name }"
+        ></p>
 
-    <oui-message data-type="warning">
+        <oui-message data-type="warning">
         <span
             data-translate="pci_projects_project_instances_instance_reinstall_erase_message"
         ></span>
-    </oui-message>
+        </oui-message>
+    </div>
+
+    <!--Deprecated image => go to edition-->
+    <div data-ng-if="$ctrl.instance.isDeprecatedImage()">
+        <p
+            data-translate="pci_projects_project_instances_instance_reinstall_deprecated_image"
+            data-translate-values="{ image: $ctrl.instance.image.name }"
+        ></p>
+
+        <oui-message data-type="warning">
+        <span
+            data-translate="pci_projects_project_instances_instance_reinstall_deprecated_image_format_message"
+        ></span>
+        </oui-message>
+    </div>
+
 </oui-modal>
+

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_de_DE.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Instanz neu installieren",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Bestätigen",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Abbrechen",
- "pci_projects_project_instances_instance_reinstall_content": "Sind Sie sicher, dass Sie die Instanz {{ instance }} neu installieren möchten?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "Sämtliche Daten werden gelöscht.",
- "pci_projects_project_instances_instance_reinstall_success_message": "Die Instanz {{ instance }} wird neu installiert.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "Bei der Neuinstallation der Instanz {{ instance }} ist ein Fehler aufgetreten: {{message}}."
+  "pci_projects_project_instances_instance_reinstall_title": "Instanz neu installieren",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Bestätigen",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Abbrechen",
+  "pci_projects_project_instances_instance_reinstall_content": "Sind Sie sicher, dass Sie die Instanz {{ instance }} neu installieren möchten?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "Sämtliche Daten werden gelöscht.",
+  "pci_projects_project_instances_instance_reinstall_success_message": "Die Instanz {{ instance }} wird neu installiert.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Bei der Neuinstallation der Instanz {{ instance }} ist ein Fehler aufgetreten: {{message}}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "Das Image, das Sie beim Erstellen der Instanz ( {{ image }} ) ausgewählt haben, wird nicht mehr unterstützt. Es kann daher nicht neu installiert werden. Wir bieten Ihnen jedoch neue Images zur Installation an.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Bitte beachten Sie: Bei der Installation eines neuen Images werden alle Daten formatiert."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_en_GB.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Re-install an instance",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Confirm",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Cancel",
- "pci_projects_project_instances_instance_reinstall_content": "Are you sure that you want to re-install the {{ instance }} instance?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "All of the data stored on it will be deleted.",
- "pci_projects_project_instances_instance_reinstall_success_message": "Your {{ instance }} instance is being re-installed.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "An error has occurred re-installing the {{ instance }} instance: {{ message }}."
+  "pci_projects_project_instances_instance_reinstall_title": "Re-install an instance",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Confirm",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Cancel",
+  "pci_projects_project_instances_instance_reinstall_content": "Are you sure that you want to re-install the {{ instance }} instance?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "All of the data stored on it will be deleted.",
+  "pci_projects_project_instances_instance_reinstall_success_message": "Your {{ instance }} instance is being re-installed.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "An error has occurred re-installing the {{ instance }} instance: {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "The image you chose when you created the instance ( {{ image }} ) is no longer maintained, and therefore cannot be reinstalled. However, you can install a new image from our range.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Please note that all data is formatted when installing a new image."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_es_ES.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Reinstalar una instancia",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Confirmar",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Cancelar",
- "pci_projects_project_instances_instance_reinstall_content": "¿Seguro que quiere reinstalar la instancia {{ instance }}?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "¡Todos los datos se borrarán!",
- "pci_projects_project_instances_instance_reinstall_success_message": "Ha comenzado la reinstalación de la instancia {{ instance }}.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "Se ha producido un error al reinstalar la instancia {{ instance }}: {{ message }}."
+  "pci_projects_project_instances_instance_reinstall_title": "Reinstalar una instancia",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Confirmar",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Cancelar",
+  "pci_projects_project_instances_instance_reinstall_content": "¿Seguro que quiere reinstalar la instancia {{ instance }}?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "¡Todos los datos se borrarán!",
+  "pci_projects_project_instances_instance_reinstall_success_message": "Ha comenzado la reinstalación de la instancia {{ instance }}.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Se ha producido un error al reinstalar la instancia {{ instance }}: {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "La imagen que usted ha elegido al crear la instancia ( {{ image }} ) ya no está soportada, por lo tanto, no puede reinstalarse. No obstante, puede instalar una imagen nueva de entre las que le proponemos.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Atención: se formatean todos los datos al instalar una imagen nueva."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_fr_CA.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_instances_instance_reinstall_title": "Réinstaller une instance",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Confirmer",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Annuler",
+  "pci_projects_project_instances_instance_reinstall_content": "Êtes-vous sûr de vouloir réinstaller l'instance {{ instance }} ?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "Toutes les données seront supprimées.",
+  "pci_projects_project_instances_instance_reinstall_success_message": "La réinstallation de l'instance {{ instance }} a commencé.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Une erreur est survenue lors de la réinstallation de l'instance {{ instance }} : {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "L'image que vous avez choisie lors de la création de l'instance ( {{ image }} ) n’est plus maintenue et ne peut donc être réinstallée. Vous pouvez néanmoins installer une nouvelle image parmi celles que nous vous proposons.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Attention, toutes les données sont formatées lors de l’installation d’une nouvelle image."
+}

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_fr_FR.json
@@ -5,5 +5,7 @@
   "pci_projects_project_instances_instance_reinstall_content": "Êtes-vous sûr de vouloir réinstaller l'instance {{ instance }} ?",
   "pci_projects_project_instances_instance_reinstall_erase_message": "Toutes les données seront supprimées.",
   "pci_projects_project_instances_instance_reinstall_success_message": "La réinstallation de l'instance {{ instance }} a commencé.",
-  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Une erreur est survenue lors de la réinstallation de l'instance {{ instance }} : {{ message }}."
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Une erreur est survenue lors de la réinstallation de l'instance {{ instance }} : {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "L'image que vous avez choisie lors de la création de l'instance ( {{ image }} ) n’est plus maintenue et ne peut donc être réinstallée. Vous pouvez néanmoins installer une nouvelle image parmi celles que nous vous proposons.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Attention, toutes les données sont formatées lors de l’installation d’une nouvelle image."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_it_IT.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Reinstalla un’istanza",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Conferma",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Annulla",
- "pci_projects_project_instances_instance_reinstall_content": "Vuoi davvero reinstallare l'istanza {{ instance }}?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "Tutti i dati verranno eliminati.",
- "pci_projects_project_instances_instance_reinstall_success_message": "La reinstallazione dell’istanza {{ instance }} è iniziata.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "Si è verificato un errore durante la reinstallazione dell'istanza {{ instance }}: {{ message }}."
+  "pci_projects_project_instances_instance_reinstall_title": "Reinstalla un’istanza",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Conferma",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Annulla",
+  "pci_projects_project_instances_instance_reinstall_content": "Vuoi davvero reinstallare l'istanza {{ instance }}?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "Tutti i dati verranno eliminati.",
+  "pci_projects_project_instances_instance_reinstall_success_message": "La reinstallazione dell’istanza {{ instance }} è iniziata.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Si è verificato un errore durante la reinstallazione dell'istanza {{ instance }}: {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "L'immagine scelta durante la creazione dell'istanza ( {{ image }} ) non è più supportata e non può quindi essere reinstallata. Puoi comunque installare una nuova immagine tra quelle che ti proponiamo.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Attenzione, tutti i dati vengono formattati durante l'installazione di una nuova immagine."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_pl_PL.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Przeprowadź reinstalację instancji",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Potwierdź",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Anuluj",
- "pci_projects_project_instances_instance_reinstall_content": "Czy na pewno chcesz przeprowadzić reinstalację instancji {{instance}}?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "Wszystkie dane zostaną usunięte!",
- "pci_projects_project_instances_instance_reinstall_success_message": "Rozpoczęła się reinstalacja instancji {{instance}}.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "Wystąpił błąd podczas reinstalacji instancji {{instance}}: {{message}}."
+  "pci_projects_project_instances_instance_reinstall_title": "Przeprowadź reinstalację instancji",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Potwierdź",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Anuluj",
+  "pci_projects_project_instances_instance_reinstall_content": "Czy na pewno chcesz przeprowadzić reinstalację instancji {{instance}}?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "Wszystkie dane zostaną usunięte!",
+  "pci_projects_project_instances_instance_reinstall_success_message": "Rozpoczęła się reinstalacja instancji {{instance}}.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Wystąpił błąd podczas reinstalacji instancji {{instance}}: {{message}}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "Obraz wybrany przez Ciebie podczas tworzenia instancji ({{image}}) nie jest już wspierany i nie może zostać ponownie zainstalowany. Możesz jednak zainstalować nowy obraz, wybierając spośród oferowanej przez nas gamy obrazów.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Uwaga: podczas instalacji nowego obrazu wszystkie dane zostają sformatowane."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/reinstall/translations/Messages_pt_PT.json
@@ -1,9 +1,11 @@
 {
- "pci_projects_project_instances_instance_reinstall_title": "Reinstalar uma instância",
- "pci_projects_project_instances_instance_reinstall_submit_label": "Confirmar",
- "pci_projects_project_instances_instance_reinstall_cancel_label": "Anular",
- "pci_projects_project_instances_instance_reinstall_content": "Tem a certeza de que quer reinstalar a instância {{ instance }}?",
- "pci_projects_project_instances_instance_reinstall_erase_message": "Todos os dados serão eliminados.",
- "pci_projects_project_instances_instance_reinstall_success_message": "A reinstalação da instância {{ instance }} foi iniciada.",
- "pci_projects_project_instances_instance_reinstall_error_reinstall": "Ocorreu um erro ao reinstalar a instância {{ instance }}: {{ message }}."
+  "pci_projects_project_instances_instance_reinstall_title": "Reinstalar uma instância",
+  "pci_projects_project_instances_instance_reinstall_submit_label": "Confirmar",
+  "pci_projects_project_instances_instance_reinstall_cancel_label": "Anular",
+  "pci_projects_project_instances_instance_reinstall_content": "Tem a certeza de que quer reinstalar a instância {{ instance }}?",
+  "pci_projects_project_instances_instance_reinstall_erase_message": "Todos os dados serão eliminados.",
+  "pci_projects_project_instances_instance_reinstall_success_message": "A reinstalação da instância {{ instance }} foi iniciada.",
+  "pci_projects_project_instances_instance_reinstall_error_reinstall": "Ocorreu um erro ao reinstalar a instância {{ instance }}: {{ message }}.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image": "A imagem que selecionou durante a criação da instância ({{ image }}) já não é suportada e não pode ser reinstalada. No entanto, pode instalar uma nova imagem entre as que lhe propomos.",
+  "pci_projects_project_instances_instance_reinstall_deprecated_image_format_message": "Atenção, todos os dados são formatados aquando da instalação de uma nova imagem."
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | DTRSD-28556
| License          | BSD 3-Clause

## Description

Aims is to redirect customers to Edit an instance page when he try to reinstall a deprecated image.

### :flags: Translations

- [x] TRANS-33714
