### PR TITLE
Fix PUD-1008 (pci.storage.databases): update pattern for redis user inputs

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
@@ -4,22 +4,22 @@ export const ADD_USER_FORM_RULES = {
     max: 32,
   },
   keys: {
-    pattern: /^[a-zA-Z0-9_@./#&+-]{1,254}$/,
+    pattern: /^\S{1,254}$/,
     min: 1,
     max: 254,
   },
   categories: {
-    pattern: /^[+-][a-zA-Z0-9_@./#&+-]{0,253}$/,
+    pattern: /^[+-][a-z@]{0,253}$/,
     min: 1,
     max: 254,
   },
   commands: {
-    pattern: /^[+-][a-zA-Z0-9_@./#&+-]{0,253}$/,
+    pattern: /^[+-][a-z@]{0,253}$/,
     min: 1,
     max: 254,
   },
   channels: {
-    pattern: /^[a-zA-Z0-9_@./#&+-]{1,254}$/,
+    pattern: /^\S{1,254}$/,
     min: 1,
     max: 254,
   },


### PR DESCRIPTION
PUD-1008

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | PUD-1008
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Redis - "Add User:: Channels" in Users&Roles should allow for special characters, in specific "*".
Backend has been updated to allow for this update in manager.

## Related

<!-- Link dependencies of this PR -->
