### PR TITLE
fix(orders): declare redirection order follow-up rule before lazyloading

### DIFF
--- a/packages/manager/modules/billing/src/index.js
+++ b/packages/manager/modules/billing/src/index.js
@@ -6,7 +6,7 @@ import 'oclazyload';
 const moduleName = 'ovhManagerDedicatedBillingLazyLoading';
 
 angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
-  /* @ngInject */ ($stateProvider) => {
+  /* @ngInject */ ($stateProvider, $urlServiceProvider) => {
     $stateProvider.state('app.account.billing.**', {
       url: '/billing',
       lazyLoad: ($transition$) => {
@@ -16,6 +16,7 @@ angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
         ).then((mod) => $ocLazyLoad.inject(mod.default || mod));
       },
     });
+    $urlServiceProvider.rules.when('/billing/order/:id', '/billing/orders/:id');
   },
 );
 

--- a/packages/manager/modules/billing/src/order/billing-order-tracking.routing.js
+++ b/packages/manager/modules/billing/src/order/billing-order-tracking.routing.js
@@ -1,7 +1,7 @@
 import controller from './billing-order-tracking.controller';
 import template from './billing-order-tracking.html';
 
-export default /* @ngInject */ ($stateProvider, $urlServiceProvider) => {
+export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.account.billing.orders.order', {
     url: '/:orderId',
     params: {
@@ -31,6 +31,4 @@ export default /* @ngInject */ ($stateProvider, $urlServiceProvider) => {
       breadcrumb: /* @ngInject */ (orderId) => orderId,
     },
   });
-
-  $urlServiceProvider.rules.when('/billing/order/:id', '/billing/orders/:id');
 };


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `release-2021-w30`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-7427,
| License          | BSD 3-Clause

## Description

Declare redirection rules as soon as possible to avoid to declare-it during lazy loading.


