### PR TITLE
fix(component-rollup-config): reorder plugin

### DIFF
--- a/packages/manager/tools/component-rollup-config/src/index.ts
+++ b/packages/manager/tools/component-rollup-config/src/index.ts
@@ -57,7 +57,6 @@ const generateConfig = (opts, pluginsOpts) =>
           output: `./dist/assets/${defaultName}`,
         }),
         resolve(),
-        commonjs(),
         translationInject({
           languages: getLanguages(pluginsOpts),
         }),
@@ -82,6 +81,7 @@ const generateConfig = (opts, pluginsOpts) =>
           presets: [['@babel/preset-env']],
           shouldPrintComment: (val) => !/@ngInject/.test(val),
         }),
+        commonjs(),
       ],
     },
     opts,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

## Description

Put babel plugin before commonjs plugin in order to use proposal like `class-properties` or `private-methods`.