### PR TITLE
fix(server.installation.ovh): add check before displaying partitioning

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -388,6 +388,10 @@ angular
         distribution,
         bypass,
       ) {
+        $scope.installation.noPartitioning = distribution.noPartitioning;
+        if (distribution.noPartitioning) {
+          $scope.installation.customInstall = false;
+        }
         // if saveSelectDistribution is not null, a partition has personnalisation
         // in progress and confirmation to delete is already display
         if ($scope.installation.saveSelectDistribution && !bypass) {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
@@ -225,7 +225,7 @@
                     class="checkbox"
                     data-ng-hide="installation.warningExistPartition || informations.gabaritName != null"
                     data-ng-class="{
-                         'disabled': informations.gabaritName != null
+                         'disabled': informations.gabaritName != null || installation.noPartitioning
                      }"
                 >
                     <label>


### PR DESCRIPTION


| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-6780
| License          | BSD 3-Clause

## Description

Hide checkbox if unavalable because partitionning doesn't work on some OS.
