### PR TITLE
fix(ai.notebook): wrong api call to get available regions

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.routing.js
@@ -1,3 +1,5 @@
+import map from 'lodash/map';
+
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('pci.projects.project.notebooks.add', {
     url: '/new',
@@ -29,12 +31,13 @@ export default /* @ngInject */ ($stateProvider) => {
         }),
 
       regions: /* @ngInject */ (projectId, NotebookService) =>
-        NotebookService.getRegions(projectId).then((regions) =>
-          regions.map((region) => ({
-            name: region,
+        NotebookService.getRegions(projectId).then((regions) => {
+          return map(regions, (region) => ({
+            ...region,
+            name: region.id,
             hasEnoughQuota: () => true,
-          })),
-        ),
+          }));
+        }),
 
       prices: /* @ngInject */ (projectId, CucPriceHelper) =>
         CucPriceHelper.getPrices(projectId),

--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
@@ -120,7 +120,7 @@ export default class NotebookService {
   getRegions(serviceName) {
     return this.$http
       .get(
-        `/cloud/project/${serviceName}/ai/capabilities/serving/region`,
+        `/cloud/project/${serviceName}/ai/capabilities/region`,
         NotebookService.getIcebergHeaders(),
       )
       .then(({ data }) => data);


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MLS-2172
| License          | BSD 3-Clause

## Description

Replace call to serving capability api to ai capabilities
