### PR TITLE
fix(project.edit): resolve isCertifiedHdsProject from routing part

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/edit/edit.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/edit/edit.routing.js
@@ -85,10 +85,10 @@ export default /* @ngInject */ ($stateProvider) => {
                   ({ data: options }) =>
                     options.find(
                       ({ billing, resource }) =>
-                        billing.plan.code.match(
+                        billing?.plan?.code.match(
                           `^${PCI_HDS_ADDON.planCodeScope}`,
                         ) &&
-                        resource.product.name ===
+                        resource?.product?.name ===
                           PCI_HDS_ADDON.certifiedProject,
                     ) !== undefined,
                 ),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w20`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-38015, DTRSD-38176
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

9551b9a - fix(project.edit): resolve isCertifiedHdsProject from routing part

It may happen that API call to `/services/{serviceId}/options`
can respond an option where both `billing.plan` and `resource.product`
are not defined.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
