### PR TITLE
fix: hide sd order based on availability

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     filter: '<',
     dedicatedServers: '<',
+    isOrderAvailable: '<',
     orderUrl: '<',
     serverStateEnum: '<',
     datacenterEnum: '<',

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.html
@@ -78,6 +78,7 @@
         <oui-datagrid-topbar>
             <a
                 class="oui-button oui-button_secondary oui-button_icon-right"
+                data-ng-if="$ctrl.isOrderAvailable"
                 data-track-on="click"
                 data-track-type="action"
                 data-track-name="dedicated::dedicated::servers::order"

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
@@ -31,6 +31,13 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       filter: /* @ngInject */ ($transition$) => $transition$.params().filter,
       orderUrl: /* @ngInject */ (User) => User.getUrlOf('dedicatedOrder'),
+      isOrderAvailable: /* @ngInject */ (ovhFeatureFlipping) =>
+        ovhFeatureFlipping
+          .checkFeatureAvailability(['dedicated-server:order'])
+          .then((orderAvailability) =>
+            orderAvailability.isFeatureAvailable('dedicated-server:order'),
+          )
+          .catch(() => false),
       getServerDashboardLink: /* @ngInject */ ($state) => (server) =>
         $state.href('app.dedicated-server.server', { productId: server.name }),
       dedicatedServers: /* @ngInject */ ($transition$, iceberg) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/trusted-nic`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7350
| License          | BSD 3-Clause

## Description

Hide/Show the Dedicated Server order button based on feature-availability
