### PR TITLE
fix(telephony.line.password): disallow % char in password

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/password/password.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/management/password/password.controller.js
@@ -137,7 +137,7 @@ export default /* @ngInject */ function TelecomTelephonyLinePasswordCtrl(
       caption: $translate.instant('telephony_line_password_rule_special', {
         list: '#{}()[]-|@=*+/!:;',
       }),
-      validator: /^[\w~"#'{}(\\)[\]\-|\\^@=*+/!:;.,?<>%*µ]+$/,
+      validator: /^[\w~"#'{}(\\)[\]\-|\\^@=*+/!:;.,?<>*µ]+$/,
       immediateWarning: true,
     },
     {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-39757
| License          | BSD 3-Clause

## Description

Disallow `%` in sip line password.