### PR TITLE
feat(ng-at-internet): set US custom vars

### DIFF
--- a/packages/components/ng-at-internet/src/constants.js
+++ b/packages/components/ng-at-internet/src/constants.js
@@ -6,7 +6,10 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Country code of the customer making the order
    */
   countryCode: {
-    path: 'site.1',
+    path: {
+      default: 'site.1',
+      US: 'site.12',
+    },
     format: '[%s]',
   },
 
@@ -14,7 +17,10 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Currency code of the customer
    */
   currencyCode: {
-    path: 'site.16',
+    path: {
+      default: 'site.16',
+      US: 'site.15',
+    },
     format: '[%s]',
   },
 
@@ -23,7 +29,10 @@ export const AT_INTERNET_CUSTOM_VARS = {
    */
 
   referrerSite: {
-    path: 'site.8', // OVH's AtInternet configuration
+    path: {
+      default: 'site.8', // OVH's AtInternet configuration
+      US: 'site.11',
+    },
     format: '[%s]',
   },
 
@@ -31,12 +40,18 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Event
    */
   event: {
-    path: 'site.20',
+    path: {
+      default: 'site.20',
+      US: 'site.6',
+    },
     format: '[%s]',
   },
 
   siteName: {
-    path: 'site.13',
+    path: {
+      default: 'site.13',
+      US: 'site.14',
+    },
     format: '[%s]',
   },
 
@@ -44,7 +59,9 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Project Id
    */
   projectId: {
-    path: 'page.1', // OVH's AtInternet configuration
+    path: {
+      default: 'page.1', // OVH's AtInternet configuration
+    },
     format: '[%s]',
   },
 
@@ -52,7 +69,9 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Voucher code used
    */
   voucherCode: {
-    path: 'page.2', // OVH's AtInternet configuration
+    path: {
+      default: 'page.2', // OVH's AtInternet configuration
+    },
     format: '[%s]',
   },
 
@@ -60,7 +79,9 @@ export const AT_INTERNET_CUSTOM_VARS = {
    * Order status used
    */
   orderStatus: {
-    path: 'page.1',
+    path: {
+      default: 'page.1',
+    },
     format: '[%s]',
   },
 };

--- a/packages/components/ng-at-internet/src/provider.js
+++ b/packages/components/ng-at-internet/src/provider.js
@@ -32,6 +32,7 @@ export default /* @ngInject */ function(AT_INTERNET_CUSTOM_VARS) {
     enabled: false, // enable or disable tracking
     debug: false, // enable or disable logging tracking in JS console
     defaults: {}, // default data to be sent with each hit
+    region: 'EU', // region used to get custom vars
   };
 
   let defaultsPromise; // to be sure that defaults are setted after a promise resoltion
@@ -106,6 +107,18 @@ export default /* @ngInject */ function(AT_INTERNET_CUSTOM_VARS) {
    */
   this.setDebug = function setDebug(state) {
     config.debug = state;
+  };
+
+  /**
+   * @ngdoc function
+   * @name atInternet.setRegion
+   * @methodOf atInternetProvider
+   * @param {String} region Region where to get custom vars
+   * @description
+   * Set the region in order to get right default custom vars.
+   */
+  this.setRegion = function setRegion(region) {
+    config.region = region;
   };
 
   this.$get = /* @ngInject */ function $get($window, $log) {
@@ -185,10 +198,14 @@ export default /* @ngInject */ function(AT_INTERNET_CUSTOM_VARS) {
       }
     }
 
+    function getCustomVarConfigPath(conf) {
+      return conf.path[config.region] || conf.path.default;
+    }
+
     function updateCustomVars(data, conf, attr, customVars) {
       // if data has custom attribute
       if (has(data, attr)) {
-        const keys = conf.path.split('.');
+        const keys = getCustomVarConfigPath(conf).split('.');
         let tmp = customVars;
 
         /*

--- a/packages/manager/modules/at-internet-configuration/package.json
+++ b/packages/manager/modules/at-internet-configuration/package.json
@@ -11,9 +11,7 @@
   "license": "BSD-3-Clause",
   "author": "OVH SAS",
   "main": "./src/index.js",
-  "dependencies": {
-    "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0",
     "@ovh-ux/ng-at-internet": "^5.4.1",

--- a/packages/manager/modules/at-internet-configuration/src/index.js
+++ b/packages/manager/modules/at-internet-configuration/src/index.js
@@ -4,8 +4,6 @@ import '@ovh-ux/manager-core';
 import '@ovh-ux/ng-at-internet';
 import '@ovh-ux/ng-at-internet-ui-router-plugin';
 
-import { Environment } from '@ovh-ux/manager-config';
-
 import provider from './provider';
 import { CUSTOM_VARIABLES, USER_ID } from './config.constants';
 
@@ -25,9 +23,11 @@ angular
       atInternetConfigurationProvider,
       atInternetProvider,
       atInternetUiRouterPluginProvider,
+      coreConfigProvider,
     ) => {
       atInternetProvider.setEnabled(trackingEnabled);
       atInternetProvider.setDebug(!trackingEnabled);
+      atInternetProvider.setRegion(coreConfigProvider.getRegion());
 
       atInternetUiRouterPluginProvider.setTrackStateChange(true);
       atInternetUiRouterPluginProvider.addStateNameFilter((routeName) => {
@@ -70,11 +70,17 @@ angular
     },
   )
   .run(
-    /* @ngInject */ ($cookies, $http, atInternet, atInternetConfiguration) => {
+    /* @ngInject */ (
+      $cookies,
+      $http,
+      atInternet,
+      atInternetConfiguration,
+      coreConfig,
+    ) => {
       const referrerSite = $cookies.get('OrderCloud');
       const data = {
         ...CUSTOM_VARIABLES,
-        ...atInternetConfiguration.getConfig(Environment.getRegion()),
+        ...atInternetConfiguration.getConfig(coreConfig.getRegion()),
         ...(referrerSite ? { referrerSite } : {}),
       };
 


### PR DESCRIPTION
Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6432
| License          | BSD 3-Clause

## Description

Add `setRegion` in provider in order to differenciate custom vars from EU/CA and US.
