### PR TITLE
 Fix PUD-1009 (pci.storage.databases): add trackdashboard to informations modal

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.component.js
@@ -7,6 +7,7 @@ const component = {
     database: '<',
     goBack: '<',
     projectId: '<',
+    trackDashboard: '<',
     user: '<',
   },
   controller,


### PR DESCRIPTION
PUD-1009

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | PUD-1007
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

The information modal does not work because of the missing tracking function in the component.