### PR TITLE
fix(xdsl.service.modal): fix modal service for content sharing

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/service/modal/service-modal.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/service/modal/service-modal.controller.js
@@ -1,17 +1,14 @@
-angular.module('managerApp').controller(
-  'XdslModemServiceModalCtrl',
-  class XdslModemServiceModalCtrl {
-    /* @ngInject */
-    constructor($uibModalInstance) {
-      this.$uibModalInstance = $uibModalInstance;
-    }
+export default class XdslModemServiceModalCtrl {
+  /* @ngInject */
+  constructor($uibModalInstance) {
+    this.$uibModalInstance = $uibModalInstance;
+  }
 
-    cancel() {
-      this.$uibModalInstance.close('cancel');
-    }
+  cancel() {
+    this.$uibModalInstance.close('cancel');
+  }
 
-    close() {
-      this.$uibModalInstance.close('confirm');
-    }
-  },
-);
+  close() {
+    this.$uibModalInstance.close('confirm');
+  }
+}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-414
| License          | BSD 3-Clause

## Description

Toggle button for content sharing doesn't work because of modal wasn't initialized correctly.
