### PR TITLE
fix(billing.payment.method): fix callback delete after page loaded

### DIFF
--- a/packages/manager/apps/dedicated/client/app/billing/payment/method/add/component.js
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/method/add/component.js
@@ -7,6 +7,7 @@ export default {
   template,
   bindings: {
     addSteps: '<',
+    callback: '<',
     currentUser: '<',
     defaultPaymentMethodIntegration: '<',
     isLastStep: '<',

--- a/packages/manager/apps/dedicated/client/app/billing/payment/method/add/index.html
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/method/add/index.html
@@ -191,6 +191,7 @@
 
                 <ovh-payment-method-integration
                     data-initial-params="$ctrl.componentInitialParams"
+                    data-callback="$ctrl.callback"
                     data-on-submit="$ctrl.onPaymentMethodIntegrationSubmit.bind($ctrl)"
                     data-on-submit-error="$ctrl.onPaymentMethodIntegrationSubmitError.bind($ctrl)"
                     data-on-submit-success="$ctrl.onPaymentMethodIntegrationSuccess.bind($ctrl)"

--- a/packages/manager/apps/dedicated/client/app/billing/payment/method/add/routing.js
+++ b/packages/manager/apps/dedicated/client/app/billing/payment/method/add/routing.js
@@ -76,6 +76,8 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
         },
       }),
 
+      callback: /* @ngInject */ ($location) => $location.search(),
+
       defaultPaymentMethodIntegration: /* @ngInject */ (
         $location,
         ovhPaymentMethodHelper,


### PR DESCRIPTION
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` for hotfix
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-39992
| License          | BSD 3-Clause

## Description

On Adyen component, when adding payment method which needs treatment after provider page redirects user, once user had validated the payment method.

It is hotfix, but maybe investigation to know why some url params disappear once the page is loaded, should be made. 