### PR TITLE
fix(translations): run translations at the right moment

### DIFF
--- a/packages/manager/modules/cloud-connect/src/details/overview/add-pop-configuration/add-pop-configuration.module.js
+++ b/packages/manager/modules/cloud-connect/src/details/overview/add-pop-configuration/add-pop-configuration.module.js
@@ -9,6 +9,14 @@ angular
   .module(moduleName, [])
   .config(routing)
   .component('cloudConnectDetailsAddPopConfiguration', component)
-  .run(/* @ngTranslationsInject:json ./translations */);
+  .run(/* @ngTranslationsInject:json ./translations */)
+  .run(
+    /* @ngInject */ ($translate, $transitions) => {
+      $transitions.onBefore(
+        { to: 'cloud-connect.details.overview.add-pop' },
+        () => $translate.refresh(),
+      );
+    },
+  );
 
 export default moduleName;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-41612
| License          | BSD 3-Clause

## Description

When we clicked on the add config pop to open the modal, the modal open with the keys of the translations instead of translations the first time. If you close and reopen the modal, they are okay. 

The goal of this PR is to load translations for the first time. 

Please refer to the ticket for more infos.
