### PR TITLE
fix(ip): ip firewall rules are not shown

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip/firewall/ip-ip-firewall.html
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/firewall/ip-ip-firewall.html
@@ -70,7 +70,7 @@
             </tbody>
 
             <tbody data-ng-if="!rulesLoading">
-                <tr data-ng-repeat="rule in rules.list.results">
+                <tr data-ng-repeat="rule in rules.list.results track by $index">
                     <th scope="row" data-ng-bind="rule.sequence"></th>
                     <td
                         data-translate="{{ 'ip_firewall_rule_' + rule.action }}"


### PR DESCRIPTION
Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-34405
| License          | BSD 3-Clause

## Description

Firewall rules are not visible if the rules contain duplicate records. This creates confusion for customers and they are trying to create them again.
