### PR TITLE
ci: add `auto-label-merge-conflicts` GitHub Action

### DIFF
--- a/.github/workflows/auto-label-merge-conflicts.yaml
+++ b/.github/workflows/auto-label-merge-conflicts.yaml
@@ -1,0 +1,14 @@
+name: Auto-label merge conflicts
+
+on: [push, pull_request]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 5
+          WAIT_MS: 5000


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

## Description

### :green_heart: Continuous Integration

9cf76b7 - ci: add `auto-label-merge-conflicts` GitHub Action

### :link: Related

https://github.com/mschilde/auto-label-merge-conflicts

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
