### PR TITLE
fix(logs.detail.input.add): add missing stateParams

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/logs-inputs-add.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/logs-inputs-add.html
@@ -34,7 +34,10 @@
             >
                 <a
                     class="oui-progress-tracker__status"
-                    data-ui-sref="dbaas-logs.detail.inputs.input.editwizard.configure(ctrl.inputId)"
+                    data-ui-sref="dbaas-logs.detail.inputs.input.editwizard.configure({
+                        inputId: ctrl.inputId,
+                        exposedPort: ctrl.input.data.info.exposedPort
+                    })"
                 >
                     <span
                         class="oui-progress-tracker__label"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-39799
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

3ae31cd - fix(logs.detail.input.add): add missing stateParams

Fix following error:
```txt
detail: Error: Transition Rejection($id: 5 type: 4, message: This transition is invalid, detail: The following parameter values are not valid for state 'dbaas-logs.detail.inputs.input.editwizard.configure': [exposedPort:undefined])
```

### :link: Related

#4972

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

