### PR TITLE
fix(otb): remove jquery dep

### DIFF
--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -49,7 +49,6 @@
     "angularjs-scroll-glue": "^2.2.0",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "core-js": "^3.6.5",
-    "jquery": "^2.1.3",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "moment": "^2.24.0",


### PR DESCRIPTION
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

<!-- 
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch 
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally 
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits 

## Description
Remove jquery dependency in otb module, which is not used.

## Related

https://github.com/ovh/manager/security/dependabot/packages/manager/apps/overthebox/package.json/jquery/open
