### PR TITLE
feat(cloud.project): handle quantity unit in billing display

### DIFF
--- a/packages/manager/modules/pci/src/components/project/billing/resource-usage/controller.js
+++ b/packages/manager/modules/pci/src/components/project/billing/resource-usage/controller.js
@@ -3,4 +3,14 @@ export default class BillingResourceUsageCtrl {
   constructor(CucRegionService) {
     this.CucRegionService = CucRegionService;
   }
+
+  static hourlyQuantity(quantity) {
+    switch (quantity.unit) {
+      case 'Minute':
+        return (quantity.value / 60).toFixed(2);
+      case 'Hour':
+      default:
+        return quantity.value;
+    }
+  }
 }

--- a/packages/manager/modules/pci/src/components/project/billing/resource-usage/index.html
+++ b/packages/manager/modules/pci/src/components/project/billing/resource-usage/index.html
@@ -28,7 +28,7 @@
     >
         <span
             data-translate="pci_billing_private_registry_consumption_value"
-            data-translate-values="{ value: $row.quantity.value }"
+            data-translate-values="{ value: $ctrl.constructor.hourlyQuantity($row.quantity) }"
         >
         </span>
     </oui-datagrid-column>


### PR DESCRIPTION
Signed-off-by: Christophe Rannou <christophe.rannou@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

In the billing control part of the Public Cloud control panel when displaying hourly usage the unit of the actual billed quantity is not handled leading to inconsistent values. 
