### PR TITLE
feat(exchange.disclaimer): not editable editor

### DIFF
--- a/packages/manager/modules/exchange/src/disclaimer/add/disclaimer-add.controller.js
+++ b/packages/manager/modules/exchange/src/disclaimer/add/disclaimer-add.controller.js
@@ -4,8 +4,16 @@ import head from 'lodash/head';
 
 export default class ExchangeAddDisclaimerCtrl {
   /* @ngInject */
-  constructor($scope, wucExchange, navigation, messaging, $translate) {
+  constructor(
+    $document,
+    $scope,
+    wucExchange,
+    navigation,
+    messaging,
+    $translate,
+  ) {
     this.services = {
+      $document,
       $scope,
       wucExchange,
       navigation,
@@ -30,6 +38,9 @@ export default class ExchangeAddDisclaimerCtrl {
 
   loadAvailableDomains() {
     this.loadingData = true;
+
+    // Remove tabindex from modal as it clashes with ckeditor modal
+    this.services.$document.find('.modal').removeAttr('tabindex');
 
     return this.services.wucExchange
       .getNewDisclaimerOptions(

--- a/packages/manager/modules/exchange/src/disclaimer/update/disclaimer-update.controller.js
+++ b/packages/manager/modules/exchange/src/disclaimer/update/disclaimer-update.controller.js
@@ -4,8 +4,16 @@ import isEmpty from 'lodash/isEmpty';
 
 export default class ExchangeUpdateDisclaimerCtrl {
   /* @ngInject */
-  constructor($scope, wucExchange, navigation, messaging, $translate) {
+  constructor(
+    $document,
+    $scope,
+    wucExchange,
+    navigation,
+    messaging,
+    $translate,
+  ) {
     this.services = {
+      $document,
       $scope,
       wucExchange,
       navigation,
@@ -15,7 +23,6 @@ export default class ExchangeUpdateDisclaimerCtrl {
     this.$routerParams = wucExchange.getParams();
     this.mceId = 'update-disclaimer-editor';
     this.data = angular.copy(navigation.currentActionData);
-
     this.loadOptions();
 
     $scope.saveDisclaimer = () => this.saveDisclaimer();
@@ -24,6 +31,9 @@ export default class ExchangeUpdateDisclaimerCtrl {
 
   loadOptions() {
     this.loadingData = true;
+
+    // Remove tabindex from modal as it clashes with ckeditor modal
+    this.services.$document.find('.modal').removeAttr('tabindex');
 
     return this.services.wucExchange
       .getUpdateDisclaimerOptions()


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-41448
| License          | BSD 3-Clause

## Description

Remove tabindex attribute from bootstrap modal as it clashes with ckeditor modal
