### PR TITLE
Feat/manager 7288: add vps announcement banner on the dashboard

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/component.js
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/component.js
@@ -1,0 +1,9 @@
+import controller from './controller';
+import template from './template.html';
+
+const component = {
+  controller,
+  template,
+};
+
+export default component;

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/controller.js
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/controller.js
@@ -1,0 +1,7 @@
+export default class VpsAnnouncementBannerComponentController {
+  /* @ngInject */
+  constructor(coreConfig) {
+    this.coreConfig = coreConfig;
+    this.tasksInfoLink = 'http://travaux.ovh.net/?do=details&id=51831';
+  }
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/index.js
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/index.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
+
+import component from './component';
+
+const moduleName = 'ovhManagerVpsComponentsVpsAnnouncementBanner';
+
+angular
+  .module(moduleName, ['pascalprecht.translate', 'oui'])
+  .component('vpsAnnouncementBanner', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/template.html
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/template.html
@@ -1,0 +1,15 @@
+<oui-message
+    class="mb-3"
+    data-type="info"
+    dismissable
+>
+    <span data-translate="pci_components_vps_announcement_banner_info"></span>
+    <p class="m-0">
+        <a
+            target="_blank"
+            rel="noopener"
+            data-translate="pci_components_vps_announcement_banner_info_link"
+            data-ng-href="{{:: $ctrl.tasksInfoLink }}"
+        ></a>
+    </p>
+</oui-message>

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_de_DE.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_de_DE.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "VPS Wartung mit Auswirkung auf die Verwaltung Ihrer Dienstleistung.",
+  "pci_components_vps_announcement_banner_info_link": "Mehr erfahren."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_en_GB.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_en_GB.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "VPS maintenance with impact on your service management.",
+  "pci_components_vps_announcement_banner_info_link": "Find out more."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_es_ES.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_es_ES.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Mantenimiento del VPS que afecta a la gestión de su servicio.",
+  "pci_components_vps_announcement_banner_info_link": "Más información."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_fr_CA.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Maintenance VPS avec impact sur le management de votre service.",
+  "pci_components_vps_announcement_banner_info_link": "En savoir plus."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Maintenance VPS avec impact sur le management de votre service.",
+  "pci_components_vps_announcement_banner_info_link": "En savoir plus."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_it_IT.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_it_IT.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Manutenzione del VPS con impatto sulla gestione del tuo servizio.",
+  "pci_components_vps_announcement_banner_info_link": "Scopri di più"
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_pl_PL.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Planowe prace modernizacyjne na serwerach VPS ograniczające czasowo zarządzanie usługą.",
+  "pci_components_vps_announcement_banner_info_link": "Dowiedz się więcej."
+}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/translations/Messages_pt_PT.json
@@ -1,0 +1,4 @@
+{
+  "pci_components_vps_announcement_banner_info": "Manutenção do VPS com impacto na gestão do seu serviço.",
+  "pci_components_vps_announcement_banner_info_link": "Saber mais"
+}

--- a/packages/manager/modules/vps/src/dashboard/index.js
+++ b/packages/manager/modules/vps/src/dashboard/index.js
@@ -33,6 +33,7 @@ import ovhManagerVpsDashboardTerminate from './terminate';
 import ovhManagerVpsDashboardTerminateOption from './modal/terminate-option';
 import ovhManagerVpsDashboardTile from './tile';
 import vpsStateInfo from './components/vps-state-info';
+import vpsAnnouncementBanner from './components/vps-announcement-banner';
 
 const moduleName = 'ovhManagerVpsDashboard';
 
@@ -62,6 +63,7 @@ angular
     ovhManagerVpsDashboardTerminateOption,
     ovhManagerVpsDashboardTile,
     vpsStateInfo,
+    vpsAnnouncementBanner,
     'ui.router',
   ])
   .service('vpsUpgradeTile', vpsUpgradeTileService)

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.component.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.component.js
@@ -42,6 +42,7 @@ export default {
     vpsMigrationTask: '<',
     vpsMigrationTaskInError: '<',
     vpsUpgradeTask: '<',
+    canDisplayVpsAnnouncementBanner: '<',
   },
   controller,
   name: 'ovhManagerVpsDashboard',

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -1,5 +1,10 @@
 <ovh-manager-incident-banner service-name="$ctrl.serviceName">
 </ovh-manager-incident-banner>
+
+<vps-announcement-banner
+    data-ng-if="$ctrl.canDisplayVpsAnnouncementBanner">
+</vps-announcement-banner>
+
 <oui-message data-ng-if="$ctrl.canScheduleMigration" data-type="warning">
     <p
         data-translate="vps_dashboard_migration_warning"

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -189,6 +189,14 @@ export default /* @ngInject */ ($stateProvider) => {
       },
       breadcrumb: () => null,
       trackingPrefix: () => 'vps::detail::dashboard',
+      canDisplayVpsAnnouncementBanner: /* @ngInject */ (ovhFeatureFlipping) => {
+        const vpsAnnouncementBannerId = 'vps:vps-announcement-banner';
+        return ovhFeatureFlipping
+          .checkFeatureAvailability(vpsAnnouncementBannerId)
+          .then((newRegionFeature) =>
+            newRegionFeature.isFeatureAvailable(vpsAnnouncementBannerId),
+          );
+      },
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7288
| License          | BSD 3-Clause

## Description

Banner to display some info concerning VPS.

### :flags: Translations

- [x] TRANS-36371