### PR TITLE
fix(training.jobs.resubmit): update confirm message

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/resubmit/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
   "pci_projects_project_training_jobs_common_cancel": "Annuler",
   "pci_projects_project_training_jobs_resubmit": "Relancer",
-  "pci_projects_project_training_jobs_confirm_resubmit": "Êtes-vous sûr de vouloir relancer ce job ?"
+  "pci_projects_project_training_jobs_confirm_resubmit": "Êtes-vous sûr de vouloir lancer un nouveau job avec les mêmes paramètres ?"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`  <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MLS-1596 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

QA said that the title of the ai-training job resubmit modal was confusing because user would expect the same job to be reused instead of a new one being created. So the title has been updated to make it more explicit
