### PR TITLE
fix(pci/ai-training): remove use of deprecated fields

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.controller.js
@@ -76,8 +76,6 @@ export default class NotebookAddController {
 
   static buildVolumesBody(volumes, region) {
     return volumes.map((volume) => ({
-      container: volume.container,
-      region: region.name,
       mountPath: volume.mountPath,
       permission: volume.permission,
       cache: false,


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no ticket
| License          | BSD 3-Clause

## Description

Remove the use of deprecated fields for notebook volumes