### PR TITLE
fix: minor bugs on pci data processing (PDATA-2912)

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.constants.js
@@ -25,6 +25,12 @@ export const DATA_PROCESSING_API_STATUSES = Object.freeze({
   TERMINATED: 'TERMINATED',
 });
 
+export const DATA_PROCESSING_ENDED_JOBS = [
+  DATA_PROCESSING_API_STATUSES.FAILED,
+  DATA_PROCESSING_API_STATUSES.COMPLETED,
+  DATA_PROCESSING_API_STATUSES.TERMINATED,
+];
+
 export const DATA_PROCESSING_UI_URL = {
   GRA: 'https://adc.gra.dataconvergence.ovh.com',
   GRA5: 'https://adc.gra.dataconvergence.ovh.com',
@@ -39,6 +45,7 @@ export default {
   DATA_PROCESSING_UI_URL,
   DATA_PROCESSING_GUIDE_URL,
   DATA_PROCESSING_API_STATUSES,
+  DATA_PROCESSING_ENDED_JOBS,
 };
 
 export const METRICS_REFRESH_INTERVAL = 5000;

--- a/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.controller.js
@@ -60,7 +60,7 @@ export default class {
       this.projectId,
       pageOffset,
       pageSize,
-      sort.property,
+      { name: sort.property, dir: sort.dir === -1 ? 'DESC' : 'ASC' },
       filters,
     );
   }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.service.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/data-processing.service.js
@@ -48,14 +48,14 @@ export default class DataProcessingService {
     projectId,
     offset = 0,
     pageSize = 25,
-    sort = 'creationDate',
+    sort = { name: 'creationDate', dir: 'desc' },
     filters = null,
   ) {
     let res = this.OvhApiCloudProjectDataProcessingJobs.query()
       .expand('CachedObjectList-Pages')
       .limit(pageSize)
       .offset(offset)
-      .sort(sort, 'desc');
+      .sort(sort.name, sort.dir);
     if (filters !== null) {
       filters.forEach((filter) => {
         res = res.addFilter(filter.name, filter.operator, filter.value);

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-dashboard/job-dashboard.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-dashboard/job-dashboard.html
@@ -24,7 +24,7 @@
             <!-- Tile item :: Created -->
             <oui-tile-definition
                 data-term="{{ :: 'data_processing_details_information_creation_date_label' | translate }}"
-                data-description="{{ $ctrl.formatDateToCalendar(job.creationDate) }}"
+                data-description="{{ $ctrl.formatDateToCalendar($ctrl.job.creationDate) }}"
             >
             </oui-tile-definition>
             <!-- Tile item :: Elapsed time -->
@@ -177,7 +177,7 @@
             <oui-tile-definition
                 data-term="{{ ::'data_processing_details_configuration_job_type_label' | translate }}"
                 title="{{ ::'data_processing_details_configuration_job_type_label' | translate }}"
-                data-description="{{ $ctrl.job.type }}"
+                data-description="{{ $ctrl.job.type}} {{$ctrl.job.engineVersion}} - {{$ctrl.job.engineParameters.job_type}}"
             >
             </oui-tile-definition>
             <oui-tile-definition

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.controller.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { formatLogsDate } from './job-logs.utils';
-import { DATA_PROCESSING_API_STATUSES } from '../../data-processing.constants';
+import { DATA_PROCESSING_ENDED_JOBS } from '../../data-processing.constants';
 
 export default class {
   /* @ngInject */
@@ -31,9 +31,7 @@ export default class {
   }
 
   isJobTerminated() {
-    return (
-      this.job.status.toUpperCase() === DATA_PROCESSING_API_STATUSES.TERMINATED
-    );
+    return DATA_PROCESSING_ENDED_JOBS.includes(this.job.status.toUpperCase());
   }
 
   downloadLogs() {

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/job-logs.html
@@ -16,7 +16,7 @@
         </div>
         <div
             class="col-md-12 logger_placeholder"
-            data-ng-if="$ctrl.logger.logs.logsAddress !== null && !$ctrl.isJobTerminated()"
+            data-ng-if="$ctrl.logger.logs.logsAddress !== null && $ctrl.isJobTerminated()"
         >
             {{ ::'data_processing_details_logs_swift' |
             translate:{swiftUrl:$ctrl.logger.logs.logsAddress} }}
@@ -30,12 +30,6 @@
                     data-translate="data_processing_details_logs_swift_download_label"
                 ></span
             ></oui-button>
-        </div>
-        <div
-            class="col-md-12 logger_placeholder"
-            data-ng-if="$ctrl.isJobTerminated()"
-        >
-            {{ ::'data_processing_details_logs_terminated' | translate }}
         </div>
     </div>
 </div>

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_de_DE.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Ihr Auftrag ist abgeschlossen. Die Logs dazu finden Sie im Objektcontainer.",
   "data_processing_details_logs_swift_download_label": "Die Logs herunterladen",
-  "data_processing_details_logs_terminated": "Ihr Auftrag wurde angehalten. Kein Log verfügbar.",
   "data_processing_details_logs_default_message": "Warten auf Logs..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_en_GB.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Your job is finished. You can find its logs in your object container.",
   "data_processing_details_logs_swift_download_label": "Download logs",
-  "data_processing_details_logs_terminated": "Your job has been stopped. No logs available.",
   "data_processing_details_logs_default_message": "Pending logs..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_es_ES.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Su job ha terminado. Consulte sus logs en el contenedor de objetos.",
   "data_processing_details_logs_swift_download_label": "Descargar los logs",
-  "data_processing_details_logs_terminated": "Su job se ha detenido. No hay ningún log disponible.",
   "data_processing_details_logs_default_message": "Buscando logs... "
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_fr_CA.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Votre job est terminé. Retrouvez ses logs dans votre conteneur d'objets.",
   "data_processing_details_logs_swift_download_label": "Télécharger les logs",
-  "data_processing_details_logs_terminated": "Votre job a été stoppé. Aucun log n'est disponible.",
   "data_processing_details_logs_default_message": "En attente de logs…"
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_fr_FR.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Votre job est terminé. Retrouvez ses logs dans votre conteneur d'objets.",
   "data_processing_details_logs_swift_download_label": "Télécharger les logs",
-  "data_processing_details_logs_terminated": "Votre job a été stoppé. Aucun log n'est disponible.",
   "data_processing_details_logs_default_message": "En attente de logs…"
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_it_IT.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "Il job è terminato. Recuperane i log nel container di oggetti.",
   "data_processing_details_logs_swift_download_label": "Scarica i log",
-  "data_processing_details_logs_terminated": "Il job è stato interrotto. Nessun log disponibile",
   "data_processing_details_logs_default_message": "In attesa dei log..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_pl_PL.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logi",
   "data_processing_details_logs_swift": "Zadanie zostało zakończone. Odszukaj logi w kontenerze obiektów.",
   "data_processing_details_logs_swift_download_label": "Pobierz logi",
-  "data_processing_details_logs_terminated": "Zadanie zostało zatrzymane. Brak dostępnych logów.",
   "data_processing_details_logs_default_message": "Oczekiwanie na logi..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/job-details/job-logs/translations/Messages_pt_PT.json
@@ -2,6 +2,5 @@
   "data_processing_details_logs_title": "Logs",
   "data_processing_details_logs_swift": "O seu job está finalizado. Consulte os logs no seu container de objetos.",
   "data_processing_details_logs_swift_download_label": "Descarregar os logs",
-  "data_processing_details_logs_terminated": "O seu job foi interrompido. Nenhum log disponível.",
   "data_processing_details_logs_default_message": "A aguardar logs..."
 }

--- a/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.constants.js
@@ -1,11 +1,7 @@
 export const MEMORY_OVERHEAD_RATIO = 0.1;
-export const MIN_MEMORY_OVERHEAD_MB = 384;
-export const MAX_MEMORY_TOTAL_MB = 30720;
 export const GIB_IN_MIB = 1024;
 
 export default {
   MEMORY_OVERHEAD_RATIO,
-  MIN_MEMORY_OVERHEAD_MB,
-  MAX_MEMORY_TOTAL_MB,
   GIB_IN_MIB,
 };

--- a/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/spark-sizing/spark-sizing.html
@@ -125,7 +125,7 @@
                     name="driver-memory"
                     data-model="$ctrl.state.driverMemoryGb"
                     data-min="$ctrl.jobParameters.driver_memory.validator.min / 1024"
-                    data-max="$ctrl.jobParameters.driver_memory.validator.max / 1024"
+                    data-max="$ctrl.maxMemoryDriverGb"
                     data-on-change="$ctrl.onChangeDriverMemoryHandler(modelValue)"
                 >
                 </oui-numeric>
@@ -140,7 +140,7 @@
                     name="driver-memory-overhead"
                     data-model="$ctrl.state.driverMemoryOverheadMb"
                     data-min="$ctrl.jobParameters.driver_memory_overhead.validator.min"
-                    data-max="$ctrl.jobParameters.driver_memory_overhead.validator.max"
+                    data-max="$ctrl.maxOverheadMemoryDriverGb"
                     data-disabled="$ctrl.state.advancedSizingDriverMemOverheadAuto"
                 >
                 </oui-numeric>
@@ -182,7 +182,7 @@
                     name="worker-memory"
                     data-model="$ctrl.state.workerMemoryGb"
                     data-min="$ctrl.jobParameters.executor_memory.validator.min / 1024"
-                    data-max="$ctrl.jobParameters.executor_memory.validator.max / 1024"
+                    data-max="$ctrl.maxMemoryWorkerGb"
                     data-on-change="$ctrl.onChangeWorkerMemoryHandler(modelValue)"
                 >
                 </oui-numeric>
@@ -197,7 +197,7 @@
                     name="worker-memory-overhead"
                     data-model="$ctrl.state.workerMemoryOverheadMb"
                     data-min="$ctrl.jobParameters.executor_memory_overhead.validator.min"
-                    data-max="$ctrl.jobParameters.executor_memory_overhead.validator.max"
+                    data-max="$ctrl.maxOverheadMemoryWorkerGb"
                     data-disabled="$ctrl.state.advancedSizingWorkerMemOverheadAuto"
                 >
                 </oui-numeric>

--- a/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/submit-job.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/submit-job.html
@@ -43,6 +43,7 @@
             data-on-submit="$ctrl.onSubmitJobSizingHandler(form)"
         >
             <pci-project-data-processing-submit-job-spark-sizing
+                data-ng-if="$ctrl.jobParameters"
                 data-project-id="$ctrl.projectId"
                 data-templates="$ctrl.state.jobEngine.templates"
                 data-values="$ctrl.state.jobSizing"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PDATA-2355 #PDATA-2701 #PDATA-2729 #PDATA-2814 #PDATA-2892
| License          | BSD 3-Clause

## Description

This PR contains multiple minor fixes included in the epic PDATA-2912. The fixes contained by this PR are :
PDATA-2355 ODP - Manager can't submit jobs with different driver and executor template
PDATA-2701 ODP - Manager - Memory overhead calculation error
PDATA-2729 ODP - Manager job details page missing spark version and inconsistency
PDATA-2814 ODP - Manager - Sorting of jobs isn't working as expected
PDATA-2892 ODP - Manager - Can't download stopped and failed jobs log 

Signed-off-by: Gael Leblan <gael.leblan@ovhcloud.com>
