### PR TITLE
fix: add missing peerDeps `@ovh-ux/ng-ui-router-breadcrumb`

### DIFF
--- a/packages/manager/tools/sao-ovh-manager-module/lib/update-pkg.js
+++ b/packages/manager/tools/sao-ovh-manager-module/lib/update-pkg.js
@@ -17,6 +17,7 @@ module.exports = ({ name, description }) => ({
   peerDependencies: {
     '@ovh-ux/manager-core': '^10.0.0 || ^11.0.0',
     '@ovh-ux/manager-ng-layout-helpers': '^2.0.0',
+    '@ovh-ux/ng-ui-router-breadcrumb': '^1.0.0',
     '@ovh-ux/ui-kit': '^4.4.3',
     '@uirouter/angularjs': '^1.0.23',
     angular: '^1.7.5',

--- a/packages/manager/tools/sao-ovh-manager-module/template/src/dashboard/module.js
+++ b/packages/manager/tools/sao-ovh-manager-module/template/src/dashboard/module.js
@@ -2,6 +2,7 @@
 <% const componentName = this.camelcase(name, { pascalCase: false }) -%>
 import angular from 'angular';
 import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ui-router-breadcrumb';
 import '@uirouter/angularjs';
 import 'angular-translate';
 
@@ -11,7 +12,12 @@ import routing from './routing';
 const moduleName = 'ovhManager<%= pascalcasedName %>Dashboard';
 
 angular
-  .module(moduleName, ['ovhManagerCore', 'pascalprecht.translate', 'ui.router'])
+  .module(moduleName, [
+    'ngUiRouterBreadcrumb',
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+  ])
   .config(routing)
   .component('<%= componentName %>', component)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/tools/sao-ovh-manager-module/template/src/index.js
+++ b/packages/manager/tools/sao-ovh-manager-module/template/src/index.js
@@ -1,11 +1,12 @@
 <% const pascalcasedName = this.camelcase(name, { pascalCase: true }) -%>
-import angular from 'angular';
+import angular from 'angular'
+import '@ovh-ux/ng-ui-router-breadcrumb';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
 const moduleName = 'ovhManager<%= pascalcasedName %>LazyLoading';
 
-angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+angular.module(moduleName, ['ngUiRouterBreadcrumb', 'ui.router', 'oc.lazyLoad']).config(
   /* @ngInject */ ($stateProvider) => {
     $stateProvider.state('app', {
       url: '/<%= name %>',

--- a/packages/manager/tools/sao-ovh-manager-module/template/src/module.js
+++ b/packages/manager/tools/sao-ovh-manager-module/template/src/module.js
@@ -2,6 +2,7 @@
 import angular from 'angular';
 
 import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ui-router-breadcrumb';
 import '@uirouter/angularjs';
 import 'angular-translate';
 
@@ -15,6 +16,7 @@ const moduleName = 'ovhManager<%= pascalcasedName %>';
 
 angular
   .module(moduleName, [
+    'ngUiRouterBreadcrumb',
     'ovhManagerCore',
     'pascalprecht.translate',
     'ui.router',

--- a/packages/manager/tools/sao-ovh-manager-module/template/src/onboarding/module.js
+++ b/packages/manager/tools/sao-ovh-manager-module/template/src/onboarding/module.js
@@ -2,6 +2,7 @@
 <% const componentName = this.camelcase(name, { pascalCase: false }) -%>
 import angular from 'angular';
 import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ui-router-breadcrumb';
 import '@uirouter/angularjs';
 import 'angular-translate';
 
@@ -14,6 +15,7 @@ const moduleName = 'ovhManager<%= pascalcasedName %>Onboarding';
 
 angular
   .module(moduleName, [
+    'ngUiRouterBreadcrumb',
     'ovhManagerCore',
     'pascalprecht.translate',
     'ui.router',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :bug: Bug Fixes

Mainly used in `routing.js` file to display breadcrumb.

a598f3f - fix: add missing peerDeps `@ovh-ux/ng-ui-router-breadcrumb`

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
