### PR TITLE
fix(kubernetes.details.service): fix command line tool typo

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_fr_CA.json
@@ -2,7 +2,7 @@
   "kube_service": "Service",
   "kube_service_error": "Une erreur s'est produite lors du chargement des informations : {{ message }}",
   "kube_service_name": "Nom",
-  "kube_service_description_information": "Vous trouverez ci-dessous les informations de votre service Kubernetes, vous permettant d'y accéder à l'aide de l' <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">outil kubetcl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
+  "kube_service_description_information": "Vous trouverez ci-dessous les informations de votre service Kubernetes, vous permettant d'y accéder à l'aide de l' <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">outil kubectl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
   "kube_service_description_reset": "Vous pouvez réinitialiser la configuration de votre cluster Kubernetes à tout moment.",
   "kube_service_offer_beta": "Service managé Kubernetes (gratuit)",
   "kube_service_file": "Fichier kubeconfig",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_fr_FR.json
@@ -2,7 +2,7 @@
   "kube_service": "Service",
   "kube_service_error": "Une erreur s'est produite lors du chargement des informations : {{ message }}",
   "kube_service_name": "Nom",
-  "kube_service_description_information": "Vous trouverez ci-dessous les informations de votre service Kubernetes, vous permettant d'y accéder à l'aide de l' <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">outil kubetcl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
+  "kube_service_description_information": "Vous trouverez ci-dessous les informations de votre service Kubernetes, vous permettant d'y accéder à l'aide de l' <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">outil kubectl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
   "kube_service_description_reset": "Vous pouvez réinitialiser la configuration de votre cluster Kubernetes à tout moment.",
   "kube_service_offer_beta": "Service managé Kubernetes (gratuit)",
   "kube_service_file": "Fichier kubeconfig",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_it_IT.json
@@ -2,7 +2,7 @@
   "kube_service": "Servizio",
   "kube_service_error": "Si è verificato un errore durante il caricamento delle informazioni: {{message}}",
   "kube_service_name": "Nome",
-  "kube_service_description_information": "Qui sotto visualizzi le informazioni relative al tuo servizio Kubernetes, che ti permetteranno di effettuare l'accesso utilizzando il tool <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">kubetcl<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>.",
+  "kube_service_description_information": "Qui sotto visualizzi le informazioni relative al tuo servizio Kubernetes, che ti permetteranno di effettuare l'accesso utilizzando il tool <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">kubectl<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>.",
   "kube_service_description_reset": "È possibile ripristinare la configurazione del tuo cluster Kubernetes in qualsiasi momento.",
   "kube_service_offer_beta": "Servizio Managed Kubernetes (gratuito)",
   "kube_service_file": "File kubeconfig",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_pl_PL.json
@@ -2,7 +2,7 @@
   "kube_service": "Usługa",
   "kube_service_error": "Wystąpił błąd podczas pobierania informacji: {{message}}.",
   "kube_service_name": "Nazwa",
-  "kube_service_description_information": "Poniżej znajdziesz dane umożliwiające dostęp do Twojej usługi Kubernetes przy użyciu <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">narzędzia kubetcl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
+  "kube_service_description_information": "Poniżej znajdziesz dane umożliwiające dostęp do Twojej usługi Kubernetes przy użyciu <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">narzędzia kubectl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
   "kube_service_description_reset": "Możesz w każdym momencie zresetować konfigurację Twojego klastra Kubernetes.",
   "kube_service_offer_beta": "Zarządzana usługa Kubernetes (bezpłatna)",
   "kube_service_file": "Plik \"kubeconfig\"",

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/translations/Messages_pt_PT.json
@@ -2,7 +2,7 @@
   "kube_service": "Serviço",
   "kube_service_error": "Ocorreu um erro ao carregar as informações: {{message}}",
   "kube_service_name": "Nome",
-  "kube_service_description_information": "Encontrará abaixo as informações do seu serviço Kubernetes, que lhe permite aceder através da <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">ferramenta kubetcl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
+  "kube_service_description_information": "Encontrará abaixo as informações do seu serviço Kubernetes, que lhe permite aceder através da <a class=\"oui-link oui-link_icon\" href=\"{{ url }}\" target=\"_blank\" rel=\"noopener\">ferramenta kubectl.<span class=\"oui-icon oui-icon-external-link\" aria-hidden=\"true\"></span></a>",
   "kube_service_description_reset": "Pode reiniciar a configuração do seu cluster Kubernetes a qualquer momento.",
   "kube_service_offer_beta": "Serviço gerido Kubernetes (grátis)",
   "kube_service_file": "Ficheiro kubeconfig",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-48810
| License          | BSD 3-Clause

<!-- 
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch 
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Replace `kubetcl` by `kubectl`.

### :bug: Bug Fixes

4337674 - fix(kubernetes.details.service): fix command line tool typo

### :house: Internal

No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
