### PR TITLE
Fix(pci.databases): avoid calling backend twice

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/create-database/create-database.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/create-database/create-database.html
@@ -1,4 +1,4 @@
-<form name="addDatabase" ng-submit="$ctrl.addDatabase()">
+<form name="addDatabase">
     <oui-modal
         data-on-dismiss="$ctrl.goBack()"
         data-primary-label="{{:: 'pci_databases_databases_create_database_confirm' | translate}}"


### PR DESCRIPTION
PUD-934

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `PUD-748`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? |no
| Tickets          | Fix #PUD-934
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Having both the ng-submit and the data-primary-action set on the create database modal seems to call the backend twice.