### PR TITLE
fix(logs.detail): update graylog api URL

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.service.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.service.js
@@ -274,7 +274,7 @@ export default class LogsHomeService {
     set(
       accountDetails,
       'graylogApiUrl',
-      `${accountDetails.graylogApiUrl}/api-browser`,
+      `${accountDetails.graylogApiUrl}/api-browser/global/index.html`,
     );
     set(
       accountDetails,


### PR DESCRIPTION
Hello,

This PR will allow LDP customers to reach Graylog API on its new url. 

ref: OB-3992

Thanks for your time on this.