### PR TITLE
fix(dedicated.servers): wrong datacenter translation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.html
@@ -53,7 +53,8 @@
             data-type-options="$ctrl.datacenterEnumFilter"
         >
             <span
-                data-translate="{{:: 'server_datacenter_' + $ctrl.constructor.toUpperSnakeCase($value) }}"
+                data-translate="{{:: 'server_datacenter_' + $ctrl.constructor.toUpperSnakeCase($value).split('_')[0] }}"
+                data-translate-values="{ number:  $ctrl.constructor.toUpperSnakeCase($value).split('_')[1] }"
             ></span>
         </oui-datagrid-column>
         <oui-datagrid-column


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-41882
| License          | BSD 3-Clause

## Description

Correct datacenter translation for dedicated servers

ref: DTRSD-41882

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
