### PR TITLE
feat(dasbhoard): add datacenters and regions to incident services status

### DIFF
--- a/packages/manager/apps/hub/src/dashboard/incident/status/status.constants.js
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/status.constants.js
@@ -3,6 +3,28 @@ export const FAQ = {
   en_GB: 'https://help.ovhcloud.com/en-gb/faq/strasbourg-incident/',
 };
 
+export const DATACENTERS = {
+  SBG1: 'SBG1',
+  SBG2: 'SBG2',
+  SBG3: 'SBG3',
+  SBG4: 'SBG4',
+  SBG5: 'SBG5',
+  SBG6: 'SBG6',
+};
+
+export const REGIONS = {
+  'os-sbg1': 'os-sbg1',
+  'os-sbg2': 'os-sbg2',
+  'os-sbg3': 'os-sbg3',
+  'os-sbg4': 'os-sbg4',
+  'os-sbg5': 'os-sbg5',
+  'os-sbg6': 'os-sbg6',
+  'os-pcs-sbg': 'os-pcs-sbg',
+  'os-pca-sbg': 'os-pca-sbg',
+};
+
 export default {
+  DATACENTERS,
   FAQ,
+  REGIONS,
 };

--- a/packages/manager/apps/hub/src/dashboard/incident/status/status.controller.js
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/status.controller.js
@@ -1,5 +1,5 @@
 import { Environment } from '@ovh-ux/manager-config';
-import { FAQ } from './status.constants';
+import { DATACENTERS, FAQ, REGIONS } from './status.constants';
 
 export default class StatusController {
   $onInit() {
@@ -12,8 +12,31 @@ export default class StatusController {
         hideOperators: true,
         values: this.translatedServiceEnum,
       },
+      datacenters: {
+        hideOperators: true,
+        values: DATACENTERS,
+      },
+      regions: {
+        hideOperators: true,
+        values: REGIONS,
+      },
     };
 
     this.faqLink = FAQ[Environment.getUserLocale()] || FAQ.en_GB;
+
+    this.datagridParameters = [
+      {
+        name: 'region',
+        hidden:
+          this.services.length > 0 &&
+          !Object.keys(this.services[0]).includes('region'),
+      },
+      {
+        name: 'datacenter',
+        hidden:
+          this.services.length > 0 &&
+          !Object.keys(this.services[0]).includes('datacenter'),
+      },
+    ];
   }
 }

--- a/packages/manager/apps/hub/src/dashboard/incident/status/template.html
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/template.html
@@ -40,7 +40,10 @@
     data-ng-href="{{$ctrl.faqLink}}"
     data-translate="manager_hub_incident_status_faq"
 ></a>
-<oui-datagrid rows="$ctrl.services">
+<oui-datagrid
+    rows="$ctrl.services"
+    columns-parameters="$ctrl.datagridParameters"
+>
     <oui-datagrid-column
         title="::'manager_hub_incident_status_service_name' | translate"
         property="serviceName"
@@ -62,6 +65,22 @@
         <span
             data-translate="{{ 'manager_hub_incident_status_product_' + $row.productType }}"
         ></span>
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        title="::'manager_hub_incident_status_service_region' | translate"
+        property="region"
+        filterable
+        type="options"
+        type-options="$ctrl.filtersOptions.regions"
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        title="::'manager_hub_incident_status_service_datacenter' | translate"
+        property="datacenter"
+        filterable
+        type="options"
+        type-options="$ctrl.filtersOptions.datacenters"
+    >
     </oui-datagrid-column>
     <oui-datagrid-column
         title="::'manager_hub_incident_status_service_status' | translate"

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_de_DE.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_de_DE.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions:",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_en_GB.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_en_GB.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions :",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_es_ES.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_es_ES.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions:",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_fr_CA.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "récupérable* : ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non récupérable :",
   "manager_hub_incident_status_service_TO_ASSESS": "en cours d'investigation :",
+  "manager_hub_incident_status_service_datacenter": "Datacentre",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "En complément de l’e-mail ou des e-mails que vous avez reçu(s) concernant l’état de vos services, vous en trouverez ci-dessous la synthèse",
   "manager_hub_incident_status_definition": "Définition des états : ",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "service isolé par mesure de sécurité pouvant être totalement ou en partie remis en service prochainement",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_fr_FR.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "récupérable* : ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non récupérable :",
   "manager_hub_incident_status_service_TO_ASSESS": "en cours d'investigation : ",
+  "manager_hub_incident_status_service_datacenter": "Datacentre",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "En complément de l’e-mail ou des e-mails que vous avez reçu(s) concernant l’état de vos services, vous en trouverez ci-dessous la synthèse.",
   "manager_hub_incident_status_definition": "Définition des états :",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "service isolé par mesure de sécurité pouvant être totalement ou en partie remis en service prochainement",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_it_IT.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_it_IT.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions:",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_pl_PL.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions:",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",

--- a/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/hub/src/dashboard/incident/status/translations/Messages_pt_PT.json
@@ -9,6 +9,8 @@
   "manager_hub_incident_status_service_RECOVERABLE": "recoverable*: ",
   "manager_hub_incident_status_service_NON_RECOVERABLE": "non-recoverable:",
   "manager_hub_incident_status_service_TO_ASSESS": "under investigation:",
+  "manager_hub_incident_status_service_datacenter": "Datacenter",
+  "manager_hub_incident_status_service_region": "OpenStack Zone",
   "manager_hub_incident_status_description": "In addition to the email(s) you have received, please find a summary of the status of your services below",
   "manager_hub_incident_status_definition": "Definitions:",
   "manager_hub_incident_status_service_status_RECOVERABLE_description": "services that have been isolated as a security measure and which may be partially or fully reactivated in the near future",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6587
| License          | BSD 3-Clause

## Description

Add datacenters and regions to incident services status

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
