### PR TITLE
fix: display full location name on backups tab

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.controller.js
@@ -1,7 +1,8 @@
 export default class {
   /* @ngInject */
-  constructor(CucCloudMessage) {
+  constructor(CucCloudMessage, ovhManagerRegionService) {
     this.CucCloudMessage = CucCloudMessage;
+    this.ovhManagerRegionService = ovhManagerRegionService;
   }
 
   $onInit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/backups.html
@@ -46,6 +46,9 @@
             data-type="string"
             data-filterable
         >
+            <span
+                data-ng-bind="$ctrl.ovhManagerRegionService.getTranslatedMacroRegion($row.region)"
+            ></span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_database_common_creation_date' | translate"


### PR DESCRIPTION
PUD-915

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-748` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-915
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Use ovhManagerRegionService to display full location's name of backups