### PR TITLE
fix(security): display popover template for maxPasswordAge field

### DIFF
--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
@@ -1146,6 +1146,7 @@
   "exchange_ACTION_renew_ssl_failure": "Une erreur est survenue lors du renouvellement de votre certificat SSL.",
   "exchange_ACTION_configure_services_label_mfa": "Double authentification",
   "exchange_ACTION_configure_services_label_account_locker": "Verouillage des comptes",
+  "exchange_ACTION_configure_services_label_security_account": "Sécurité des comptes",
   "exchange_ACTION_configure_services_label_lockoutDuration": "Durée de verrouillage",
   "exchange_ACTION_configure_services_label_lockoutObservationWindow": "Délai de réinitialisation",
   "exchange_ACTION_configure_services_label_lockoutThreshold": "Seuil de verrouillage",

--- a/packages/manager/modules/exchange/src/security/security.html
+++ b/packages/manager/modules/exchange/src/security/security.html
@@ -169,7 +169,10 @@
             </oui-field>
         </div>
 
-        <h2 class="oui-heading_underline">Sécurité des comptes</h2>
+        <h2
+            class="oui-heading_underline"
+            data-translate="exchange_ACTION_configure_services_label_security_account"
+        ></h2>
 
         <!-- Complexity Enabled -->
         <oui-checkbox
@@ -242,6 +245,14 @@
                     data-oui-popover-scope="$ctrl"
                     data-oui-popover-template="exchange_ACTION_configure_help_maxPasswordAge_text.html"
                 ></button>
+                <script
+                    type="text/ng-template"
+                    id="exchange_ACTION_configure_help_maxPasswordAge_text.html"
+                >
+                    <div
+                        data-ng-bind-html="'exchange_ACTION_configure_help_maxPasswordAge_text' | translate"
+                    ></div>
+                </script>
             </oui-field>
         </div>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-37373
| License          | BSD 3-Clause

## Description

Following patch is inspired by the way that popover are currently displayed into this section.
See: https://github.com/ovh/manager/blob/c7074416bc31eb2af8ba15cdd80dd16271a4b253/packages/manager/modules/exchange/src/security/security.html#L47-L54

We could imagine as a long-term solution to rely on following component:
- https://ovh.github.io/ovh-ui-kit/?path=/story/design-system-components-field-webcomponent--label-popover

### :bug: Bug Fixes

c707441 - fix(security): display popover template for maxPasswordAge field

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
