### PR TITLE
feat(billing.autorenew): track service type on resiliation

### DIFF
--- a/packages/manager/modules/billing-components/src/components/resiliation/index.js
+++ b/packages/manager/modules/billing-components/src/components/resiliation/index.js
@@ -4,6 +4,7 @@ import '@ovh-ux/ui-kit';
 import '@ovh-ux/manager-core';
 import '@ovh-ux/ng-ovh-payment-method';
 import '@ovh-ux/ng-translate-async-loader';
+import ngAtInternet from '@ovh-ux/ng-at-internet';
 
 import component from './resiliation.component';
 import utils from '../utils';
@@ -18,6 +19,7 @@ angular
     'ui.router',
     'ngTranslateAsyncLoader',
     'ovhManagerCore',
+    ngAtInternet,
     utils,
   ])
   .component(component.name, component)

--- a/packages/manager/modules/billing-components/src/components/resiliation/resiliation.component.js
+++ b/packages/manager/modules/billing-components/src/components/resiliation/resiliation.component.js
@@ -10,6 +10,7 @@ export default {
     onSuccess: '<',
     service: '<',
     serviceName: '<',
+    serviceType: '<',
   },
   controller,
   name: 'ovhManagerBillingResiliation',

--- a/packages/manager/modules/billing-components/src/components/resiliation/resiliation.controller.js
+++ b/packages/manager/modules/billing-components/src/components/resiliation/resiliation.controller.js
@@ -1,11 +1,16 @@
 export default class BillingResiliationController {
   /* @ngInject */
-  constructor($translate, BillingService) {
+  constructor($translate, atInternet, BillingService) {
     this.$translate = $translate;
+    this.atInternet = atInternet;
     this.BillingService = BillingService;
   }
 
   resiliate() {
+    this.atInternet.trackClick({
+      name: `dedicated::account::billing::autorenew::${this.serviceType}::resiliation::confirm`,
+      type: 'action',
+    });
     this.isResiliating = true;
 
     return this.BillingService.putEndRuleStrategy(
@@ -28,5 +33,13 @@ export default class BillingResiliationController {
       .finally(() => {
         this.isResiliating = false;
       });
+  }
+
+  onCancel() {
+    this.atInternet.trackClick({
+      name: `dedicated::account::billing::autorenew::${this.serviceType}::resiliation::cancel`,
+      type: 'action',
+    });
+    this.goBack();
   }
 }

--- a/packages/manager/modules/billing-components/src/components/resiliation/resiliation.html
+++ b/packages/manager/modules/billing-components/src/components/resiliation/resiliation.html
@@ -45,7 +45,7 @@
                 data-translate-values="{ 'serviceName': '<strong>' + $ctrl.serviceName + '</strong>' }"
             ></p>
 
-            <oui-button variant="secondary" on-click="$ctrl.goBack()">
+            <oui-button variant="secondary" on-click="$ctrl.onCancel()">
                 <span data-translate="billing_resiliation_cancel"></span>
             </oui-button>
             <oui-button

--- a/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
+++ b/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
@@ -45,7 +45,7 @@ export default class ServicesActionsCtrl {
 
     const resiliationByEndRuleLink =
       (this.getResiliationLink && this.getResiliationLink()) ||
-      `${this.autorenewLink}/resiliation?serviceId=${this.service.id}&serviceName=${this.service.serviceId}`;
+      `${this.autorenewLink}/resiliation?serviceId=${this.service.id}&serviceName=${this.service.serviceId}${serviceTypeParam}`;
 
     switch (this.service.serviceType) {
       case SERVICE_TYPE.EXCHANGE:

--- a/packages/manager/modules/billing/src/autoRenew/resiliation/resiliation.routing.js
+++ b/packages/manager/modules/billing/src/autoRenew/resiliation/resiliation.routing.js
@@ -1,8 +1,10 @@
+import kebabCase from 'lodash/kebabCase';
+
 import { BillingService as Service } from '@ovh-ux/manager-models';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.account.billing.autorenew.resiliation', {
-    url: '/resiliation?serviceId&serviceName',
+    url: '/resiliation?serviceId&serviceName&serviceType',
     component: 'ovhManagerBillingResiliation',
     resolve: {
       availableStrategies: /* @ngInjecgt */ (endStrategyEnum, service) =>
@@ -30,10 +32,19 @@ export default /* @ngInject */ ($stateProvider) => {
         $transition$.params().serviceId,
       serviceName: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceName,
+      serviceType: /* @ngInject */ ($transition$) =>
+        $transition$.params().serviceType,
       validate: /* @ngInject */ (BillingService, serviceId) => (strategy) =>
         BillingService.putEndRuleStrategy(serviceId, strategy),
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('billing_autorenew_resiliate'),
+    },
+    atInternet: {
+      rename: /* @ngInject */ ($state) =>
+        // We're limited with the possible injection as we listen to onBefore hook
+        `dedicated::account::billing::autorenew::${kebabCase(
+          $state.transition.params().serviceType,
+        )}::resiliation`,
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7044
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Add tracking for confirm and cancel buttons on resiliation page. Also add serviceType for the resiliation page tracking.