### PR TITLE
build: remove `experimental-worker` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "packages/manager/fragments/*"
   ],
   "scripts": {
-    "build": "node --experimental-worker scripts/build.js",
+    "build": "node scripts/build.js",
     "clean": "lerna clean -y && yarn run clean:dist && rimraf node_modules",
     "clean:dist": "rimraf \"packages/**/dist?(-EU|-CA|-US)\"",
     "format": "run-p format:*",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         |  no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

Since Node.js 12, Worker threads is stable.

### 👷 Build

850c4e1 - build: remove `experimental-worker` flag

### 🔗 Related

see: https://nodejs.org/docs/latest-v12.x/api/worker_threads.html#apicontent

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>