### PR TITLE
fix(storages.databases): add beta agreement to databases

### DIFF
--- a/packages/manager/modules/pci/src/components/project/labs/lab.class.js
+++ b/packages/manager/modules/pci/src/components/project/labs/lab.class.js
@@ -18,7 +18,7 @@ export default class Lab {
     return this.status === STATUS.OPEN;
   }
 
-  isActivationg() {
+  isActivating() {
     return this.status === STATUS.ACTIVATING;
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.component.js
@@ -7,6 +7,7 @@ export default {
     databaseGuideUrl: '<',
     engines: '<',
     guideUrl: '<',
+    lab: '<',
     onDatabaseAdd: '<',
     projectId: '<',
     privateNetworks: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -26,6 +26,7 @@ export default class {
   }
 
   $onInit() {
+    this.labAccepted = this.lab.isActivated();
     this.messageContainer = 'pci.projects.project.storages.databases.add';
     this.loadMessages();
     this.model = {
@@ -48,6 +49,10 @@ export default class {
       name: this.$translate.instant('pci_database_common_none'),
     };
     this.trackDatabases('configuration', 'page');
+  }
+
+  acceptLab(accepted) {
+    this.labAccepted = accepted;
   }
 
   loadMessages() {
@@ -166,11 +171,14 @@ export default class {
       'action',
       false,
     );
-    this.DatabaseService.createDatabase(
-      this.projectId,
-      this.model.engine.name,
-      this.orderData,
-    )
+    return this.DatabaseService.activateLab(this.projectId, this.lab)
+      .then(() =>
+        this.DatabaseService.createDatabase(
+          this.projectId,
+          this.model.engine.name,
+          this.orderData,
+        ),
+      )
       .then((databaseInfo) => {
         this.trackDatabases(
           `config_create_database_validated::${this.model.engine.name}`,
@@ -198,5 +206,9 @@ export default class {
         this.$anchorScroll('addMessages');
         this.processingOrder = false;
       });
+  }
+
+  $onDestroy() {
+    this.DatabaseService.stopPollingLabActivationStatus(this.lab.id);
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -220,6 +220,8 @@
         name="review_order"
         data-header="{{:: 'pci_database_add_step6_title' | translate }}"
         data-on-focus="$ctrl.prepareOrderData()"
+        data-valid="$ctrl.labAccepted"
+        data-prevent-next="true"
         data-submit-text="{{:: 'pci_database_add_create_database' | translate }}"
         data-editable="!$ctrl.processingOrder"
     >
@@ -236,6 +238,13 @@
             data-order-data="$ctrl.orderData"
             data-user="$ctrl.user"
         ></database-order-command>
+        <div class="mb-3">
+            <pci-project-lab-agreements
+                data-lab="$ctrl.lab"
+                data-ng-if="!$ctrl.lab.isActivated()"
+                data-on-accept="$ctrl.acceptLab(accepted)"
+            ></pci-project-lab-agreements>
+        </div>
         <div data-ng-if="$ctrl.processingOrder">
             <oui-spinner data-size="s"></oui-spinner>
             <span

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.module.js
@@ -8,6 +8,7 @@ import component from './add.component';
 import enginesList from '../components/engines-list';
 import flavorBilling from '../../../../../components/project/flavor-billing';
 import flavorsList from '../components/flavors-list';
+import labs from '../../../../../components/project/labs';
 import orderCommand from '../components/order-command';
 import orderReview from '../components/order-review';
 import plansList from '../components/plans-list';
@@ -24,6 +25,7 @@ angular
     enginesList,
     flavorBilling,
     flavorsList,
+    labs,
     orderCommand,
     orderReview,
     plansList,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.routing.js
@@ -13,6 +13,9 @@ export default /* @ngInject */ ($stateProvider) => {
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('pci_database_add_title'),
 
+      lab: /* @ngInject */ (PciProjectLabsService, projectId) =>
+        PciProjectLabsService.getLabByName(projectId, 'databases'),
+
       onDatabaseAdd: /* @ngInject */ (
         databases,
         getDatabaseObject,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.module.js
@@ -10,6 +10,7 @@ import add from './add';
 import component from './databases.component';
 import database from './database';
 import deteleDatabase from './delete';
+import labs from '../../../../components/project/labs';
 import node from './components/node';
 import onboarding from './onboarding';
 import routing from './databases.routing';
@@ -24,6 +25,7 @@ angular
     add,
     database,
     deteleDatabase,
+    labs,
     ngOvhSwimmingPoll,
     node,
     onboarding,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7205
| License          | BSD 3-Clause

## Description

The Beta Lab agreements was added to the databases configuration page. Since we would have new agreements for the user to accept, whenever we have new engines added (in beta), it was decided to have it on the configuration page, rather than the onboarding page.
