### PR TITLE
fix(telephony.ovhpabx.dialplan.extension.edit): fix ccs scheduler link

### DIFF
--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/dialplan/extension/edit/edit.html
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/dialplan/extension/edit/edit.html
@@ -214,6 +214,9 @@
                     class="alert alert-info mb-0"
                     role="alert"
                     data-translate="telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos"
+                    data-translate-values="{
+                        sref: 'telecom.telephony.billingAccount.alias.details.configuration.schedulerOvhPabx',
+                    }"
                     data-translate-compile
                 ></div>
 

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_de_DE.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Zeitschlitz 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Zeitschlitz 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Zeitschlitz 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_en_GB.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Créneau 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Créneau 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Créneau 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_es_ES.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Franja 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Franja 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Franja 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_es_US.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_es_US.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Franja 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Franja 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Franja 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_fr_CA.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Créneau 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Créneau 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Créneau 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_fr_FR.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Créneau 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Créneau 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Créneau 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_it_IT.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Fascia 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Fascia 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Fascia 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_pl_PL.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Créneau 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Créneau 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Créneau 3",

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/translations/Messages_pt_PT.json
@@ -51,7 +51,7 @@
   "telephony_number_feature_ovh_pabx_step_conditions_none": "Aucune condition définie",
   "telephony_number_feature_ovh_pabx_step_no_conditions": "Aucune condition",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler": "Jours exceptionnels",
-  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"telecom.telephony.alias.configuration.scheduler.ovhPabx\">sur cette page</a>.",
+  "telephony_number_feature_ovh_pabx_step_conditions_scheduler_infos": "Vous pouvez paramétrer vos jours de fermetures exceptionnelles <a data-ui-sref=\"{{ sref }}\">sur cette page</a>.",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler1": "Créneau 1",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler2": "Créneau 2",
   "telephony_number_feature_ovh_pabx_step_conditions_scheduler_scheduler3": "Créneau 3",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-33163
| License          | BSD 3-Clause

## Description

fix wrong link to scheduler infos in CCS