### PR TITLE
feat(pack.xdsl.access.comfort-exchange): select contact for modem exchange

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.component.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     xdslId: '<',
     openedRMAs: '<',
+    packName: '<',
   },
   controller,
   template,

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
@@ -1,7 +1,5 @@
 import assign from 'lodash/assign';
-import filter from 'lodash/filter';
 import get from 'lodash/get';
-import groupBy from 'lodash/groupBy';
 import map from 'lodash/map';
 import { COMFORT_EXCHANGE_TYPE_ERROR } from './comfort-exchange.constant';
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
@@ -1,5 +1,7 @@
 import assign from 'lodash/assign';
+import filter from 'lodash/filter';
 import get from 'lodash/get';
+import groupBy from 'lodash/groupBy';
 import map from 'lodash/map';
 import { COMFORT_EXCHANGE_TYPE_ERROR } from './comfort-exchange.constant';
 
@@ -46,7 +48,7 @@ export default class XdslAccessComfortExchangeCtrl {
         context: 'voipLine',
       })
       .$promise.then((shippingAddresses) => {
-        this.ovhContactOptions.customList = map(
+        this.ovhContactOptions.filter = map(
           shippingAddresses,
           (shippingAddress) =>
             new this.OvhContact({

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
@@ -97,14 +97,13 @@ export default class XdslAccessComfortExchangeCtrl {
   }
 
   comfortExchange() {
-    // console.log('contact options', this.ovhContactOptions, this.shipping);
     return this.OvhApiXdsl.Modem()
       .v6()
       .comfortExchange(
         {
           xdslId: this.xdslId,
         },
-        {},
+        { contactShipping: this.shipping.id },
       )
       .$promise.then((result) => {
         this.exchange.isSuccess = true;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.controller.js
@@ -1,12 +1,24 @@
 import assign from 'lodash/assign';
+import get from 'lodash/get';
+import map from 'lodash/map';
 import { COMFORT_EXCHANGE_TYPE_ERROR } from './comfort-exchange.constant';
 
 export default class XdslAccessComfortExchangeCtrl {
   /* @ngInject */
-  constructor($q, $translate, OvhApiXdsl, TucToast, TucToastError) {
+  constructor(
+    $q,
+    $translate,
+    OvhApiPackXdsl,
+    OvhApiXdsl,
+    OvhContact,
+    TucToast,
+    TucToastError,
+  ) {
     this.$q = $q;
     this.$translate = $translate;
+    this.OvhApiPackXdsl = OvhApiPackXdsl;
     this.OvhApiXdsl = OvhApiXdsl;
+    this.OvhContact = OvhContact;
     this.TucToast = TucToast;
     this.TucToastError = TucToastError;
   }
@@ -23,10 +35,40 @@ export default class XdslAccessComfortExchangeCtrl {
       isSuccess: false,
     };
     this.isAvailable = false;
+    this.shipping = null;
 
     if (this.openedRMAs) {
       this.getListOpenedRMA();
     }
+    return this.OvhApiPackXdsl.v6()
+      .shippingAddresses({
+        packName: this.packName,
+        context: 'voipLine',
+      })
+      .$promise.then((shippingAddresses) => {
+        this.ovhContactOptions.customList = map(
+          shippingAddresses,
+          (shippingAddress) =>
+            new this.OvhContact({
+              address: {
+                line1: shippingAddress.address,
+                city: shippingAddress.cityName,
+                country: shippingAddress.countryCode,
+                zip: shippingAddress.zipCode,
+              },
+              firstName: shippingAddress.firstName,
+              lastName: shippingAddress.lastName,
+              id: shippingAddress.shippingId,
+            }),
+        );
+      })
+      .catch((error) => {
+        const msgErr = `${this.$translate(
+          'xdsl_access_comfort_exchange_shipping_addresses_error',
+        )} ${get(error, 'data.message', '')}`;
+        this.TucToast.error(msgErr);
+        return this.$q.reject(error);
+      });
   }
 
   getListOpenedRMA() {
@@ -55,6 +97,7 @@ export default class XdslAccessComfortExchangeCtrl {
   }
 
   comfortExchange() {
+    // console.log('contact options', this.ovhContactOptions, this.shipping);
     return this.OvhApiXdsl.Modem()
       .v6()
       .comfortExchange(

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
@@ -75,20 +75,22 @@
                 ></p>
             </oui-message>
             <!-- CONTACT CHOICE -->
-            <div class="contact-choice col-xs-12 col-md-6">
-                <h3
-                    data-translate="xdsl_access_comfort_exchange_shipping_contact"
-                    class="mb-3"
-                ></h3>
+            <div class="row">
+                <div class="contact-choice col-xs-12 col-md-6">
+                    <h3
+                        data-translate="xdsl_access_comfort_exchange_shipping_contact"
+                        class="mb-3"
+                    ></h3>
 
-                <ovh-contact
-                    data-ng-model="$ctrl.shipping"
-                    data-ovh-contact-choice-options="$ctrl.ovhContactOptions"
-                >
-                    <div class="text-center">
-                        <oui-spinner></oui-spinner>
-                    </div>
-                </ovh-contact>
+                    <ovh-contact
+                        data-ng-model="$ctrl.shipping"
+                        data-ovh-contact-choice-options="$ctrl.ovhContactOptions"
+                    >
+                        <div class="text-center">
+                            <oui-spinner></oui-spinner>
+                        </div>
+                    </ovh-contact>
+                </div>
             </div>
             <!-- CONTACT CHOICE -->
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
@@ -74,22 +74,42 @@
                     data-translate="xdsl_access_comfort_exchange_warning_part2"
                 ></p>
             </oui-message>
-            <div
-                class="mb-2"
-                data-translate="xdsl_access_comfort_exchange_confirm_title"
-            ></div>
-            <div
-                class="mb-2"
-                data-translate="xdsl_access_comfort_exchange_confirm_subtitle"
-            ></div>
+            <!-- CONTACT CHOICE -->
+            <div class="contact-choice col-xs-12 col-md-6">
+                <h3
+                    data-translate="xdsl_access_comfort_exchange_shipping_contact"
+                    class="mb-3"
+                ></h3>
 
-            <oui-button
-                data-variant="primary"
-                data-ng-disabled="$ctrl.isAvailable"
-                data-ng-click="$ctrl.comfortExchange()"
-            >
-                <span data-translate="xdsl_modem_exchange"></span>
-            </oui-button>
+                <ovh-contact
+                    data-ng-model="$ctrl.shipping"
+                    data-ovh-contact-choice-options="$ctrl.ovhContactOptions"
+                >
+                    <div class="text-center">
+                        <oui-spinner></oui-spinner>
+                    </div>
+                </ovh-contact>
+            </div>
+            <!-- CONTACT CHOICE -->
+
+            <div class="col-md-8 mt-2 mb-3">
+                <div
+                    class="mb-2"
+                    data-translate="xdsl_access_comfort_exchange_confirm_title"
+                ></div>
+                <div
+                    class="mb-2"
+                    data-translate="xdsl_access_comfort_exchange_confirm_subtitle"
+                ></div>
+
+                <oui-button
+                    data-variant="primary"
+                    data-ng-disabled="$ctrl.isAvailable"
+                    data-ng-click="$ctrl.comfortExchange()"
+                >
+                    <span data-translate="xdsl_modem_exchange"></span>
+                </oui-button>
+            </div>
         </div>
 
         <div data-ng-if="$ctrl.exchange.isSuccess">

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
@@ -94,23 +94,25 @@
             </div>
             <!-- CONTACT CHOICE -->
 
-            <div class="col-md-8 mt-2 mb-3">
-                <div
-                    class="mb-2"
-                    data-translate="xdsl_access_comfort_exchange_confirm_title"
-                ></div>
-                <div
-                    class="mb-2"
-                    data-translate="xdsl_access_comfort_exchange_confirm_subtitle"
-                ></div>
+            <div class="row">
+                <div class="col-md-8 mt-2 mb-3">
+                    <div
+                        class="mb-2"
+                        data-translate="xdsl_access_comfort_exchange_confirm_title"
+                    ></div>
+                    <div
+                        class="mb-2"
+                        data-translate="xdsl_access_comfort_exchange_confirm_subtitle"
+                    ></div>
 
-                <oui-button
-                    data-variant="primary"
-                    data-ng-disabled="$ctrl.isAvailable"
-                    data-ng-click="$ctrl.comfortExchange()"
-                >
-                    <span data-translate="xdsl_modem_exchange"></span>
-                </oui-button>
+                    <oui-button
+                        data-variant="primary"
+                        data-ng-disabled="$ctrl.isAvailable"
+                        data-ng-click="$ctrl.comfortExchange()"
+                    >
+                        <span data-translate="xdsl_modem_exchange"></span>
+                    </oui-button>
+                </div>
             </div>
         </div>
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.html
@@ -85,6 +85,7 @@
                     <ovh-contact
                         data-ng-model="$ctrl.shipping"
                         data-ovh-contact-choice-options="$ctrl.ovhContactOptions"
+                        data-ovh-contact-init-deferred="$ctrl.contactDeferred"
                     >
                         <div class="text-center">
                             <oui-spinner></oui-spinner>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.routing.js
@@ -7,6 +7,8 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       xdslId: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceName,
+      packName: /* @ngInject */ ($transition$) =>
+        $transition$.params().packName,
       openedRMAs: /* @ngInject */ (XdslAccessComfortExchangeService, xdslId) =>
         XdslAccessComfortExchangeService.getOpenedRMAs(xdslId),
       breadcrumb: /* @ngInject */ ($translate) =>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/comfort-exchange.routing.js
@@ -7,8 +7,6 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       xdslId: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceName,
-      packName: /* @ngInject */ ($transition$) =>
-        $transition$.params().packName,
       openedRMAs: /* @ngInject */ (XdslAccessComfortExchangeService, xdslId) =>
         XdslAccessComfortExchangeService.getOpenedRMAs(xdslId),
       breadcrumb: /* @ngInject */ ($translate) =>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/comfortExchange/translations/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "xdsl_access_comfort_exchange_title": "Échange de modem de confort",
   "xdsl_access_comfort_exchange_confirm_title": "Êtes-vous sûr(e) de vouloir effectuer cet échange ?",
-  "xdsl_access_comfort_exchange_confirm_subtitle": "Le modem sera envoyé automatiquement à l'adresse de raccordement.",
+  "xdsl_access_comfort_exchange_confirm_subtitle": "Le modem sera envoyé automatiquement à l'adresse de contact sélectionnée.",
   "xdsl_access_comfort_exchange_success_message": "Vous allez recevoir un e-mail vous décrivant la marche à suivre pour nous renvoyer votre ancien modem.",
   "xdsl_access_comfort_exchange_error_ERR011": "Erreur lors de la tentative de récupération des informations sur l'accès internet.",
   "xdsl_access_comfort_exchange_error_ERR012": "Erreur lors de la récupération des informations liées au contrat internet.",
@@ -30,5 +30,7 @@
   "xdsl_access_comfort_exchange_rma_status": "État de la demande",
   "xdsl_access_comfort_exchange_link_in_new_tab": "Ouverture du lien du bon de commande dans un nouvel onglet",
   "xdsl_access_comfort_exchange_warning_part1": "Cet échange a pour seul but de vous proposer un modem plus récent si les fonctionnalités de votre modem actuel ne conviennent plus à votre besoin.",
-  "xdsl_access_comfort_exchange_warning_part2": "En cas de défaut sur votre modem actuel, merci de ne pas initier d'échange via cet outil et de contacter le support."
+  "xdsl_access_comfort_exchange_warning_part2": "En cas de défaut sur votre modem actuel, merci de ne pas initier d'échange via cet outil et de contacter le support.",
+  "xdsl_access_comfort_exchange_shipping_addresses_error": "Oups ! Une erreur est survenue lors du chargement de vos adresses de livraisons.",
+  "xdsl_access_comfort_exchange_shipping_contact": "Adresse de livraison du nouveau modem"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | yes/no
| Tickets          | Fix #UXCT-244
| License          | BSD 3-Clause

## Description

On modem comfort exchange, add the ability to the customer to select the contact shipping to receive the new modem.
