### PR TITLE
feat(manager-components): added edit name and format dc components

### DIFF
--- a/packages/manager/modules/manager-components/src/edit-name/README.md
+++ b/packages/manager/modules/manager-components/src/edit-name/README.md
@@ -1,0 +1,55 @@
+# ovh-manager-edit-name
+
+The `ovh-manager-edit-name` component provides a reusable interface to update service name.
+
+## Installation
+
+```js
+import 'angular';
+import {
+  managerEditName,
+ } from '@ovh-ux/manager-components';
+
+angular.module('myModule', [managerEditName]);
+```
+
+## Attributes
+
+| Attribute         | Type            | Binding | One-time binding | Values                    | Default    | Description
+| ----              | ----            | ----    | ----             | ----                      | ----       | ----
+| `name`            | string          | @       | no              | n/a                       | n/a        | current name
+| `serviceId`      | string          | @?      | no              | n/a                       | n/a        | serviceId of the current service, obtained from serviceInfo API)
+| `serviceInfoApiUrl`       | string          | @?      | no              | n/a  | n/a  | url to fetch serviceId if not provided
+| `urlParams`       | Object          | <?      | no              | n/a  | n/a  | parameters for the url provided
+| `onSuccess`       | function          | &?      | no              | n/a  | n/a  | on success handler
+| `onError`       | function          | &?      | no              | n/a  | n/a  | on error handler
+| `onCancel`       | function          | &?      | no              | n/a  | n/a  | on cancel handler
+
+## Basic Usage
+Below is the simplest form of using this component,
+
+```html
+
+ <manager-edit-name
+  service-info-api-url="/dedicated/server/:serviceName/serviceInfos"
+  url-params="{ serviceName: 'service-name' }"
+  on-success="$ctrl.handleSuccess(res)"
+  on-error="$ctrl.handleError(error)"
+  on-cancel="$ctrl.handleCancel()">
+ </manager-edit-name>
+  or
+ <manager-edit-name
+  service-id="service-id"
+  on-success="$ctrl.handleSuccess(res)"
+  on-error="$ctrl.handleError(error)"
+  on-cancel="$ctrl.handleCancel()">
+ </manager-edit-name>
+```
+
+## Contributing
+
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
+
+## License
+
+[BSD-3-Clause](LICENSE) © OVH SAS

--- a/packages/manager/modules/manager-components/src/edit-name/component.js
+++ b/packages/manager/modules/manager-components/src/edit-name/component.js
@@ -1,0 +1,30 @@
+import controller from './controller';
+import template from './template.html';
+
+/**
+ * either serviceId or (serviceInfoApiUrl and urlParams) is required
+ * ex:
+ * <manager-edit-name
+ *  service-info-api-url="/dedicated/server/:serviceName/serviceInfos"
+ *  url-params="{ serviceName: 'service-name' }">
+ * </manager-edit-name>
+ * or
+ * <manager-edit-name
+ *  service-id="service-id">
+ * </manager-edit-name>
+ *
+ * */
+export default {
+  bindings: {
+    name: '@',
+    serviceId: '@?',
+    serviceInfoApiUrl: '@?',
+    urlParams: '<?',
+    loading: '<?',
+    onSuccess: '&?',
+    onCancel: '&?',
+    onError: '&?',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/manager-components/src/edit-name/controller.js
+++ b/packages/manager/modules/manager-components/src/edit-name/controller.js
@@ -1,0 +1,115 @@
+import isFunction from 'lodash/isFunction';
+
+export default class ManagerComponentsEditNameController {
+  /* @ngInject */
+  constructor($http, $log, $translate, $q) {
+    this.$http = $http;
+    this.$log = $log;
+    this.$translate = $translate;
+    this.$q = $q;
+  }
+
+  $onInit() {
+    this.isUpdating = false;
+
+    // either serviceId or (serviceInfoApiUrl and urlParams) is required
+    if (this.serviceId || (this.serviceInfoApiUrl && this.urlParams)) {
+      this.serviceId = this.getServiceId()
+        .then((serviceId) => serviceId)
+        .catch((error) => {
+          this.$log.warn(
+            'Not able to fetch serviceId. Provide valid serviceInfoApiUrl and urlParams.',
+          );
+          this.handleError(error);
+        });
+    } else {
+      this.$log.warn(
+        'Either serviceId or (serviceInfoApiUrl and urlParams) is required',
+      );
+    }
+  }
+
+  saveName() {
+    this.isUpdating = true;
+    return this.$q
+      .when(this.serviceId)
+      .then((serviceId) => {
+        return this.$http.put(`/service/${serviceId}`, {
+          resource: {
+            displayName: this.name,
+          },
+        });
+      })
+      .then(() => {
+        this.handleSuccess(
+          this.name,
+          this.$translate.instant(
+            'server_name_edit_success',
+          ),
+        )
+      })
+      .catch((error) => {
+        this.handleError(
+          error,
+          this.$translate.instant(
+            'server_name_edit_error',
+            {
+              message: error.message || error.data?.message,
+            }
+          ),
+        );
+      })
+      .finally(() => {
+        this.isUpdating = false;
+      });
+  }
+
+  getServiceId() {
+    if (this.serviceId) {
+      return this.$q.when(this.serviceId);
+    }
+    return this.$http
+      .get(this.constructUrl())
+      .then(({ data }) => data.serviceId);
+  }
+
+  constructUrl() {
+    if (this.serviceInfoApiUrl && this.urlParams) {
+      return ServerEditNameController.formatUrl(
+        this.serviceInfoApiUrl,
+        this.urlParams,
+      );
+    }
+    return null;
+  }
+
+  static formatUrl(url, params) {
+    return url.replace(
+      /(^|\/):(\w+)(?=\/|$)/g,
+      (m, g1, g2) => g1 + (params[g2] || m),
+    );
+  }
+
+  handleCancel() {
+    if (isFunction(this.onCancel)) {
+      this.onCancel();
+    }
+  }
+
+  handleError(error, message = null) {
+    if (isFunction(this.onError)) {
+      this.onError({
+        error: { message, data: error }
+      });
+    }
+  }
+
+  handleSuccess(name, message) {
+    if (isFunction(this.onSuccess)) {
+      this.onSuccess({
+        name,
+        message,
+      });
+    }
+  }
+}

--- a/packages/manager/modules/manager-components/src/edit-name/index.js
+++ b/packages/manager/modules/manager-components/src/edit-name/index.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+
+import '@ovh-ux/ui-kit';
+import 'angular-translate';
+import '@ovh-ux/ng-translate-async-loader';
+
+import component from './component';
+
+const moduleName = 'ovhManagerComponentsEditNameComponent';
+
+angular
+  .module(moduleName, [
+    'oui',
+    'pascalprecht.translate',
+    'ngTranslateAsyncLoader',
+  ])
+  .component('managerEditName', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/manager-components/src/edit-name/template.html
+++ b/packages/manager/modules/manager-components/src/edit-name/template.html
@@ -1,0 +1,31 @@
+<form
+    id="serverEditName"
+    name="serverEditName"
+    data-ng-submit="serverEditName.$valid && $ctrl.saveName()"
+    novalidate
+>
+    <oui-modal
+        data-heading="{{:: 'server_name_edit_title' | translate }}"
+        data-primary-label="{{:: 'server_name_edit_common_save' | translate }}"
+        data-secondary-label="{{:: 'server_name_edit_common_cancel' | translate }}"
+        data-secondary-action="$ctrl.handleCancel()"
+        data-on-dismiss="$ctrl.handleCancel()"
+        data-loading="$ctrl.loading || $ctrl.isUpdating"
+        data-type="warning"
+    >
+        <p data-translate="server_name_edit_help"></p>
+        <oui-field
+            data-label="{{:: 'server_name_edit_displayname_label' | translate }}"
+        >
+            <input
+                class="oui-input"
+                type="text"
+                name="server-edit-name"
+                id="server-edit-name"
+                data-ng-model="$ctrl.name"
+                required
+                autofocus
+            />
+        </oui-field>
+    </oui-modal>
+</form>

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_de_DE.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_de_DE.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Namen ändern",
+  "server_name_edit_help": "Den im Header angezeigten Namen ändern.",
+  "server_name_edit_displayname_label": "Name",
+  "server_name_edit_common_save": "Speichern",
+  "server_name_edit_common_cancel": "Abbrechen"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_en_GB.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_en_GB.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Change the name",
+  "server_name_edit_help": "Changes the name displayed in the header.",
+  "server_name_edit_displayname_label": "Name",
+  "server_name_edit_common_save": "Save",
+  "server_name_edit_common_cancel": "Cancel"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_es_ES.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_es_ES.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Modificar el nombre",
+  "server_name_edit_help": "Modificar el nombre en el encabezado.",
+  "server_name_edit_displayname_label": "Apellidos",
+  "server_name_edit_common_save": "Guardar",
+  "server_name_edit_common_cancel": "Cancelar"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_fr_CA.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Modifier le nom",
+  "server_name_edit_help": "Modifie le nom affiché dans l'entête.",
+  "server_name_edit_displayname_label": "Nom",
+  "server_name_edit_common_save": "Sauvegarder",
+  "server_name_edit_common_cancel": "Annuler"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_fr_FR.json
@@ -1,0 +1,9 @@
+{
+  "server_name_edit_title": "Modifier le nom",
+  "server_name_edit_help": "Modifie le nom affiché dans l'entête.",
+  "server_name_edit_displayname_label": "Nom",
+  "server_name_edit_common_save": "Sauvegarder",
+  "server_name_edit_common_cancel": "Annuler",
+  "server_name_edit_success": "Nom mis à jour avec succès",
+  "server_name_edit_error": "Impossible de mettre à jour le nom:: {{ message }}"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_it_IT.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_it_IT.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Modifica il nome",
+  "server_name_edit_help": "Modifica il nome visualizzato nell'intestazione.",
+  "server_name_edit_displayname_label": "Nome",
+  "server_name_edit_common_save": "Salva",
+  "server_name_edit_common_cancel": "Annulla"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_pl_PL.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Zmień nazwę",
+  "server_name_edit_help": "Zmień nazwę, która wyświetla się w nagłówku.",
+  "server_name_edit_displayname_label": "Nazwa",
+  "server_name_edit_common_save": "Zapisz",
+  "server_name_edit_common_cancel": "Anuluj"
+}

--- a/packages/manager/modules/manager-components/src/edit-name/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/manager-components/src/edit-name/translations/Messages_pt_PT.json
@@ -1,0 +1,7 @@
+{
+  "server_name_edit_title": "Alterar o nome",
+  "server_name_edit_help": "Altera o nome indicado no cabeçalho.",
+  "server_name_edit_displayname_label": "Apelido",
+  "server_name_edit_common_save": "Guardar",
+  "server_name_edit_common_cancel": "Cancelar"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/README.md
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/README.md
@@ -1,0 +1,38 @@
+# ovh-manager-format-fatacenter-name
+
+The `ovh-manager-format-fatacenter-name` component formats and displays human redable DC name.
+
+## Installation
+
+```js
+import 'angular';
+import {
+  managerFormatDatacenterName,
+ } from '@ovh-ux/manager-components';
+
+angular.module('myModule', [managerFormatDatacenterName]);
+```
+
+## Attributes
+
+| Attribute         | Type            | Binding | One-time binding | Values                    | Default    | Description
+| ----              | ----            | ----    | ----             | ----                      | ----       | ----
+| `name`            | string          | @       | no              | n/a                       | n/a        | DC name
+
+## Basic Usage
+
+```html
+
+ <manager-format-fatacenter-name
+    name="GRA1">
+ </manager-format-fatacenter-name>
+ <!-- formats to 'Gravelines (GRA1) - France' -->
+```
+
+## Contributing
+
+Always feel free to help out! Whether it's [filing bugs and feature requests](https://github.com/ovh/manager/issues/new) or working on some of the [open issues](https://github.com/ovh/manager/issues), our [contributing guide](https://github.com/ovh/manager/blob/master/CONTRIBUTING.md) will help get you started.
+
+## License
+
+[BSD-3-Clause](LICENSE) © OVH SAS

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/component.js
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/component.js
@@ -1,0 +1,10 @@
+import controller from './controller';
+import template from './template.html';
+
+export default {
+  bindings: {
+    name: '@',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/controller.js
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/controller.js
@@ -1,0 +1,23 @@
+export default class ManagerComponentsFormatDatacenterNameCtrl {
+  /* @ngInject */
+  constructor($translate) {
+    this.$translate = $translate;
+    this.translationPrefix = 'server_datacenter_';
+  }
+
+  getFormatedName() {
+    const [dcCode, dcNumber] = this.name.split('_');
+    if (dcCode && dcNumber) {
+      const formatedName = this.$translate.instant(
+        `${this.translationPrefix}${dcCode}`,
+        {
+          number: dcNumber,
+        },
+      );
+      return formatedName.startsWith(this.translationPrefix)
+        ? this.name
+        : formatedName;
+    }
+    return this.name;
+  }
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/index.js
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/index.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import 'angular-translate';
+import '@ovh-ux/ng-translate-async-loader';
+
+import component from './component';
+
+const moduleName = 'ovhManagerManagerComponentsFormatDatacenterNameComponent';
+
+angular
+  .module(moduleName, ['pascalprecht.translate', 'ngTranslateAsyncLoader'])
+  .component('managerFormatDatacenterName', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/template.html
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/template.html
@@ -1,0 +1,1 @@
+<span data-ng-bind="$ctrl.getFormatedName()"></span>

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_de_DE.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_de_DE.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "London (ERI {{number}}) - England",
+  "server_datacenter_BHS": "Beauharnois (BHS {{number}}) - Kanada",
+  "server_datacenter_DC": "Beauharnois (DC {{number}}) - Kanada",
+  "server_datacenter_P": "Paris (P {{number}}) - Frankreich",
+  "server_datacenter_GRA": "Gravelines (GRA {{number}}) - Frankreich",
+  "server_datacenter_HIL": "Hillsboro (HIL {{number}}) - USA",
+  "server_datacenter_LIM": "Limburg (LIM {{number}}) - Deutschland",
+  "server_datacenter_RBX": "Roubaix (RBX {{number}}) - Frankreich",
+  "server_datacenter_SBG": "Straßburg (SBG {{number}}) - Frankreich",
+  "server_datacenter_SGP": "Singapur (SGP {{number}}) - Asien",
+  "server_datacenter_SYD": "Sydney (SYD {{number}}) - Australien",
+  "server_datacenter_VIN": "Vint Hill (VIN {{number}}) - USA",
+  "server_datacenter_WAW": "Warschau (WAW {{number}}) - Polen",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - Frankreich",
+  "server_datacenter_GSW": "(GSW) - Frankreich"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_en_GB.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_en_GB.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "London (ERI {{number}}) - UK",
+  "server_datacenter_BHS": "Beauharnois (BHS{{number}}) - Canada",
+  "server_datacenter_DC": "Beauharnois (DC{{number}}) - Canada",
+  "server_datacenter_P": "Paris (P{{number}}) - France",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - France",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - United States",
+  "server_datacenter_LIM": "Limburg (LIM{{number}}) - Germany",
+  "server_datacenter_RBX": "Roubaix (RBX{{number}}) - France",
+  "server_datacenter_SBG": "Strasbourg (SBG{{number}}) - France",
+  "server_datacenter_SGP": "Singapore (SGP{{number}}) - Asia",
+  "server_datacenter_SYD": "Sydney (SYD{{number}}) - Australia",
+  "server_datacenter_VIN": "Vint Hill (VIN{{number}}) - United States",
+  "server_datacenter_WAW": "Warsaw (WAW{{number}}) - Poland",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - France",
+  "server_datacenter_GSW": "(GSW) - France"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_es_ES.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_es_ES.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londres (ERI{{number}}) - Reino Unido",
+  "server_datacenter_BHS": "Beauharnois (BHS{{number}}) - Canadá",
+  "server_datacenter_DC": "Beauharnois (DC{{number}}) - Canadá",
+  "server_datacenter_P": "París (P{{number}}) - Francia",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - Francia",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - Estados Unidos",
+  "server_datacenter_LIM": "Limburg (LIM{{number}}) - Alemania",
+  "server_datacenter_RBX": "Roubaix (RBX{{number}}) - Francia",
+  "server_datacenter_SBG": "Estrasburgo (SBG{{number}}) - Francia",
+  "server_datacenter_SGP": "Singapur (SGP{{number}}) - Asia",
+  "server_datacenter_SYD": "Sídney (SYD{{number}}) - Australia",
+  "server_datacenter_VIN": "Vint Hill (VIN{{number}}) - Estados Unidos",
+  "server_datacenter_WAW": "Varsovia (WAW{{number}}) - Polonia",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - Francia",
+  "server_datacenter_GSW": "(GSW) - Francia"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_fr_CA.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londres (ERI{{number}}) - Angleterre",
+  "server_datacenter_BHS": "Beauharnois (BHS{{number}}) - Canada",
+  "server_datacenter_DC": "Beauharnois (DC{{number}}) - Canada",
+  "server_datacenter_P": "Paris (P{{number}}) - France",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - France",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - États-Unis",
+  "server_datacenter_LIM": "Limburg (LIM{{number}}) - Allemagne",
+  "server_datacenter_RBX": "Roubaix (RBX{{number}}) - France",
+  "server_datacenter_SBG": "Strasbourg (SBG{{number}}) - France",
+  "server_datacenter_SGP": "Singapour (SGP{{number}}) - Asie",
+  "server_datacenter_SYD": "Sydney (SYD{{number}}) - Australie",
+  "server_datacenter_VIN": "Vint Hill (VIN{{number}}) - États-Unis",
+  "server_datacenter_WAW": "Varsovie (WAW{{number}}) - Pologne",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - France",
+  "server_datacenter_GSW": "(GSW) - France"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_fr_FR.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londres (ERI{{number}}) - Angleterre",
+  "server_datacenter_BHS": "Beauharnois (BHS{{number}}) - Canada",
+  "server_datacenter_DC": "Beauharnois (DC{{number}}) - Canada",
+  "server_datacenter_P": "Paris (P{{number}}) - France",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - France",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - États-Unis",
+  "server_datacenter_LIM": "Limburg (LIM{{number}}) - Allemagne",
+  "server_datacenter_RBX": "Roubaix (RBX{{number}}) - France",
+  "server_datacenter_SBG": "Strasbourg (SBG{{number}}) - France",
+  "server_datacenter_SGP": "Singapour (SGP{{number}}) - Asie",
+  "server_datacenter_SYD": "Sydney (SYD{{number}}) - Australie",
+  "server_datacenter_VIN": "Vint Hill (VIN{{number}}) - États-Unis",
+  "server_datacenter_WAW": "Varsovie (WAW{{number}}) - Pologne",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - France",
+  "server_datacenter_GSW": "(GSW) - France"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_it_IT.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_it_IT.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londra  (ERI{{number}} - Inghilterra",
+  "server_datacenter_BHS": "Beauharnois ((BHS{{number}}) - Canada",
+  "server_datacenter_DC": "Beauharnois ((DC{{number}})  - Canada",
+  "server_datacenter_P": "Parigi (P{{number}}) - Francia",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - Francia",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - Stati Uniti",
+  "server_datacenter_LIM": "Limburg (LIM{{number}}) - Germania",
+  "server_datacenter_RBX": "Roubaix ((RBX{{number}}) - Francia",
+  "server_datacenter_SBG": "Strasburgo (SBG{{number}}) - Francia",
+  "server_datacenter_SGP": "Singapore (SGP{{number}}) - Asia",
+  "server_datacenter_SYD": "Sydney ((SYD{{number}}) - Australia",
+  "server_datacenter_VIN": "Vint Hill  (VIN{{number}}) - Stati Uniti",
+  "server_datacenter_WAW": "Varsavia (WAW{{number}}) - Polonia",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - Francia",
+  "server_datacenter_GSW": "(GSW) - Francia"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_pl_PL.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londyn (ERI {{number}}) - Wielka Brytania",
+  "server_datacenter_BHS": "Beauharnois (BHS {{number}}) - Kanada",
+  "server_datacenter_DC": "Beauharnois (DC {{number}}) - Kanada",
+  "server_datacenter_P": "Paryż (P {{number}}) - Francja",
+  "server_datacenter_GRA": "Gravelines (GRA {{number}}) - Francja",
+  "server_datacenter_HIL": "Hillsboro (HIL {{number}}) - Stany Zjednoczone",
+  "server_datacenter_LIM": "Limburg (LIM {{number}}) - Niemcy",
+  "server_datacenter_RBX": "Roubaix (RBX {{number}}) - Francja",
+  "server_datacenter_SBG": "Strasburg (SBG {{number}}) - Francja",
+  "server_datacenter_SGP": "Singapur (SGP {{number}}) - Azja",
+  "server_datacenter_SYD": "Sydney (SYD {{number}}) - Australia",
+  "server_datacenter_VIN": "Vint Hill (VIN {{number}}) - Stany Zjednoczone",
+  "server_datacenter_WAW": "Warszawa (WAW {{number}}) - Polska",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - Francja",
+  "server_datacenter_GSW": "(GSW) - Francja"
+}

--- a/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/manager-components/src/format-datacenter-name/translations/Messages_pt_PT.json
@@ -1,0 +1,17 @@
+{
+  "server_datacenter_ERI": "Londres (ERI{{number}}) - Inglaterra",
+  "server_datacenter_BHS": "Beauharnois (BHS{{number}}) - Canadá",
+  "server_datacenter_DC": "Beauharnois (DC{{number}}) - Canadá",
+  "server_datacenter_P": "Paris (P{{number}}) - França",
+  "server_datacenter_GRA": "Gravelines (GRA{{number}}) - França",
+  "server_datacenter_HIL": "Hillsboro (HIL{{number}}) - Estados Unidos",
+  "server_datacenter_LIM": "Limburgo (LIM{{number}}) - Alemanha",
+  "server_datacenter_RBX": "Roubaix (RBX{{number}}) - França",
+  "server_datacenter_SBG": "Estrasburgo (SBG{{number}}) - França",
+  "server_datacenter_SGP": "Singapura (SGP{{number}}) - Ásia",
+  "server_datacenter_SYD": "Sydney (SYD{{number}}) - Austrália",
+  "server_datacenter_VIN": "Vint Hill (VIN{{number}}) - Estados Unidos",
+  "server_datacenter_WAW": "Varsóvia (WAW{{number}}) - Polónia",
+  "server_datacenter_RBX_HZ": "Roubaix (RBXHZ) - França",
+  "server_datacenter_GSW": "(GSW) - França"
+}

--- a/packages/manager/modules/manager-components/src/index.js
+++ b/packages/manager/modules/manager-components/src/index.js
@@ -1,3 +1,3 @@
-import resourceSelector from './resource-selector';
-
-export default resourceSelector;
+export { default as managerResourceSelector } from './resource-selector';
+export { default as managerEditName } from './edit-name';
+export { default as managerFormatDatacenterName } from './format-datacenter-name';

--- a/packages/manager/modules/manager-components/src/resource-selector/README.md
+++ b/packages/manager/modules/manager-components/src/resource-selector/README.md
@@ -6,7 +6,9 @@ The `ovh-manager-resource-selector` component provides a quick way to create a h
 
 ```js
 import 'angular';
-import resourceSelector from '@ovh-ux/manager-components';
+import {
+  managerResourceSelector,
+} from '@ovh-ux/manager-components';
 
 angular.module('myModule', [resourceSelector]);
 ```


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

## Description

Added below reusable components
1. Edit name
2. Format DC name

These components are not used in any app/module. It will be used in new projects and can also be replaced in existing projects. No QC is required. It will be verified when it used in any service.
