### PR TITLE
Show notebook creator in notebook list

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.html
@@ -100,7 +100,6 @@
             data-filterable
             data-sortable
         >
-            <span data-ng-bind="::$value"></span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_notebook_list_status' | translate"

--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.html
@@ -93,6 +93,16 @@
             <span data-ng-bind=":: $row.durationString"></span>
         </oui-datagrid-column>
         <oui-datagrid-column
+            data-title=":: 'pci_notebook_list_creator' | translate"
+            data-property="user"
+            data-type="string"
+            data-searchable
+            data-filterable
+            data-sortable
+        >
+            <span data-ng-bind="::$value"></span>
+        </oui-datagrid-column>
+        <oui-datagrid-column
             data-title=":: 'pci_notebook_list_status' | translate"
             data-property="state"
             data-sortable

--- a/packages/manager/modules/pci/src/projects/project/notebooks/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/translations/Messages_fr_FR.json
@@ -9,6 +9,7 @@
   "pci_notebook_list_privacy_private": "Privé",
   "pci_notebook_list_privacy_public": "Public",
   "pci_notebook_list_running_time": "Durée de fonctionnement",
+  "pci_notebook_list_creator": "Utilisateur",
   "pci_notebook_list_status": "Statut",
   "pci_notebook_list_status_STARTING": "Démarrage",
   "pci_notebook_list_status_RUNNING": "En service",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7511
| License          | BSD 3-Clause

## Description

When listing notebooks from the AI/notebook product, the user that created the notebook is now displayed and we can filter  notebooks based on it. 
