### PR TITLE
fix(private-database): use right translations path location

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/dashboard/private-database.module.js
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/private-database.module.js
@@ -27,6 +27,6 @@ angular
 
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */)
-  .run(/* @ngTranslationsInject:json ../hosting/translations */);
+  .run(/* @ngTranslationsInject:json ./../../hosting/dashboard/translations */);
 
 export default moduleName;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-37354
| License          | BSD 3-Clause

## Description

Translations are missing when user tries to import database.

### :bug: Bug Fixes

0eec982 - fix(private-database): use right translations path location

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>