### PR TITLE
fix(public-cloud): fix add kubernetes cluster regions list

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
@@ -176,7 +176,7 @@ export default class {
     const { name, enabled } = region;
     this.displaySelectedRegion = true;
 
-    if (!enabled) {
+    if (enabled === false) {
       this.isAddingNewRegion = true;
 
       return this.Kubernetes.addRegion(this.projectId, region)

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/kubernetes.routing.js
@@ -93,8 +93,24 @@ export default /* @ngInject */ ($stateProvider) => {
       highestVersion: (versions) =>
         max(versions, (version) => parseFloat(`${version}`)),
 
-      regions: /* @ngInject */ (projectId, coreConfig, Kubernetes) =>
-        Kubernetes.getRegions(projectId, coreConfig.getUser().ovhSubsidiary),
+      regions: /* @ngInject */ (
+        OvhApiCloudProjectKube,
+        projectId,
+        coreConfig,
+        Kubernetes,
+      ) =>
+        coreConfig.getUser().ovhSubsidiary !== 'US'
+          ? Kubernetes.getRegions(projectId, coreConfig.getUser().ovhSubsidiary)
+          : OvhApiCloudProjectKube.v6()
+              .getRegions({
+                serviceName: projectId,
+              })
+              .$promise.then((regions) =>
+                map(regions, (region) => ({
+                  name: region,
+                  hasEnoughQuota: () => true,
+                })),
+              ),
 
       antiAffinityMaxNodes: /* @ngInject */ () => ANTI_AFFINITY_MAX_NODES,
       addPrivateNetworksLink: /* @ngInject */ ($state, projectId) =>


### PR DESCRIPTION
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

## Description

Using old logic to get regions for add Kubernetes cluster in US.
Flag `enabled` doesn't exists in payload from 
