### PR TITLE
fix(billing): manual renew url for apac subs

### DIFF
--- a/packages/manager/apps/dedicated/client/app/config/constants.config.js
+++ b/packages/manager/apps/dedicated/client/app/config/constants.config.js
@@ -1120,6 +1120,8 @@ const constants = {
       CZ: 'http://www.ovh.cz/podpora/new_nic.xml',
     },
     billingRenew: {
+      AU:
+        'https://ca.ovh.com/au/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
       CA:
         'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
       CZ:
@@ -1154,6 +1156,8 @@ const constants = {
         'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
       RU:
         'https://www.ovh.co.uk/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
+      SG:
+        'https://ca.ovh.com/sg/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
       SN:
         'https://www.ovh.sn/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
       TN:

--- a/packages/manager/modules/billing/src/components/services-actions/service-actions.constants.js
+++ b/packages/manager/modules/billing/src/components/services-actions/service-actions.constants.js
@@ -11,6 +11,7 @@ export const SERVICE_TYPE = {
 
 export const RENEW_URL = {
   default: '/cgi-bin/order/renew.cgi?domainChooser=',
+  AU: 'https://ca.ovh.com/au/cgi-bin/order/renew.cgi?domainChooser=',
   CA: 'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser=',
   CZ: 'https://www.ovh.cz/cgi-bin/order/renew.cgi?domainChooser=',
   DE: 'https://www.ovh.de/cgi-bin/order/renew.cgi?domainChooser=',
@@ -28,6 +29,7 @@ export const RENEW_URL = {
   PT: 'https://www.ovh.pt/cgi-bin/order/renew.cgi?domainChooser=',
   QC: 'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser=',
   RU: 'https://www.ovh.co.uk/cgi-bin/order/renew.cgi?domainChooser=',
+  SG: 'https://ca.ovh.com/sg/cgi-bin/order/renew.cgi?domainChooser=',
   SN: 'https://www.ovh.sn/cgi-bin/order/renew.cgi?domainChooser=',
   TN: 'https://www.ovh.com/tn/cgi-bin/order/renew.cgi?domainChooser=',
   WE: 'https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser=',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-34353
| License          | BSD 3-Clause

## Description

Fix manual renew url for APAC subsidiaries

ref: DTRSD-34353

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
