### PR TITLE
fix(server.interfaces): fix ola detection on legacy

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/ola.class.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/ola.class.js
@@ -1,4 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
+import { VIRTUAL_TYPE } from './interfaces.constants';
 
 import { OLA_MODES } from './ola-configuration/ola-configuration.constants';
 
@@ -22,6 +23,9 @@ export default class Ola {
   }
 
   isConfigured() {
-    return this.interfaces.length === 1;
+    return (
+      this.interfaces.length === 1 &&
+      this.interfaces[0].type === VIRTUAL_TYPE.vrackAggregation
+    );
   }
 }


### PR DESCRIPTION
Signed-off-by: jjuret <julien.juret.ext@ovhcloud.com>


| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w14`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-33511
| License          | BSD 3-Clause

this PR is because we looking if a server have only 1 interface to know if have OLA because new server have double aggregation by default. Here i just double check if this only interface is aggregated.
