### PR TITLE
fix(sms.compose): apply corresponding coding to the message

### DIFF
--- a/packages/manager/modules/sms/src/sms/components/sms-composition/sms-composition.controller.js
+++ b/packages/manager/modules/sms/src/sms/components/sms-composition/sms-composition.controller.js
@@ -45,7 +45,11 @@ export default class SmsCompositionController {
             data.maxCharactersPerPart - data.characters;
           this.model.messageDetails.defaultSize = data.maxCharactersPerPart;
           this.model.messageDetails.equivalence = data.parts;
-          this.model.messageDetails.coding = data.charactersClass;
+          // TODO: Align both Enum `sms.EncodingEnum` and `sms.CodingEnum`.
+          // Since `charactersClass` could be `7bits` or `unicode`, we manually
+          // set the expected `coding`.
+          this.model.messageDetails.coding =
+            data.charactersClass === '7bits' ? '7bit' : '8bit';
 
           return this.model.messageDetails;
         })

--- a/packages/manager/modules/sms/src/sms/sms/compose/telecom-sms-sms-compose.controller.js
+++ b/packages/manager/modules/sms/src/sms/sms/compose/telecom-sms-sms-compose.controller.js
@@ -293,7 +293,10 @@ export default class {
           data.maxCharactersPerPart - data.characters;
         smsInfoText.defaultSize = data.maxCharactersPerPart;
         smsInfoText.equivalence = data.parts;
-        smsInfoText.coding = data.charactersClass;
+        // TODO: Align both Enum `sms.EncodingEnum` and `sms.CodingEnum`.
+        // Since `charactersClass` could be `7bits` or `unicode`, we manually
+        // set the expected `coding`.
+        smsInfoText.coding = data.charactersClass === '7bits' ? '7bit' : '8bit';
 
         return assign(this.message, smsInfoText);
       })


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-50895
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

### :bug: Bug Fixes

655ffaa - fix(sms.compose): apply corresponding coding to the message

## Related

- SMS-803
