### PR TITLE
fix(users): use horizon URL based on customer region

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/users/users.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/users/users.constants.js
@@ -1,5 +1,9 @@
-export const HORIZON_LINK =
-  'https://horizon.cloud.ovh.net/auth/login?username={username}';
+export const HORIZON_LINK = {
+  EU: 'https://horizon.cloud.ovh.net/auth/login?username={username}',
+  CA: 'https://horizon.cloud.ovh.net/auth/login?username={username}',
+  US: 'https://horizon.cloud.ovh.us/auth/login?username={username}',
+};
+
 export const ALPHA_CHARACTERS_REGEX = /^[a-zA-Z-]+$/;
 
 export const REGION_CAPACITY = 'storage';

--- a/packages/manager/modules/pci/src/projects/project/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/users/users.routing.js
@@ -22,8 +22,11 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.go('pci.projects.project.users.add', {
           projectId,
         }),
-      openStackHorizonLink: /* @ngInject */ () => (user) =>
-        HORIZON_LINK.replace('{username}', user.username),
+      openStackHorizonLink: /* @ngInject */ (coreConfig) => (user) =>
+        HORIZON_LINK[coreConfig.getRegion()].replace(
+          '{username}',
+          user.username,
+        ),
       downloadOpenStackOpenRc: /* @ngInject */ ($state, projectId) => (user) =>
         $state.go('pci.projects.project.users.download-openrc', {
           projectId,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-6557
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

fix(users): use horizon URL based on customer region

Previous URL for a US customer was:
- https://horizon.cloud.ovh.net

Now it's replaced by:
- https://horizon.cloud.ovh.us

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
