### PR TITLE
feat(xdsl.statistics): add HEC, FEC and CRC

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/statistics.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/statistics.constant.js
@@ -58,6 +58,9 @@ export const PACK_XDSL_STATISTICS = {
   },
 };
 
+export const PREVIEW = 'preview';
+
 export default {
   PACK_XDSL_STATISTICS,
+  PREVIEW,
 };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/statistics.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/statistics.html
@@ -243,5 +243,55 @@
                 ></div>
             </div>
         </li>
+
+        <!-- Errors HEC/FEC/CRC -->
+        <li class="oui-tile__item">
+            <div class="oui-tile__definition">
+                <h5
+                    class="mb-2"
+                    data-translate="xdsl_statistics_errors_title"
+                ></h5>
+
+                <form
+                    class="form-horizontal"
+                    data-ng-if="XdslStatistics.errors.haveSeries"
+                >
+                    <div class="form-group">
+                        <label
+                            for="errorsPeriod"
+                            class="col-xs-3 col-md-2 control-label text-left"
+                            data-translate="xdsl_statistics_period"
+                        >
+                        </label>
+                        <div class="col-xs-9 col-md-4 clearfix">
+                            <select
+                                id="errorsPeriod"
+                                name="errorsPeriod"
+                                class="form-control"
+                                data-ng-disabled="XdslStatistics.errors.loading"
+                                data-ng-change="XdslStatistics.getErrorsStatistics(XdslStatistics.errors.period)"
+                                data-ng-model="XdslStatistics.errors.period"
+                                data-ng-options="'xdsl_statistics_' + period  + '_label'| translate for period in XdslStatistics.periodOptions"
+                            >
+                            </select>
+                        </div>
+                    </div>
+                </form>
+
+                <div
+                    data-tuc-chartjs="XdslStatistics.errors.chart"
+                    class="chart-container"
+                >
+                </div>
+
+                <div
+                    class="my-3 alert alert-warning"
+                    role="alert"
+                    data-ng-if="!XdslStatistics.errors.haveSeries && !XdslStatistics.errors.loading"
+                    data-translate="xdsl_statistics_error"
+                >
+                </div>
+            </div>
+        </li>
     </ul>
 </div>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/statistics/translations/Messages_fr_FR.json
@@ -20,5 +20,11 @@
   "xdsl_statistics_decibel_legend": "dB",
   "xdsl_statistics_ping_ms": "{{value}} ms",
   "xdsl_statistics_ping_s": "{{value}} s",
-  "xdsl_statistics_decibel": "{{value}} dB"
+  "xdsl_statistics_decibel": "{{value}} dB",
+  "xdsl_statistics_errors_title": "Erreurs",
+  "xdsl_statistics_hec_label": "HEC",
+  "xdsl_statistics_fec_label": "FEC",
+  "xdsl_statistics_crc_label": "CRC",
+  "xdsl_statistics_count": "{{value}} erreurs",
+  "xdsl_statistics_count_legend": "erreurs"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-413
| License          | BSD 3-Clause

## Description

Display HEC, FEC and CRC errors statistics for xDSL/Fiber service
