### PR TITLE
fix(dedicated-cloud.license): display error on spla license activation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/license/enable/dedicatedCloud-license-enable.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/license/enable/dedicatedCloud-license-enable.controller.js
@@ -39,7 +39,7 @@ export default class {
         this.goBack(
           `${this.$translate.instant(
             'dedicatedCloud_tab_licences_active_spla_load_fail',
-          )}: ${error.message || error}`,
+          )}: ${error.data.message || error.data}`,
           'danger',
         );
       })


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-6686
| License          | BSD 3-Clause

## Description

Display correct error when SPLA license activation failed

ref: MANAGER-6686

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>