### PR TITLE
fix(ip): enabled pagination for ip parking

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.controller.js
@@ -264,10 +264,6 @@ angular.module('Module.ip.controllers').controller(
         params.type = 'failover';
       } else if ($scope.serviceName === '_PARK') {
         params.type = 'failover';
-        params.pageSize = 5000;
-        params.pageNumber = 1;
-        $location.search('page', params.pageNumber);
-        $location.search('pageSize', params.pageSize);
       } else if ($scope.serviceName && $scope.serviceName !== '_ALL') {
         params.serviceName = $scope.serviceName;
       }
@@ -353,6 +349,7 @@ angular.module('Module.ip.controllers').controller(
 
     $scope.selectService = ({ serviceName }) => {
       $scope.pageNumber = 1;
+      $scope.paginationOffset = 1;
       $scope.serviceName = serviceName;
       $location.search('page', $scope.pageNumber);
       $location.search('serviceName', serviceName);

--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
@@ -639,7 +639,7 @@
             </table>
 
             <oui-pagination
-                data-ng-if="!loading.table && ipsCount > 0 && serviceName !== '_PARK'"
+                data-ng-if="!loading.table && ipsCount > 0"
                 data-current-offset="paginationOffset"
                 data-page-size="pageSize"
                 data-total-items="ipsCount"


### PR DESCRIPTION
ip page times out and shows error while loading ip parking when there is more than 300 entries

ref: DTRSD-35234

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-35234
| License          | BSD 3-Clause

## Description

There is no pagination enabled while loading IP parking. When there are more than 300 entries the API takes too long to respond and times out. Because of this UI shows an error. This can be reproducible with the customer NIC mentioned in the associated Jira ticket.

I have enabled pagination for IP parking. This makes sure only 10 records are fetched at once and shown on UI.
