### PR TITLE
feat(sidebar): remove beta label for ai-training

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.constant.js
@@ -127,7 +127,7 @@ export const getMenu = ({ DBAAS_LOGS_URL }) => [
     subitems: [
       {
         id: 'training',
-        beta: true,
+        new: true,
         options: {
           state: 'pci.projects.project.training',
         },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6682
| License          | BSD 3-Clause

## Description

Release date: calendar 01/06/2021

### :sparkles: Features

95c9aeb  - feat(sidebar): remove beta label for ai-training

Add label `new`.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

