### PR TITLE
feat: add manager components module

### DIFF
--- a/packages/manager/modules/manager-components/README.md
+++ b/packages/manager/modules/manager-components/README.md
@@ -1,0 +1,25 @@
+# manager-components
+
+## Install
+
+```sh
+yarn add @ovh-ux/manager-components
+```
+
+## Usage
+This module supports importing only the required component, instead of importing the entire module at 1 shot. For example, to import a component named `my-component`, below is the code. Refer to the individual component's documentation, to find out exactly how to use the respective components.
+
+```js
+import 'angular';
+import myComponent from '@ovh-ux/manager-components';
+
+angular.module('myApp', [myComponent]);
+```
+
+## Contributing
+
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
+
+## License
+
+[BSD-3-Clause](LICENSE) © OVH SAS

--- a/packages/manager/modules/manager-components/package.json
+++ b/packages/manager/modules/manager-components/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ovh-ux/manager-components",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A set of reusable UI components, to be used across the OVH Manager",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ovh/manager.git",
+    "directory": "packages/manager/modules/manager-components"
+  },
+  "license": "BSD-3-Clause",
+  "author": "OVH SAS",
+  "sideEffects": false,
+  "main": "./src/index.js",
+  "dependencies": {
+    "bootstrap4": "twbs/bootstrap#v4.0.0",
+    "lodash": "^4.17.15"
+  },
+  "peerDependencies": {
+    "@ovh-ux/ui-kit": "^4.4.3",
+    "angular": "^1.7.5"
+  }
+}

--- a/packages/manager/modules/manager-components/src/index.js
+++ b/packages/manager/modules/manager-components/src/index.js
@@ -1,0 +1,3 @@
+import resourceSelector from './resource-selector';
+
+export default resourceSelector;

--- a/packages/manager/modules/manager-components/src/resource-selector/README.md
+++ b/packages/manager/modules/manager-components/src/resource-selector/README.md
@@ -1,0 +1,71 @@
+# ovh-manager-resource-selector
+
+The `ovh-manager-resource-selector` component provides a quick way to create a horizontal tile, with the price and additional controls included. This is usually used, but not limited to, for resource selection and hence the name.
+
+## Installation
+
+```js
+import 'angular';
+import resourceSelector from '@ovh-ux/manager-components';
+
+angular.module('myModule', [resourceSelector]);
+```
+
+## Attributes
+
+| Attribute         | Type            | Binding | One-time binding | Values                    | Default    | Description
+| ----              | ----            | ----    | ----             | ----                      | ----       | ----
+| `price`            | string          | @       | no              | n/a                       | n/a        | The price to be shown
+| `price-suffix`      | string          | @?      | no              | n/a                       | n/a        | This is a suffix that gets added to the price (in the next line)
+| `title`       | string          | @?      | no              | n/a  | n/a  | The title for the resource selector tile
+
+## Basic Usage
+Below is the simplest form of using this component, where all the attributes are supplied
+
+```html
+<ovh-manager-resource-selector
+    price="100 €"
+    price-suffix="/month"
+    title="My title"
+>
+</ovh-manager-resource-selector>
+```
+
+## Transclude price
+Sometimes, you might need to format the price differently, or might need to customise it further. In this case, the `ovh-manager-resource-selector` component supports a named transclude `resourceSelectorPrice`. When this named transclude is used, it overrides the `price` and the `price-suffix` attributes, which are no longer required. Below is an example usage
+
+```html
+<ovh-manager-resource-selector
+    title="My title"
+>
+    <resource-selector-price>
+        <p>$100/Month/Resource</p>
+        <p>Only</p>
+    </resource-selector-price>
+</ovh-manager-resource-selector>
+```
+
+## Default Transclude
+The component also supports a default transclude. This content gets transcluded to the right of the price slot.
+
+```html
+<ovh-manager-resource-selector
+    title="My title"
+>
+    <resource-selector-price>
+        <p>$100/Month/Resource</p>
+        <p>Only</p>
+    </resource-selector-price>
+    <div>
+        <p>Default transclude content here</p>
+    </div>
+</ovh-manager-resource-selector>
+```
+
+## Contributing
+
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
+
+## License
+
+[BSD-3-Clause](LICENSE) © OVH SAS

--- a/packages/manager/modules/manager-components/src/resource-selector/component.js
+++ b/packages/manager/modules/manager-components/src/resource-selector/component.js
@@ -1,0 +1,13 @@
+import template from './template.html';
+
+export default {
+  bindings: {
+    price: '<?',
+    priceSuffix: '@?',
+    title: '@',
+  },
+  template,
+  transclude: {
+    price: '?resourceSelectorPrice',
+  },
+};

--- a/packages/manager/modules/manager-components/src/resource-selector/index.js
+++ b/packages/manager/modules/manager-components/src/resource-selector/index.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+import '@ovh-ux/ui-kit';
+
+import component from './component';
+import './index.scss';
+
+const moduleName = 'ovhManagerComponentsResourceSelector';
+
+angular
+  .module(moduleName, ['oui'])
+  .component('managerResourceSelector', component);
+
+export default moduleName;

--- a/packages/manager/modules/manager-components/src/resource-selector/index.scss
+++ b/packages/manager/modules/manager-components/src/resource-selector/index.scss
@@ -1,0 +1,6 @@
+ovh-manager-resource-selector {
+  @import 'bootstrap4/scss/_functions.scss';
+  @import 'bootstrap4/scss/_variables.scss';
+  @import 'bootstrap4/scss/_mixins.scss';
+  @import 'bootstrap4/scss/_utilities.scss';
+}

--- a/packages/manager/modules/manager-components/src/resource-selector/template.html
+++ b/packages/manager/modules/manager-components/src/resource-selector/template.html
@@ -1,0 +1,8 @@
+<div class="oui-tile d-flex m-2">
+    <h6 class="w-50" data-ng-bind="$ctrl.title"></h6>
+    <div class="text-right ml-auto mr-3" ng-transclude="price">
+        <p class="oui-heading_6 m-0" data-ng-bind="$ctrl.price"></p>
+        <span data-ng-bind=":: $ctrl.priceSuffix"></span>
+    </div>
+    <div class="oui-tile__body" ng-transclude></div>
+</div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? |no
| Tickets          | Fix #MANAGER-7074
| License          | BSD 3-Clause

## Description

Add Manager Components module to house all reusable UI components, to be used, across the manager. Currently, the resource-selector component has been added.
