### PR TITLE
fix(project): prevent displaying duplicate quota message

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/project.html
+++ b/packages/manager/modules/pci/src/projects/project/project.html
@@ -49,7 +49,10 @@
                             <ovh-manager-incident-banner
                                 service-name="$ctrl.project.project_id"
                             ></ovh-manager-incident-banner>
-                            <oui-message data-type="info">
+                            <oui-message
+                                data-type="info"
+                                data-ng-if="!$ctrl.projectQuotaAboveThreshold"
+                            >
                                 <p
                                     data-translate="pci_projects_project_quota_warning_message"
                                     data-translate-values="{ quotaUrl: 'pci.projects.project.quota' }"


### PR DESCRIPTION
ref: DTRSD-32397

Signed-off-by: mohammed-zahaf <mohammed.zahaf.ext@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-32397
| License          | BSD 3-Clause

## Description

Currently and in certain case we had two banner which explain same things.
The requirement if the yellow banner is displayed we must "hide" the blue banner.
