### PR TITLE
fix(hub): payment status tile tracking

### DIFF
--- a/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
+++ b/packages/manager/modules/hub/src/components/payment-status-tile/payment-status-tile.html
@@ -38,7 +38,7 @@
                             data-ng-href="{{:: service.url }}"
                             data-ng-bind="::service.domain"
                             data-track-on="click"
-                            data-track-name="{{ ::$ctrl.trackingPrefix + 'activity::payment-status::go-to-service' }}"
+                            data-track-name="{{ ::$ctrl.trackingPrefix + '::activity::payment-status::go-to-service' }}"
                         >
                         </a>
                         <span


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-6849
| License          | BSD 3-Clause

## Description

Update tracking key on payment status tile

ref: MANAGER-6849

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
