### PR TITLE
feat: enable veeam enterprise order for US

### DIFF
--- a/packages/manager/modules/server-sidebar/src/order.constants.js
+++ b/packages/manager/modules/server-sidebar/src/order.constants.js
@@ -424,7 +424,10 @@ export const ORDER_URLS = {
       US: 'https://us.ovhcloud.com/cloud/cloud-disk-array/',
     },
     veeam: {},
-    veeam_enterprise: {},
+    veeam_enterprise: {
+      US:
+        'https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/veeam-enterprise/',
+    },
     vrack: {
       US:
         "https://us.ovhcloud.com/order/express/#/express/review?products=~(~(planCode~'vrack~quantity~1~productId~'vrack))",
@@ -439,7 +442,7 @@ export const ORDER_URLS = {
       US: 'https://us.ovhcloud.com/manager/cloud/#/iaas/pci/offer',
     },
     publicCloudProjectOrder: {
-      FR: 'https://us.ovhcloud.com/manager/public-cloud/#!/pci/projects/new',
+      US: 'https://us.ovhcloud.com/manager/public-cloud/#/pci/projects/new',
     },
     publicCloudKubernetes: {},
     express_review_base: {


### PR DESCRIPTION
ref: #MANAGER-7208

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          |develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-7208
| License          | BSD 3-Clause

## Description

Enable veeam enterprise order for US region
