### PR TITLE
fix(tracking): update defaults initialization

### DIFF
--- a/packages/manager/modules/at-internet-configuration/src/index.js
+++ b/packages/manager/modules/at-internet-configuration/src/index.js
@@ -77,18 +77,19 @@ angular
         ...atInternetConfiguration.getConfig(Environment.getRegion()),
         ...(referrerSite ? { referrerSite } : {}),
       };
-      $http
-        .get('/me')
-        .then(({ data: me }) => me)
-        .catch(() => {})
-        .then((me) => {
-          atInternet.setDefaults({
+
+      atInternet.setDefaultsPromise(
+        $http
+          .get('/me')
+          .then(({ data: me }) => me)
+          .catch(() => {})
+          .then((me) => ({
             ...data,
             countryCode: me.country,
             currencyCode: me.currency && me.currency.code,
             visitorId: me.customerCode,
-          });
-        });
+          })),
+      );
     },
   );
 


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-5814,
| License          | BSD 3-Clause

## Description

Avoid race condition between API call and routing initialization to send first track page event.
Use defaultPromise instead of setting defaults when the promise is resolved.



