### PR TITLE
fix: display unique plan values if min and max are the same

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.html
@@ -14,6 +14,7 @@
         <oui-select-picker-section>
             <p
                 class="mb-0"
+                data-ng-if="plan.minMemory !== plan.maxMemory"
                 data-translate="pci_database_plans_list_spec_ram"
                 data-translate-values="{ 
                     min: (plan.minMemory | cucBytes:0:false:'GB'),
@@ -22,6 +23,15 @@
             ></p>
             <p
                 class="mb-0"
+                data-ng-if="plan.minMemory === plan.maxMemory"
+                data-translate="pci_database_plans_list_spec_ram_unique"
+                data-translate-values="{ 
+                    ram: (plan.minMemory | cucBytes:0:false:'GB')
+                }"
+            ></p>
+            <p
+                class="mb-0"
+                data-ng-if="plan.minCores !== plan.maxCores"
                 data-translate="pci_database_plans_list_spec_core"
                 data-translate-values="{
                     min: plan.minCores,
@@ -30,10 +40,27 @@
             ></p>
             <p
                 class="mb-0"
+                data-ng-if="plan.minCores === plan.maxCores"
+                data-translate="pci_database_plans_list_spec_core_unique"
+                data-translate-values="{
+                    core: plan.minCores
+                }"
+            ></p>
+            <p
+                class="mb-0"
+                data-ng-if="plan.minStorage !== plan.maxStorage"
                 data-translate="pci_database_plans_list_spec_storage"
                 data-translate-values="{ 
                 min: (plan.minStorage | cucBytes:2:false:'GB'),
                 max: (plan.maxStorage | cucBytes:2:false:'GB')
+            }"
+            ></p>
+            <p
+                class="mb-0"
+                data-ng-if="plan.minStorage === plan.maxStorage"
+                data-translate="pci_database_plans_list_spec_storage_unique"
+                data-translate-values="{ 
+                    storage: (plan.minStorage | cucBytes:2:false:'GB')
             }"
             ></p>
             <p

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
@@ -6,5 +6,8 @@
   "pci_database_plans_list_spec_nodes_single": "{{min}} nœud",
   "pci_database_plans_list_spec_nodes_range": "{{min}} nœuds inclus, jusqu'à {{max}} nœuds",
   "pci_database_plans_list_spec_nodes_range_single_min": "{{min}} nœuds inclus, jusqu'à {{max}} nœuds",
-  "pci_database_plans_list_spec_backup": "Sauvegardes manuelles et automatiques"
+  "pci_database_plans_list_spec_backup": "Sauvegardes manuelles et automatiques",
+  "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
+  "pci_database_plans_list_spec_core_unique": "{{core}} VCores",
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
 }


### PR DESCRIPTION
PUD-900

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-748`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #PUD-900
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description
If min and max plan's value are the same, only display a unique value.