### PR TITLE
fix(pci): instances dropdown

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instances.module.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.module.js
@@ -29,6 +29,8 @@ import component from './instances.component';
 import routing from './instances.routing';
 import service from './instances.service';
 
+import './instances.scss';
+
 const moduleName = 'ovhManagerPciInstances';
 
 angular

--- a/packages/manager/modules/pci/src/projects/project/instances/instances.scss
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.scss
@@ -1,0 +1,3 @@
+#publicCloudInstancesDatagrid {
+  margin-bottom: 20rem;
+}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          |  DTRSD-45478
| License          | BSD 3-Clause

## Description

Fix instances dropdown not clickable / scrollable ; a proper way to fix this would be to refactor completely pci module layout because it's currently using a mix of absolute and flex positioning, causing dropdowns not triggering page scroll.