### PR TITLE
fix(training.jobs.submit): load GPU on init

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import head from 'lodash/head';
 import { nameGenerator } from '../../../data-processing/data-processing.utils';
 import { COMMUNITY_URL } from '../../training.constants';
 import convertJobSpecToCliCommand from '../../command_line_converter';
@@ -79,6 +80,7 @@ export default class PciTrainingJobsSubmitController {
     this.showAdvancedImage = false;
     this.emptyData = this.containers.length === 0;
     this.filterContainers();
+    this.onChangeRegion(head(this.regions));
   }
 
   filterContainers() {


### PR DESCRIPTION
Signed-off-by: Adrien Carreira <adrien.carreira@ovhcloud.com>


| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w25`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets           | DTRSD-41196
| License          | BSD 3-Clause

## Description

Load gpu on init for job submit
