### PR TITLE
fix: fix button download in ODP (PDATA-2890)

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.component.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.component.js
@@ -8,5 +8,6 @@ export default {
   bindings: {
     job: '<',
     projectId: '<',
+    redirectToObjectStorage: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.html
@@ -25,7 +25,6 @@
                 class="logs__downloadbutton"
                 data-variant="primary"
                 data-on-click="$ctrl.downloadLogs()"
-                disabled="$ctrl.isDownloadButtonDisabled"
                 ><span
                     data-translate="data_processing_details_logs_swift_download_label"
                 ></span

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.routing.js
@@ -15,6 +15,25 @@ export default /* @ngInject */ ($stateProvider) =>
         ) => dataProcessingService.getJob(projectId, jobId),
         breadcrumb: /* @ngInject */ ($translate) =>
           $translate.instant('data_processing_details_logs_title'), // update breadcrumb with "/ Logs"
+
+        /**
+         * Redirect to the object storage and project provided while including a filter on the job id
+         */
+        redirectToObjectStorage: /* @ngInject */ ($state, jobId) => (
+          projectId,
+          containerId,
+        ) =>
+          $state.go('pci.projects.project.storages.objects.object', {
+            projectId,
+            containerId,
+            defaultCriteria: [
+              {
+                property: 'name',
+                operator: 'contains',
+                value: jobId,
+              },
+            ],
+          }),
       },
     },
   );

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.component.js
@@ -14,5 +14,6 @@ export default {
     guideUrl: '<',
     projectId: '<',
     refresh: '<',
+    defaultCriteria: '<?',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.html
@@ -84,6 +84,7 @@
         <oui-datagrid
             data-rows="$ctrl.container.objects"
             data-columns-parameters="$ctrl.columnsParameters"
+            data-criteria="$ctrl.defaultCriteria"
         >
             <oui-datagrid-column
                 data-title=":: 'pci_projects_project_storages_containers_container_name_label' | translate"

--- a/packages/manager/modules/pci/src/projects/project/storages/objects/object/object.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/objects/object/object.routing.js
@@ -2,9 +2,14 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('pci.projects.project.storages.objects.object', {
     url: '/{containerId}',
     component: 'pciProjectStorageContainersContainer',
+    params: {
+      defaultCriteria: [],
+    },
     resolve: {
       containerId: /* @ngInject */ ($transition$) =>
         $transition$.params().containerId,
+      defaultCriteria: /* @ngInject */ ($transition$) =>
+        $transition$.params().defaultCriteria,
       container: /* @ngInject */ (
         PciProjectStorageContainersService,
         projectId,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PDATA-2890, MANAGER-7230
| License          | BSD 3-Clause

## Description
There is now a system of job log rotation on data processing meaning that what used to be an url to access the logs is now a set of logs on the object storage page (as stated in the ticket PDATA-2890). These changes allows us to redirect the user to the object storage page on the right container with a filter already set to see only the logs generated by this job.

Signed-off-by: Gaël Leblan <gael.leblan@ovhcloud.com>
