### PR TITLE
fix(telephony): use the expected back button

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/accessories/accessories.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/accessories/accessories.html
@@ -1,9 +1,9 @@
 <section class="telecom-telephony-line-phone-accessories">
     <header>
-        <oui-back-button data-on-click="::$ctrl.goBack()">
-            <span
-                data-translate="telephony_group_line_phone_section_back_link"
-            ></span>
+        <oui-back-button
+            data-on-click="::$ctrl.goBack()"
+            previous-page="{{::'telephony_group_line_phone_section_back_link_target' | translate}}"
+        >
         </oui-back-button>
         <h1 data-translate="telephony_line_phone_accessories_title"></h1>
     </header>

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/attachLine/attach-line.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/attachLine/attach-line.html
@@ -1,9 +1,9 @@
 <div class="telecom-telephony-line-phone-attach">
     <header>
-        <oui-back-button data-on-click="::$ctrl.goBack()">
-            <span
-                data-translate="telephony_group_line_phone_section_back_link"
-            ></span>
+        <oui-back-button
+            data-on-click="::$ctrl.goBack()"
+            previous-page="{{::'telephony_group_line_phone_section_back_link_target' | translate}}"
+        >
         </oui-back-button>
     </header>
     <tuc-toast-message></tuc-toast-message>

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.controller.js
@@ -10,6 +10,7 @@ export default /* @ngInject */ function TelecomTelephonyLinePhoneCodecCtrl(
   $q,
   $stateParams,
   $translate,
+  goBack,
   TelephonyMediator,
   TucToast,
   OvhApiTelephony,
@@ -18,6 +19,8 @@ export default /* @ngInject */ function TelecomTelephonyLinePhoneCodecCtrl(
 ) {
   const self = this;
   let codecsAuto = null;
+
+  self.goBack = goBack;
 
   self.loading = {
     init: false,

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.html
@@ -1,10 +1,10 @@
 <section class="telecom-telephony-line-phone-codec">
     <header>
-        <tuc-section-back-link
-            data-tuc-section-back-link-to-state="telecom.telephony.billingAccount.line.dashboard.phone"
-            data-tuc-section-back-link-title="{{ 'telephony_group_line_phone_section_back_link' | translate }}"
+        <oui-back-button
+            data-on-click="CodecCtrl.goBack()"
+            previous-page="{{::'telephony_group_line_phone_section_back_link_target' | translate}}"
         >
-        </tuc-section-back-link>
+        </oui-back-button>
         <h1 data-translate="telephony_line_phone_codec_title"></h1>
     </header>
 

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/codec/codec.routing.js
@@ -16,6 +16,8 @@ export default /* @ngInject */ ($stateProvider) => {
       resolve: {
         breadcrumb: /* @ngInject */ ($translate) =>
           $translate.instant('telephony_line_phone_codec_title'),
+        goBack: /* @ngInject */ ($state) => () =>
+          $state.go('telecom.telephony.billingAccount.line.dashboard.phone'),
       },
     },
   );

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/details/details.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/details/details.html
@@ -1,10 +1,10 @@
 <div class="telecom-telephony-line-phone-informations">
     <header>
-        <tuc-section-back-link
-            data-tuc-section-back-link-to-state="telecom.telephony.billingAccount.line.dashboard.phone"
-            data-tuc-section-back-link-title="{{ 'telephony_group_line_phone_section_back_link' | translate }}"
+        <oui-back-button
+            data-href="{{$ctrl.$state.href('telecom.telephony.billingAccount.line.dashboard.phone')}}"
+            previous-page="{{::'telephony_group_line_phone_section_back_link_target' | translate}}"
         >
-        </tuc-section-back-link>
+        </oui-back-button>
         <h1 data-translate="telephony_line_phone_informations_title"></h1>
     </header>
 

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/order.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/order.html
@@ -1,9 +1,9 @@
 <div class="telecom-telephony-line-phone-order">
     <header>
-        <oui-back-button data-on-click="::$ctrl.goBack()">
-            <span
-                data-translate="telephony_group_line_phone_section_back_link"
-            ></span>
+        <oui-back-button
+            data-on-click="::$ctrl.goBack()"
+            previous-page="{{::'telephony_group_line_phone_section_back_link_target' | translate}}"
+        >
         </oui-back-button>
         <h1
             data-ng-if="!$ctrl.phone"

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_en_GB.json
@@ -2,10 +2,10 @@
   "telephony_line_phone_actions_line_details_phon_offer": "General information",
   "telephony_line_phone_actions_line_codecs_management": "Codecs",
   "telephony_line_phone_actions_line_interface": "Choice of interface",
-  "telephony_line_phone_actions_line_plug_and_phone_custom_parameters_list": "Custom Plug & Phone settings",
+  "telephony_line_phone_actions_line_plug_and_phone_custom_parameters_list": "Custom Plug &amp; Phone settings",
   "telephony_line_phone_actions_line_programmable_keys": "Programmable keys",
   "telephony_line_phone_actions_line_phone_upgrade_firmware": "Firmware update",
-  "telephony_line_phone_actions_line_phone_reboot": "Reboot",
+  "telephony_line_phone_actions_line_phone_reboot": "Restart",
   "telephony_line_phone_actions_line_phone_order_phone": "Order a VoIP telephone",
   "telephony_line_phone_actions_line_phone_change_phone": "Change a telephone",
   "telephony_line_phone_actions_line_order_accessories": "Order accessories",
@@ -13,5 +13,6 @@
   "telephony_group_line_phone_section_back_link": "Return to telephone management",
   "telephony_line_phone_actions_line_phone_order_attach": "Attach line to current hardware",
   "telephony_line_phone_actions_line_phone_order_detach": "Detach a telephone line",
-  "telephony_line_phone_actions_line_details_phone_breadcrumb": "Phone"
+  "telephony_line_phone_actions_line_details_phone_breadcrumb": "Phone",
+  "telephony_group_line_phone_section_back_link_target": "telephone management"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_fr_CA.json
@@ -12,6 +12,7 @@
   "telephony_line_phone_actions_line_order_accessories": "Commander des accessoires",
   "telephony_line_phone_actions_line_phonebook": "Carnets de contacts",
   "telephony_group_line_phone_section_back_link": "Retour à la gestion du téléphone",
+  "telephony_group_line_phone_section_back_link_target": "la gestion du téléphone",
   "telephony_line_phone_actions_line_phone_order_attach": "Rattacher la ligne à un équipement actuel",
   "telephony_line_phone_actions_line_phone_order_detach": "Détacher la ligne d'un téléphone"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/translations/Messages_fr_FR.json
@@ -12,6 +12,7 @@
   "telephony_line_phone_actions_line_order_accessories": "Commander des accessoires",
   "telephony_line_phone_actions_line_phonebook": "Carnets de contacts",
   "telephony_group_line_phone_section_back_link": "Retour à la gestion du téléphone",
+  "telephony_group_line_phone_section_back_link_target": "la gestion du téléphone",
   "telephony_line_phone_actions_line_phone_order_attach": "Rattacher la ligne à un équipement actuel",
   "telephony_line_phone_actions_line_phone_order_detach": "Détacher la ligne d'un téléphone"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-30272
| License          | BSD 3-Clause

## Description

Fix and use back-button on telephony pages

### :flags: Translations

- [x] TRANS-35242