### PR TITLE
fix: prevent to reach clickable items when element is hidden

### DIFF
--- a/packages/manager/modules/account-sidebar/src/index.less
+++ b/packages/manager/modules/account-sidebar/src/index.less
@@ -17,6 +17,10 @@
 
   .manager-hub-user-panel {
     width: 0;
+    a,
+    button {
+      pointer-events: none;
+    }
   }
 
   .sidebar-show() {
@@ -27,6 +31,10 @@
 
     .manager-hub-user-panel {
       width: @ovh-sidebar-width;
+      a,
+      button {
+        pointer-events: auto;
+      }
     }
   }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

In the manager when clicking next to the scrollbar, some account sidebar links can be triggered despite the sidebar being hidden. Also visible when inspecting dom elements.
This PR makes links & button unclickable when the sidebar is hidden.