### PR TITLE
fix(telecom.alias.css): modification regex internal or external agent detection

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/agents/ovhPabx/ovh-pabx.constants.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/agents/ovhPabx/ovh-pabx.constants.js
@@ -1,6 +1,6 @@
 export const ALLOWED_FEATURE_TYPES = ['alias', 'line'];
 
-export const NUMBER_PREFIXES = /[+]32|32|[+]33|33|[+]41|41|0032|0033|0041/;
+export const NUMBER_PREFIXES = /[+]32|^32|[+]33|^33|[+]41|^41|^0032|^0033|^0041/;
 
 export default {
   ALLOWED_FEATURE_TYPES,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`<!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8039
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixed the bug of detection of internal OVHcloud or external line when the number contains 33 / 34 / 41 or 0033 / 0034 / 0041 in the number when adding a member in the CCS. If the number contains 33 / 34 / 41 or 0033 / 0034 / 0041 in a place other than the beginning, the number is detected externally and displays a potential billing message (wrongly). Changing the regex corrects the anomaly.

## Related

<!-- Link dependencies of this PR -->
