### PR TITLE
perf: remove ng-ckeditor import

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -49,9 +49,6 @@ import 'script-loader!messenger/build/js/messenger.min.js';
 import 'script-loader!filesize/lib/filesize.js';
 import 'script-loader!angular-websocket/dist/angular-websocket';
 
-// Ckeditor 4.x
-import 'ng-ckeditor';
-
 import './app.less';
 import './css/source.scss';
 /* eslint-enable import/no-webpack-loader-syntax, import/no-unresolved, import/extensions */
@@ -170,7 +167,6 @@ export default (containerEl, environment) => {
         moduleLicense,
         otrs,
         ovhManagerMfaEnrollment,
-        'ng.ckeditor',
         'ngMessages',
         ngAtInternet,
         ngAtInternetUiRouterPlugin,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7406
| License          | BSD 3-Clause

## Description

ng-ckeditor is not used in manager dedicated, it's used in exchange module and it's already importing it ; there is no need to import this angular module at global level