### PR TITLE
fix(dedicated): change backup url for snc hpc

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.constants.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.constants.js
@@ -47,6 +47,12 @@ export const BACKUP_TARIFF_URL = {
     'https://www.ovhcloud.com/es/enterprise/products/hosted-private-cloud/prices/',
 };
 
+export const TRUSTED_ACCOUNT_BACKUP_TARIFF_URL = {
+  FR:
+    'https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/secnumcloud/prices/',
+};
+
 export default {
   BACKUP_TARIFF_URL,
+  TRUSTED_ACCOUNT_BACKUP_TARIFF_URL,
 };

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.routing.js
@@ -12,7 +12,10 @@ import {
   BACKUP_MINIMUM_HOST_COUNT,
 } from '../../../components/dedicated-cloud/datacenter/backup/backup.constants';
 
-import { BACKUP_TARIFF_URL } from './backup.constants';
+import {
+  BACKUP_TARIFF_URL,
+  TRUSTED_ACCOUNT_BACKUP_TARIFF_URL,
+} from './backup.constants';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.dedicatedCloud.details.datacenter.details.backup', {
@@ -116,8 +119,13 @@ export default /* @ngInject */ ($stateProvider) => {
           currentUser.ovhSubsidiary,
           BACKUP_CONDITIONS_URL.FR,
         ),
-      backupTariffUrl: /* @ngInject */ (currentUser) =>
-        get(BACKUP_TARIFF_URL, currentUser.ovhSubsidiary, BACKUP_TARIFF_URL.FR),
+      backupTariffUrl: /* @ngInject */ (currentUser) => {
+        const BACKUP_URL = currentUser.isTrusted
+          ? TRUSTED_ACCOUNT_BACKUP_TARIFF_URL
+          : BACKUP_TARIFF_URL;
+        return get(BACKUP_URL, currentUser.ovhSubsidiary, BACKUP_URL.FR);
+      },
+
       goToUpgradeOffer: /* @ngInject */ ($state, productId, datacenterId) => (
         actualOffer,
       ) =>


### PR DESCRIPTION
use secnumcloud host backup price URL for SNC HPC account

ref: MANAGER-7531

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md
-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/trusted-nic-hpc`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7531
| License          | BSD 3-Clause

## Description
URL
https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/prices/

become ->

https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/secnumcloud/prices/

Only for SNC HPC customer.
