### PR TITLE
Feat/manager 6801: allow customers to add new regions

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.component.js
@@ -11,6 +11,7 @@ export default {
     projectId: '<',
     privateNetworks: '<',
     quotas: '<',
+    loadQuotas: '<',
     regions: '<',
     versions: '<',
     sendKubeTrack: '<',

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.html
@@ -2,12 +2,12 @@
 
 <cui-message-container data-messages="$ctrl.messages"></cui-message-container>
 
-<oui-stepper>
+<oui-stepper data-current-index="$ctrl.currentStep">
+    <!--Select region-->
     <oui-step-form
         name="kubernetes_add_region"
         data-header="{{:: 'kubernetes_add_region_title' | translate }}"
         data-editable="!$ctrl.isAdding"
-        data-valid="$ctrl.cluster.region"
         data-navigation="$ctrl.cluster.region"
         data-on-focus="$ctrl.displaySelectedRegion = false"
         data-on-submit="$ctrl.onRegionSubmit()"
@@ -17,17 +17,27 @@
             data-selected-region="$ctrl.cluster.region"
             data-display-selected-region="$ctrl.displaySelectedRegion"
         ></pci-project-regions-list>
+
+        <!--Add new region banner info-->
+        <oui-message type="info" data-ng-if="!$ctrl.displaySelectedRegion && $ctrl.cluster.region && !$ctrl.cluster.region.enabled">
+            <span data-translate="kubernetes_add_region_info"></span>
+        </oui-message>
     </oui-step-form>
+
+    <!--Select kube version-->
     <oui-step-form
+        name="kubernetes_add_version"
         data-header="{{:: 'kubernetes_add_version_title' | translate }}"
         data-editable="!$ctrl.isAdding"
         data-valid="$ctrl.cluster.version"
         data-navigation="$ctrl.cluster.version"
-        data-on-focus="$ctrl.displaySelectedVersion = false"
+        data-on-focus="$ctrl.onKubeVersionFocus()"
         data-on-submit="$ctrl.displaySelectedVersion = true"
-        name="kubernetes_add_version"
+        data-loading="$ctrl.isAddingNewRegion"
+        data-loading-text="{{ 'kubernetes_add_region_inprogress' | translate: { name: $ctrl.cluster.region.name } }}"
     >
         <pci-project-versions-list
+            data-ng-if="!$ctrl.isAddingNewRegion"
             data-versions="$ctrl.versions"
             data-selected-version="$ctrl.cluster.version"
             data-highest-version="$ctrl.highestVersion"
@@ -35,7 +45,8 @@
         >
         </pci-project-versions-list>
     </oui-step-form>
-    <!-- private network -->
+
+    <!--Select private network -->
     <oui-step-form
         data-header="{{:: 'kubernetes_add_private_network' | translate }}"
         data-editable="!$ctrl.isAdding"
@@ -67,7 +78,7 @@
         </oui-field>
     </oui-step-form>
 
-    <!-- select node pool configuration -->
+    <!--Select node pool configuration -->
     <oui-step-form
         data-header="{{:: 'kube_common_node_pool_title' | translate }}"
         data-editable="!$ctrl.isAdding"
@@ -132,6 +143,7 @@
         <p data-translate="kubernetes_add_billing_type_payment_method"></p>
     </oui-step-form>
 
+    <!--Choose the kube name-->
     <oui-step-form
         data-header="{{:: 'kubernetes_add_name_title' | translate }}"
         data-editable="!$ctrl.isAdding"

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_de_DE.json
@@ -9,5 +9,8 @@
   "kubernetes_add_name": "Name",
   "kubernetes_add_billing_type_description": "Alle künftigen Nodes in diesem Node-Pool werden nach diesem Modus berechnet. Sie können später jeden Ihrer Nodes einzeln von der stündlichen auf die monatliche Abrechnung umstellen.",
   "kubernetes_add_billing_type_payment_method": "Die Rechnung wird über Ihr Standardzahlungsmittel beglichen.",
-  "kubernetes_add_billing_anti_affinity_title": "Abrechnung und Anti-Affinität"
+  "kubernetes_add_billing_anti_affinity_title": "Abrechnung und Anti-Affinität",
+  "kubernetes_add_region_info": "Die ausgewählte Region ist noch nicht in Ihrem Projekt aktiv. Das Hinzufügen dauert einige Sekunden und hat keinerlei Auswirkungen auf die Abrechnung.",
+  "kubernetes_add_region_inprogress": "Die Region {{ name }} wird hinzugefügt...",
+  "kubernetes_add_region_failed": "Beim Hinzufügen der Region {{ name }} ist ein Fehler aufgetreten: {{message}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_en_GB.json
@@ -9,5 +9,8 @@
   "kubernetes_add_name": "Name",
   "kubernetes_add_billing_type_description": "All future nodes in this node pool will be billed in this way. You can then switch each of your nodes individually from hourly to monthly billing.",
   "kubernetes_add_billing_type_payment_method": "You will be billed via your default payment method.",
-  "kubernetes_add_billing_anti_affinity_title": "Billing and anti-affinity"
+  "kubernetes_add_billing_anti_affinity_title": "Billing and anti-affinity",
+  "kubernetes_add_region_info": "The selected region is not yet active on your project. This addition takes a few seconds, and does not affect billing.",
+  "kubernetes_add_region_inprogress": "Adding region {{name}}...",
+  "kubernetes_add_region_failed": "An error has occurred adding the {{name}} region: {{message}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_es_ES.json
@@ -9,5 +9,8 @@
   "kubernetes_add_name": "Nombre",
   "kubernetes_add_billing_type_description": "Este modo de facturación se aplicará a todos los nodos futuros del pool. Más adelante podrá modificar la facturación de cada uno de sus nodos pasando de la modalidad por horas a la mensual.",
   "kubernetes_add_billing_type_payment_method": "El importe se cargará en su forma de pago por defecto.",
-  "kubernetes_add_billing_anti_affinity_title": "Facturación y antiafinidad"
+  "kubernetes_add_billing_anti_affinity_title": "Facturación y antiafinidad",
+  "kubernetes_add_region_info": "La región seleccionada todavía no está activa en su proyecto. Esta adición tardará unos segundos y no afectará a la facturación.",
+  "kubernetes_add_region_inprogress": "Se está añadiendo la región {{ name }}...",
+  "kubernetes_add_region_failed": "Se ha producido un error al añadir la región {{ name }}: {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_fr_CA.json
@@ -4,6 +4,9 @@
   "kubernetes_add_error": "Une erreur est survenue lors de la création de votre cluster: {{ message }}",
   "kubernetes_add_loading": "La création du cluster est en cours",
 
+  "kubernetes_add_region_info": "La région sélectionnée n'est pas encore active sur votre projet. Cet ajout prend quelques secondes et n'a aucune incidence sur la facturation.",
+  "kubernetes_add_region_inprogress": "La région {{ name }} est en cours d'ajout…",
+  "kubernetes_add_region_failed": "Une erreur est survenue lors de l'ajout de la région {{ name }} : {{ message }}",
   "kubernetes_add_region_title": "Sélectionnez une localisation",
   "kubernetes_add_version_title": "Sélectionnez la version mineure de Kubernetes souhaitée",
   "kubernetes_add_name_title": "Nommez votre cluster",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_fr_FR.json
@@ -4,6 +4,9 @@
   "kubernetes_add_error": "Une erreur est survenue lors de la création de votre cluster: {{ message }}",
   "kubernetes_add_loading": "La création du cluster est en cours",
 
+  "kubernetes_add_region_info": "La région sélectionnée n'est pas encore active sur votre projet. Cet ajout prend quelques secondes et n'a aucune incidence sur la facturation.",
+  "kubernetes_add_region_inprogress": "La région {{ name }} est en cours d'ajout…",
+  "kubernetes_add_region_failed": "Une erreur est survenue lors de l'ajout de la région {{ name }} : {{ message }}",
   "kubernetes_add_region_title": "Sélectionnez une localisation",
   "kubernetes_add_version_title": "Sélectionnez la version mineure de Kubernetes souhaitée",
   "kubernetes_add_name_title": "Nommez votre cluster",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_it_IT.json
@@ -7,5 +7,8 @@
   "kubernetes_add_version_title": "Seleziona una versione minor di Kubernetes",
   "kubernetes_add_name_title": "Assegna un nome al tuo cluster",
   "kubernetes_add_name": "Nome",
-  "kubernetes_add_billing_type_description": "Dopo il deploy del cluster è possibile modificare il pool di nodi per passare dalla fatturazione oraria al forfait mensile."
+  "kubernetes_add_billing_type_description": "Dopo il deploy del cluster è possibile modificare il pool di nodi per passare dalla fatturazione oraria al forfait mensile.",
+  "kubernetes_add_region_info": "La Region selezionata non è ancora attiva sul tuo progetto. Questa aggiunta richiede pochi secondi e non ha alcun impatto sulla fatturazione.",
+  "kubernetes_add_region_inprogress": "Aggiunta Region {{ name }} in corso...",
+  "kubernetes_add_region_failed": "Si è verificato un errore durante l’aggiunta della Region {{ name }}: {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_pl_PL.json
@@ -9,5 +9,8 @@
   "kubernetes_add_name": "Nazwa",
   "kubernetes_add_billing_type_description": "Ten tryb płatności zostanie zastosowany do wszystkich utworzonych w przyszłości węzłów w tej puli. Będziesz mógł później zmienić płatność za godzinę na płatność miesięczną dla każdego węzła osobno.",
   "kubernetes_add_billing_type_payment_method": "Opłata zostanie pobrana pomocą domyślnego sposobu płatności.",
-  "kubernetes_add_billing_anti_affinity_title": "Płatności i ochrona przed koligacją (anti-affinity)"
+  "kubernetes_add_billing_anti_affinity_title": "Płatności i ochrona przed koligacją (anti-affinity)",
+  "kubernetes_add_region_info": "Wybrany region nie jest jeszcze aktywny dla Twojego projektu. Dodanie regionu zajmie kilka sekund i nie wpłynie na płatności.",
+  "kubernetes_add_region_inprogress": "Trwa dodawanie regionu {{name}}...",
+  "kubernetes_add_region_failed": "Wystąpił błąd podczas dodawania regionu: {{name}}: {{message}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/translations/Messages_pt_PT.json
@@ -9,5 +9,8 @@
   "kubernetes_add_name": "Nome",
   "kubernetes_add_billing_type_description": "Todos os nós futuros deste pool de nós estarão sujeitos a este modo de faturação. Posteriormente, poderá passar cada um dos seus nós individualmente da faturação à hora para a faturação mensal.",
   "kubernetes_add_billing_type_payment_method": "A faturação será realizada através do seu método de pagamento predefinido.",
-  "kubernetes_add_billing_anti_affinity_title": "Faturação e anti-afinidade"
+  "kubernetes_add_billing_anti_affinity_title": "Faturação e anti-afinidade",
+  "kubernetes_add_region_info": "A região selecionada ainda não está ativa para o seu projeto. Esta adição demorará alguns segundos e não terá qualquer impacto na faturação.",
+  "kubernetes_add_region_inprogress": "A região {{ name }} está a ser adicionada...",
+  "kubernetes_add_region_failed": "Ocorreu um erro ao adicionar a região {{ name }}: {{ message }}"
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.constants.js
@@ -7,9 +7,11 @@ export const SCALE_DEFAULT_VALUES = {
   HIGHEST_VALUE: 100,
   HIGHEST_MAX_VALUE: 100,
 };
+export const KUBE_PRODUCT_ID = 'kubernetes';
 
 export default {
   VERSION_ENUM_KEY,
   ANTI_AFFINITY_MAX_NODES,
   SCALE_DEFAULT_VALUES,
+  KUBE_PRODUCT_ID,
 };

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.routing.js
@@ -93,17 +93,8 @@ export default /* @ngInject */ ($stateProvider) => {
       highestVersion: (versions) =>
         max(versions, (version) => parseFloat(`${version}`)),
 
-      regions: /* @ngInject */ (OvhApiCloudProjectKube, projectId) =>
-        OvhApiCloudProjectKube.v6()
-          .getRegions({
-            serviceName: projectId,
-          })
-          .$promise.then((regions) =>
-            map(regions, (region) => ({
-              name: region,
-              hasEnoughQuota: () => true,
-            })),
-          ),
+      regions: /* @ngInject */ (projectId, coreConfig, Kubernetes) =>
+        Kubernetes.getRegions(projectId, coreConfig.getUser().ovhSubsidiary),
 
       antiAffinityMaxNodes: /* @ngInject */ () => ANTI_AFFINITY_MAX_NODES,
       addPrivateNetworksLink: /* @ngInject */ ($state, projectId) =>

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/service.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/service.js
@@ -13,7 +13,10 @@ import {
   PROCESSING_STATUS,
 } from './details/constants';
 
-import { ANTI_AFFINITY_MAX_NODES } from './kubernetes.constants';
+import {
+  ANTI_AFFINITY_MAX_NODES,
+  KUBE_PRODUCT_ID,
+} from './kubernetes.constants';
 
 export default class Kubernetes {
   /* @ngInject */
@@ -211,6 +214,27 @@ export default class Kubernetes {
           type: 'private',
         }),
       );
+  }
+
+  getRegions(projectId, ovhSubsidiary) {
+    const product = KUBE_PRODUCT_ID;
+    return this.$http
+      .get(`/cloud/project/${projectId}/capabilities/productAvailability`, {
+        params: { product, ovhSubsidiary },
+      })
+      .then(({ data }) =>
+        data.products
+          .find(({ name }) => name === product)
+          .regions.map(({ name, enabled }) => ({
+            name,
+            enabled,
+            hasEnoughQuota: () => true,
+          })),
+      );
+  }
+
+  addRegion(serviceName, { name: region }) {
+    return this.$http.post(`/cloud/project/${serviceName}/region`, { region });
   }
 
   static getPrivateNetwork(privateNetworks, openstackId) {

--- a/packages/manager/modules/pci/src/projects/project/project.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/project.routing.js
@@ -39,8 +39,9 @@ export default /* @ngInject */ ($stateProvider) => {
         OvhApiCloudProject.v6().get({
           serviceName: projectId,
         }).$promise,
+      quotas: /* @ngInject */ (loadQuotas) => loadQuotas(),
 
-      quotas: /* @ngInject */ (PciProjectsService, projectId) =>
+      loadQuotas: /* @ngInject */ (PciProjectsService, projectId) => () =>
         PciProjectsService.getQuotas(projectId),
 
       breadcrumb: /* @ngInject */ (project) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-6801
| License          | BSD 3-Clause

## Description

Aims of this feature it to give to all our customers the ability to buy all products evens are into another region.
To do that if customer select a region that are note yet into his scope we will add it.

### :flags: Translations

- [x] TRANS-36483