### PR TITLE
fix(hub): remove useless prefix for warning notifications

### DIFF
--- a/packages/manager/apps/hub/src/translations/Messages_en_GB.json
+++ b/packages/manager/apps/hub/src/translations/Messages_en_GB.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Warning: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Skip to main content",
   "manager_hub_sbg_incident": "View the status of your services in Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_es_ES.json
+++ b/packages/manager/apps/hub/src/translations/Messages_es_ES.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Atención: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Ir al contenido principal",
   "manager_hub_sbg_incident": "View the status of your services in Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/hub/src/translations/Messages_fr_CA.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Attention: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Aller au contenu principal",
   "manager_hub_sbg_incident": "Consultez l’état de vos services à Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/hub/src/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Attention: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Aller au contenu principal",
   "manager_hub_sbg_incident": "Consultez l’état de vos services à Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_it_IT.json
+++ b/packages/manager/apps/hub/src/translations/Messages_it_IT.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Attenzione: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Vai al contenuto principale",
   "manager_hub_sbg_incident": "View the status of your services in Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/hub/src/translations/Messages_pl_PL.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Uwaga: {{content}}",
+  "manager_hub_notification_warning": "{{content}}",
   "manager_hub_skip_to_main_content": "Przejdź do głównej sekcji",
   "manager_hub_sbg_incident": "View the status of your services in Strasbourg (SBG)"
 }

--- a/packages/manager/apps/hub/src/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/hub/src/translations/Messages_pt_PT.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_notification_warning": "Atenção: {{ content }}",
+  "manager_hub_notification_warning": "{{ content }}",
   "manager_hub_skip_to_main_content": "Aceder ao conteúdo principal",
   "manager_hub_sbg_incident": "View the status of your services in Strasbourg (SBG)"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

## Description

Remove useless prefix for warning notifications

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>