### PR TITLE
fix(pci.storages.databases): disable unavailable networks

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/flavor.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/flavor.class.js
@@ -14,6 +14,10 @@ export default class Flavor {
     this.isDefault = some(availability, 'default');
   }
 
+  isNetworkSupported(networkName) {
+    return some(this.availability, { network: networkName });
+  }
+
   get nodesCount() {
     return get(head(this.availability), 'minNodeNumber');
   }
@@ -38,5 +42,13 @@ export default class Flavor {
       priceInUcents: this.nodeMonthlyPrice.priceInUcents * this.nodesCount,
       tax: this.nodeMonthlyPrice.tax * this.nodesCount,
     };
+  }
+
+  get supportsPrivateNetwork() {
+    return this.isNetworkSupported('private');
+  }
+
+  get supportsPublicNetwork() {
+    return this.isNetworkSupported('public');
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -82,7 +82,7 @@ export default class {
   }
 
   onFlavorSelect() {
-    this.model.usePrivateNetwork = false;
+    this.model.usePrivateNetwork = !this.model.flavor.supportsPublicNetwork;
     this.model.privateNetwork = this.defaultPrivateNetwork;
     this.model.subnet = null;
     this.model.name = `${this.model.engine.name}-${this.model.flavor.name}-${this.model.plan.name}-`;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -127,13 +127,26 @@
             />
         </oui-field>
 
+        <oui-message
+            data-ng-if="!($ctrl.model.flavor.supportsPublicNetwork && $ctrl.model.flavor.supportsPrivateNetwork)"
+            data-type="info"
+        >
+            <span
+                data-ng-bind="(
+                    $ctrl.model.flavor.supportsPublicNetwork
+                        ? 'pci_database_add_network_mode_private_incompatible'
+                        : 'pci_database_add_network_mode_public_incompatible'
+                    ) | translate"
+            ></span>
+        </oui-message>
+
         <oui-field
             data-label="{{ :: 'pci_database_add_network_mode_label' | translate }}"
         >
             <oui-radio-group data-model="$ctrl.model.usePrivateNetwork">
                 <oui-radio
                     data-value="false"
-                    data-disabled="$ctrl.loadingSubnets"
+                    data-disabled="$ctrl.loadingSubnets || !$ctrl.model.flavor.supportsPublicNetwork"
                 >
                     <span
                         data-translate="pci_database_add_network_mode_public"
@@ -141,7 +154,7 @@
                 </oui-radio>
                 <oui-radio
                     data-value="true"
-                    data-disabled="$ctrl.loadingSubnets"
+                    data-disabled="$ctrl.loadingSubnets || !$ctrl.model.flavor.supportsPrivateNetwork"
                 >
                     <span
                         data-translate="pci_database_add_network_mode_private"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_de_DE.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Eine Datenbank-Instanz erstellen",
   "pci_database_add_create_database_processing": "Der Datenserver wird gerade erstellt.",
   "pci_database_add_create_database_success": "Ihre Datenbank wird gerade erstellt und ist in einigen Minuten verfügbar.",
-  "pci_database_add_create_database_error": "Bei der Erstellung Ihrer Datenbank ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal: {{message}}"
+  "pci_database_add_create_database_error": "Bei der Erstellung Ihrer Datenbank ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal: {{message}}",
+  "pci_database_add_network_mode_public_incompatible": "Das gewählte Angebot ist nicht mit öffentlichen Netzwerken kompatibel.",
+  "pci_database_add_network_mode_private_incompatible": "Das gewählte Angebot ist nicht mit privaten Netzwerken kompatibel."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_en_GB.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Create a database instance",
   "pci_database_add_create_database_processing": "Creating data server...",
   "pci_database_add_create_database_success": "Your database is being created, and will be available in a few minutes.",
-  "pci_database_add_create_database_error": "An error has occurred creating your database. Please try the operation again later: {{message}}"
+  "pci_database_add_create_database_error": "An error has occurred creating your database. Please try the operation again later: {{message}}",
+  "pci_database_add_network_mode_public_incompatible": "The solution selected is not compatible with public networks.",
+  "pci_database_add_network_mode_private_incompatible": "The solution selected is not compatible with private networks."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_es_ES.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Crear una instancia de base de datos",
   "pci_database_add_create_database_processing": "Creando el servidor de datos...",
   "pci_database_add_create_database_success": "La base de datos se está creando y estará disponible en unos minutos.",
-  "pci_database_add_create_database_error": "Se ha producido un error al crear la base de datos. Por favor, vuelva a intentarlo más tarde: {{message}}"
+  "pci_database_add_create_database_error": "Se ha producido un error al crear la base de datos. Por favor, vuelva a intentarlo más tarde: {{message}}",
+  "pci_database_add_network_mode_public_incompatible": "El producto seleccionado no es compatible con las redes públicas.",
+  "pci_database_add_network_mode_private_incompatible": "El producto seleccionado no es compatible con las redes privadas."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_CA.json
@@ -17,6 +17,8 @@
   "pci_database_add_network_mode_label": "Type de réseau",
   "pci_database_add_network_mode_public": "Public",
   "pci_database_add_network_mode_private": "Privé",
+  "pci_database_add_network_mode_public_incompatible": "L'offre sélectionnée n'est pas compatible avec les réseaux publics.",
+  "pci_database_add_network_mode_private_incompatible": "L'offre sélectionnée n'est pas compatible avec les réseaux privés.",
   "pci_database_add_privateNetwork_label": "Réseau privé attaché",
   "pci_database_add_privateNetwork_description": "Par défaut, les bases de données possèdent un réseau public. Vous pouvez également ajouter un réseau privé, mais vous perdrez la configuration que vous venez d’établir.",
   "pci_database_add_privateNetwork_add": "Créer un réseau privé",

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
@@ -17,6 +17,8 @@
   "pci_database_add_network_mode_label": "Type de réseau",
   "pci_database_add_network_mode_public": "Public",
   "pci_database_add_network_mode_private": "Privé",
+  "pci_database_add_network_mode_public_incompatible": "L'offre sélectionnée n'est pas compatible avec les réseaux publics.",
+  "pci_database_add_network_mode_private_incompatible": "L'offre sélectionnée n'est pas compatible avec les réseaux privés.",
   "pci_database_add_privateNetwork_label": "Réseau privé attaché",
   "pci_database_add_privateNetwork_description": "Par défaut, les bases de données possèdent un réseau public. Vous pouvez également ajouter un réseau privé, mais vous perdrez la configuration que vous venez d’établir.",
   "pci_database_add_privateNetwork_add": "Créer un réseau privé",

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_it_IT.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Crea un'istanza di database",
   "pci_database_add_create_database_processing": "Creazione del server dati in corso...",
   "pci_database_add_create_database_success": "La creazione del database è in corso e sarà disponibile tra pochi minuti.",
-  "pci_database_add_create_database_error": "Si è verificato un errore durante la creazione del database. Riprova l'operazione in seguito: {{message}}"
+  "pci_database_add_create_database_error": "Si è verificato un errore durante la creazione del database. Riprova l'operazione in seguito: {{message}}",
+  "pci_database_add_network_mode_public_incompatible": "L'offerta selezionata non è compatibile con le reti pubbliche.",
+  "pci_database_add_network_mode_private_incompatible": "L'offerta selezionata non è compatibile con le reti private."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_pl_PL.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Tworzenie instancji bazy danych",
   "pci_database_add_create_database_processing": "Trwa tworzenie serwera danych",
   "pci_database_add_create_database_success": "Trwa tworzenie bazy danych. Będzie ona dostępna za kilka minut.",
-  "pci_database_add_create_database_error": "Wystąpił błąd podczas tworzenia bazy danych. Spróbuj ponownie później: {{message}} "
+  "pci_database_add_create_database_error": "Wystąpił błąd podczas tworzenia bazy danych. Spróbuj ponownie później: {{message}} ",
+  "pci_database_add_network_mode_public_incompatible": "Wybrana oferta nie jest kompatybilna z sieciami publicznymi.",
+  "pci_database_add_network_mode_private_incompatible": "Wybrana oferta nie jest kompatybilna z sieciami prywatnymi."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_pt_PT.json
@@ -28,5 +28,7 @@
   "pci_database_add_create_database": "Criar uma instância de base de dados",
   "pci_database_add_create_database_processing": "O servidor de dados está a ser criado",
   "pci_database_add_create_database_success": "A sua base de dados está a ser criada e estará disponível dentro de alguns minutos.",
-  "pci_database_add_create_database_error": "Ocorreu um erro aquando da criação da sua base de dados. Tente novamente mais tarde: {{message}}"
+  "pci_database_add_create_database_error": "Ocorreu um erro aquando da criação da sua base de dados. Tente novamente mais tarde: {{message}}",
+  "pci_database_add_network_mode_public_incompatible": "A oferta selecionada não é compatível com as redes públicas.",
+  "pci_database_add_network_mode_private_incompatible": "A oferta selecionada não é compatível com as redes privadas."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7190
| License          | BSD 3-Clause

## Description

Disable the network (private/public) that is not available and auto-select the one that is available. Also display a message info, telling the user that the particular network is not available for the selected offer (only if one of the networks is not available).
