### PR TITLE
feat(modem.ports): add internal port end for port mapping

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.constants.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.constants.js
@@ -1,0 +1,13 @@
+export const PACK_XDSL = {
+  min: 1,
+  max: 65535,
+  maxlength: 5,
+  portExternalPortStartPlaceHolder: '80',
+  portExternalPortEndPlaceHolder: '85',
+  internalPortPlaceHolder: '8080',
+  internalPortEndPlaceHolder: '8085',
+};
+
+export default {
+  PACK_XDSL,
+};

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.controller.js
@@ -3,10 +3,11 @@ import map from 'lodash/map';
 import remove from 'lodash/remove';
 import set from 'lodash/set';
 
+import { PACK_XDSL } from './ports.constants';
+
 export default /* @ngInject */ function XdslModemPortsCtrl(
   $stateParams,
   $translate,
-  $scope,
   OvhApiXdslModemPort,
   TucToast,
   PackXdslModemPortObject,
@@ -17,6 +18,7 @@ export default /* @ngInject */ function XdslModemPortsCtrl(
   self.loader = true;
   this.validator = tucValidator;
   this.mediator = TucPackXdslModemMediator;
+  this.PACK_XDSL = PACK_XDSL;
 
   this.protocol = ['TCP', 'UDP'];
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.factory.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.factory.js
@@ -16,6 +16,7 @@ export default /* @ngInject */ (OvhApiXdsl, $translate, TucToast) => {
     internalClient: '',
     allowedRemoteIp: '',
     internalPort: null,
+    internalPortEnd: null,
     id: null,
   };
 
@@ -86,10 +87,11 @@ export default /* @ngInject */ (OvhApiXdsl, $translate, TucToast) => {
         );
         return self;
       })
-      .catch(() => {
+      .catch((error) => {
         TucToast.error(
           $translate.instant('xdsl_modem_ports_add_error', {
             name: self.name,
+            reason: error.data?.message || '',
           }),
         );
       })

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/ports.html
@@ -65,6 +65,10 @@
                             data-translate="xdsl_modem_ports_internal_port"
                         ></span>
                     </th>
+                    <th
+                        scope="col"
+                        data-translate="xdsl_modem_ports_internal_port_end"
+                    ></th>
                     <th data-translate="common_actions"></th>
                 </tr>
             </thead>
@@ -99,7 +103,13 @@
                     <td
                         data-title="{{ 'xdsl_modem_ports_internal_port' | translate }}"
                         data-ng-bind="port.internalPort"
-                    ></td>
+                    >
+                    </td>
+                    <td
+                        data-title="{{:: 'xdsl_modem_ports_internal_port_end' | translate }}"
+                        data-ng-bind="port.internalPortEnd"
+                    >
+                    </td>
                     <td class="dropdown">
                         <div
                             class="btn-group"
@@ -218,11 +228,11 @@
                             id="portExternalPortStart"
                             class="form-control"
                             data-ng-model="port.tempValue.externalPortStart"
-                            maxlength="5"
-                            min="1"
-                            max="65535"
+                            maxlength="{{PortCtrl.PACK_XDSL.maxlength}}"
+                            min="{{PortCtrl.PACK_XDSL.min}}"
+                            max="{{PortCtrl.PACK_XDSL.max}}"
                             required
-                            placeholder="80"
+                            placeholder="{{PortCtrl.PACK_XDSL.portExternalPortStartPlaceHolder}}"
                         />
                     </td>
 
@@ -242,11 +252,11 @@
                             id="portExternalPortEnd"
                             class="form-control"
                             data-ng-model="port.tempValue.externalPortEnd"
-                            maxlength="5"
-                            min="1"
-                            max="65535"
+                            maxlength="{{PortCtrl.PACK_XDSL.maxlength}}"
+                            min="{{PortCtrl.PACK_XDSL.min}}"
+                            max="{{PortCtrl.PACK_XDSL.max}}"
                             required
-                            placeholder="85"
+                            placeholder="{{PortCtrl.PACK_XDSL.portExternalPortEndPlaceHolder}}"
                         />
                     </td>
 
@@ -307,11 +317,33 @@
                             id="internalPort"
                             class="form-control"
                             data-ng-model="port.tempValue.internalPort"
-                            placeholder="8080"
-                            maxlength="5"
-                            min="1"
+                            maxlength="{{PortCtrl.PACK_XDSL.maxlength}}"
+                            min="{{PortCtrl.PACK_XDSL.min}}"
+                            max="{{PortCtrl.PACK_XDSL.max}}"
+                            placeholder="{{PortCtrl.PACK_XDSL.internalPortPlaceHolder}}"
                             required
-                            max="65535"
+                        />
+                    </td>
+                    <td
+                        data-title="{{ 'xdsl_modem_ports_internal_port_end' | translate }}"
+                        class="form-group"
+                        data-ng-class="{ 'has-error': localForm.internalPortEnd.$touched && localForm.internalPortEnd.$invalid }"
+                    >
+                        <label
+                            for="internalPortEnd"
+                            data-translate="xdsl_modem_ports_port_end"
+                            class="sr-only"
+                        ></label>
+                        <input
+                            type="number"
+                            name="internalPortEnd"
+                            id="internalPortEnd"
+                            class="form-control"
+                            data-ng-model="port.tempValue.internalPortEnd"
+                            maxlength="{{PortCtrl.PACK_XDSL.maxlength}}"
+                            min="{{PortCtrl.PACK_XDSL.min}}"
+                            max="{{PortCtrl.PACK_XDSL.max}}"
+                            placeholder="{{PortCtrl.PACK_XDSL.internalPortEndPlaceHolder}}"
                         />
                     </td>
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/router/ports/translations/Messages_fr_FR.json
@@ -7,8 +7,9 @@
   "xdsl_modem_ports_port_end": "Port de fin",
   "xdsl_modem_ports_protocol": "Protocole",
   "xdsl_modem_ports_internal_client": "IP de destination",
-  "xdsl_modem_ports_internal_port": "Port interne",
-  "xdsl_modem_ports_internal_port_tooltip": "Si le port de fin est différent du port de début, la redirection sera effective vers une plage de port interne de taille équivalante commençant à la valeur spécifiée dans \"Port Interne\"",
+  "xdsl_modem_ports_internal_port": "Port interne de début",
+  "xdsl_modem_ports_internal_port_end": "Port interne de fin",
+  "xdsl_modem_ports_internal_port_tooltip": "Si le port de fin est différent du port de début, la redirection sera effective vers une plage de port interne de taille équivalente commençant à la valeur spécifiée dans \"Port Interne\"",
   "xdsl_modem_ports_add": "Ajouter une Redirection de Ports",
   "xdsl_modem_ports_delete_really": "Êtes-vous sûr(e) de vouloir supprimer cette redirection de port ?",
   "xdsl_modem_ports_placeholder_redirection": "HTTP",
@@ -19,7 +20,7 @@
   "xdsl_modem_ports_firewall_info": "Afin d'assurer le bon fonctionnement de vos règles de redirections, le pare-feu de votre modem doit-être désactiver.",
   "xdsl_modem_ports_firewall_explaination": "La sécurité de votre réseau n'en sera pas impactée. Le pare-feu laissera seulement passer les requêtes entrantes à destination d'une IP faisant l'objet d'une règle de redirection.",
   "xdsl_modem_ports_read_error": "Oups ! Nous n'avons pas réussi à lire vos redirections de ports.",
-  "xdsl_modem_ports_add_error": "Impossible d'ajouter la redirection de port <strong>{{ name }}</strong>",
+  "xdsl_modem_ports_add_error": "Impossible d'ajouter la redirection de port <strong>{{ name }}</strong> : {{ reason }}",
   "xdsl_modem_ports_edit_error": "Impossible de mettre à jour la redirection de port <strong>{{ name }}</strong>",
   "xdsl_modem_ports_del_error": "Impossible de mettre à jour la redirection de port <strong>{{ name }}</strong>"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w27`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-398
| License          | BSD 3-Clause

## Description

<!-- Write a brief description of the changes introduced by this PR -->
