### PR TITLE
fix(deps): add missing @ovh-ux/manager-advices dependency

### DIFF
--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ovh-ux/manager-account-migration": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-account-sidebar": "^2.0.0 || ^3.0.0",
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-at-internet-configuration": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-banner": "^1.1.3",
     "@ovh-ux/manager-beta-preference": "^1.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     |  no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

99ca5da - fix(deps): add missing @ovh-ux/manager-advices dependency

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

