### PR TITLE
fix(pci.instance.edit): get instance flavor type if no image available

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
@@ -90,17 +90,22 @@ export default class PciInstanceEditController {
   }
 
   onFlavorChange(flavorGroup) {
-    if (flavorGroup && this.instance.image) {
+    if (
+      flavorGroup &&
+      (this.instance.image || this.instance.volumes.length > 0)
+    ) {
+      const flavorType =
+        this.instance?.image?.type || this.instance.flavor.osType;
       if (!this.defaultFlavor) {
         const flavor = new Flavor(this.instance.flavor);
         this.defaultFlavor = flavorGroup.getFlavorByOsType(
-          this.instance.image.type,
+          flavorType,
           flavor.isFlex(),
         );
       }
 
       this.editInstance.flavorId = flavorGroup.getFlavorId(
-        this.instance.image.type,
+        flavorType,
         this.instance.region,
         this.defaultFlavor.isFlex(),
       );


### PR DESCRIPTION
ref: DTRSD-49053

Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w8`
| Bug fix?         | yes/no
| New feature?     | yes/no
| Breaking change? | yes/no
| Tickets          | Fix #DTRSD-49053 
| License          | BSD 3-Clause

<!-- 
  Before submitting your PR, please review the following checklist:
-->

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [X] Branch is up-to-date with target branch 
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally 
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

In case where instance has no image, and is bootable from its volume, we can retrieve information about the flavor from the instance, when resizing the instance.