### PR TITLE
fix(user.session): prevent display `server` as current universe

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/user/session/user-session.controller.js
@@ -1,5 +1,6 @@
 import isString from 'lodash/isString';
 import set from 'lodash/set';
+import startsWith from 'lodash/startsWith';
 
 angular.module('App').controller(
   'SessionCtrl',
@@ -29,7 +30,15 @@ angular.module('App').controller(
     $onInit() {
       this.$scope.$on('switchUniverse', (event, universe) => {
         this.sidebarNamespace = universe === 'server' ? undefined : 'hpc';
-        this.navbarOptions.universe = universe;
+        this.$transitions.onSuccess({}, (transition) => {
+          // Prevent displaying `server` as the current universe if user is
+          // browsing in account/billing section.
+          if (startsWith(transition.to().name, 'app.account')) {
+            this.navbarOptions.universe = undefined;
+          } else {
+            this.navbarOptions.universe = universe;
+          }
+        });
         this.coreConfig.setUniverse(universe);
       });
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #4353
| License          | BSD 3-Clause

## Description

### 🐛 Bug Fixes

e73b239 - fix(user.session): prevent display `server` as current universe

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>
