### PR TITLE
feat(vps.dashboard): inform VPS customers for planned migration

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/component.js
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/component.js
@@ -1,8 +1,9 @@
-import controller from './controller';
 import template from './template.html';
 
 const component = {
-  controller,
+  bindings: {
+    stein: '<',
+  },
   template,
 };
 

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/controller.js
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/controller.js
@@ -1,7 +1,0 @@
-export default class VpsAnnouncementBannerComponentController {
-  /* @ngInject */
-  constructor(coreConfig) {
-    this.coreConfig = coreConfig;
-    this.tasksInfoLink = 'http://travaux.ovh.net/?do=details&id=51831';
-  }
-}

--- a/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/template.html
+++ b/packages/manager/modules/vps/src/dashboard/components/vps-announcement-banner/template.html
@@ -1,6 +1,6 @@
 <oui-message
     class="mb-3"
-    data-type="info"
+    data-type="warning"
     dismissable
 >
     <span data-translate="pci_components_vps_announcement_banner_info"></span>
@@ -9,7 +9,7 @@
             target="_blank"
             rel="noopener"
             data-translate="pci_components_vps_announcement_banner_info_link"
-            data-ng-href="{{:: $ctrl.tasksInfoLink }}"
+            data-ng-href="{{:: $ctrl.stein.travaux }}"
         ></a>
     </p>
 </oui-message>

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_de_DE.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Wird ausgeführt",
   "vps_dashboard_state_stopped": "Angehalten",
   "vps_dashboard_state_stopping": "Wird gelöscht",
-  "vps_dashboard_state_upgrading": "Angebot hierfür wird gerade gewechselt"
+  "vps_dashboard_state_upgrading": "Angebot hierfür wird gerade gewechselt",
+  "vps_dashboard_state_rescued": "im Rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_en_GB.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Running...",
   "vps_dashboard_state_stopped": "Stopped",
   "vps_dashboard_state_stopping": "Cancelling...",
-  "vps_dashboard_state_upgrading": "Changing solution..."
+  "vps_dashboard_state_upgrading": "Changing solution...",
+  "vps_dashboard_state_rescued": "In rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_es_ES.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Ejecutando",
   "vps_dashboard_state_stopped": "Cancelado",
   "vps_dashboard_state_stopping": "Cancelando",
-  "vps_dashboard_state_upgrading": "Cambiando de solución"
+  "vps_dashboard_state_upgrading": "Cambiando de solución",
+  "vps_dashboard_state_rescued": "En rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_fr_CA.json
@@ -11,6 +11,7 @@
   "vps_dashboard_state_backuping": "En cours de sauvegarde",
   "vps_dashboard_state_installing": "En cours d'installation",
   "vps_dashboard_state_maintenance": "En cours de maintenance",
+  "vps_dashboard_state_rescued": "En rescue",
   "vps_dashboard_state_rebooting": "En cours de redémarrage",
   "vps_dashboard_state_running": "En cours d'exécution",
   "vps_dashboard_state_stopped": "Arrêté",

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_fr_FR.json
@@ -11,6 +11,7 @@
   "vps_dashboard_state_backuping": "En cours de sauvegarde",
   "vps_dashboard_state_installing": "En cours d'installation",
   "vps_dashboard_state_maintenance": "En cours de maintenance",
+  "vps_dashboard_state_rescued": "En rescue",
   "vps_dashboard_state_rebooting": "En cours de redémarrage",
   "vps_dashboard_state_running": "En cours d'exécution",
   "vps_dashboard_state_stopped": "Arrêté",

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_it_IT.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Esecuzione in corso...",
   "vps_dashboard_state_stopped": "Cancellato",
   "vps_dashboard_state_stopping": "Cancellazione in corso...",
-  "vps_dashboard_state_upgrading": "Modifica dell'offerta in corso..."
+  "vps_dashboard_state_upgrading": "Modifica dell'offerta in corso...",
+  "vps_dashboard_state_rescued": "In Rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_pl_PL.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Trwa wykonywanie",
   "vps_dashboard_state_stopped": "Zatrzymano",
   "vps_dashboard_state_stopping": "Wygasanie w trakcie",
-  "vps_dashboard_state_upgrading": "Zmiana oferty w trakcie"
+  "vps_dashboard_state_upgrading": "Zmiana oferty w trakcie",
+  "vps_dashboard_state_rescued": "W trybie rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/vps/src/dashboard/translations/Messages_pt_PT.json
@@ -15,5 +15,6 @@
   "vps_dashboard_state_running": "Execução em curso",
   "vps_dashboard_state_stopped": "Cancelado",
   "vps_dashboard_state_stopping": "Cancelamento em curso",
-  "vps_dashboard_state_upgrading": "Alteração da oferta em curso"
+  "vps_dashboard_state_upgrading": "Alteração da oferta em curso",
+  "vps_dashboard_state_rescued": "Em modo Rescue"
 }

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.component.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.component.js
@@ -47,6 +47,8 @@ export default {
     canDisplayVpsAnnouncementBanner: '<',
     migrationLink: '<',
     user: '<',
+    stein: '<',
+    isVpsMaintenance: '<',
   },
   controller,
   name: 'ovhManagerVpsDashboard',

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.constants.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.constants.js
@@ -12,7 +12,7 @@ export const NEW_RANGE_VERSION = '2019v1';
 
 export const VPS_STATES = {
   ERROR: ['maintenance', 'stopped', 'stopping'],
-  WARNING: ['backuping', 'installing', 'rebooting', 'upgrading'],
+  WARNING: ['backuping', 'installing', 'rebooting', 'upgrading', 'rescued'],
   SUCCESS: ['running'],
 };
 

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -1,7 +1,8 @@
 <ovh-manager-incident-banner service-name="$ctrl.serviceName">
 </ovh-manager-incident-banner>
 
-<vps-announcement-banner data-ng-if="$ctrl.canDisplayVpsAnnouncementBanner">
+<vps-announcement-banner data-ng-if="$ctrl.isVpsMaintenance"
+                         data-stein="$ctrl.stein">
 </vps-announcement-banner>
 
 <oui-message

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -154,14 +154,15 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.go('vps.detail.dashboard.migrate'),
       breadcrumb: () => null,
       trackingPrefix: () => 'vps::detail::dashboard',
-      canDisplayVpsAnnouncementBanner: /* @ngInject */ (ovhFeatureFlipping) => {
-        const vpsAnnouncementBannerId = 'vps:vps-announcement-banner';
-        return ovhFeatureFlipping
-          .checkFeatureAvailability(vpsAnnouncementBannerId)
-          .then((newRegionFeature) =>
-            newRegionFeature.isFeatureAvailable(vpsAnnouncementBannerId),
-          );
-      },
+
+      stein: /* @ngInject */ ($http, stateVps) =>
+        $http
+          .get('/vps/migrationStein')
+          .then(({ data: steins }) =>
+            steins.find(({ zone }) => zone === stateVps.zone),
+          ),
+
+      isVpsMaintenance: /* @ngInject */ (stein) => stein !== undefined,
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7428
| License          | BSD 3-Clause

## Description

Display banner based on the right zone `/.../vps/migrationStein`
### :flags: Translations

- [x] TRANS-37847