### PR TITLE
feat(training): add job resubmit

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/command_line_converter.js
+++ b/packages/manager/modules/pci/src/projects/project/training/command_line_converter.js
@@ -1,0 +1,34 @@
+function convertJobSpecToCliCommand(jobSpec) {
+  const baseCmdArray = [
+    'job run',
+    `--gpu ${jobSpec.resources.gpu}`,
+    `--name ${jobSpec.name}`,
+  ];
+
+  if (jobSpec.volumes?.length > 0) {
+    jobSpec.volumes
+      .map(({ container, region, prefix, mountPath, permission, cache }) => {
+        const prefixStr = prefix ? `:/${prefix}` : '';
+        const cacheStr = cache ? ':cache' : '';
+        return `--volume ${container}@${region}${prefixStr}:${mountPath}:${permission}${cacheStr}`;
+      })
+      .forEach((x) => baseCmdArray.push(x));
+  }
+
+  if (jobSpec.labels) {
+    Object.keys(jobSpec.labels).forEach((key) =>
+      baseCmdArray.push(`--label ${key}=${jobSpec.labels[key]}`),
+    );
+  }
+
+  baseCmdArray.push(`${jobSpec.image}`);
+
+  if (jobSpec.command && jobSpec.command.length > 0) {
+    baseCmdArray.push('--');
+    jobSpec.command.forEach((x) => baseCmdArray.push(x));
+  }
+
+  return baseCmdArray.join(' \\\n\t');
+}
+
+export default convertJobSpecToCliCommand;

--- a/packages/manager/modules/pci/src/projects/project/training/command_line_converter.js
+++ b/packages/manager/modules/pci/src/projects/project/training/command_line_converter.js
@@ -1,23 +1,27 @@
 function convertJobSpecToCliCommand(jobSpec) {
-  const baseCmdArray = [
+  let baseCmdArray = [
     'job run',
     `--gpu ${jobSpec.resources.gpu}`,
     `--name ${jobSpec.name}`,
   ];
 
   if (jobSpec.volumes?.length > 0) {
-    jobSpec.volumes
-      .map(({ container, region, prefix, mountPath, permission, cache }) => {
-        const prefixStr = prefix ? `:/${prefix}` : '';
-        const cacheStr = cache ? ':cache' : '';
-        return `--volume ${container}@${region}${prefixStr}:${mountPath}:${permission}${cacheStr}`;
-      })
-      .forEach((x) => baseCmdArray.push(x));
+    baseCmdArray = baseCmdArray.concat(
+      jobSpec.volumes.map(
+        ({ container, region, prefix, mountPath, permission, cache }) => {
+          const prefixStr = prefix ? `:/${prefix}` : '';
+          const cacheStr = cache ? ':cache' : '';
+          return `--volume ${container}@${region}${prefixStr}:${mountPath}:${permission}${cacheStr}`;
+        },
+      ),
+    );
   }
 
   if (jobSpec.labels) {
-    Object.keys(jobSpec.labels).forEach((key) =>
-      baseCmdArray.push(`--label ${key}=${jobSpec.labels[key]}`),
+    baseCmdArray = baseCmdArray.concat(
+      Object.keys(jobSpec.labels).map(
+        (key) => `--label ${key}=${jobSpec.labels[key]}`,
+      ),
     );
   }
 
@@ -25,7 +29,7 @@ function convertJobSpecToCliCommand(jobSpec) {
 
   if (jobSpec.command && jobSpec.command.length > 0) {
     baseCmdArray.push('--');
-    jobSpec.command.forEach((x) => baseCmdArray.push(x));
+    baseCmdArray = baseCmdArray.concat(jobSpec.command);
   }
 
   return baseCmdArray.join(' \\\n\t');

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/dashboard.component.js
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/dashboard.component.js
@@ -24,6 +24,7 @@ export default {
     billingLink: '<',
     jobInfo: '<',
     jobKill: '<',
+    jobResubmit: '<',
     jobInfoLink: '<',
     allUsers: '<',
     userLink: '<',

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/dashboard.html
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/dashboard.html
@@ -349,6 +349,13 @@
                                         ></span>
                                     </oui-action-menu-item>
                                     <oui-action-menu-item
+                                        data-on-click="$ctrl.jobResubmit(job.id)"
+                                    >
+                                        <span
+                                            data-translate="pci_projects_project_training_jobs_resubmit"
+                                        ></span>
+                                    </oui-action-menu-item>
+                                    <oui-action-menu-item
                                         data-on-click="$ctrl.jobKill(job.id)"
                                         data-disabled="!job.canBeKilled()"
                                     >

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/registry.component.js
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/registry.component.js
@@ -10,5 +10,6 @@ export default {
     goToDashboard: '<',
     goBack: '<',
     regions: '<',
+    currentRegion: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/registry.html
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/registry.html
@@ -10,6 +10,42 @@
         {{:: 'pci_projects_project_training_registry_section_1_title_info_1' |
         translate }}
     </oui-message>
+
+    <span
+        >{{:: 'pci_projects_project_training_registry_select_region' | translate
+        }}</span
+    >
+    <label class="oui-select oui-select_inline" for="region">
+        <select
+            class="oui-select__input"
+            ng-model="$ctrl.currentRegion"
+            id="region"
+        >
+            <option ng-repeat="region in $ctrl.regions" ng-value="region"
+                >{{region.name}}</option
+            >
+        </select>
+        <span class="oui-icon oui-icon-chevron-down" aria-hidden="true"></span>
+    </label>
+
+    <dl class="oui-description">
+        <dt>
+            Docker Registry
+            <button
+                type="button"
+                class="oui-popover-button"
+                oui-popover="{{:: 'pci_projects_project_training_registry_docker_registry_help' | translate }}"
+                oui-popover-placement="right"
+            ></button>
+        </dt>
+        <dd>{{ $ctrl.currentRegion.registryUrl }}</dd>
+        <dt>
+            {{:: 'pci_projects_project_training_registry_public_cloud_project' |
+            translate }}
+        </dt>
+        <dd>{{$ctrl.projectId }}</dd>
+    </dl>
+
     <p>
         {{:: 'pci_projects_project_training_registry_section_1_message_1' |
         translate }}
@@ -31,9 +67,9 @@
         {{:: 'pci_projects_project_training_registry_section_1_message_5' |
         translate }}
     </p>
-    <pre><code>docker tag image {{ $ctrl.currentRegion.registryUrl }}/{{$ctrl.projectId }}/image
+    <pre><code>docker tag &lt;image&gt; {{ $ctrl.currentRegion.registryUrl }}/{{$ctrl.projectId }}/&lt;image&gt;
 
-docker push {{ $ctrl.currentRegion.registryUrl }}/{{$ctrl.projectId }}/image</code></pre>
+docker push {{ $ctrl.currentRegion.registryUrl }}/{{$ctrl.projectId }}/&lt;image&gt;</code></pre>
     <p>
         {{:: 'pci_projects_project_training_registry_section_1_message_6' |
         translate }}

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/registry/translations/Messages_fr_FR.json
@@ -6,5 +6,8 @@
   "pci_projects_project_training_registry_section_1_message_3": "utilisateurs configurés",
   "pci_projects_project_training_registry_section_1_message_4": " au sein du même projet Public Cloud.",
   "pci_projects_project_training_registry_section_1_message_5": "Vous pouvez ensuite marquer vos images et les charger sur le registre.",
-  "pci_projects_project_training_registry_section_1_message_6": "Votre image est maintenant utilisable dans un job AI Training."
+  "pci_projects_project_training_registry_section_1_message_6": "Votre image est maintenant utilisable dans un job AI Training.",
+  "pci_projects_project_training_registry_select_region": "Sélectionnez la région que vous souhaitez utiliser :",
+  "pci_projects_project_training_registry_docker_registry_help": "Cette registry contient les images docker partagées.",
+  "pci_projects_project_training_registry_public_cloud_project": "Projet Public Cloud"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/dashboard/translations/Messages_fr_FR.json
@@ -20,5 +20,6 @@
   "pci_projects_project_training_dashboard_users_list_name": "Nom",
   "pci_projects_project_training_dashboard_users_list_description": "Description",
   "pci_projects_project_training_dashboard_users_list_none": "Vous n'avez créé aucun utilisateur avec les rôles « AI Training Operator » et « ObjectStore Operator »",
-  "pci_projects_project_training_dashboard_jobs_list_see_jobs": "Voir tous les jobs"
+  "pci_projects_project_training_dashboard_jobs_list_see_jobs": "Voir tous les jobs",
+  "pci_projects_project_training_jobs_resubmit": "Relancer"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/job.service.js
+++ b/packages/manager/modules/pci/src/projects/project/training/job.service.js
@@ -19,6 +19,15 @@ export default class PciProjectTrainingJobService {
       );
   }
 
+  resubmit(projectId, jobSpec) {
+    let toSubmit = jobSpec;
+    if (Object.prototype.hasOwnProperty.call(jobSpec, 'shutdown')) {
+      // remove shutdown before submitting as it is forbidden server side and irrelevant when resubmitting
+      toSubmit = (({ shutdown, ...j }) => j)(jobSpec);
+    }
+    return this.submit(projectId, toSubmit);
+  }
+
   getAll(projectId) {
     return this.OvhApiCloudProjectAi.Training()
       .Job()

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.component.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.component.js
@@ -7,6 +7,7 @@ export default {
   bindings: {
     job: '<',
     goToJobKill: '<',
+    goToJobResubmit: '<',
     user: '<',
     getTax: '<',
     getPrice: '<',

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
@@ -249,6 +249,11 @@
                 class="h-100"
                 data-heading="{{ 'pci_projects_project_training_jobs_info_title_actions' | translate  }}"
             >
+                <oui-tile-button data-on-click="$ctrl.goToJobResubmit()">
+                    <span
+                        data-translate="pci_projects_project_training_jobs_resubmit"
+                    ></span>
+                </oui-tile-button>
                 <oui-tile-button
                     data-on-click="$ctrl.goToJobKill()"
                     data-disabled="!$ctrl.job.canBeKilled()"

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.routing.js
@@ -29,6 +29,11 @@ export default /* @ngInject */ ($stateProvider) => {
           jobId,
           previousState: 'info',
         }),
+      goToJobResubmit: /* @ngInject */ ($state, jobId) => () =>
+        $state.go('pci.projects.project.training.jobs.resubmit', {
+          jobId,
+          previousState: 'info',
+        }),
     },
   });
 };

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_FR.json
@@ -28,5 +28,6 @@
   "pci_projects_project_training_jobs_info_title_4": "Données",
   "pci_projects_project_training_jobs_info_title_5": "Timeline",
   "pci_projects_project_training_jobs_info_title_actions": "Actions",
-  "pci_projects_project_training_job_logs_text_pre_running": "Le job est encore en attente de démarrage… L'onglet se rafraîchira automatiquement une fois que le job aura commencé."
+  "pci_projects_project_training_job_logs_text_pre_running": "Le job est encore en attente de démarrage… L'onglet se rafraîchira automatiquement une fois que le job aura commencé.",
+  "pci_projects_project_training_jobs_resubmit": "Relancer"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/jobs.component.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/jobs.component.js
@@ -9,6 +9,7 @@ export default {
     projectId: '<',
     jobInfo: '<',
     jobKill: '<',
+    jobResubmit: '<',
     submitJobLink: '<',
     submitJob: '<',
     regions: '<',

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/jobs.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/jobs.html
@@ -86,6 +86,11 @@
                     data-translate="pci_projects_project_training_jobs_info"
                 ></span>
             </oui-action-menu-item>
+            <oui-action-menu-item data-on-click="$ctrl.jobResubmit($row.id)">
+                <span
+                    data-translate="pci_projects_project_training_jobs_resubmit"
+                ></span>
+            </oui-action-menu-item>
             <oui-action-menu-item
                 data-on-click="$ctrl.jobKill($row.id)"
                 data-disabled="!$row.canBeKilled()"

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/kill/kill.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/kill/kill.html
@@ -20,9 +20,7 @@
             class="h-100"
             data-heading="{{:: 'pci_projects_project_training_job_kill' | translate  }}"
         >
-            <oui-tile-definition
-                data-term="{{:: 'pci_projects_project_training_jobs_id' | translate  }}"
-            >
+            <oui-tile-definition data-term="Job ID">
                 <oui-tile-description
                     data-ng-bind="$ctrl.job.id"
                 ></oui-tile-description>
@@ -32,7 +30,7 @@
                 data-term="{{:: 'pci_projects_project_training_jobs_region' | translate  }}"
             >
                 <oui-tile-description
-                    data-ng-bind="$ctrl.job.region"
+                    data-ng-bind="$ctrl.job.spec.region"
                 ></oui-tile-description>
             </oui-tile-definition>
 
@@ -40,7 +38,7 @@
                 data-term="{{:: 'pci_projects_project_training_jobs_image' | translate  }}"
             >
                 <oui-tile-description
-                    data-ng-bind="$ctrl.job.image"
+                    data-ng-bind="$ctrl.job.spec.image"
                 ></oui-tile-description>
             </oui-tile-definition>
 
@@ -71,7 +69,7 @@
                 data-term="{{:: 'pci_projects_project_training_jobs_created' | translate  }}"
             >
                 <oui-tile-description
-                    data-ng-bind="$ctrl.job.created | date:'medium'"
+                    data-ng-bind="$ctrl.job.createdAt | date:'medium'"
                 ></oui-tile-description>
             </oui-tile-definition>
         </oui-tile>

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/index.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/index.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerPciTrainingJobsResubmitLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state('pci.projects.project.training.jobs.resubmit.**', {
+      url: '/resubmit/:jobId',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./resubmit.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      },
+    });
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.component.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.component.js
@@ -1,0 +1,14 @@
+import controller from './resubmit.controller';
+import template from './resubmit.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    goToJobs: '<',
+    goToJobInfo: '<',
+    job: '<',
+    resubmitJob: '<',
+    previousState: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
@@ -39,7 +39,9 @@ export default class PciTrainingJobsResubmitController {
           'error',
         ),
       )
-      .finally(() => { this.loading = false; });
+      .finally(() => {
+        this.loading = false;
+      });
   }
 
   goBack() {

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
@@ -38,7 +38,8 @@ export default class PciTrainingJobsResubmitController {
           ),
           'error',
         ),
-      );
+      )
+      .finally(() => { this.loading = false; });
   }
 
   goBack() {

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.controller.js
@@ -1,0 +1,55 @@
+import get from 'lodash/get';
+
+export default class PciTrainingJobsResubmitController {
+  /* @ngInject */
+  constructor($translate, atInternet) {
+    this.$translate = $translate;
+    this.atInternet = atInternet;
+  }
+
+  $onInit() {
+    this.loading = false;
+  }
+
+  confirmResubmitJob() {
+    this.atInternet.trackClick({
+      name:
+        'public-cloud::pci::projects::project::training::jobs::resubmit::confirm',
+      type: 'action',
+    });
+
+    this.loading = true;
+    return this.resubmitJob()
+      .then(() =>
+        this.goToJobs(
+          this.$translate.instant(
+            'pci_projects_project_training_jobs_resubmit_success',
+          ),
+          'success',
+        ),
+      )
+      .catch((error) =>
+        this.goToJobs(
+          this.$translate.instant(
+            'pci_projects_project_training_jobs_resubmit_error',
+            {
+              message: get(error, 'data.message'),
+            },
+          ),
+          'error',
+        ),
+      );
+  }
+
+  goBack() {
+    if (this.previousState === 'info') {
+      this.goToJobInfo();
+    } else {
+      this.goToJobs();
+    }
+  }
+
+  getResubmitCliCommand() {
+    return `job run --from ${this.job.id}`;
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.html
@@ -1,0 +1,43 @@
+<form
+    id="trainingResubmitJob"
+    name="trainingResubmitJob"
+    data-ng-submit="$ctrl.confirmResubmitJob()"
+>
+    <oui-modal
+        data-primary-label="{{:: 'pci_projects_project_training_jobs_resubmit' | translate }}"
+        data-secondary-label="{{:: 'pci_projects_project_training_jobs_common_cancel' | translate }}"
+        data-secondary-action="$ctrl.goBack()"
+        data-on-dismiss="$ctrl.goBack()"
+        data-loading="$ctrl.loading"
+    >
+        <oui-tile
+            class="h-100"
+            data-heading="{{:: 'pci_projects_project_training_jobs_confirm_resubmit' | translate  }}"
+        >
+            <oui-tile-definition data-term="Job ID">
+                <oui-tile-description
+                    data-ng-bind="$ctrl.job.id"
+                ></oui-tile-description>
+            </oui-tile-definition>
+
+            <oui-tile-definition
+                data-term="{{:: 'pci_projects_project_training_jobs_region' | translate  }}"
+            >
+                <oui-tile-description
+                    data-ng-bind="$ctrl.job.spec.region"
+                ></oui-tile-description>
+            </oui-tile-definition>
+            <oui-tile-definition
+                data-term="{{:: 'pci_projects_project_training_jobs_submit_validation_equivalent_command' | translate  }}"
+            >
+                <oui-tile-description>
+                    <span
+                        data-translate="pci_projects_project_training_jobs_submit_ovhai_info"
+                    ></span>
+                    <pre class="ng-scope">
+<code>{{:: 'pci_projects_project_training_parter_cli_name' | translate }} {{ $ctrl.getResubmitCliCommand() }}</code></pre>
+                </oui-tile-description>
+            </oui-tile-definition>
+        </oui-tile>
+    </oui-modal>
+</form>

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.html
@@ -35,7 +35,7 @@
                         data-translate="pci_projects_project_training_jobs_submit_ovhai_info"
                     ></span>
                     <pre class="ng-scope">
-<code>{{:: 'pci_projects_project_training_parter_cli_name' | translate }} {{ $ctrl.getResubmitCliCommand() }}</code></pre>
+<code><span data-translate="pci_projects_project_training_parter_cli_name"></span> <span data-ng-bind="$ctrl.getResubmitCliCommand()"></span></code></pre>
                 </oui-tile-description>
             </oui-tile-definition>
         </oui-tile>

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.module.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.module.js
@@ -6,15 +6,10 @@ import '@uirouter/angularjs';
 import 'angular-translate';
 import 'ovh-api-services';
 
-import info from './info';
-import submit from './submit';
-import resubmit from './resubmit';
-import kill from './kill';
-import component from './jobs.component';
-import routing from './jobs.routing';
-import service from '../job.service';
+import component from './resubmit.component';
+import routing from './resubmit.routing';
 
-const moduleName = 'ovhManagerPciTrainingJobs';
+const moduleName = 'ovhManagerPciTrainingJobsResubmit';
 
 angular
   .module(moduleName, [
@@ -25,14 +20,9 @@ angular
     'ovhManagerCore',
     'pascalprecht.translate',
     'ui.router',
-    info,
-    submit,
-    resubmit,
-    kill,
   ])
   .config(routing)
-  .component('pciProjectTrainingJobsComponent', component)
-  .service('PciProjectTrainingJobsService', service)
+  .component('pciProjectTrainingJobsResubmitComponent', component)
   .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.routing.js
@@ -1,0 +1,37 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('pci.projects.project.training.jobs.resubmit', {
+    url: '/resubmit/:jobId',
+    views: {
+      modal: {
+        component: 'pciProjectTrainingJobsResubmitComponent',
+      },
+    },
+    layout: 'modal',
+    params: {
+      previousState: null,
+    },
+    resolve: {
+      breadcrumb: /* @ngInject */ ($translate) =>
+        $translate.instant('pci_projects_project_training_jobs_resubmit'),
+      jobId: /* @ngInject */ ($transition$) => $transition$.params().jobId,
+      previousState: /* @ngInject */ ($transition$) => {
+        return $transition$.params().previousState;
+      },
+      job: /* @ngInject */ (PciProjectTrainingJobService, projectId, jobId) => {
+        return PciProjectTrainingJobService.get(projectId, jobId);
+      },
+      resubmitJob: /* @ngInject */ (
+        PciProjectTrainingJobService,
+        projectId,
+        job,
+      ) => () => {
+        return PciProjectTrainingJobService.resubmit(projectId, job.spec);
+      },
+      goToJobInfo: /* @ngInject */ ($state, projectId, jobId) => () =>
+        $state.go('pci.projects.project.training.jobs.info', {
+          projectId,
+          jobId,
+        }),
+    },
+  });
+};

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/resubmit.routing.js
@@ -24,9 +24,7 @@ export default /* @ngInject */ ($stateProvider) => {
         PciProjectTrainingJobService,
         projectId,
         job,
-      ) => () => {
-        return PciProjectTrainingJobService.resubmit(projectId, job.spec);
-      },
+      ) => () => PciProjectTrainingJobService.resubmit(projectId, job.spec),
       goToJobInfo: /* @ngInject */ ($state, projectId, jobId) => () =>
         $state.go('pci.projects.project.training.jobs.info', {
           projectId,

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_de_DE.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Neu starten",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Sind Sie sicher, dass Sie diesen Auftrag neu starten möchten?",
+  "pci_projects_project_training_jobs_resubmit_success": "Der Auftrag wurde neu gestartet",
+  "pci_projects_project_training_jobs_resubmit_error": "Beim Neustart des Auftrags ist ein Fehler aufgetreten: {{ message }}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_en_GB.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Relaunch",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Are you sure you want to relaunch this job?",
+  "pci_projects_project_training_jobs_resubmit_success": "Job relaunched successfully",
+  "pci_projects_project_training_jobs_resubmit_error": "An error has occurred relaunching the job: {{ message }}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_es_ES.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Reanudar",
+  "pci_projects_project_training_jobs_confirm_resubmit": "¿Seguro que quiere reanudar el job?",
+  "pci_projects_project_training_jobs_resubmit_success": "El job se ha reanudado correctamente.",
+  "pci_projects_project_training_jobs_resubmit_error": "Se ha producido un error al reanudar el job: {{ message }}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_CA.json
@@ -1,0 +1,5 @@
+{
+  "pci_projects_project_training_jobs_common_cancel": "Annuler",
+  "pci_projects_project_training_jobs_resubmit": "Resubmit",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Êtes-vous sûr de vouloir relancer ce job ?"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "pci_projects_project_training_jobs_common_cancel": "Annuler",
+  "pci_projects_project_training_jobs_resubmit": "Resubmit",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Êtes-vous sûr de vouloir relancer ce job ?"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
   "pci_projects_project_training_jobs_common_cancel": "Annuler",
-  "pci_projects_project_training_jobs_resubmit": "Resubmit",
+  "pci_projects_project_training_jobs_resubmit": "Relancer",
   "pci_projects_project_training_jobs_confirm_resubmit": "Êtes-vous sûr de vouloir relancer ce job ?"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_it_IT.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Riavvia",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Vuoi davvero riavviare il job?",
+  "pci_projects_project_training_jobs_resubmit_success": "Il job è stato riavviato correttamente",
+  "pci_projects_project_training_jobs_resubmit_error": "Si è verificato un errore durante il riavvio del job: {{ message }}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_pl_PL.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Uruchom ponownie",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Czy na pewno chcesz uruchomić ponownie to zadanie?",
+  "pci_projects_project_training_jobs_resubmit_success": "Zadanie zostało poprawnie uruchomione",
+  "pci_projects_project_training_jobs_resubmit_error": "Wystąpił błąd podczas ponownego uruchamiania zadania: {{message}}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_pt_PT.json
@@ -1,0 +1,6 @@
+{
+  "pci_projects_project_training_jobs_resubmit": "Relançar",
+  "pci_projects_project_training_jobs_confirm_resubmit": "Tem a certeza de que deseja relançar este job?",
+  "pci_projects_project_training_jobs_resubmit_success": "O job foi corretamente relançado",
+  "pci_projects_project_training_jobs_resubmit_error": "Ocorreu um erro durante o relançamento do job: {{ message }}"
+}

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -2,6 +2,7 @@ import get from 'lodash/get';
 import remove from 'lodash/remove';
 import { nameGenerator } from '../../../data-processing/data-processing.utils';
 import { COMMUNITY_URL } from '../../training.constants';
+import convertJobSpecToCliCommand from '../../command_line_converter';
 
 export default class PciTrainingJobsSubmitController {
   /* @ngInject */
@@ -99,29 +100,7 @@ export default class PciTrainingJobsSubmitController {
   }
 
   cliCommand() {
-    const baseCmdArray = [
-      'job run',
-      `--gpu ${this.job.resources.gpu}`,
-      `--name ${this.job.name}`,
-    ];
-
-    if (this.job.volumes && this.job.volumes.length > 0) {
-      this.job.volumes
-        .map(
-          ({ container, region, mountPath, permission }) =>
-            `--volume ${container}@${region}:${mountPath}:${permission}`,
-        )
-        .forEach((x) => baseCmdArray.push(x));
-    }
-
-    baseCmdArray.push(`${this.job.image.id}`);
-
-    if (this.job.command) {
-      baseCmdArray.push('--');
-      this.splitStringCommandIntoArray().forEach((x) => baseCmdArray.push(x));
-    }
-
-    return baseCmdArray.join(' \\\n\t');
+    return convertJobSpecToCliCommand(this.computeJobSpec());
   }
 
   splitStringCommandIntoArray() {
@@ -150,6 +129,8 @@ export default class PciTrainingJobsSubmitController {
     };
     if (this.job.command) {
       payload.command = this.splitStringCommandIntoArray();
+    } else {
+      payload.command = null;
     }
     return payload;
   }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_de_DE.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "Fehlt ein Framework?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Schlagen Sie in der OVHcloud AI Community weitere Framework-Optionen vor.",
   "pci_projects_project_training_jobs_submit_ovhai_info": "Mit dem folgenden Befehl können Sie den gleichen Auftrag über unser OVHAI CLI starten:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Hier finden Sie weitere Informationen zu den verfügbaren Einstellungen:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Hier finden Sie weitere Informationen zu den verfügbaren Einstellungen:",
+  "pci_projects_project_training_jobs_id": "Auftrag-ID",
+  "pci_projects_project_training_jobs_common_cancel": "Abbrechen"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_en_GB.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "Missing framework?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Suggest additional frameworks on the OVHcloud AI Community",
   "pci_projects_project_training_jobs_submit_ovhai_info": "With the following command, you can launch the same job using our ovhai CLI:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "For more information on the available settings:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "For more information on the available settings:",
+  "pci_projects_project_training_jobs_id": "Job ID",
+  "pci_projects_project_training_jobs_common_cancel": "Cancel"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_es_ES.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "¿No encuentra un framework?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Puede sugerir frameworks adicionales en la OVHcloud AI Community.",
   "pci_projects_project_training_jobs_submit_ovhai_info": "El siguiente comando le permite lanzar el mismo job gracias a nuestro CLI ovhai:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Para más información sobre los parámetros disponibles:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Para más información sobre los parámetros disponibles:",
+  "pci_projects_project_training_jobs_id": "Job ID",
+  "pci_projects_project_training_jobs_common_cancel": "Cancelar"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_CA.json
@@ -39,5 +39,8 @@
   "pci_projects_project_training_jobs_submit_data_permission_RO": "Lecture Seule",
   "pci_projects_project_training_jobs_submit_data_permission_RW": "Lecture & Ecriture",
   "pci_projects_project_training_jobs_submit_ovhai_info": "La commande suivante vous permet de lancer le même job grâce à notre CLI ovhai :",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Pour plus d'information sur les paramètres disponibles :"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Pour plus d'information sur les paramètres disponibles :",
+  "pci_projects_project_training_jobs_common_cancel": "Annuler",
+  "pci_projects_project_training_jobs_resubmit_success": "Le job a correctement été relancé",
+  "pci_projects_project_training_jobs_resubmit_error": "Une erreur s'est produite durant le relancement du job : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -39,5 +39,8 @@
   "pci_projects_project_training_jobs_submit_data_permission_RO": "Lecture Seule",
   "pci_projects_project_training_jobs_submit_data_permission_RW": "Lecture & Ecriture",
   "pci_projects_project_training_jobs_submit_ovhai_info": "La commande suivante vous permet de lancer le même job grâce à notre CLI ovhai :",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Pour plus d'information sur les paramètres disponibles :"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Pour plus d'information sur les paramètres disponibles :",
+  "pci_projects_project_training_jobs_common_cancel": "Annuler",
+  "pci_projects_project_training_jobs_resubmit_success": "Le job a correctement été relancé",
+  "pci_projects_project_training_jobs_resubmit_error": "Une erreur s'est produite durant le relancement du job : {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_it_IT.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "Framework mancante?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Suggerisci framework aggiuntivi su OVH AI Community",
   "pci_projects_project_training_jobs_submit_ovhai_info": "Il seguente comando ti permette di avviare lo stesso job con la nostra CLI ovhai:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Per maggiori informazioni sui parametri disponibili:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Per maggiori informazioni sui parametri disponibili:",
+  "pci_projects_project_training_jobs_id": "Job ID",
+  "pci_projects_project_training_jobs_common_cancel": "Annulla"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pl_PL.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "Nie znajdujesz jakiegoś frameworku?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Zasugeruj dodatkowe frameworki dla OVHcloud AI Community",
   "pci_projects_project_training_jobs_submit_ovhai_info": "Następujące polecenie pozwala uruchomić to samo zadanie w ramach CLI ovhai:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Więcej informacji na temat dostępnych parametrów:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Więcej informacji na temat dostępnych parametrów:",
+  "pci_projects_project_training_jobs_id": "ID zadania",
+  "pci_projects_project_training_jobs_common_cancel": "Anuluj"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pt_PT.json
@@ -39,5 +39,7 @@
   "pci_projects_project_training_jobs_submit_select_image_preset_missing_framework": "Framework em falta?",
   "pci_projects_project_training_jobs_submit_select_image_preset_request": "Sugira frameworks adicionais na OVHcloud AI Community",
   "pci_projects_project_training_jobs_submit_ovhai_info": "O comando seguinte permite-lhe lançar o mesmo job graças ao nosso CLI ovhai:",
-  "pci_projects_project_training_jobs_submit_ovhai_help": "Para mais informações sobre os parâmetros disponíveis:"
+  "pci_projects_project_training_jobs_submit_ovhai_help": "Para mais informações sobre os parâmetros disponíveis:",
+  "pci_projects_project_training_jobs_id": "ID do job",
+  "pci_projects_project_training_jobs_common_cancel": "Cancelar"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/training.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.routing.js
@@ -47,6 +47,10 @@ export default /* @ngInject */ ($stateProvider) => {
           projectId,
           jobId,
         }),
+      jobResubmit: /* @ngInject */ ($state) => (jobId) =>
+        $state.go('pci.projects.project.training.jobs.resubmit', {
+          jobId,
+        }),
       jobKill: /* @ngInject */ ($state, projectId) => (jobId) =>
         $state.go('pci.projects.project.training.jobs.kill', {
           projectId,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6617
| License          | BSD 3-Clause

## Description

This PR is related to the following jira task in AI Training project:

- MLS-1082: add a resubmit button in ai training dashboard, ai training job list, and ai training job info pages, to launch a new job with the same specification as the one selected

- MLS-1178: some fields were not displayed properly when stopping a job in the dedicated modal

- MLS-1117: add a dropdown in the shared registry modal to change URLs depending on the selected region

- MLS-1164: volume permission was Read &amp Write instead of Read & Write

### Translations 
- [x] TRANS-33569