### PR TITLE
fix(dedicated-cloud.operation): ignore operations description errors

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/operation/dedicatedCloud-operation.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/operation/dedicatedCloud-operation.controller.js
@@ -170,10 +170,12 @@ export default class {
     if (operation.description === '') {
       return this.DedicatedCloud.getOperationDescription(this.productId, {
         name: operation.name,
-      }).then((robot) => {
-        set(operation, 'description', robot.description);
-        return operation;
-      });
+      })
+        .then((robot) => {
+          set(operation, 'description', robot.description);
+          return operation;
+        })
+        .catch(() => operation);
     }
     return this.$q.when(operation);
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w20`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | internal DTRSD-37968
| License          | BSD 3-Clause

## Description

if fetch operation description fails, ignore it in order to still display the operation without description