### PR TITLE
fix(telecom): text overflow on telephony alias configuration

### DIFF
--- a/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/dialplan/dialplan.less
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/group/number/feature/ovhPabx/dialplan/dialplan.less
@@ -152,7 +152,6 @@
         max-width: 348px;
         flex-shrink: 0;
         padding: 8px 16px;
-        white-space: nowrap;
       }
 
       &-name {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7183
| License          | BSD 3-Clause

## Description

Text overflow on telephony alias configuration page
