### PR TITLE
 Translation account form : fix Réunion name for French

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -288,7 +288,7 @@
   "signup_enum_country_PY": "Paraguay",
   "signup_enum_country_QA": "Qatar",
   "signup_enum_country_QC": "Quebec",
-  "signup_enum_country_RE": "Réunion, Îles",
+  "signup_enum_country_RE": "Réunion, Île de la",
   "signup_enum_country_RO": "Roumanie",
   "signup_enum_country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "signup_enum_country_RU": "Russie",

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -288,7 +288,7 @@
   "signup_enum_country_PY": "Paraguay",
   "signup_enum_country_QA": "Qatar",
   "signup_enum_country_QC": "Quebec",
-  "signup_enum_country_RE": "Réunion, Île de la",
+  "signup_enum_country_RE": "La Réunion",
   "signup_enum_country_RO": "Roumanie",
   "signup_enum_country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "signup_enum_country_RU": "Russie",

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -288,7 +288,7 @@
   "signup_enum_country_PY": "Paraguay",
   "signup_enum_country_QA": "Qatar",
   "signup_enum_country_QC": "Quebec",
-  "signup_enum_country_RE": "Réunion, Îles",
+  "signup_enum_country_RE": "Réunion, Île de la",
   "signup_enum_country_RO": "Roumanie",
   "signup_enum_country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "signup_enum_country_RU": "Russie",

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -288,7 +288,7 @@
   "signup_enum_country_PY": "Paraguay",
   "signup_enum_country_QA": "Qatar",
   "signup_enum_country_QC": "Quebec",
-  "signup_enum_country_RE": "Réunion, Île de la",
+  "signup_enum_country_RE": "La Réunion",
   "signup_enum_country_RO": "Roumanie",
   "signup_enum_country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "signup_enum_country_RU": "Russie",

--- a/packages/manager/apps/dedicated/client/app/common/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/common/translations/Messages_fr_CA.json
@@ -378,7 +378,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/apps/dedicated/client/app/common/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/common/translations/Messages_fr_FR.json
@@ -378,7 +378,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/apps/telecom/src/app/common/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/common/translations/Messages_fr_CA.json
@@ -410,7 +410,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/apps/telecom/src/app/common/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/common/translations/Messages_fr_FR.json
@@ -410,7 +410,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/apps/web/client/app/core/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/core/translations/Messages_fr_CA.json
@@ -437,7 +437,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/apps/web/client/app/core/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/core/translations/Messages_fr_FR.json
@@ -437,7 +437,7 @@
   "country_PY": "Paraguay",
   "country_QA": "Qatar",
   "country_QC": "Quebec",
-  "country_RE": "Réunion",
+  "country_RE": "La Réunion",
   "country_RO": "Roumanie",
   "country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "country_RU": "Russie",

--- a/packages/manager/modules/billing/src/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/billing/src/translations/Messages_fr_CA.json
@@ -439,7 +439,7 @@
   "payment_mean_contact_creation_country_PW": "Palau",
   "payment_mean_contact_creation_country_PY": "Paraguay",
   "payment_mean_contact_creation_country_QA": "Qatar",
-  "payment_mean_contact_creation_country_RE": "Reunion",
+  "payment_mean_contact_creation_country_RE": "La Réunion",
   "payment_mean_contact_creation_country_RO": "Romania",
   "payment_mean_contact_creation_country_RS": "Serbia",
   "payment_mean_contact_creation_country_RU": "Russian Federation",

--- a/packages/manager/modules/billing/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/translations/Messages_fr_FR.json
@@ -439,7 +439,7 @@
   "payment_mean_contact_creation_country_PW": "Palau",
   "payment_mean_contact_creation_country_PY": "Paraguay",
   "payment_mean_contact_creation_country_QA": "Qatar",
-  "payment_mean_contact_creation_country_RE": "Reunion",
+  "payment_mean_contact_creation_country_RE": "La Réunion",
   "payment_mean_contact_creation_country_RO": "Romania",
   "payment_mean_contact_creation_country_RS": "Serbia",
   "payment_mean_contact_creation_country_RU": "Russian Federation",

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_fr_FR.json
@@ -190,7 +190,7 @@
   "sign_up_form_enum_country_PY": "Paraguay",
   "sign_up_form_enum_country_QA": "Qatar",
   "sign_up_form_enum_country_QC": "Quebec",
-  "sign_up_form_enum_country_RE": "Réunion, Île",
+  "sign_up_form_enum_country_RE": "La Réunion",
   "sign_up_form_enum_country_RO": "Roumanie",
   "sign_up_form_enum_country_RS": "République de Serbie (Anciennement Serbie et Monténégro code cs)",
   "sign_up_form_enum_country_RU": "Russie",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` for bug fixes <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-45424
| License          | BSD 3-Clause

## Description

La Réunion is a single island. Do not use plural form in French translations.