### PR TITLE
fix(billing.ovhaccount): enable cash out for DE subsidiary

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/billing-credits.service.js
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/billing-credits.service.js
@@ -40,6 +40,12 @@ angular.module('Billing.services').service(
       );
     }
 
+    getOrder(orderId) {
+      return this.OvhHttp.get(`/me/order/${orderId}`, {
+        rootPath: 'apiv6',
+      });
+    }
+
     /* -----  End of API CALLS  ------ */
   },
 );

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/movements/billing-credits-movements.controller.js
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/movements/billing-credits-movements.controller.js
@@ -35,6 +35,14 @@ angular.module('Billing.controllers').controller(
 
       return this.billingCredits
         .getBalanceMovement(this.$stateParams.balanceName, movementId)
+        .then((data) => {
+          return data.orderId
+            ? this.billingCredits.getOrder(data.orderId).then((order) => ({
+                ...data,
+                orderUrl: order.url,
+              }))
+            : this.$q.resolve(data);
+        })
         .catch((error) => {
           this.Alerter.set(
             'alert-danger',

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/movements/billing-credits-movements.html
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/movements/billing-credits-movements.html
@@ -18,6 +18,11 @@
                             data-translate="billing_credit_balance_movements_header_date"
                         ></span>
                     </th>
+                    <th scope="col">
+                        <span
+                            data-translate="billing_credit_balance_movements_header_operation"
+                        ></span>
+                    </th>
                     <th class="text-right" scope="col">
                         <span
                             data-translate="billing_credit_balance_header_amount"
@@ -26,16 +31,6 @@
                     <th class="text-center" scope="col">
                         <span
                             data-translate="billing_credit_balance_header_expiration_date"
-                        ></span>
-                    </th>
-                    <th scope="col">
-                        <span
-                            data-translate="billing_credit_balance_movements_header_operation"
-                        ></span>
-                    </th>
-                    <th scope="col">
-                        <span
-                            data-translate="billing_credit_balance_header_order"
                         ></span>
                     </th>
                 </tr>
@@ -58,6 +53,26 @@
                             data-ng-bind="movement.creationDate | date:'mediumDate'"
                         ></span>
                     </td>
+                    <td>
+                        <span
+                            data-ng-if="movement.amount.value >= 0"
+                            data-translate="billing_credit_balance_movements_operation_credit"
+                        >
+                        </span>
+
+                        <span
+                            data-ng-if="movement.amount.value < 0 && movement.orderId"
+                            data-translate="billing_credit_balance_movements_operation_debit_order"
+                            data-translate-values="{ orderId: movement.orderId, orderUrl: movement.orderUrl }"
+                        >
+                        </span>
+
+                        <span
+                            data-ng-if="movement.amount.value < 0 && !movement.orderId"
+                            data-translate="billing_credit_balance_movements_operation_debit"
+                        >
+                        </span>
+                    </td>
                     <td class="text-right">
                         <span data-ng-bind="movement.amount.text"></span>
                     </td>
@@ -67,23 +82,6 @@
                             data-ng-class="{ 'text-danger': movement.expireSoon }"
                         >
                         </span>
-                    </td>
-                    <td>
-                        <span
-                            data-ng-if="movement.amount.value >= 0"
-                            data-translate="billing_credit_balance_movements_operation_credit"
-                        >
-                        </span>
-                        <span
-                            data-ng-if="movement.amount.value < 0"
-                            data-translate="billing_credit_balance_movements_operation_debit"
-                        >
-                        </span>
-                    </td>
-                    <td>
-                        <span
-                            data-ng-bind="movement.amount.orderId || '-'"
-                        ></span>
                     </td>
                 </tr>
             </tbody>

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_en_GB.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Order",
   "billing_credit_balance_movements_operation_credit": "Credit",
   "billing_credit_balance_movements_operation_debit": "Debit",
+  "billing_credit_balance_movements_operation_debit_order": "Debit from order <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "An error has occurred loading voucher operations.",
   "billing_credit_back": "Back to your vouchers"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_es_ES.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Pedido",
   "billing_credit_balance_movements_operation_credit": "Crédito",
   "billing_credit_balance_movements_operation_debit": "Débito",
+  "billing_credit_balance_movements_operation_debit_order": "Debit from order <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Se ha producido un error al cargar los movimientos de su voucher.",
   "billing_credit_back": "Volver a mis vouchers"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_fr_CA.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Commande",
   "billing_credit_balance_movements_operation_credit": "Crédit",
   "billing_credit_balance_movements_operation_debit": "Débit",
+  "billing_credit_balance_movements_operation_debit_order": "Débit sur la commande <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Une erreur est survenue lors du chargement des mouvements de votre bon d'achat.",
   "billing_credit_back": "Retourner à mes bons d'achat"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_fr_FR.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Commande",
   "billing_credit_balance_movements_operation_credit": "Crédit",
   "billing_credit_balance_movements_operation_debit": "Débit",
+  "billing_credit_balance_movements_operation_debit_order": "Débit sur la commande <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Une erreur est survenue lors du chargement des mouvements de votre bon d'achat.",
   "billing_credit_back": "Retourner à mes bons d'achat"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_it_IT.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Ordine",
   "billing_credit_balance_movements_operation_credit": "Credito",
   "billing_credit_balance_movements_operation_debit": "Debito",
+  "billing_credit_balance_movements_operation_debit_order": "Debit from order <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Si è verificato un errore durante il caricamento dei movimenti del tuo voucher.",
   "billing_credit_back": "Ritorna ai tuoi voucher"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_pl_PL.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Zamówienie",
   "billing_credit_balance_movements_operation_credit": "Zasilenie",
   "billing_credit_balance_movements_operation_debit": "Wykorzystane środki",
+  "billing_credit_balance_movements_operation_debit_order": "Debit from order <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Wystąpił błąd podczas pobierania listy transakcji powiązanych z Twoim voucherem.",
   "billing_credit_back": "Powrót do voucherów"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/credits/translations/Messages_pt_PT.json
@@ -19,6 +19,7 @@
   "billing_credit_balance_header_order": "Comando",
   "billing_credit_balance_movements_operation_credit": "Crédito",
   "billing_credit_balance_movements_operation_debit": "Débito",
+  "billing_credit_balance_movements_operation_debit_order": "Debit from order <a href=\"{{orderUrl}}\" target=\"_blank\">{{ orderId }}</a>",
   "billing_credit_balance_movements_load_error": "Ocorreu um erro aquando do carregamento dos movimentos do seu voucher.",
   "billing_credit_back": "Voltar aos meus vouchers"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/billing-ovhAccount.html
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/billing-ovhAccount.html
@@ -84,7 +84,7 @@
         <button
             class="oui-button oui-button_secondary"
             type="button"
-            data-ng-if="user && user.ovhSubsidiary === 'FR' && !(ovhAccountLoading || !ovhAccount.model.hasOvhAccount)"
+            data-ng-if="user && (user.ovhSubsidiary === 'FR' || user.ovhSubsidiary === 'DE') && !(ovhAccountLoading || !ovhAccount.model.hasOvhAccount)"
             data-ng-click="setAction('retrieve', ovhAccount.model, 'ovhaccount')"
             data-ng-disabled="ovhAccount.model.balance.value <= 0"
             data-track-on="click"

--- a/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/retrieve/billing-ovhAccount-retrieve.controller.js
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/retrieve/billing-ovhAccount-retrieve.controller.js
@@ -59,6 +59,13 @@ angular
       };
 
       $scope.initStep2 = () => {
+        $scope.price = $scope.accountModel.balanceText.replace(
+          /([0-9]|\s|\.|,)+/g,
+          $scope.retrieve.amount,
+        );
+      };
+
+      $scope.validate = () => {
         $scope.loading = true;
         BillingOvhAccount.retrieveMoney(
           $scope.accountModel.accountId,
@@ -66,42 +73,38 @@ angular
           $scope.retrieve.account.paymentMethodId,
         )
           .then((order) => {
+            atInternet.trackClick({
+              name: 'validation_transfer_bank_account',
+              type: 'action',
+              chapter1: 'payment_types',
+              chapter2: 'prepaid_account',
+            });
             $scope.$emit(OVH_ACCOUNT_EVENT.TRANSFER_TO_BANK_ACCOUNT);
             $scope.retrieveOrder = {
               ...order,
               prices: {
-                withTax: order.priceWithTax,
+                withTax: order.priceWithTax.text.replace('-', ''),
                 withoutTax: order.priceWithoutTax,
                 tax: order.tax,
               },
             };
+            $window.open($scope.retrieveOrder.url);
+            Alerter.success(
+              $translate.instant('ovhAccount_retrieve_success', {
+                t0: $scope.retrieveOrder.url,
+              }),
+            );
           })
           .catch((err) => {
             Alerter.alertFromSWS(
               $translate.instant('ovhAccount_retrieve_error'),
               err,
             );
-            $scope.resetAction();
           })
           .finally(() => {
             $scope.loading = false;
+            $scope.resetAction();
           });
-      };
-
-      $scope.retrieve = () => {
-        $window.open($scope.retrieveOrder.url);
-        Alerter.success(
-          $translate.instant('ovhAccount_retrieve_success', {
-            t0: $scope.retrieveOrder.url,
-          }),
-        );
-        $scope.resetAction();
-        atInternet.trackClick({
-          name: 'validation_transfer_bank_account',
-          type: 'action',
-          chapter1: 'payment_types',
-          chapter2: 'prepaid_account',
-        });
       };
     },
   );

--- a/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/retrieve/billing-ovhAccount-retrieve.html
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/ovhAccount/retrieve/billing-ovhAccount-retrieve.html
@@ -2,7 +2,7 @@
     <div
         data-wizard
         data-wizard-on-cancel="resetAction"
-        data-wizard-on-finish="retrieve"
+        data-wizard-on-finish="validate"
         data-wizard-title="::'ovhAccount_retrieve_title' | translate"
         data-wizard-confirm-button-text="::'wizard_pay' | translate"
     >
@@ -94,8 +94,10 @@
                 <div data-ng-if="!loading">
                     <span data-translate="ovhAccount_retrieve_resume_1"></span>
                     <strong
-                        class="text-danger"
-                        data-ng-bind-html="retrieveOrder.prices | ducPrice:user.ovhSubsidiary"
+                        data-translate="billing_price_ttc_label"
+                        data-translate-values="{
+                            price: price
+                        }"
                     >
                     </strong>
                     <span data-translate="ovhAccount_retrieve_resume_2"></span>(

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_de_DE.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Rückerstattung",
   "statements_operation_description_refund_unknown": "Rückerstattung",
   "billing_date_range_choose_custom_date": "Zeitraum festlegen",
-  "billing_date_range_text": "Vom {{t0}} bis zum {{t1}}"
+  "billing_date_range_text": "Vom {{t0}} bis zum {{t1}}",
+  "billing_price_ttc_label": "{{price}} inkl. MwSt."
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_en_GB.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Refund",
   "statements_operation_description_refund_unknown": "Refund",
   "billing_date_range_choose_custom_date": "Define the period ",
-  "billing_date_range_text": "From {{t0}} to {{t1}}"
+  "billing_date_range_text": "From {{t0}} to {{t1}}",
+  "billing_price_ttc_label": "{{price}} incl. VAT"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_es_ES.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Devolución",
   "statements_operation_description_refund_unknown": "Devolución",
   "billing_date_range_choose_custom_date": "Indicar un período",
-  "billing_date_range_text": "Del {{t0}} al {{t1}}"
+  "billing_date_range_text": "Del {{t0}} al {{t1}}",
+  "billing_price_ttc_label": "{{price}} IVA incl."
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_es_US.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_es_US.json
@@ -908,5 +908,6 @@
   "statements_operation_description_refund": "Remboursement",
   "statements_operation_description_refund_unknown": "Remboursement",
   "billing_date_range_choose_custom_date": "Indicar un período",
-  "billing_date_range_text": "De {{t0}} a {{t1}}"
+  "billing_date_range_text": "De {{t0}} a {{t1}}",
+  "billing_price_ttc_label": "{{price}} IVA incl."
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_CA.json
@@ -908,5 +908,6 @@
   "statements_operation_description_refund": "Remboursement",
   "statements_operation_description_refund_unknown": "Remboursement",
   "billing_date_range_choose_custom_date": "Définir une période",
-  "billing_date_range_text": "Du {{t0}} au {{t1}}"
+  "billing_date_range_text": "Du {{t0}} au {{t1}}",
+  "billing_price_ttc_label": "{{price}} TTC"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_fr_FR.json
@@ -173,8 +173,8 @@
   "ovhAccount_retrieve_amount_disponible": "Somme disponible :",
   "ovhAccount_retrieve_error": "Suite à une erreur votre opération n'a pas pu être effectuée.",
   "ovhAccount_retrieve_explanation": "Vous avez la possibilité de lancer un virement d'un montant choisi depuis votre compte client OVH vers un compte bancaire. Veuillez noter que seules les sommes issues des reversements et des remboursements sont disponibles.",
-  "ovhAccount_retrieve_success": "Votre demande a été traité avec succès. Afin de valider le bon de commande, <a href=\"{{t0}}\" target=\"_blank\">cliquez ici.</a>",
-  "ovhAccount_retrieve_resume_1": "Confirmez-vous le virement de",
+  "ovhAccount_retrieve_success": "Votre demande de virement a été traitée avec succès.",
+  "ovhAccount_retrieve_resume_1": "Confirmez-vous le virement d'un montant de",
   "ovhAccount_retrieve_resume_2": "de votre compte prépayé vers votre compte bancaire",
   "ovhAccount_retrieve_tips": "Cliquez sur \"Régler\" pour ouvrir le bon de commande. Il faut que votre navigateur accepte les pop-up.",
   "ovhAccount_create_alert": "Définir une alerte",
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Remboursement",
   "statements_operation_description_refund_unknown": "Remboursement",
   "billing_date_range_choose_custom_date": "Définir une période",
-  "billing_date_range_text": "Du {{t0}} au {{t1}}"
+  "billing_date_range_text": "Du {{t0}} au {{t1}}",
+  "billing_price_ttc_label": "{{price}} TTC"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_it_IT.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Rimborso",
   "statements_operation_description_refund_unknown": "Rimborso",
   "billing_date_range_choose_custom_date": "Definisci un periodo",
-  "billing_date_range_text": "Dal {{t0}} al {{t1}}"
+  "billing_date_range_text": "Dal {{t0}} al {{t1}}",
+  "billing_price_ttc_label": "{{price}} IVA incl."
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_pl_PL.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Zwrot",
   "statements_operation_description_refund_unknown": "Zwrot",
   "billing_date_range_choose_custom_date": "Zdefiniuj okres",
-  "billing_date_range_text": "Od {{t0}} do {{t1}}"
+  "billing_date_range_text": "Od {{t0}} do {{t1}}",
+  "billing_price_ttc_label": "{{price}} brutto"
 }

--- a/packages/manager/apps/dedicated/client/app/billing/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/billing/translations/Messages_pt_PT.json
@@ -903,5 +903,6 @@
   "statements_operation_description_refund": "Reembolso",
   "statements_operation_description_refund_unknown": "Reembolso",
   "billing_date_range_choose_custom_date": "Definir um período",
-  "billing_date_range_text": "De {{t0}} a {{t1}}"
+  "billing_date_range_text": "De {{t0}} a {{t1}}",
+  "billing_price_ttc_label": "{{price}} IVA incl."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

## Description

Enable  cash out from OVH Account for DE subsidiary

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
