### PR TITLE
Fix/manager 6759

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cdn/shared/hosting-cdn-shared-settings.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/shared/hosting-cdn-shared-settings.controller.js
@@ -103,7 +103,8 @@ export default class CdnSharedSettingsController {
       },
     ];
     this.hstsMaxAgeValue = this.model.hsts?.config.ttl;
-    [this.hstsMaxAgeUnit] = this.hstsMaxAgeUnits; // Max age is expressed in seconds by default
+    this.hstsMaxAgeUnit = maxBy(this.hstsMaxAgeUnits, 'value'); // Max age is expressed in months by default
+    this.handleHSTSUnit(this.hstsMaxAgeUnit);
     this.redirection = this.redirections.find(
       ({ value }) => value === this.model.https_redirect?.config?.statusCode,
     );
@@ -330,6 +331,10 @@ export default class CdnSharedSettingsController {
   setHstsMaxAge() {
     this.model.hsts.config.ttl =
       this.hstsMaxAgeValue * this.hstsMaxAgeUnit.value;
+  }
+
+  handleHSTSUnit(unit) {
+    this.hstsMaxAgeValue = this.model.hsts.config.ttl / unit.value;
   }
 
   hasSecurityOptions(config) {

--- a/packages/manager/apps/web/client/app/hosting/cdn/shared/hosting-cdn-shared-settings.html
+++ b/packages/manager/apps/web/client/app/hosting/cdn/shared/hosting-cdn-shared-settings.html
@@ -316,7 +316,7 @@
                             items="$ctrl.hstsMaxAgeUnits"
                             model="$ctrl.hstsMaxAgeUnit"
                             disabled="!$ctrl.model.hsts.enabled"
-                            on-change="$ctrl.setHstsMaxAge()"
+                            on-change="$ctrl.handleHSTSUnit(modelValue)"
                         >
                             <span data-ng-bind="$item.key"></span>
                         </oui-select>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-6759
| License          | BSD 3-Clause

## Description

- Make month as the default unit selected for CDN HSTS setting
- Automate the conversion to the new unit, when the unit changes (for CDN HSTS setting)