### PR TITLE
fix(offers): change display price for install fees

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
@@ -174,7 +174,8 @@
                                         </strong>
                                         <br/>
                                         <del>
-                                            <small data-ng-bind-html="offer.promotion.installFee.discount.text | tucFormatPrice"></small>
+                                            <small data-ng-bind-html="offer.promotion.installFee.discount.text | tucFormatPrice: { withoutTax: false }"></small>
+                                            <small data-translate="common_without_tax"></small>
                                         </del>
                                     </div>
                                 </td>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
@@ -139,7 +139,7 @@
   "telecom_pack_migration_pto_yes_not_known_description": "Avez-vous bien vérifié que vous ne disposez pas de la référence de la prise optique (PTO) ? Cela peut avoir avoir une incidence sur le délai de votre raccordement.",
   "telecom_pack_migration_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "telecom_pack_migration_promotion_subscription_months_offered": "{{ duration }} mois offerts",
-  "telecom_pack_migration_promotion_installation_fees_offered": "Frais de mises en service offerts",
+  "telecom_pack_migration_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "telecom_pack_migration_confirm_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
   "telecom_pack_migration_confirm_first_year_promo": "Réduction sur la première année",
   "telecom_pack_migration_confirm_modem_rental": "Location modem",

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
@@ -139,7 +139,7 @@
   "telecom_pack_migration_pto_yes_not_known_description": "Avez-vous bien vérifié que vous ne disposez pas de la référence de la prise optique (PTO) ? Cela peut avoir avoir une incidence sur le délai de votre raccordement.",
   "telecom_pack_migration_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "telecom_pack_migration_promotion_subscription_months_offered": "{{ duration }} mois offerts",
-  "telecom_pack_migration_promotion_installation_fees_offered": "Frais de mises en service offerts",
+  "telecom_pack_migration_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "telecom_pack_migration_confirm_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
   "telecom_pack_migration_confirm_first_year_promo": "Réduction sur la première année",
   "telecom_pack_migration_confirm_modem_rental": "Location modem",

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
@@ -141,7 +141,10 @@
                             >
                                 <span
                                     ng-if="offer.prices.installFees.price"
-                                    data-ng-bind-html="offer.prices.installFees.price.text | tucFormatPrice"
+                                    data-ng-bind-html="offer.prices.installFees.price.text | tucFormatPrice { withoutTax: false }"
+                                ></span>
+                                <span
+                                    data-translate="common_without_tax"
                                 ></span>
 
                                 <!-- Other Promotion -->
@@ -160,8 +163,11 @@
                                     <del>
                                         <span
                                             class="text-small"
-                                            data-ng-bind-html="offer.prices.promotion.installFee.discount.text | tucFormatPrice">
+                                            data-ng-bind-html="offer.prices.promotion.installFee.discount.text | tucFormatPrice: { withoutTax: false }">
                                         </span>
+                                        <span
+                                            data-translate="common_without_tax"
+                                        ></span>
                                     </del>
                                 </div>
                             </td>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
@@ -249,6 +249,6 @@
   "pack_move_building_details_error": "Une erreur s'est produite lors de la récupération des informations sur votre bâtiment",
   "pack_move_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
-  "pack_move_promotion_installation_fees_offered": "Frais de mises en service offerts",
+  "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport)."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
@@ -249,6 +249,6 @@
   "pack_move_building_details_error": "Une erreur s'est produite lors de la récupération des informations sur votre bâtiment",
   "pack_move_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
-  "pack_move_promotion_installation_fees_offered": "Frais de mises en service offerts",
+  "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport)."
 }


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-399
| License          | BSD 3-Clause

## Description

- for offers move and offers migration, install fees price is just HT (and not HT/month)
- fix typo into french label for install fees

