### PR TITLE
fix(deps): add missing deps related to @ovh-ux/manager-advices

### DIFF
--- a/packages/manager/apps/exchange/package.json
+++ b/packages/manager/apps/exchange/package.json
@@ -18,11 +18,13 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-exchange-app' --include-dependencies -- npm run dev:watch --if-present"
   },
   "dependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^12.0.0",
     "@ovh-ux/manager-exchange": "^2.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
+    "@ovh-ux/ng-at-internet": "^5.5.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.1",
     "@ovh-ux/ng-ovh-http": "^5.0.1",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@ovh-ux/manager-account-sidebar": "^3.3.1",
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-freefax": "^6.0.0 || ^7.0.0",

--- a/packages/manager/apps/office/package.json
+++ b/packages/manager/apps/office/package.json
@@ -18,11 +18,13 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-office-app' --include-dependencies -- npm run dev:watch --if-present"
   },
   "dependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/manager-office": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
+    "@ovh-ux/ng-at-internet": "^5.5.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.1",
     "@ovh-ux/ng-ovh-payment-method": "^8.0.0",

--- a/packages/manager/apps/sharepoint/package.json
+++ b/packages/manager/apps/sharepoint/package.json
@@ -18,11 +18,13 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-sharepoint-app' --include-dependencies -- npm run dev:watch --if-present"
   },
   "dependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/manager-sharepoint": "^2.0.0",
+    "@ovh-ux/ng-at-internet": "^5.5.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.1",
     "@ovh-ux/ng-ovh-payment-method": "^8.0.0",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -19,6 +19,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-sms-app' --include-dependencies -- npm run dev:watch --if-present"
   },
   "dependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -19,6 +19,7 @@
     "punycode": "^1.4.1"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.4.1",

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -20,6 +20,7 @@
     "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",

--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -20,12 +20,13 @@
     "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.1",
     "@ovh-ux/ng-ovh-utils": "^14.0.13",
     "@ovh-ux/ng-ovh-web-universe-components": "^8.0.0 || ^9.0.0",
-    "@ovh-ux/ui-kit": "^4.4.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.3",
+    "@ovh-ux/ui-kit": "^4.4.1",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -18,12 +18,13 @@
     "punycode": "^1.4.1"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
+    "@ovh-ux/ng-at-internet": "^5.4.1",
     "@ovh-ux/ng-ovh-utils": "^14.0.13",
-    "@ovh-ux/ui-kit": "^4.4.1",
     "@ovh-ux/ng-ovh-web-universe-components": "^9.0.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.3",
-    "@ovh-ux/ng-at-internet": "^5.4.1",
+    "@ovh-ux/ui-kit": "^4.4.1",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -21,6 +21,7 @@
     "bootstrap": "~3.3.7"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-config": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | no
| License          | BSD 3-Clause

## Description

78f1f55 - fix(deps): add missing deps related to @ovh-ux/manager-advices

Add some missing dependencies such as:
- @ovh-ux/manager-advices
- @ovh-ux/ng-at-internet

For following standalone applications:
- exchange
- freefax
- office
- sharepoint
- sms

Relates to #4597

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
