### PR TITLE
fix(web.hosting.cdn): change price range to single price

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cdn/order/hosting-cdn-order.routing.js
@@ -148,10 +148,7 @@ export default /* @ngInject */ ($stateProvider) => {
     pricingType: () => pricingConstants.PRICING_CAPACITIES.UPGRADE,
     workflowType: () => workflowConstants.WORKFLOW_TYPES.SERVICES,
     workflowOptions: /* @ngInject */ (
-      catalog,
-      isV1CDN,
       ovhManagerProductOffersActionService,
-      ovhManagerProductOffersService,
       serviceInfo,
       trackClick,
     ) => {
@@ -176,23 +173,8 @@ export default /* @ngInject */ ($stateProvider) => {
                 HOSTING_CDN_ORDER_CATALOG_ADDONS_PLAN_CODE_CDN_BUSINESS_FREE,
               ].includes(planCode),
           );
-
-          const cdn1Addon = catalog.addons.find(
-            (addon) =>
-              addon.planCode ===
-              HOSTING_CDN_ORDER_CATALOG_ADDONS_PLAN_CODE_CDN_BUSINESS,
-          );
-
-          const [
-            cdn1Price,
-          ] = ovhManagerProductOffersService.constructor.filterPricingsByCapacity(
-            cdn1Addon.pricings,
-            pricingConstants.PRICING_CAPACITIES.RENEW,
-          );
-
           return {
             plancodes: cdnUpgrades,
-            currentOptionPrice: isV1CDN ? cdn1Price : null,
             onPricingSubmit: () => {
               trackClick('web::hosting::cdn::order::next');
             },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-6758
| License          | BSD 3-Clause

## Description

The `currentOptionPrice` attribute to `ovh-manager-product-offers` component is required only when we need a price range to be displayed. This is not required for the current use-case and hence this option is not being passed now. All code related to getting `currentOptionPrice` has been removed.