### PR TITLE
fix(*): remove less tilde imports

### DIFF
--- a/packages/components/ng-at-internet-ui-router-plugin/package.json
+++ b/packages/components/ng-at-internet-ui-router-plugin/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-at-internet": "^5.4.1",

--- a/packages/components/ng-at-internet/package.json
+++ b/packages/components/ng-at-internet/package.json
@@ -37,7 +37,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "~1.6"

--- a/packages/components/ng-ovh-actions-menu/package.json
+++ b/packages/components/ng-ovh-actions-menu/package.json
@@ -35,7 +35,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-actions-menu' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.3",

--- a/packages/components/ng-ovh-browser-alert/package.json
+++ b/packages/components/ng-ovh-browser-alert/package.json
@@ -38,7 +38,7 @@
     "bowser": "^1.8.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7.5"

--- a/packages/components/ng-ovh-checkbox-table/package.json
+++ b/packages/components/ng-ovh-checkbox-table/package.json
@@ -39,7 +39,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "~1.6"

--- a/packages/components/ng-ovh-contact/package.json
+++ b/packages/components/ng-ovh-contact/package.json
@@ -38,7 +38,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",

--- a/packages/components/ng-ovh-contacts/package.json
+++ b/packages/components/ng-ovh-contacts/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/translate-async-loader": "^1.0.8",

--- a/packages/components/ng-ovh-contracts/package.json
+++ b/packages/components/ng-ovh-contracts/package.json
@@ -38,7 +38,7 @@
     "animated-scroll-to": "^1.2.2"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ui-kit": "^4.4.1",

--- a/packages/components/ng-ovh-doc-url/package.json
+++ b/packages/components/ng-ovh-doc-url/package.json
@@ -44,7 +44,7 @@
     "urijs": "^1.19.2"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.3.x"

--- a/packages/components/ng-ovh-export-csv/package.json
+++ b/packages/components/ng-ovh-export-csv/package.json
@@ -36,7 +36,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-export-csv' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7.8",

--- a/packages/components/ng-ovh-feature-flipping/package.json
+++ b/packages/components/ng-ovh-feature-flipping/package.json
@@ -35,7 +35,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-feature-flipping' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7"

--- a/packages/components/ng-ovh-http/package.json
+++ b/packages/components/ng-ovh-http/package.json
@@ -40,7 +40,7 @@
     "urijs": "^1.19.2"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.3.x"

--- a/packages/components/ng-ovh-jquery-ui-draggable/package.json
+++ b/packages/components/ng-ovh-jquery-ui-draggable/package.json
@@ -40,7 +40,7 @@
     "set-value": "^2.0.1"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "~1.6",

--- a/packages/components/ng-ovh-line-diagnostics/package.json
+++ b/packages/components/ng-ovh-line-diagnostics/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-at-internet": "^5.4.1",

--- a/packages/components/ng-ovh-mondial-relay/package.json
+++ b/packages/components/ng-ovh-mondial-relay/package.json
@@ -46,7 +46,7 @@
     "ovh-ui-kit-bs": "^4.2.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",

--- a/packages/components/ng-ovh-mondial-relay/src/index.less
+++ b/packages/components/ng-ovh-mondial-relay/src/index.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/variables.less';
+@import 'bootstrap/less/variables.less';
 
 /* stylelint-disable-next-line selector-type-no-unknown */
 ovh-mondial-relay,

--- a/packages/components/ng-ovh-otrs/package.json
+++ b/packages/components/ng-ovh-otrs/package.json
@@ -39,7 +39,7 @@
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "bootstrap": "^3.3.6"
   },
   "peerDependencies": {

--- a/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.less
+++ b/packages/components/ng-ovh-otrs/src/otrs-popup/otrs-popup.less
@@ -1,4 +1,4 @@
-@import '~/bootstrap/less/variables.less';
+@import 'bootstrap/less/variables.less';
 
 @module-otrs-header-color: #3b4151;
 

--- a/packages/components/ng-ovh-payment-method/package.json
+++ b/packages/components/ng-ovh-payment-method/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.11"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",

--- a/packages/components/ng-ovh-payment-method/rollup.config.js
+++ b/packages/components/ng-ovh-payment-method/rollup.config.js
@@ -1,19 +1,8 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: './src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: './src/index.js',
+});
 
 const outputs = [config.es()];
 

--- a/packages/components/ng-ovh-proxy-request/package.json
+++ b/packages/components/ng-ovh-proxy-request/package.json
@@ -39,7 +39,7 @@
     "set-value": "^2.0.1"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.6.10"

--- a/packages/components/ng-ovh-responsive-popover/package.json
+++ b/packages/components/ng-ovh-responsive-popover/package.json
@@ -42,7 +42,7 @@
     "jquery": "^2.1.3"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7.0",

--- a/packages/components/ng-ovh-sidebar-menu/package.json
+++ b/packages/components/ng-ovh-sidebar-menu/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.8",

--- a/packages/components/ng-ovh-sidebar-menu/rollup.config.js
+++ b/packages/components/ng-ovh-sidebar-menu/rollup.config.js
@@ -1,19 +1,8 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: './src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: './src/index.js',
+});
 
 const outputs = [
   config.es({

--- a/packages/components/ng-ovh-simple-country-list/package.json
+++ b/packages/components/ng-ovh-simple-country-list/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "1.6.10"

--- a/packages/components/ng-ovh-sso-auth-modal-plugin/package.json
+++ b/packages/components/ng-ovh-sso-auth-modal-plugin/package.json
@@ -43,7 +43,7 @@
     "lodash": "~4.17.11"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-sso-auth": "^4.4.0",

--- a/packages/components/ng-ovh-sso-auth/package.json
+++ b/packages/components/ng-ovh-sso-auth/package.json
@@ -38,7 +38,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-sso-auth' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.5.0",

--- a/packages/components/ng-ovh-swimming-poll/package.json
+++ b/packages/components/ng-ovh-swimming-poll/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "~1.6.10"

--- a/packages/components/ng-ovh-timeline/package.json
+++ b/packages/components/ng-ovh-timeline/package.json
@@ -37,7 +37,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-timeline' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7.5"

--- a/packages/components/ng-ovh-toaster/package.json
+++ b/packages/components/ng-ovh-toaster/package.json
@@ -38,7 +38,7 @@
     "set-value": "^2.0.1"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "~1.6",

--- a/packages/components/ng-ovh-ui-confirm-modal/package.json
+++ b/packages/components/ng-ovh-ui-confirm-modal/package.json
@@ -34,7 +34,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-ui-confirm-modal' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.7.5",

--- a/packages/components/ng-ovh-user-pref/package.json
+++ b/packages/components/ng-ovh-user-pref/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.1",

--- a/packages/components/ng-ovh-utils/package.json
+++ b/packages/components/ng-ovh-utils/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",

--- a/packages/components/ng-pagination-front/package.json
+++ b/packages/components/ng-pagination-front/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ui-kit": "^4.4.1",

--- a/packages/components/ng-q-allsettled/package.json
+++ b/packages/components/ng-q-allsettled/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "1.6.10"

--- a/packages/components/ng-tail-logs/package.json
+++ b/packages/components/ng-tail-logs/package.json
@@ -43,7 +43,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "1.6.10",

--- a/packages/components/ng-translate-async-loader/package.json
+++ b/packages/components/ng-translate-async-loader/package.json
@@ -37,7 +37,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-translate-async-loader' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "angular": "^1.5.0"

--- a/packages/components/ng-ui-router-breadcrumb/package.json
+++ b/packages/components/ng-ui-router-breadcrumb/package.json
@@ -36,7 +36,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ui-router-breadcrumb' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@uirouter/angularjs": "^1.0.22",

--- a/packages/components/ng-ui-router-layout/package.json
+++ b/packages/components/ng-ui-router-layout/package.json
@@ -41,7 +41,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ui-kit": "^4.4.1",

--- a/packages/components/ng-ui-router-line-progress/package.json
+++ b/packages/components/ng-ui-router-line-progress/package.json
@@ -40,7 +40,7 @@
     "nprogress": "^0.2.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@uirouter/angularjs": "^1.0.22",

--- a/packages/components/ng-ui-router-title/package.json
+++ b/packages/components/ng-ui-router-title/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@uirouter/angularjs": "^1.0.0",

--- a/packages/manager/apps/public-cloud/src/assets/theme/default/_sidebar.less
+++ b/packages/manager/apps/public-cloud/src/assets/theme/default/_sidebar.less
@@ -1,4 +1,4 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 @import './_variables.less';
 
 cloud-sidebar {

--- a/packages/manager/apps/telecom/src/app/app.less
+++ b/packages/manager/apps/telecom/src/app/app.less
@@ -1,18 +1,18 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
-@import (less) '~@ovh-ux/ui-kit/dist/css/oui.css';
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
-@import '~ovh-manager-webfont/dist/less/ovh-font';
-@import '~font-awesome/less/font-awesome.less';
-@import (less) '~leaflet/dist/leaflet.css';
-@import (less) '~fullcalendar/dist/fullcalendar.css';
-@import (less) '~ui-select/dist/select.css';
-@import (less) '~messenger/build/css/messenger.css';
-@import (less) '~messenger/build/css/messenger-theme-future.css';
-@import (less) '~messenger/build/css/messenger-theme-flat.css';
-@import (less) '~messenger/build/css/messenger-theme-block.css';
-@import (less) '~intl-tel-input/build/css/intlTelInput.css';
-@import (less) '~ovh-ng-input-password/dist/ovh-ng-input-password.css';
-@import '~flag-icon-css/less/flag-icon.less';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
+@import (less) '@ovh-ux/ui-kit/dist/css/oui.css';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-manager-webfont/dist/less/ovh-font';
+@import 'font-awesome/less/font-awesome.less';
+@import (less) 'leaflet/dist/leaflet.css';
+@import (less) 'fullcalendar/dist/fullcalendar.css';
+@import (less) 'ui-select/dist/select.css';
+@import (less) 'messenger/build/css/messenger.css';
+@import (less) 'messenger/build/css/messenger-theme-future.css';
+@import (less) 'messenger/build/css/messenger-theme-flat.css';
+@import (less) 'messenger/build/css/messenger-theme-block.css';
+@import (less) 'intl-tel-input/build/css/intlTelInput.css';
+@import (less) 'ovh-ng-input-password/dist/ovh-ng-input-password.css';
+@import 'flag-icon-css/less/flag-icon.less';
 
 // Mobile
 @media (max-width: @screen-sm-max) {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/index.less
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/index.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 @import '../../common/less/navbar.less';
 @import '../../common/less/variables.less';

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.less
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-pack-migration {
   .table-comparison {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/portabilities.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/portability/portabilities/portabilities.less
@@ -1,5 +1,5 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telephony-portabilities {
   li {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/groupRepayments/group-repayments.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/groupRepayments/group-repayments.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-billing-account-billing-group-repayments {
   .all-group-repayment {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/dashboard/dashboard.less
@@ -1,4 +1,4 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 
 .telephony-card {
   &__title {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/order-alias.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/order-alias.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 div.telephony-order {
   border-bottom: solid 1px @gray-light;

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/assist/troubleshooting/troubleshooting.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/assist/troubleshooting/troubleshooting.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-line-assist-troubleshooting {
   .content-container {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/configuration/configuration.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/configuration/configuration.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-line-phone-configuration {
   label {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/choice/choice.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/choice/choice.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-line-phone-order {
   .phone-item {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/fax/settings/settings.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/fax/settings/settings.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-service-fax-settings {
   .control-label {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/telecom-telephony.less
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/telecom-telephony.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony {
   footer.voip-action-bar {

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/alias/members/members.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/alias/members/members.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-telephony-alias-members {
   .well {

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/consumption/pie-chart/pie-chart.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/consumption/pie-chart/pie-chart.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 group-consumption-pie-chart {
   display: table;

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/conference/conference.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/conference/conference.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telephony-number-conference-participant-actions-menu {
   margin-left: 3px;

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/number.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/number.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 @import '../../../../../app/common/less/mixins.less';
 
 @import './variables.less';

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/scheduler.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/scheduler/scheduler.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 @import './../variables.less';
 
 .colorize-event-categories(@color) {

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/timeCondition/time-condition.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/timeCondition/time-condition.less
@@ -1,4 +1,4 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 @import './../../../../app/common/less/mixins.less';
 @import './../variables.less';
 /* =============================

--- a/packages/manager/modules/account-migration/package.json
+++ b/packages/manager/modules/account-migration/package.json
@@ -24,7 +24,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-account-migration' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "lodash": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/manager/modules/account-sidebar/package.json
+++ b/packages/manager/modules/account-sidebar/package.json
@@ -24,7 +24,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-account-sidebar' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/manager-hub": "^1.0.0 || ^2.0.0",
     "lodash": "^4.17.15"
   },

--- a/packages/manager/modules/account-sidebar/rollup.config.js
+++ b/packages/manager/modules/account-sidebar/rollup.config.js
@@ -1,18 +1,7 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: 'src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: 'src/index.js',
+});
 
 export default [config.es()];

--- a/packages/manager/modules/advices/package.json
+++ b/packages/manager/modules/advices/package.json
@@ -24,11 +24,11 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-advices' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
-    "@ovh-ux/ng-at-internet": "^5.5.0",
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
+    "@ovh-ux/ng-at-internet": "^5.5.0",
     "@ovh-ux/ui-kit": "^4.4.1",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",

--- a/packages/manager/modules/banner/package.json
+++ b/packages/manager/modules/banner/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",

--- a/packages/manager/modules/banner/rollup.config.js
+++ b/packages/manager/modules/banner/rollup.config.js
@@ -1,18 +1,7 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: 'src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: 'src/index.js',
+});
 
 export default [config.es()];

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -24,7 +24,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-cloud-styles' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ui-kit": "^4.6.0",
     "bootstrap": "~3.3.7",
     "font-awesome": "^4.0.0",

--- a/packages/manager/modules/cloud-styles/rollup.config.js
+++ b/packages/manager/modules/cloud-styles/rollup.config.js
@@ -1,18 +1,7 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: 'src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: 'src/index.js',
+});
 
 export default [config.es()];

--- a/packages/manager/modules/cloud-styles/src/cloud.less
+++ b/packages/manager/modules/cloud-styles/src/cloud.less
@@ -1,12 +1,14 @@
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
-@import '~bootstrap/less/mixins';
-@import '~bootstrap/less/utilities';
-@import '~bootstrap/less/glyphicons';
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
-@import '~font-awesome/less/mixins';
-@import '~font-awesome/less/variables';
-@import '~ovh-common-style/less/helpers';
-@import '~ovh-common-style/less/fonts/open-sans';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import 'bootstrap/less/mixins';
+@import 'bootstrap/less/utilities';
+@import 'bootstrap/less/glyphicons';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'font-awesome/less/mixins';
+@import 'font-awesome/less/variables';
+@import 'ovh-common-style/less/helpers';
+
+@ovh-common-style-font-path: '~ovh-common-syle/fonts';
+@import 'ovh-common-style/less/fonts/open-sans';
 
 .cloud-legacy {
   @TopNavResponsiveLeft: 15px;

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -41,7 +41,7 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-user-pref": "^2.0.1",

--- a/packages/manager/modules/cloud-universe-components/rollup.config.js
+++ b/packages/manager/modules/cloud-universe-components/rollup.config.js
@@ -1,18 +1,7 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: './src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: './src/index.js',
+});
 
 export default [config.es()];

--- a/packages/manager/modules/config/package.json
+++ b/packages/manager/modules/config/package.json
@@ -31,6 +31,6 @@
     "whatwg-fetch": "^3.5.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   }
 }

--- a/packages/manager/modules/cookie-policy/package.json
+++ b/packages/manager/modules/cookie-policy/package.json
@@ -33,7 +33,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-cookie-policy' --include-dependencies -- yarn run dev:watch"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-config": "^5.0.1",

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -32,7 +32,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/manager-models": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/manager/modules/enterprise-cloud-database/package.json
+++ b/packages/manager/modules/enterprise-cloud-database/package.json
@@ -38,7 +38,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -17,7 +17,7 @@
     "ovh-manager-webfont": "^1.2.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",

--- a/packages/manager/modules/incident-banner/package.json
+++ b/packages/manager/modules/incident-banner/package.json
@@ -36,12 +36,12 @@
     "@ovh-ux/manager-config": "^5.0.1 || ^6.0.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.6.1",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.2",
-    "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",
     "@ovh-ux/ufrontend": "^1.0.0 || ^2.0.0",
     "@ovh-ux/ui-kit": "^4.4.4",

--- a/packages/manager/modules/nasha/src/components/space-meter/legend/index.less
+++ b/packages/manager/modules/nasha/src/components/space-meter/legend/index.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/variables.less';
+@import 'bootstrap/less/variables.less';
 
 /* Cloud Space Meter - Legend - Item */
 @cloud-space-meter-legend-item-background-color_used: #64afa0;

--- a/packages/manager/modules/navbar/package.json
+++ b/packages/manager/modules/navbar/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ui-kit": "^4.6.0"
   },
   "peerDependencies": {

--- a/packages/manager/modules/navbar/rollup.config.js
+++ b/packages/manager/modules/navbar/rollup.config.js
@@ -1,19 +1,8 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: 'src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: 'src/index.js',
+});
 
 export default [
   config.es({

--- a/packages/manager/modules/navbar/src/index.less
+++ b/packages/manager/modules/navbar/src/index.less
@@ -1,5 +1,5 @@
 ovh-manager-navbar {
-  @import '~@ovh-ux/ui-kit/dist/less/_tokens';
+  @import '@ovh-ux/ui-kit/dist/less/_tokens';
 
   .oui-navbar-menu_toggle {
     button.oui-navbar-link::after {

--- a/packages/manager/modules/navbar/src/navbar-menu-header/index.less
+++ b/packages/manager/modules/navbar/src/navbar-menu-header/index.less
@@ -1,5 +1,5 @@
 ovh-manager-navbar {
-  @import '~@ovh-ux/ui-kit/dist/less/_tokens';
+  @import '@ovh-ux/ui-kit/dist/less/_tokens';
 
   .oui-navbar {
     .oui-navbar-link {

--- a/packages/manager/modules/ng-layout-helpers/package.json
+++ b/packages/manager/modules/ng-layout-helpers/package.json
@@ -24,7 +24,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-ng-layout-helpers' --include-dependencies -- npm run dev:watch --if-present"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "lodash": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/manager/modules/ng-ovh-order-tracking/package.json
+++ b/packages/manager/modules/ng-ovh-order-tracking/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",

--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-advices": "^0.0.0 || ^1.0.0",

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-config": "^5.0.0",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.less
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.less
@@ -1,6 +1,6 @@
 ovh-manager-pci-instances-add {
-  @import '~flag-icon-css/less/flag-icon.less';
-  @import '~@ovh-ux/ui-kit/dist/less/tokens/_colors.less';
+  @import 'flag-icon-css/less/flag-icon.less';
+  @import '@ovh-ux/ui-kit/dist/less/tokens/_colors.less';
 
   /* ==================================================
   =            Add some flags definitions            =

--- a/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.less
+++ b/packages/manager/modules/pci/src/projects/project/sidebar/sidebar.less
@@ -1,5 +1,5 @@
 cloud-sidebar-project-list {
-  @import '~@ovh-ux/ui-kit/dist/less/tokens/_colors';
+  @import '@ovh-ux/ui-kit/dist/less/tokens/_colors';
 
   .project-warning-icon {
     display: block;

--- a/packages/manager/modules/preloader/package.json
+++ b/packages/manager/modules/preloader/package.json
@@ -24,6 +24,6 @@
     "nprogress": "^0.2.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   }
 }

--- a/packages/manager/modules/request-tagger/package.json
+++ b/packages/manager/modules/request-tagger/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@uirouter/angularjs": "^1.0.22",

--- a/packages/manager/modules/server-sidebar/package.json
+++ b/packages/manager/modules/server-sidebar/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.0",
     "@ovh-ux/ui-kit": "^4.6.0"
   },

--- a/packages/manager/modules/server-sidebar/rollup.config.js
+++ b/packages/manager/modules/server-sidebar/rollup.config.js
@@ -1,18 +1,7 @@
-import path from 'path';
 import rollupConfig from '@ovh-ux/component-rollup-config';
 
-const config = rollupConfig(
-  {
-    input: 'src/index.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: [
-        path.resolve(__dirname, 'node_modules'),
-        path.resolve(__dirname, '../../../../node_modules'),
-      ],
-    },
-  },
-);
+const config = rollupConfig({
+  input: 'src/index.js',
+});
 
 export default [config.es()];

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -16,7 +16,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/ui-kit": "^4.6.0",
     "bootstrap": "~3.3.7"
   },

--- a/packages/manager/modules/sms/src/sms/sms/compose/addPhonebookContact/telecom-sms-sms-compose-addPhonebookContact.less
+++ b/packages/manager/modules/sms/src/sms/sms/compose/addPhonebookContact/telecom-sms-sms-compose-addPhonebookContact.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/variables';
+@import 'bootstrap/less/variables';
 
 @media (min-width: @screen-sm-min) {
   .table--header-fixed > thead,

--- a/packages/manager/modules/sms/src/sms/telecom-sms.less
+++ b/packages/manager/modules/sms/src/sms/telecom-sms.less
@@ -1,5 +1,5 @@
-@import '~bootstrap/less/variables.less';
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'bootstrap/less/variables.less';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 
 /* stylelint-disable no-descending-specificity */
 @service-button-bg-color: @gray-lighter;

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-banner": "^1.1.3",

--- a/packages/manager/modules/telecom-dashboard/src/telecom-dashboard.less
+++ b/packages/manager/modules/telecom-dashboard/src/telecom-dashboard.less
@@ -1,5 +1,5 @@
-@import '~bootstrap/less/variables.less';
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'bootstrap/less/variables.less';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 
 .telecom-dashboard {
   div.flash {

--- a/packages/manager/modules/telecom-styles/package.json
+++ b/packages/manager/modules/telecom-styles/package.json
@@ -17,6 +17,6 @@
     "ovh-ui-kit-bs": "^4.2.0"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   }
 }

--- a/packages/manager/modules/telecom-styles/src/telecom.less
+++ b/packages/manager/modules/telecom-styles/src/telecom.less
@@ -1,5 +1,5 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
-@import '~ovh-ui-kit-bs/dist/less/bootstrap/_variables';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'ovh-ui-kit-bs/dist/less/bootstrap/_variables';
 
 .telecom-legacy {
   .telecom-section-alert {

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0"
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",

--- a/packages/manager/modules/telecom-universe-components/src/gauge/gauge.less
+++ b/packages/manager/modules/telecom-universe-components/src/gauge/gauge.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/variables';
+@import 'bootstrap/less/variables';
 
 [data-tuc-gauge],
 [tuc-gauge] {

--- a/packages/manager/modules/telecom-universe-components/src/slider/slider.less
+++ b/packages/manager/modules/telecom-universe-components/src/slider/slider.less
@@ -1,4 +1,4 @@
-@import '~bootstrap/less/variables';
+@import 'bootstrap/less/variables';
 
 tuc-slider,
 [tuc-slider],

--- a/packages/manager/modules/telecom-universe-components/src/successDrawingCheck/successDrawingCheck.less
+++ b/packages/manager/modules/telecom-universe-components/src/successDrawingCheck/successDrawingCheck.less
@@ -1,5 +1,5 @@
-@import '~bootstrap/less/mixins/clearfix';
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import 'bootstrap/less/mixins/clearfix';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 
 tuc-success-drawing-check {
   @success-drawing-check-size: 50px;

--- a/packages/manager/modules/telecom-universe-components/src/telecom/telephony/bulkAction/telephony-bulk-action.less
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/telephony/bulkAction/telephony-bulk-action.less
@@ -1,4 +1,4 @@
-@import '~@ovh-ux/ui-kit/dist/less/_tokens';
+@import '@ovh-ux/ui-kit/dist/less/_tokens';
 
 .bulk-action-modal {
   .oui-search-input {

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^8.0.0 || ^9.0.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "bootstrap": "~3.3.7"
   },
   "peerDependencies": {

--- a/packages/manager/tools/component-rollup-config/README.md
+++ b/packages/manager/tools/component-rollup-config/README.md
@@ -108,32 +108,6 @@ class MyController {
 angular.module('myModule', []).controller('myController', MyController);
 ```
 
-### rollup-plugin-less-tilde-importer
-
-Provides ~ (tilde) prefix to tell less compiler that it should resolve imports using a configured array of paths.
-
-```js
-import configGenerator from '@ovh-ux/component-rollup-config';
-
-const config = configGenerator(
-  {
-    input: './src/my-library.js',
-  },
-  {
-    lessTildeImporter: {
-      paths: ['/foo/bar', '/hello/world'],
-    },
-  },
-);
-
-export default [config.cjs()];
-```
-
-```less
-// try importing bootstrap from '/foo/bar/bootstrap' then from '/hello/world/bootstrap'
-@import '~bootstrap';
-```
-
 ### Performance
 
 Regarding the translations related plugins, it's possible to only process translations files for a single language. Please refer to the example below. This can be useful if you want faster builds in your development environment for example.
@@ -167,10 +141,6 @@ $ rollup -c --environment LANGUAGES:fr_FR-en_GB-en_US
 ```sh
 $ yarn test
 ```
-
-## Related
-
-- [@ovh-ux/rollup-plugin-less-tilde-importer](https://github.com/ovh/rollup-plugin-less-tilde-importer) - Rollup plugin to facilitate less imports with a ~ (tilde) prefix
 
 ## Contributing
 

--- a/packages/manager/tools/component-rollup-config/package.json
+++ b/packages/manager/tools/component-rollup-config/package.json
@@ -25,7 +25,6 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.10.3",
     "@ovh-ux/rollup-plugin-less-inject": "^1.0.5",
-    "@ovh-ux/rollup-plugin-less-tilde-importer": "^1.0.3",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-dynamic-import-vars": "^1.1.0",

--- a/packages/manager/tools/component-rollup-config/src/index.js
+++ b/packages/manager/tools/component-rollup-config/src/index.js
@@ -9,7 +9,6 @@ const image = require('@rollup/plugin-image');
 const json = require('@rollup/plugin-json');
 const lessInject = require('@ovh-ux/rollup-plugin-less-inject');
 const lessPluginRemcalc = require('less-plugin-remcalc');
-const lessTildeImporter = require('@ovh-ux/rollup-plugin-less-tilde-importer');
 const path = require('path');
 const peerdeps = require('rollup-plugin-peer-deps-external');
 const resolve = require('@rollup/plugin-node-resolve');
@@ -56,7 +55,6 @@ const generateConfig = (opts, pluginsOpts) =>
           compact: true,
           namedExports: false,
         }),
-        lessTildeImporter(pluginsOpts.lessTildeImporter),
         lessInject({
           option: {
             plugins: [lessPluginRemcalc],

--- a/packages/manager/tools/webpack-config/package.json
+++ b/packages/manager/tools/webpack-config/package.json
@@ -26,7 +26,7 @@
     "@babel/plugin-proposal-private-methods": "^7.10.1",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.10.3",
-    "@ovh-ux/component-rollup-config": "^9.1.0",
+    "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0",
     "@ovh-ux/manager-webpack-dev-server": "^2.8.2",
     "acorn": "^6.0.5",
     "acorn-class-fields": "^0.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,14 +3008,6 @@
     lodash "^4.17.15"
     rollup-pluginutils "^2.8.2"
 
-"@ovh-ux/rollup-plugin-less-tilde-importer@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/rollup-plugin-less-tilde-importer/-/rollup-plugin-less-tilde-importer-1.0.3.tgz#fe3235522ec3ac340c01a9693fa4b0ae679f5548"
-  integrity sha512-v+Fa7vKcVmiM0iEIFjvcq8+NvFyRz0ELbGOy3IKxQR28u9HvMEvnw6qAj57BNbSVKH5d5QlYSCafgM7FYMW3nA==
-  dependencies:
-    magic-string "^0.25.7"
-    rollup-pluginutils "^2.8.2"
-
 "@ovh-ux/translate-async-loader@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | internal MANAGER-7041
| License          | BSD 3-Clause

## Description

remove @ovh-ux/rollup-plugin-less-tilde-importer usage (~ import syntax in less files)as the dependency is deprecated
also the benefits is to make our stack simpler and more respectful of standards