### PR TITLE
perf: lazy load payment methods

### DIFF
--- a/packages/manager/modules/account-sidebar/src/controller.js
+++ b/packages/manager/modules/account-sidebar/src/controller.js
@@ -38,6 +38,7 @@ export default class OvhManagerAccountSidebarCtrl {
       this.me = this.coreConfig.getUser();
     }
 
+    this.isSidebarVisible = this.expand;
     this.hasChatbot = false;
     return this.$translate
       .refresh()

--- a/packages/manager/modules/account-sidebar/src/payment-mean/component.js
+++ b/packages/manager/modules/account-sidebar/src/payment-mean/component.js
@@ -4,4 +4,7 @@ import template from './template.html';
 export default {
   template,
   controller,
+  bindings: {
+    visible: '<',
+  },
 };

--- a/packages/manager/modules/account-sidebar/src/payment-mean/controller.js
+++ b/packages/manager/modules/account-sidebar/src/payment-mean/controller.js
@@ -1,9 +1,11 @@
 export default class ManagerHubPaymentMeanCtrl {
   /* @ngInject */
-  constructor($q, $translate, coreURLBuilder, ovhPaymentMethod) {
+  constructor($q, $scope, $translate, coreURLBuilder, ovhPaymentMethod) {
     this.$q = $q;
+    this.$scope = $scope;
     this.$translate = $translate;
     this.ovhPaymentMethod = ovhPaymentMethod;
+    this.fetchPending = null;
 
     this.PAYMENT_METHOD_URL = coreURLBuilder.buildURL(
       'dedicated',
@@ -13,9 +15,21 @@ export default class ManagerHubPaymentMeanCtrl {
 
   $onInit() {
     this.isLoading = true;
-    return this.$translate
-      .refresh()
-      .then(() => this.ovhPaymentMethod.getDefaultPaymentMethod())
+    this.$scope.$watch(
+      () => this.visible,
+      () => {
+        if (this.visible && !this.fetchPending) {
+          this.fetchPending = this.fetchPaymentMethods();
+        }
+      },
+    );
+    return this.$translate.refresh();
+  }
+
+  fetchPaymentMethods() {
+    this.isLoading = true;
+    return this.ovhPaymentMethod
+      .getDefaultPaymentMethod()
       .then((paymentMethod) => {
         this.paymentMethod = paymentMethod;
       })

--- a/packages/manager/modules/account-sidebar/src/template.html
+++ b/packages/manager/modules/account-sidebar/src/template.html
@@ -15,7 +15,8 @@
             </ovh-manager-hub-user-infos>
         </div>
         <div data-ng-if="!$ctrl.me.isEnterprise" class="mb-4">
-            <ovh-manager-hub-payment-mean> </ovh-manager-hub-payment-mean>
+            <ovh-manager-hub-payment-mean data-visible="$ctrl.isSidebarVisible">
+            </ovh-manager-hub-payment-mean>
         </div>
         <div class="mb-4">
             <ovh-manager-hub-shortcuts


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

fetching payment methods with api takes time, add lazy load to account sidebar payment method so the calls are not slowing down the manager's startup