### PR TITLE
fix: add controls for add redis user modal inputs

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.component.js
@@ -5,6 +5,9 @@ export default {
   bindings: {
     model: '=',
     label: '@',
+    min: '<?',
+    max: '<?',
+    pattern: '<?',
     buttonLabel: '@',
   },
   controller,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.constants.js
@@ -1,0 +1,9 @@
+export const DEFAULT_MIN_LENGTH = 1;
+export const DEFAULT_MAX_LENGTH = 5;
+export const DEFAULT_PATTERN = null;
+
+export default {
+  DEFAULT_MIN_LENGTH,
+  DEFAULT_MAX_LENGTH,
+  DEFAULT_PATTERN,
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.controller.js
@@ -8,6 +8,9 @@ export default class PciTagsInputController {
     this.model.forEach((element) => {
       this.items.push({ title: element });
     });
+    this.min = this.min || 1;
+    this.max = this.max || 255;
+    this.pattern = this.pattern || null;
   }
 
   addTag() {
@@ -25,13 +28,14 @@ export default class PciTagsInputController {
 
   isDisabled() {
     const isEmptyOrSpaces =
-      this.tag === null || this.tag.match(/^ *$/) !== null;
+      !this.tag || this.tag === null || this.tag.match(/^ *$/) !== null;
     return isEmptyOrSpaces || this.model.indexOf(this.tag) !== -1;
   }
 
-  handleKeyPressed(key) {
-    if (key.which === 13) {
+  handleKeyPressed(e) {
+    if (e.which === 13) {
       this.addTag();
+      e.preventDefault();
     }
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.controller.js
@@ -1,5 +1,10 @@
 import remove from 'lodash/remove';
 import pull from 'lodash/pull';
+import {
+  DEFAULT_MIN_LENGTH,
+  DEFAULT_MAX_LENGTH,
+  DEFAULT_PATTERN,
+} from './tags-input.constants';
 
 export default class PciTagsInputController {
   $onInit() {
@@ -8,9 +13,9 @@ export default class PciTagsInputController {
     this.model.forEach((element) => {
       this.items.push({ title: element });
     });
-    this.min = this.min || 1;
-    this.max = this.max || 255;
-    this.pattern = this.pattern || null;
+    this.min = this.min || DEFAULT_MIN_LENGTH;
+    this.max = this.max || DEFAULT_MAX_LENGTH;
+    this.pattern = this.pattern || DEFAULT_PATTERN;
   }
 
   addTag() {
@@ -27,8 +32,7 @@ export default class PciTagsInputController {
   }
 
   isDisabled() {
-    const isEmptyOrSpaces =
-      !this.tag || this.tag === null || this.tag.match(/^ *$/) !== null;
+    const isEmptyOrSpaces = !this.tag || this.tag.match(/^ *$/) !== null;
     return isEmptyOrSpaces || this.model.indexOf(this.tag) !== -1;
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.html
@@ -1,4 +1,4 @@
-<form novalidate>
+<form ng-submit="$ctrl.addTag()">
     <oui-field data-label="{{ $ctrl.label }}" data-size="xl">
         <div class="oui-input-group oui-input-group_xl">
             <input

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/tags-input/tags-input.html
@@ -1,21 +1,25 @@
-<oui-field data-label="{{ $ctrl.label }}" data-size="xl">
-    <div class="oui-input-group oui-input-group_xl">
-        <input
-            class="oui-input"
-            type="text"
-            id="tagInput"
-            name="tagInput"
-            ng-model="$ctrl.tag"
-            maxlength="255"
-            ng-keypress="$ctrl.handleKeyPressed($event)"
-        />
-        <oui-button disabled="$ctrl.isDisabled()" ng-click="$ctrl.addTag()"
-            ><span data-ng-bind="$ctrl.buttonLabel"></span
-        ></oui-button>
-    </div>
-    <oui-chips
-        items="$ctrl.items"
-        on-remove="$ctrl.removeTag(removed)"
-        closable
-    ></oui-chips>
-</oui-field>
+<form novalidate>
+    <oui-field data-label="{{ $ctrl.label }}" data-size="xl">
+        <div class="oui-input-group oui-input-group_xl">
+            <input
+                class="oui-input"
+                type="text"
+                id="tagInput"
+                name="tagInput"
+                ng-model="$ctrl.tag"
+                ng-minlength="$ctrl.min"
+                ng-maxlength="$ctrl.max"
+                ng-pattern="$ctrl.pattern"
+                ng-keypress="$ctrl.handleKeyPressed($event)"
+            />
+            <oui-button disabled="$ctrl.isDisabled()" ng-click="$ctrl.addTag()"
+                ><span data-ng-bind="$ctrl.buttonLabel"></span
+            ></oui-button>
+        </div>
+        <oui-chips
+            items="$ctrl.items"
+            on-remove="$ctrl.removeTag(removed)"
+            closable
+        ></oui-chips>
+    </oui-field>
+</form>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
@@ -1,7 +1,30 @@
-export const NAME_PATTERN = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,253}$/;
-export const NAME_MAX_LENGTH = 254;
+export const ADD_USER_FORM_RULES = {
+  name: {
+    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,253}$/,
+    max: 254,
+  },
+  keys: {
+    pattern: /^[a-zA-Z0-9_@./#&+-]{1,254}$/,
+    min: 1,
+    max: 254,
+  },
+  categories: {
+    pattern: /^[+-][a-zA-Z0-9_@./#&+-]{0,253}$/,
+    min: 1,
+    max: 254,
+  },
+  commands: {
+    pattern: /^[+-][a-zA-Z0-9_@./#&+-]{0,253}$/,
+    min: 1,
+    max: 254,
+  },
+  channels: {
+    pattern: /^[a-zA-Z0-9_@./#&+-]{1,254}$/,
+    min: 1,
+    max: 254,
+  },
+};
 
 export default {
-  NAME_PATTERN,
-  NAME_MAX_LENGTH,
+  ADD_USER_FORM_RULES,
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -1,14 +1,13 @@
 import get from 'lodash/get';
 import { DATABASE_TYPES } from '../../../databases.constants';
-import { NAME_PATTERN, NAME_MAX_LENGTH } from './add.constants';
+import { ADD_USER_FORM_RULES } from './add.constants';
 
 export default class {
   /* @ngInject */
   constructor($translate, DatabaseService) {
     this.$translate = $translate;
     this.DatabaseService = DatabaseService;
-    this.NAME_PATTERN = NAME_PATTERN;
-    this.NAME_MAX_LENGTH = NAME_MAX_LENGTH;
+    this.inputRules = ADD_USER_FORM_RULES;
   }
 
   $onInit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
@@ -15,8 +15,8 @@
             id="username"
             name="username"
             ng-model="$ctrl.model.username"
-            data-ng-pattern="$ctrl.NAME_PATTERN"
-            data-ng-maxlength="$ctrl.NAME_MAX_LENGTH"
+            data-ng-pattern="$ctrl.inputRules.name.pattern"
+            data-ng-maxlength="$ctrl.inputRules.name.max"
             required
         />
     </oui-field>
@@ -46,24 +46,36 @@
         <tags-input
             name="keys"
             data-model="$ctrl.model.keys"
+            data-min="$ctrl.inputRules.keys.min"
+            data-max="$ctrl.inputRules.keys.max"
+            data-pattern="$ctrl.inputRules.keys.pattern"
             data-label="{{:: 'pci_databases_users_add_keys_label' | translate }}"
             data-button-label="{{:: 'pci_databases_users_add_keys_button_label' | translate }}"
         ></tags-input>
         <tags-input
             name="categories"
             data-model="$ctrl.model.categories"
+            data-min="$ctrl.inputRules.categories.min"
+            data-max="$ctrl.inputRules.categories.max"
+            data-pattern="$ctrl.inputRules.categories.pattern"
             data-label="{{:: 'pci_databases_users_add_categories_label' | translate }}"
             data-button-label="{{:: 'pci_databases_users_add_categories_button_label' | translate }}"
         ></tags-input>
         <tags-input
             name="commands"
             data-model="$ctrl.model.commands"
+            data-min="$ctrl.inputRules.commands.min"
+            data-max="$ctrl.inputRules.commands.max"
+            data-pattern="$ctrl.inputRules.commands.pattern"
             data-label="{{:: 'pci_databases_users_add_commands_label' | translate }}"
             data-button-label="{{:: 'pci_databases_users_add_commands_button_label' | translate }}"
         ></tags-input>
         <tags-input
             name="channels"
             data-model="$ctrl.model.channels"
+            data-min="$ctrl.inputRules.channels.min"
+            data-max="$ctrl.inputRules.channels.max"
+            data-pattern="$ctrl.inputRules.channels.pattern"
             data-label="{{:: 'pci_databases_users_add_channels_label' | translate }}"
             data-button-label="{{:: 'pci_databases_users_add_channels_button_label' | translate }}"
         ></tags-input>


### PR DESCRIPTION
PUD-917

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-748`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-917
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Add controls for the inputs on the add user modal for redis engine.
Fixed a bug in tags-input component where pressing the enter key would add a tag, then immediately trigger "remove" event on the inner oui-chips component.