### PR TITLE
feat MANAGER-7755 (pci.storage.databases): display current offer for plans and flavors

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/flavors-list.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/flavors-list.component.js
@@ -8,6 +8,7 @@ export default {
     flavors: '<',
     selectedFlavor: '=',
     user: '<',
+    allowLowerSelection: '<?',
   },
   controller,
   template,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/flavors-list.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/flavors-list.html
@@ -4,13 +4,19 @@
         data-ng-repeat="flavor in $ctrl.flavors track by flavor.name"
         data-name="{{:: flavor.name }}"
         data-model="$ctrl.selectedFlavor"
-        data-disabled="$ctrl.currentFlavor && $ctrl.currentFlavor.compare(flavor) < 0"
+        data-disabled="!$ctrl.allowLowerSelection && $ctrl.currentFlavor && $ctrl.currentFlavor.compare(flavor) <= 0"
         data-label="{{:: $ctrl.capitalize(flavor.name) }}"
         data-values="[flavor]"
         data-variant="light"
         data-on-change="$ctrl.onChange({ selectedFlavor: modelValue })"
         data-required
     >
+        <oui-select-picker-picture data-ng-if="$ctrl.currentFlavor === flavor">
+            <span
+                class="oui-badge oui-badge_s oui-badge_info"
+                data-translate="pci_database_flavors_list_current_offer"
+            ></span>
+        </oui-select-picker-picture>
         <oui-select-picker-section>
             <div class="d-flex">
                 <span

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_de_DE.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} SSD-Storage",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mbit/s",
   "pci_database_flavors_list_price_hourly": "{{price}} / Stunde (zzgl. MwSt)",
-  "pci_database_flavors_list_price_monthly": "Ab {{price}} / Monat (zzgl. MwSt.)"
+  "pci_database_flavors_list_price_monthly": "Ab {{price}} / Monat (zzgl. MwSt.)",
+  "pci_database_flavors_list_current_offer": "Derzeitiges Angebot"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_en_GB.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} SSD storage",
   "pci_database_flavors_list_spec_bandwidth": "{{bandwidth}}Mbit/s",
   "pci_database_flavors_list_price_hourly": "{{price}} ex. VAT/hour",
-  "pci_database_flavors_list_price_monthly": "From {{price}} ex. VAT/month"
+  "pci_database_flavors_list_price_monthly": "From {{price}} ex. VAT/month",
+  "pci_database_flavors_list_current_offer": "Current solution"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_es_ES.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} de almacenamiento SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mb/s",
   "pci_database_flavors_list_price_hourly": "{{price}}/hora + IVA",
-  "pci_database_flavors_list_price_monthly": "Desde {{price}}/mes + IVA"
+  "pci_database_flavors_list_price_monthly": "Desde {{price}}/mes + IVA",
+  "pci_database_flavors_list_current_offer": "Solución actual"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_CA.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} de stockage SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mbit/s",
   "pci_database_flavors_list_price_hourly": "{{price}} HT/heure",
-  "pci_database_flavors_list_price_monthly": "À partir de {{price}} HT/mois"
+  "pci_database_flavors_list_price_monthly": "À partir de {{price}} HT/mois",
+  "pci_database_flavors_list_current_offer": "Offre actuelle"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_FR.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} de stockage SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mbit/s",
   "pci_database_flavors_list_price_hourly": "{{price}} HT/heure",
-  "pci_database_flavors_list_price_monthly": "À partir de {{price}} HT/mois"
+  "pci_database_flavors_list_price_monthly": "À partir de {{price}} HT/mois",
+  "pci_database_flavors_list_current_offer": "Offre actuelle"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_it_IT.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} di storage SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mbps",
   "pci_database_flavors_list_price_hourly": "{{price}} + IVA/ora",
-  "pci_database_flavors_list_price_monthly": "A partire da {{price}} +IVA/mese"
+  "pci_database_flavors_list_price_monthly": "A partire da {{price}} +IVA/mese",
+  "pci_database_flavors_list_current_offer": "Soluzione corrente"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_pl_PL.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} przestrzeni dyskowej SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{bandwidth}} Mbps",
   "pci_database_flavors_list_price_hourly": "{{price}} netto/godz.",
-  "pci_database_flavors_list_price_monthly": "Od {{price}} netto/m-c"
+  "pci_database_flavors_list_price_monthly": "Od {{price}} netto/m-c",
+  "pci_database_flavors_list_current_offer": "Aktualna oferta"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_pt_PT.json
@@ -4,5 +4,6 @@
   "pci_database_flavors_list_spec_storage": "{{storage}} de armazenamento SSD",
   "pci_database_flavors_list_spec_bandwidth": "{{ bandwidth }} Mbps",
   "pci_database_flavors_list_price_hourly": "{{price}} /hora + IVA",
-  "pci_database_flavors_list_price_monthly": "A partir de {{price}} /mês + IVA"
+  "pci_database_flavors_list_price_monthly": "A partir de {{price}} /mês + IVA",
+  "pci_database_flavors_list_current_offer": "Oferta atual"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.component.js
@@ -8,6 +8,7 @@ export default {
     plans: '<',
     selectedPlan: '=',
     user: '<',
+    allowLowerSelection: '<?',
   },
   controller,
   template,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/plans-list.html
@@ -2,7 +2,7 @@
     <oui-select-picker
         class="d-inline-block col-md-6 col-xl-4 my-3"
         data-ng-repeat="plan in $ctrl.plans track by plan.name"
-        data-disabled="$ctrl.currentPlan && $ctrl.currentPlan.compare(plan) < 0"
+        data-disabled="!$ctrl.allowLowerSelection && $ctrl.currentPlan && $ctrl.currentPlan.compare(plan) <= 0"
         data-name="{{:: plan.name }}"
         data-model="$ctrl.selectedPlan"
         data-label="{{:: $ctrl.capitalize(plan.name) }}"
@@ -11,6 +11,12 @@
         data-on-change="$ctrl.onChange({ selectedPlan: modelValue })"
         data-required
     >
+        <oui-select-picker-picture data-ng-if="$ctrl.currentPlan === plan">
+            <span
+                class="oui-badge oui-badge_s oui-badge_info"
+                data-translate="pci_database_plans_list_current_offer"
+            ></span>
+        </oui-select-picker-picture>
         <oui-select-picker-section>
             <p
                 class="mb-0"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_de_DE.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Manuelle und automatische Backups",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{vcore}} vCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Derzeitiges Angebot"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_en_GB.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Manual and automatic backups",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{core}} VCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Current solution"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_es_ES.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Copias de seguridad manuales y automáticas",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{core}} vCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Solución actual"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_CA.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Sauvegardes manuelles et automatiques",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{core}} VCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Offre actuelle"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Sauvegardes manuelles et automatiques",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{core}} VCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Offre actuelle"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_it_IT.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Backup manuali e automatici",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{core}} vCore",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Soluzione corrente"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pl_PL.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Ręczne i automatyczne kopie zapasowe",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{vcore}} vCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Aktualna oferta"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pt_PT.json
@@ -9,5 +9,6 @@
   "pci_database_plans_list_spec_backup": "Backups manuais e automáticos",
   "pci_database_plans_list_spec_ram_unique": "{{ram}} RAM",
   "pci_database_plans_list_spec_core_unique": "{{vcore}} vCores",
-  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD"
+  "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD",
+  "pci_database_plans_list_current_offer": "Oferta atual"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
@@ -45,6 +45,7 @@
         data-selected-plan="$ctrl.model.plan"
         data-user="$ctrl.user"
         data-on-change="$ctrl.onPlanSelect()"
+        data-allow-lower-selection="true"
     >
     </database-plans-list>
 
@@ -77,6 +78,7 @@
         data-selected-flavor="$ctrl.model.flavor"
         data-user="$ctrl.user"
         data-on-change="$ctrl.onFlavorSelect()"
+        data-allow-lower-selection="true"
     >
     </database-flavors-list>
 


### PR DESCRIPTION
MANAGER-7755

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          |  MANAGER-7755
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Add badges to plans & flavors components showing current offer. 
Disable the selection of current offer by default
Allow selection of current offer for fork page with an attribute to the component

### :flags: Translation

- [x] TRANS-38937
