### PR TITLE
fix(domain): restore dns anycast activation link

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -103,7 +103,7 @@
                     <oui-action-menu
                         data-compact
                         data-placement="end"
-                        data-ng-if="!$ctrl.domain.hasDnsAnycast && $ctrl.domain.dnsAvailableOptions.length"
+                        data-ng-if="!$ctrl.domain.hasDnsAnycast && $ctrl.dnsAvailableOptions.length"
                     >
                         <oui-action-menu-item
                             data-on-click="$ctrl.goToDnsAnycast()"


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-48760
| License          | BSD 3-Clause

## Description

Restore link to enable/order DNS Anycast