### PR TITLE
fix(telecom): use line country when ordering phone

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/choice/choice.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/order/choice/choice.controller.js
@@ -74,7 +74,7 @@ export default class TelephonyLinePhoneOrderChoiceCtrl {
 
   fetchOfferPhones(offer) {
     return this.OvhApiTelephony.v6().getLineOfferPhones({
-      country: this.coreConfig.getUser().country.toLowerCase(),
+      country: this.line.getCountry(),
       offer,
     }).$promise;
   }

--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/line/line.factory.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/line/line.factory.js
@@ -219,6 +219,28 @@ export default /* @ngInject */ (
     return $q.when(self.hasSupportsPhonebook);
   };
 
+  TelephonyGroupLine.prototype.getCountry = function getCountry() {
+    // list of supported countries comes from apiv6 : telephony.NumberCountryEnum
+    switch (this.serviceName.substring(0, 4)) {
+      case '0032':
+        return 'be';
+      case '0041':
+        return 'ch';
+      case '0049':
+        return 'de';
+      case '0034':
+        return 'es';
+      case '0033':
+        return 'fr';
+      case '0044':
+        return 'gb';
+      case '0039':
+        return 'it';
+      default:
+        throw new Error(`Unhandled country for line ${this.serviceName}`);
+    }
+  };
+
   TelephonyGroupLine.prototype.getPhone = function getPhone() {
     const self = this;
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-41269
| License          | BSD 3-Clause

## Description

use line country instead of subsidiary when ordering phone