### PR TITLE
fix: notebook dashboard references outdated volume fields

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/attach-data/attach-data.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/attach-data/attach-data.html
@@ -41,17 +41,13 @@
                 title=":: 'pci_notebooks_tab_attach_data_page_volumes_column_name' | translate"
                 sortable="true"
             >
-                <span
-                    data-ng-bind="$row.container || $row.privateSwift.container"
-                ></span>
+                <span data-ng-bind="$row.privateSwift.container"></span>
             </oui-datagrid-column>
             <oui-datagrid-column
                 title=":: 'pci_notebooks_tab_attach_data_page_volumes_column_region' | translate"
                 sortable="true"
             >
-                <span
-                    data-ng-bind="$row.region || $row.privateSwift.region"
-                ></span>
+                <span data-ng-bind="$row.privateSwift.region"></span>
             </oui-datagrid-column>
             <oui-datagrid-column
                 title=":: 'pci_notebooks_tab_attach_data_page_volumes_column_mount_path' | translate"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7524
| License          | BSD 3-Clause

## Description

In the API, `volume.[container|region|prefix]` have been moved to `volume.privateSwift.[container|region|prefix]`.
This code was trying to parse a volume using the old fields, and if it failed, tried the new ones.
The API does not set the old fields anymore so this code is of no use and we should always parse the new format instead.
