### PR TITLE
fix(dbaas.logs): streams loading error

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.controller.js
@@ -152,7 +152,7 @@ export default class LogsStreamsHomeCtrl {
 
   retentionInfo(stream) {
     const foundRetention = this.findRetention(stream);
-    if (foundRetention.duration) {
+    if (foundRetention?.duration) {
       if (
         foundRetention.duration === this.LogsConstants.RETENTION.FORTY_FIVE_DAYS
       ) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

## Description

Streams tab loading after an update cause manager freeze

Signed-off-by: Cyril Biencourt <cyril.biencourt@ovhcloud.com>
