### PR TITLE
fix(dedicated): cpanel commitment not working

### DIFF
--- a/packages/manager/modules/billing-components/src/components/commitment/commitment.constants.js
+++ b/packages/manager/modules/billing-components/src/components/commitment/commitment.constants.js
@@ -1,6 +1,7 @@
 export const CATALOG_MAPPING = {
   '/dedicated/server/{serviceName}': 'baremetalServers',
   '/vps/{serviceName}': 'vps',
+  '/license/cpanel/{serviceName}': 'licensecPanel',
 };
 
 export default {


### PR DESCRIPTION
ref: #DTRSD-43193

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-43193
| License          | BSD 3-Clause

## Description

Customer is not able to renew commitment of cpanel licence.
