### PR TITLE
feat(webhosting): move infra statistics from dashboard to statistics tab

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
@@ -36,7 +36,6 @@
   "hosting_dashboard_disk_usage_total": "Espace utilisé :",
   "hosting_dashboard_disk_usage_configuration": "{{t0}} sont alloués à la configuration du serveur",
   "hosting_dashboard_trafic_usage": "Traffic utilisé",
-  "hosting_dashboard_hosting_activities": "Activités de l’hébergement",
   "hosting_dashboard_php_support_SECURITY_FIXES": "Vous utilisez actuellement une version de PHP qui n'évoluera plus. Seules les failles de sécurité seront corrigées. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_END_OF_LIFE": "Vous utilisez actuellement une version de PHP qui n'est plus maintenue. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_BETA": "Version beta",

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -848,19 +848,5 @@
                 </div>
             </div>
         </div>
-
-        <div class="row d-md-flex">
-            <div class="col-md-12">
-                <div class="oui-tile mt-5" data-ng-if="!hosting.isCloudWeb">
-                    <h2
-                        class="oui-tile__title oui-heading_4"
-                        data-translate="hosting_dashboard_hosting_activities"
-                    ></h2>
-                    <div
-                        data-ng-include="'hosting/statistics/STATISTICS.html'"
-                    ></div>
-                </div>
-            </div>
-        </div>
     </div>
 </div>

--- a/packages/manager/apps/web/client/app/hosting/user-logs/USER_LOGS.html
+++ b/packages/manager/apps/web/client/app/hosting/user-logs/USER_LOGS.html
@@ -43,6 +43,7 @@
                 ></span>
             </a>
         </div>
+
         <div data-ng-if="ctrl.logs.logs" class="mb-3">
             <h3 data-translate="hosting_user_logs_dashboard_logs"></h3>
             <p
@@ -67,6 +68,13 @@
             </a>
         </div>
     </div>
+
+    <div data-ng-if="!hosting.isCloudWeb">
+        <h3 data-translate="hosting_user_logs_dashboard_infra_stats"></h3>
+
+        <div data-ng-include="'hosting/statistics/STATISTICS.html'"></div>
+    </div>
+
     <div>
         <h3 data-translate="hosting_user_logs_dashboard_users"></h3>
         <p data-translate="hosting_user_logs_dashboard_users_description"></p>

--- a/packages/manager/apps/web/client/app/hosting/user-logs/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/user-logs/translations/Messages_fr_FR.json
@@ -2,10 +2,10 @@
   "hosting_user_logs": "Statistiques et Logs",
   "hosting_user_logs_guide_help": "Besoin d'aide pour les statistiques et logs de votre site ?",
   "hosting_user_logs_guide_consult": "Consultez nos guides en ligne.",
-  "hosting_user_logs_dashboard_stats": "Website statistics",
+  "hosting_user_logs_dashboard_stats": "Statistiques de visites",
   "hosting_user_logs_dashboard_stats_description": "Pour vous aider à suivre et piloter le trafic de vos sites web, utilisez l’outil de visualisation des statistiques de fréquentation et de mesure d’audience des sites web de votre hébergement mutualisé OVHcloud Web Statistics.",
   "hosting_user_logs_dashboard_go_to_stats": "Voir les statistiques",
-  "hosting_user_logs_dashboard_logs": "Website Logs ",
+  "hosting_user_logs_dashboard_logs": "Logs du site web",
   "hosting_user_logs_dashboard_logs_description": "Les logs de vos sites sont disponibles en moins de 15 minutes, ils vous permettent donc de vérifier la santé technique de votre site ou de manipuler les logs de votre plateforme quasiment en direct.",
   "hosting_user_logs_dashboard_go_to_logs": "Voir les logs",
   "hosting_user_logs_dashboard_users": "Administration des utilisateurs",
@@ -19,5 +19,6 @@
   "hosting_user_logs_dashboard_users_description": "Vous pouvez créer de nouveaux utilisateurs si vous désirez ouvrir l'accès à l'interface OVHcloud Web Statistics à d'autres collaborateurs que ceux spécifiés comme contacts principaux (administratif, technique et facturation). Ces comptes seront administrables dans le tableau ci-dessous :",
   "hosting_user_logs_table_popover_modify": "Modifier",
   "hosting_user_logs_table_popover_update_password": "Changer le mot de passe",
-  "hosting_user_logs_table_popover_delete": "Supprimer"
+  "hosting_user_logs_table_popover_delete": "Supprimer",
+  "hosting_user_logs_dashboard_infra_stats": "Statistiques de l'infrastructure"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feature/DTRSD-37623`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6874
| License          | BSD 3-Clause

## Description

A new "statistics & logs" tabs was revamped few months ago. It didn't include infrastructure statistics. But users doesn't see in the dashboard theses statistics. And the feedback was: thanks for the visitors statistics, but can we have infrastructure statistics?
