### PR TITLE
fix(vps): remove cluster information

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/tile/information/information.html
+++ b/packages/manager/modules/vps/src/dashboard/tile/information/information.html
@@ -82,8 +82,8 @@
         </oui-action-menu>
     </oui-tile-definition>
     <oui-tile-definition
-        term="{{ ::('vps_zone' | translate)+' ('+('vps_cluster' | translate)+')' }}"
-        description="{{ ::$ctrl.vps.zone+' ('+$ctrl.vps.cluster+')' }}"
+        term="{{ ::('vps_zone' | translate) }}"
+        description="{{ ::$ctrl.vps.zone }}"
     >
     </oui-tile-definition>
     <oui-tile-definition

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -171,8 +171,8 @@
                 >
                 </oui-tile-definition>
                 <oui-tile-definition
-                    data-term="{{ ::('vps_zone' | translate)+' ('+('vps_cluster' | translate)+')' }}"
-                    data-description="{{ ::$ctrl.vps.zone+' ('+$ctrl.vps.cluster+')' }}"
+                    data-term="{{ ::('vps_zone' | translate) }}"
+                    data-description="{{ ::$ctrl.vps.zone }}"
                 >
                 </oui-tile-definition>
                 <oui-tile-definition


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-6580
| License          | BSD 3-Clause

## Description

Remove useless cluster information

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
