### PR TITLE
ci: update label for public-cloud application [skip ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,7 @@ tests:
   - packages/manager/tools/testcafe/**
 translation required:
   - packages/**/Messages_fr_FR.json
-univers-public-cloud:
+universe-public-cloud:
   - packages/manager/*/pci/**
   - packages/manager/apps/public-cloud/**
 universe-bare-metal-cloud:


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :green_heart: Continuous Integration

d5b9226 - ci: update label for public-cloud application [skip ci]

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

