### PR TITLE
fix(core): pause transition during translation refresh

### DIFF
--- a/packages/manager/modules/core/src/index.js
+++ b/packages/manager/modules/core/src/index.js
@@ -261,9 +261,7 @@ export const registerCoreModule = (environment) => {
     )
     .run(
       /* @ngInject */ ($transitions, $translate) => {
-        $transitions.onBefore({}, () => {
-          $translate.refresh();
-        });
+        $transitions.onBefore({}, () => $translate.refresh());
       },
     );
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release-2021-w36`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-48828,
| License          | BSD 3-Clause

## Description

Pause transition during `$translate.refresh`.

/cc @frenautvh @marie-j 