### PR TITLE
fix(dedicated): handle double os install display

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
@@ -171,7 +171,7 @@
                                 <oui-action-menu-item
                                     data-on-click="$ctrl.openOsInstallation('choice')"
                                     data-disabled="$ctrl.dedicatedServer.$scope.disable.reboot || $ctrl.dedicatedServer.$scope.disable.byOtherTask"
-                                    data-ng-if="!$ctrl.server.os && !$ctrl.dedicatedServer.$scope.disable.installationInProgress"
+                                    data-ng-if="!$ctrl.server.os && !$ctrl.dedicatedServer.$scope.disable.installationInProgress && $ctrl.ola.isConfigured()"
                                 >
                                     <span
                                         data-translate="server_configuration_installation_button"


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-6779
| License          | BSD 3-Clause

## Description

small fix to prevent double display of install button
