### PR TITLE
fix: add corresponding translations for `netapp` product

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/contacts/service/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/contacts/service/translations/Messages_fr_FR.json
@@ -38,5 +38,6 @@
   "account_contacts_service_contact_tech": "Contact technique",
   "account_contacts_service_contact_billing": "Contact facturation",
   "account_contacts_service_infos": "Vous avez la possibilité de changer les comptes administateur, technique et facturation de vos services.",
-  "account_contacts_service_category_LOGS": "Logs Data Platform"
+  "account_contacts_service_category_LOGS": "Logs Data Platform",
+  "account_contacts_service_category_NETAPP": "NetApp"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_FR.json
@@ -125,6 +125,7 @@
   "billing_autorenew_service_type_webcoach": "WebCoach",
   "billing_autorenew_service_type_OVH_CLOUD_CONNECT": "OVHcloud Connect",
   "billing_autorenew_service_type_WEB_PAAS": "Web PaaS",
+  "billing_autorenew_service_type_NETAPP": "NetApp",
   "billing_export_csv": "Exporter en CSV",
   "billing_common_link_new_window": "(nouvelle fenêtre)",
   "billing_autorenew_renew_action": "Renouveler",

--- a/packages/manager/modules/hub/src/components/products/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/hub/src/components/products/translations/Messages_fr_FR.json
@@ -46,6 +46,7 @@
   "manager_hub_products_LICENCE_SQL_SERVER": "Licences SQL Server",
   "manager_hub_products_METRICS": "Metrics",
   "manager_hub_products_MS_SERVICES_SHAREPOINT": "Microsoft SharePoint",
+  "manager_hub_products_NETAPP": "NetApp",
   "manager_hub_products_OVH_CLOUD_CONNECT": "OVHcloud Connect",
   "manager_hub_products_OVER_THE_BOX": "OverTheBox",
   "manager_hub_products_PACK_XDSL": "Packs xDSL",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/netapp`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7267
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

729acf1 - fix: add corresponding translations for `netapp` product

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>

cc @marie-j @JeremyDec 
