### PR TITLE
feat(*): all dom termination enhancement

### DIFF
--- a/packages/manager/modules/billing-components/src/components/services-actions/service-actions.constants.js
+++ b/packages/manager/modules/billing-components/src/components/services-actions/service-actions.constants.js
@@ -7,6 +7,7 @@ export const SERVICE_TYPE = {
   OVH_CLOUD_CONNECT: 'OVH_CLOUD_CONNECT',
   SMS: 'SMS',
   WEBCOACH: 'WEBCOACH',
+  ALL_DOM: 'ALL_DOM',
 };
 
 export const RENEW_URL = {

--- a/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
+++ b/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
@@ -70,6 +70,11 @@ export default class ServicesActionsCtrl {
           { serviceName: this.service.serviceId },
         );
         break;
+      case SERVICE_TYPE.ALL_DOM:
+        this.resiliateLink = this.service.canResiliateByEndRule()
+          ? resiliationByEndRuleLink
+          : `${this.autorenewLink}/delete-all-dom?serviceId=${this.service.serviceId}&serviceType=${this.service.serviceType}`;
+        break;
       default:
         this.resiliateLink = this.service.canResiliateByEndRule()
           ? resiliationByEndRuleLink

--- a/packages/manager/modules/billing/package.json
+++ b/packages/manager/modules/billing/package.json
@@ -36,6 +36,8 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.3",
     "@ovh-ux/ng-ui-router-layout": "^4.0.4",
     "@ovh-ux/ui-kit": "^5.0.0",
+    "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.1.2",
+    "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.4",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "1.7.x",
     "angular-route": "1.7.x",

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/component.js
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/component.js
@@ -1,0 +1,13 @@
+import controller from './controller';
+import template from './template.html';
+
+export default {
+  bindings: {
+    goBack: '<',
+    domains: '<',
+    serviceType: '<',
+    serviceId: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/controller.js
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/controller.js
@@ -1,0 +1,151 @@
+import set from 'lodash/set';
+import kebabCase from 'lodash/kebabCase';
+import map from 'lodash/map';
+import filter from 'lodash/filter';
+import { BillingService } from '@ovh-ux/manager-models';
+
+const DOMAIN_SERVICE_TYPE = 'DOMAIN';
+export default class {
+  /* @ngInject */
+  constructor($translate, $http, $q, atInternet, BillingAutoRenew) {
+    this.$translate = $translate;
+    this.$http = $http;
+    this.$q = $q;
+    this.atInternet = atInternet;
+    this.BillingAutoRenew = BillingAutoRenew;
+  }
+
+  $onInit() {
+    this.isLoading = false;
+    this.cancelAllDom = true;
+    this.allDomainsSelected = false;
+  }
+
+  toggleSelectAllDomains(selectAll) {
+    if (selectAll) {
+      this.domains.forEach((domain) => set(domain, 'selected', true));
+      this.allDomainsSelected = true;
+    } else {
+      this.domains.forEach((domain) => set(domain, 'selected', false));
+      this.allDomainsSelected = false;
+    }
+  }
+
+  getSelectedDomains() {
+    return this.domains.filter((domain) => domain.selected);
+  }
+
+  toggleSelectDomain(select) {
+    if (this.allDomainsSelected || !select) {
+      this.allDomainsSelected = false;
+    } else if (
+      select &&
+      this.getSelectedDomains().length + 1 === this.domains.length
+    ) {
+      this.allDomainsSelected = true;
+    }
+  }
+
+  cancelServices() {
+    const domainsSelected = filter(this.domains, (domain) => domain.selected);
+    if (this.cancelAllDom || domainsSelected.length > 0) {
+      this.isLoading = true;
+      const servicesToTerminate = [];
+      if (this.cancelAllDom) {
+        servicesToTerminate.push(
+          this.$http.get(`/allDom/${this.serviceId}/serviceInfos`).then(
+            ({ data }) =>
+              new BillingService({
+                ...data,
+                serviceId: data.id,
+                serviceType: this.serviceType,
+              }),
+          ),
+        );
+        this.trackCancel(this.serviceType);
+      }
+      domainsSelected.forEach((domain) => {
+        servicesToTerminate.push(
+          this.$http
+            .get(`/domain/${domain.name}/serviceInfos`)
+            .then(({ data }) => {
+              return new BillingService({
+                ...data,
+                serviceId: data.id,
+                serviceType: DOMAIN_SERVICE_TYPE,
+              });
+            }),
+        );
+        this.trackCancel(DOMAIN_SERVICE_TYPE);
+      });
+      this.$q
+        .all(servicesToTerminate)
+        .then((services) =>
+          map(services, (service) => {
+            service.setForResiliation();
+            return {
+              serviceId: service.domain,
+              serviceType: service.serviceType,
+              renew: service.renew,
+            };
+          }),
+        )
+        .then((services) => this.BillingAutoRenew.updateServices(services))
+        .then(() => this.onSuccess())
+        .catch((errorPromise) => {
+          this.$q.when(errorPromise).then((error) => {
+            if (error.messages) {
+              this.onPartialSuccess(error.messages);
+            } else {
+              this.onError(error);
+            }
+          });
+        });
+    } else {
+      this.goBack();
+    }
+  }
+
+  getService(serviceId, serviceType) {
+    return this.BillingAutoRenew.getService(serviceId, serviceType).then(
+      (service) =>
+        new BillingService({
+          ...service,
+          serviceId: service.id,
+        }),
+    );
+  }
+
+  trackCancel(serviceType) {
+    this.atInternet.trackClick({
+      name: `autorenew::${kebabCase(serviceType)}::delete::confirm`,
+      type: 'action',
+      chapter1: 'dedicated',
+      chapter2: 'account',
+      chapter3: 'billing',
+    });
+  }
+
+  onSuccess() {
+    this.goBack(this.$translate.instant('autorenew_all_dom_terminate_success'));
+  }
+
+  onPartialSuccess(errors) {
+    const messages = [
+      this.$translate.instant('autorenew_all_dom_terminate_error'),
+      ...errors.map(
+        (message) => `<strong>${message.id}</strong>: ${message.message}`,
+      ),
+    ];
+    this.goBack(messages.join('</br>'), 'danger');
+  }
+
+  onError(error) {
+    this.goBack(
+      this.$translate.instant('autorenew_all_dom_terminate_error', {
+        message: error.data?.message || error.message,
+      }),
+      'danger',
+    );
+  }
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/module.js
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/module.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import angularTranslate from 'angular-translate';
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
+import '@ovh-ux/ui-kit';
+import uiRouter from '@uirouter/angularjs';
+
+import component from './component';
+import routing from './routing';
+
+import './style.less';
+
+const moduleName = 'ovhManagerBillingAutorenewTerminateAllDom';
+
+angular
+  .module(moduleName, [
+    angularTranslate,
+    ngTranslateAsyncLoader,
+    'oui',
+    uiRouter,
+  ])
+  .config(routing)
+  .component('billingAutorenewTerminateAllDom', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/routing.js
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/routing.js
@@ -1,0 +1,30 @@
+import map from 'lodash/map';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('app.account.billing.autorenew.terminate-all-dom', {
+    url: '/delete-all-dom?serviceId&serviceType',
+    views: {
+      modal: {
+        component: 'billingAutorenewTerminateAllDom',
+      },
+    },
+    layout: 'modal',
+    resolve: {
+      goBack: /* @ngInject */ (goToAutorenew) => goToAutorenew,
+      serviceId: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceId,
+      serviceType: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceType,
+      domains: /* @ngInject */ ($http, serviceId) =>
+        $http.get(`/allDom/${serviceId}/domain`).then(({ data }) =>
+          map(data, (domain) => {
+            return {
+              name: domain,
+              selected: false,
+            };
+          }),
+        ),
+      breadcrumb: () => null,
+    },
+  });
+};

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/style.less
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/style.less
@@ -1,0 +1,3 @@
+.all-dom-line-separator {
+  border-top: 1px solid #bef1ff;
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/template.html
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/template.html
@@ -1,0 +1,39 @@
+<oui-modal
+    data-heading="{{:: 'autorenew_all_dom_terminate_title' | translate }}"
+    data-primary-action="$ctrl.cancelServices()"
+    data-primary-label="{{:: 'autorenew_all_dom_terminate_confirm' | translate }}"
+    data-primary-disabled="$ctrl.domainsSelected.length > 0"
+    data-secondary-label="{{:: 'autorenew_all_dom_terminate_cancel' | translate }}"
+    data-secondary-action="$ctrl.goBack()"
+    data-on-dismiss="$ctrl.goBack()"
+    data-loading="$ctrl.isLoading"
+>
+    <oui-message class="mb-3" data-type="info">
+        <span data-translate="autorenew_all_dom_terminate_info"></span>
+    </oui-message>
+    <p data-translate="autorenew_all_dom_terminate_choose_option"></p>
+    <oui-checkbox name="all_dom_case" data-model="$ctrl.cancelAllDom">
+        <span
+            data-translate="autorenew_all_dom_terminate_select_all_dom"
+        ></span>
+    </oui-checkbox>
+    <div class="ml-3 all-dom-line-separator">
+        <oui-checkbox
+            name="all_dom_case"
+            data-model="$ctrl.allDomainsSelected"
+            on-change="$ctrl.toggleSelectAllDomains(modelValue)"
+        >
+            <span
+                data-translate="autorenew_all_dom_terminate_select_all_domains"
+            ></span>
+        </oui-checkbox>
+        <oui-checkbox
+            data-ng-repeat="domain in $ctrl.domains track by domain.name"
+            name="{{ 'domain-' + domain.name }}"
+            model="domain.selected"
+            on-change="$ctrl.toggleSelectDomain(modelValue)"
+        >
+            <span data-ng-bind="domain.name"></span>
+        </oui-checkbox>
+    </div>
+</oui-modal>

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_de_DE.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_de_DE.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Sie haben die Kündigung Ihres AllDom Pakets beantragt",
+  "autorenew_all_dom_terminate_info": "Achtung: Die Kündigung dieses Pakets hat nicht die Kündigung der damit verbundenen Domains zur Folge.",
+  "autorenew_all_dom_terminate_choose_option": "Bitte wählen Sie die Domains aus, die Sie kündigen möchten:",
+  "autorenew_all_dom_terminate_select_all_dom": "AllDom Paket",
+  "autorenew_all_dom_terminate_select_all_domains": "Alles auswählen",
+  "autorenew_all_dom_terminate_confirm": "Bestätigen",
+  "autorenew_all_dom_terminate_cancel": "Abbrechen",
+  "autorenew_all_dom_terminate_success": "Ihre Kündigungsanfrage wurde erfolgreich durchgeführt.",
+  "autorenew_all_dom_terminate_error": "Ihre Kündigungsanfrage konnte für eine oder mehrere Domains nicht durchgeführt werden. Bitte versuchen Sie es später erneut."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_en_GB.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_en_GB.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "You have requested the cancellation of your AllDom pack",
+  "autorenew_all_dom_terminate_info": "Warning: Cancelling this pack does not also cancel the domains attached to it.",
+  "autorenew_all_dom_terminate_choose_option": "Please select the domain names you wish to cancel below:",
+  "autorenew_all_dom_terminate_select_all_dom": "AllDom Pack",
+  "autorenew_all_dom_terminate_select_all_domains": "Select all",
+  "autorenew_all_dom_terminate_confirm": "Confirm",
+  "autorenew_all_dom_terminate_cancel": "Cancel",
+  "autorenew_all_dom_terminate_success": "Your cancellation request has been processed.",
+  "autorenew_all_dom_terminate_error": "Your cancellation request could not be processed for one or more domains. Please try again later."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_es_ES.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_es_ES.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Ha solicitado la baja de su pack AllDom.",
+  "autorenew_all_dom_terminate_info": "Atención: la baja de este pack no conlleva la baja de los dominios asociados.",
+  "autorenew_all_dom_terminate_choose_option": "Seleccione los dominios que quiere dar de baja:",
+  "autorenew_all_dom_terminate_select_all_dom": "Pack AllDom",
+  "autorenew_all_dom_terminate_select_all_domains": "Seleccionar todo",
+  "autorenew_all_dom_terminate_confirm": "Confirmar",
+  "autorenew_all_dom_terminate_cancel": "Cancelar",
+  "autorenew_all_dom_terminate_success": "La solicitud de baja se ha enviado correctamente.",
+  "autorenew_all_dom_terminate_error": "La solicitud de baja no se ha podido enviar para uno o varios dominios. Por favor, vuelva a intentarlo más adelante."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_CA.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Vous avez demandé la résiliation de votre pack alldom",
+  "autorenew_all_dom_terminate_info": "Attention, la résiliation de ce pack n'entraîne pas la résiliation des domaines qui y sont attachés.",
+  "autorenew_all_dom_terminate_choose_option": "Veuillez sélectionner les noms de domaines que vous souhaitez résilier ci-dessous :",
+  "autorenew_all_dom_terminate_select_all_dom": "Pack Alldom",
+  "autorenew_all_dom_terminate_select_all_domains": "Tout sélectionner",
+  "autorenew_all_dom_terminate_confirm": "Confirmer",
+  "autorenew_all_dom_terminate_cancel": "Annuler",
+  "autorenew_all_dom_terminate_success": "Votre demande de résiliation a bien été prise en compte",
+  "autorenew_all_dom_terminate_error": "Votre demande de résiliation n'a pas pu être prise en compte pour un ou plusieurs domaines. Merci d’essayer ultérieurement."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_FR.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Vous avez demandé la résiliation de votre pack alldom",
+  "autorenew_all_dom_terminate_info": "Attention, la résiliation de ce pack n'entraîne pas la résiliation des domaines qui y sont attachés.",
+  "autorenew_all_dom_terminate_choose_option": "Veuillez sélectionner les noms de domaines que vous souhaitez résilier ci-dessous :",
+  "autorenew_all_dom_terminate_select_all_dom": "Pack Alldom",
+  "autorenew_all_dom_terminate_select_all_domains": "Tout sélectionner",
+  "autorenew_all_dom_terminate_confirm": "Confirmer",
+  "autorenew_all_dom_terminate_cancel": "Annuler",
+  "autorenew_all_dom_terminate_success": "Votre demande de résiliation a bien été prise en compte",
+  "autorenew_all_dom_terminate_error": "Votre demande de résiliation n'a pas pu être prise en compte pour un ou plusieurs domaines. Merci d’essayer ultérieurement."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_it_IT.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_it_IT.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Hai chiesto la disattivazione del tuo pack alldom",
+  "autorenew_all_dom_terminate_info": "Attenzione: la disattivazione di questo pack non comporta anche la dismissione dei domini ad esso associati.",
+  "autorenew_all_dom_terminate_choose_option": "Seleziona qui sotto i domini che vuoi disattivare:",
+  "autorenew_all_dom_terminate_select_all_dom": "Pack AllDom",
+  "autorenew_all_dom_terminate_select_all_domains": "Seleziona tutto",
+  "autorenew_all_dom_terminate_confirm": "Conferma",
+  "autorenew_all_dom_terminate_cancel": "Annulla",
+  "autorenew_all_dom_terminate_success": "La tua richiesta di disattivazione è stata presa in carico.",
+  "autorenew_all_dom_terminate_error": "Non è stato possibile prendere in carico la richiesta di disattivazione per uno o più domini. Ti preghiamo di riprovare."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_pl_PL.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Zgłosiłeś rezygnację z pakietu Alldom",
+  "autorenew_all_dom_terminate_info": "Uwaga: rezygnacja z tego pakietu nie powoduje rezygnacji z przypisanych do niego domen.",
+  "autorenew_all_dom_terminate_choose_option": "Wybierz domeny, z których chcesz zrezygnować:",
+  "autorenew_all_dom_terminate_select_all_dom": "Pakiet Alldom",
+  "autorenew_all_dom_terminate_select_all_domains": "Zaznacz wszystko",
+  "autorenew_all_dom_terminate_confirm": "Zatwierdź",
+  "autorenew_all_dom_terminate_cancel": "Anuluj",
+  "autorenew_all_dom_terminate_success": "Rezygnacja została zarejestrowana.",
+  "autorenew_all_dom_terminate_error": "Rezygnacja nie mogła zostać zarejestrowana dla jednej lub kilku domen. Spróbuj później."
+}

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_pt_PT.json
@@ -1,0 +1,11 @@
+{
+  "autorenew_all_dom_terminate_title": "Solicitou a rescisão do seu pack alldom",
+  "autorenew_all_dom_terminate_info": "Atenção: a rescisão deste pack não implica a rescisão dos domínios que lhe estão associados.",
+  "autorenew_all_dom_terminate_choose_option": "Selecione os domínios que deseja rescindir a seguir:",
+  "autorenew_all_dom_terminate_select_all_dom": "Pack Alldom",
+  "autorenew_all_dom_terminate_select_all_domains": "Selecionar",
+  "autorenew_all_dom_terminate_confirm": "Confirmar",
+  "autorenew_all_dom_terminate_cancel": "Cancelar",
+  "autorenew_all_dom_terminate_success": "O seu pedido de rescisão foi registado com êxito.",
+  "autorenew_all_dom_terminate_error": "Não foi possível ter em conta o seu pedido de rescisão para um ou vários domínios. Tente mais tarde."
+}

--- a/packages/manager/modules/billing/src/autoRenew/autorenew.module.js
+++ b/packages/manager/modules/billing/src/autoRenew/autorenew.module.js
@@ -28,6 +28,7 @@ import terminateEnterpriseCloudDatabase from './actions/terminate-enterprise-clo
 import terminateHostingWeb from './actions/terminateHostingWeb/hosting-web.module';
 import terminatePrivateDatabase from './actions/terminatePrivateDatabase/private-database.module';
 import terminateWebCoach from './actions/terminate-webcoach/terminate-webcoach.module';
+import terminateAllDOm from './actions/terminate-all-dom/module';
 import update from './actions/update/update.module';
 import warnNicBilling from './actions/warnNicBilling/warnNicBilling.module';
 import warnPendingDebt from './actions/warnPendingDebt/pending-debt.module';
@@ -67,6 +68,7 @@ angular
     terminateHostingWeb,
     terminatePrivateDatabase,
     terminateWebCoach,
+    terminateAllDOm,
     uiRouter,
     update,
     warnNicBilling,

--- a/packages/manager/modules/billing/src/billing.module.js
+++ b/packages/manager/modules/billing/src/billing.module.js
@@ -8,6 +8,8 @@ import ovhManagerCore from '@ovh-ux/manager-core';
 import set from 'lodash/set';
 import uiBootstrap from 'angular-ui-bootstrap';
 import uiRouter from '@uirouter/angularjs';
+import ngAtInternetUiRouterPlugin from '@ovh-ux/ng-at-internet-ui-router-plugin';
+import '@ovh-ux/ng-ui-router-breadcrumb';
 
 import autorenew from './autoRenew/autorenew.module';
 import billingMain from './main/billing-main.module';
@@ -65,6 +67,8 @@ angular
     termination,
     uiBootstrap,
     uiRouter,
+    'ngUiRouterBreadcrumb',
+    ngAtInternetUiRouterPlugin,
   ])
   .config(routing)
   .service('billingFeatureAvailability', featureAvailability)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w45`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-7515
| License          | BSD 3-Clause

<!-- 
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch 
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally ~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

allDom termination enhancement. Allow customer to select domain to terminate while terminating allDom.

## Translations

- [x] TRANS-38570
