### PR TITLE
fix(hosting.cdn.order): prevent ngRepeat console error

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
@@ -16,9 +16,25 @@ export default /* @ngInject */ ($stateProvider) => {
     autoPayWithPreferredPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
       ovhPaymentMethod.hasDefaultPaymentMethod(),
 
-    availablePlans: /* @ngInject */ (availableOptions, cdnProperties) =>
+    availablePlans: /* @ngInject */ (
+      availableOptions,
+      cdnProperties,
+      ovhManagerProductOffersService,
+    ) =>
       availableOptions
         .filter(({ family }) => family === 'cdn')
+        .sort((planCodeA, planCodeB) => {
+          const planCodeAPrice = ovhManagerProductOffersService.constructor.getUniquePricingOfCapacity(
+            planCodeA.prices,
+            'renew',
+          );
+          const planCodeBPrice = ovhManagerProductOffersService.constructor.getUniquePricingOfCapacity(
+            planCodeB.prices,
+            'renew',
+          );
+
+          return planCodeAPrice.priceInUcents > planCodeBPrice.priceInUcents;
+        })
         .map(({ planCode }) => ({
           planCode,
           available:

--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
@@ -21,15 +21,12 @@ export default /* @ngInject */ ($stateProvider) => {
         .filter(({ family }) => family === 'cdn')
         .map(({ planCode }) => ({
           planCode,
-          available: !planCode.includes(cdnProperties?.type),
+          available:
+            !planCode.includes(cdnProperties?.type) &&
+            planCode !==
+              HOSTING_CDN_ORDER_CATALOG_ADDONS_PLAN_CODE_CDN_ADVANCED,
           current: planCode.includes(cdnProperties?.type),
-        }))
-        .concat([
-          {
-            planCode: HOSTING_CDN_ORDER_CATALOG_ADDONS_PLAN_CODE_CDN_ADVANCED,
-            available: false,
-          },
-        ]),
+        })),
 
     catalog: /* @ngInject */ (user, WucOrderCartService) =>
       WucOrderCartService.getProductPublicCatalog(


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-39681
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

b907771 - fix(hosting.cdn.order): prevent ngRepeat console error

```txt
Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed.

Use 'track by' expression to specify unique keys.

Repeater: cdn in $ctrl.availablePlans track by cdn.planCode,
Duplicate key: cdn-advanced,
Duplicate value: {"planCode":"cdn-advanced","available":false}
```

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
