### PR TITLE
fix(server): translate correctly localization filter

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.controller.js
@@ -22,7 +22,7 @@ export default class ServersCtrl {
       this.serverStateEnum,
       'server_configuration_state_',
     );
-    this.datacenterEnumFilter = this.getEnumFilter(
+    this.datacenterEnumFilter = this.getDcEnumFilter(
       this.datacenterEnum,
       'server_datacenter_',
     );
@@ -38,6 +38,28 @@ export default class ServersCtrl {
 
   static toUpperSnakeCase(str) {
     return snakeCase(str).toUpperCase();
+  }
+
+  getDcEnumFilter(list, translationPrefix) {
+    return {
+      values: reduce(
+        list,
+        (result, item) => {
+          const splittedDcEnumItem = item.split(/(\d+)/);
+
+          return {
+            ...result,
+            [item]: this.$translate.instant(
+              `${translationPrefix}${this.constructor.toUpperSnakeCase(
+                splittedDcEnumItem[0],
+              )}`,
+              { number: splittedDcEnumItem?.[1] },
+            ),
+          };
+        },
+        {},
+      ),
+    };
   }
 
   getEnumFilter(list, translationPrefix) {


### PR DESCRIPTION
ref: DTRSD-53969

Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-53969
| License          | BSD 3-Clause

## Description

Add the right translation for localization filter in dedicated server list page.

Translation keys looks like: `server_datacenter_RBX` and values like: `Roubaix (RBX{{number}}) - France`. As enum provide values like `rbx1`, those values need to be splitted in order to use existing translations.