### PR TITLE
Databases - Block Actions when not in Ready state

### DIFF
--- a/packages/manager/modules/pci/src/components/project/users/users.component.js
+++ b/packages/manager/modules/pci/src/components/project/users/users.component.js
@@ -14,6 +14,7 @@ export default {
     goToModifyPassword: '<?',
     guideUrl: '<?',
     hideRolesMatrix: '<?',
+    isActionDisabled: '<?',
     openStackHorizonLink: '<',
     projectId: '<',
     regeneratePassword: '<?',

--- a/packages/manager/modules/pci/src/components/project/users/users.html
+++ b/packages/manager/modules/pci/src/components/project/users/users.html
@@ -71,6 +71,7 @@
         <oui-action-menu data-compact data-placement="end">
             <oui-action-menu-item
                 data-ng-if="$ctrl.openStackHorizonLink"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-href="{{ $ctrl.openStackHorizonLink($row) }}"
                 data-external
             >
@@ -80,6 +81,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="$ctrl.downloadOpenStackOpenRc"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-on-click="$ctrl.downloadOpenStackOpenRc($row)"
             >
                 <span
@@ -88,6 +90,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="$ctrl.downloadOpenStackRclone"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-on-click="$ctrl.downloadOpenStackRclone($row)"
             >
                 <span
@@ -96,6 +99,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="$ctrl.generateOpenStackToken"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-on-click="$ctrl.generateOpenStackToken($row)"
             >
                 <span
@@ -104,6 +108,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="$ctrl.editRoles"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-on-click="$ctrl.editRoles($row)"
             >
                 <span
@@ -112,6 +117,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="!$ctrl.goToModifyPassword"
+                data-disabled="$ctrl.isActionDisabled()"
                 data-on-click="$ctrl.generatePassword($row)"
             >
                 <span
@@ -121,7 +127,7 @@
             <oui-action-menu-item
                 data-ng-if="$ctrl.goToModifyPassword"
                 data-on-click="$ctrl.goToModifyPassword($row)"
-                data-disabled="$ctrl.constructor.isPending($row)"
+                data-disabled="$ctrl.constructor.isPending($row) || $ctrl.isActionDisabled()"
             >
                 <span
                     data-translate="pci_projects_project_users_modify_password_label"
@@ -129,7 +135,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-on-click="$ctrl.deleteUser($row)"
-                data-disabled="$ctrl.constructor.isPending($row)"
+                data-disabled="$ctrl.constructor.isPending($row) || $ctrl.isActionDisabled()"
             >
                 <span
                     data-translate="pci_projects_project_users_delete_label"
@@ -138,7 +144,10 @@
         </oui-action-menu>
 
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.addUser()">
+            <oui-button
+                data-disabled="$ctrl.isActionDisabled()"
+                data-on-click="$ctrl.addUser()"
+            >
                 <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
                 <span
                     data-translate="pci_projects_project_users_add_label"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/allowed-ips.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/allowed-ips.component.js
@@ -4,6 +4,7 @@ import controller from './allowed-ips.controller';
 export default {
   bindings: {
     allowedIps: '<',
+    database: '<',
     goToAddIp: '<',
     goToDeleteIpBlock: '<',
     goToUpdateIp: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/allowed-ips.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/allowed-ips.html
@@ -22,15 +22,22 @@
             data-searchable
         ></oui-datagrid-column>
         <oui-action-menu data-compact data-placement="end">
-            <oui-action-menu-item data-on-click="$ctrl.openUpdateIp($row)"
+            <oui-action-menu-item
+                data-disabled="!$ctrl.database.isActive()"
+                data-on-click="$ctrl.openUpdateIp($row)"
                 ><span data-translate="pci_databases_allowed_ip_update"></span>
             </oui-action-menu-item>
-            <oui-action-menu-item data-on-click="$ctrl.openDeleteIp($row)"
+            <oui-action-menu-item
+                data-disabled="!$ctrl.database.isActive()"
+                data-on-click="$ctrl.openDeleteIp($row)"
                 ><span data-translate="pci_databases_allowed_ip_delete"></span>
             </oui-action-menu-item>
         </oui-action-menu>
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.openAddIp()">
+            <oui-button
+                data-disabled="!$ctrl.database.isActive()"
+                data-on-click="$ctrl.openAddIp()"
+            >
                 <span
                     class="oui-icon oui-icon-add pr-1"
                     aria-hidden="true"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/delete/delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/allowed-ips/delete/delete.controller.js
@@ -39,9 +39,6 @@ export default class {
           }),
           'error',
         );
-      })
-      .finally(() => {
-        this.isLoading = false;
       });
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.html
@@ -56,7 +56,7 @@
         <oui-action-menu data-compact data-placement="end">
             <oui-action-menu-item
                 data-on-click="$ctrl.restoreBackup($row)"
-                data-disabled="!$row.isActive()"
+                data-disabled="!($row.isActive() && $ctrl.database.isActive())"
             >
                 <span data-translate="pci_databases_backup_restore"></span>
             </oui-action-menu-item>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
@@ -58,6 +58,9 @@ export default /* @ngInject */ ($stateProvider) => {
           );
         },
 
+        isActionDisabled: /* @ngInject */ (database) => () =>
+          !database.isActive(),
+
         roles: /* @ngInject */ (DatabaseService, database, projectId) =>
           DatabaseService.getRoles(projectId, database.engine, database.id),
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w24`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7159
| License          | BSD 3-Clause

## Description

Block actions on Users, IP and Backup management page, when the database is not in ready state