### PR TITLE
Fix - Lower version of chartjs to avoid chart breaking

### DIFF
--- a/packages/manager/modules/manager-components/package.json
+++ b/packages/manager/modules/manager-components/package.json
@@ -14,7 +14,7 @@
   "main": "./src/index.js",
   "dependencies": {
     "bootstrap4": "twbs/bootstrap#v4.0.0",
-    "chart.js": "^3.5.1",
+    "chart.js": "^2.8.0",
     "lodash": "^4.17.15"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-748`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

With version 3 of chartjs, charts are broken, we need to lower the version of chartjs used in manager-components to 2.8.