### PR TITLE
fix(i18n): remove unused locales

### DIFF
--- a/packages/manager/modules/core/src/index.js
+++ b/packages/manager/modules/core/src/index.js
@@ -101,17 +101,11 @@ angular
       case 'es-es':
         angularLocalePromise = import('angular-i18n/angular-locale_es-es.js');
         break;
-      case 'fi-fi':
-        angularLocalePromise = import('angular-i18n/angular-locale_fi-fi.js');
-        break;
       case 'fr-ca':
         angularLocalePromise = import('angular-i18n/angular-locale_fr-ca.js');
         break;
       case 'it-it':
         angularLocalePromise = import('angular-i18n/angular-locale_it-it.js');
-        break;
-      case 'lt-lt':
-        angularLocalePromise = import('angular-i18n/angular-locale_lt-lt.js');
         break;
       case 'pl-pl':
         angularLocalePromise = import('angular-i18n/angular-locale_pl-pl.js');


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix
| License          | BSD 3-Clause

## Description

As mentioned by @antleblanc , we could remove `fi-fi` and `lt-lt`.

Relates to: #4229 and #4365