### PR TITLE
Fix(pci.databases): change max user name length to 64

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
@@ -1,7 +1,7 @@
 export const ADD_USER_FORM_RULES = {
   name: {
-    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,253}$/,
-    max: 254,
+    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,63}$/,
+    max: 64,
   },
   keys: {
     pattern: /^[a-zA-Z0-9_@./#&+-]{1,254}$/,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `PUD-748`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-936
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Change control on user name max length from 254 to 64.