### PR TITLE
perf(feature-availability): use coreConfig user

### DIFF
--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -44,6 +44,7 @@
     "@ovh-ux/component-rollup-config": "^9.0.0 || ^10.0.0"
   },
   "peerDependencies": {
+    "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^2.0.1",
     "@ovh-ux/ng-translate-async-loader": "^2.1.1",
     "@ovh-ux/ui-kit": "^4.4.1",

--- a/packages/manager/modules/cloud-universe-components/src/featureAvailability/service.js
+++ b/packages/manager/modules/cloud-universe-components/src/featureAvailability/service.js
@@ -5,17 +5,11 @@ import { FEATURE_AVAILABILITY } from './constants';
 
 export default class CucFeatureAvailabilityService {
   /* @ngInject */
-  constructor(OvhApiMe, CucConfig) {
-    this.User = OvhApiMe;
+  constructor($q, coreConfig, CucConfig) {
     this.CucConfig = CucConfig;
 
-    this.locale = null;
-    this.localePromise = this.User.v6()
-      .get()
-      .$promise.then((user) => {
-        this.locale = user.ovhSubsidiary;
-        return user.ovhSubsidiary;
-      });
+    this.locale = coreConfig.getUser().ovhSubsidiary;
+    this.localePromise = $q.when(this.locale);
   }
 
   hasFeature(product, feature, locale = this.locale) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

reuse coreConfig user in cloud universe components feature availability to avoid making unecessary network call