### PR TITLE
fix(validator): allow `0` netmask value

### DIFF
--- a/packages/manager/modules/web-universe-components/src/validator/validator.service.js
+++ b/packages/manager/modules/web-universe-components/src/validator/validator.service.js
@@ -22,7 +22,7 @@ export default function() {
     return (
       split.length === 2 &&
       this.isValidIpv4(split[0]) &&
-      parseInt(split[1], 10) > 0 &&
+      parseInt(split[1], 10) >= 0 &&
       parseInt(split[1], 10) < 33
     );
   };
@@ -37,7 +37,7 @@ export default function() {
     return (
       split.length === 2 &&
       this.isValidIpv6(split[0]) &&
-      parseInt(split[1], 10) > 0 &&
+      parseInt(split[1], 10) >= 0 &&
       parseInt(split[1], 10) < 129
     );
   };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7601
| License          | BSD 3-Clause

<!-- 
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch 
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~ (not applicable)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Ip block validation functions currently refuse a 0 netmask. But something like `0.0.0.0/0` is a valid ip block (to allow every existing IPv4)

## Related

