### PR TITLE
fix: topics max replication is equal to cluster node number

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/topics/create-topic/create-topic.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/topics/create-topic/create-topic.html
@@ -38,6 +38,7 @@
                         model="$ctrl.model.replication"
                         name="replication"
                         min="2"
+                        max="$ctrl.database.nodes.length"
                     >
                     </oui-numeric>
                 </oui-field>


### PR DESCRIPTION
PUD-913

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-748`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-913
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Add a maximum to topic's replication equal to the number of nodes of the cluster.
