### PR TITLE
feat PUD-823 (pci.storage.databases): auto-update the user tab

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/user.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/user.class.js
@@ -1,0 +1,59 @@
+import Base from './base.class';
+
+export default class User extends Base {
+  constructor({
+    createdAt,
+    id,
+    roles,
+    status,
+    username,
+    acls,
+    categories,
+    channels,
+    commands,
+    keys,
+  }) {
+    super();
+    this.updateData({
+      createdAt,
+      id,
+      rolesArray: roles,
+      status,
+      username,
+      acls,
+      categories,
+      channels,
+      commands,
+      keys,
+    });
+  }
+
+  updateData({
+    createdAt,
+    id,
+    rolesArray,
+    status,
+    username,
+    acls,
+    categories,
+    channels,
+    commands,
+    keys,
+  }) {
+    Object.assign(this, {
+      createdAt,
+      id,
+      rolesArray,
+      status,
+      username,
+      acls,
+      categories,
+      channels,
+      commands,
+      keys,
+    });
+    this.roles = this.rolesArray?.map((role, index) => {
+      return { id: index, name: role };
+    });
+  }
+}

--- a/packages/manager/modules/pci/src/components/project/users/users.component.js
+++ b/packages/manager/modules/pci/src/components/project/users/users.component.js
@@ -24,5 +24,6 @@ export default {
     regeneratePassword: '<?',
     roles: '<',
     users: '<',
+    onDestroy: '<?',
   },
 };

--- a/packages/manager/modules/pci/src/components/project/users/users.controller.js
+++ b/packages/manager/modules/pci/src/components/project/users/users.controller.js
@@ -121,4 +121,8 @@ export default class CloudProjectUsersCtrl {
         ),
       );
   }
+
+  $onDestroy() {
+    this.onDestroy();
+  }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
@@ -16,6 +16,7 @@ import Database from '../../../../components/project/storages/databases/database
 import Engine from '../../../../components/project/storages/databases/engine.class';
 import Lab from '../../../../components/project/labs/lab.class';
 import Node from '../../../../components/project/storages/databases/node.class';
+import User from '../../../../components/project/storages/databases/user.class';
 
 export default class DatabaseService {
   /* @ngInject */
@@ -325,6 +326,23 @@ export default class DatabaseService {
         DatabaseService.getIcebergHeaders(),
       )
       .then(({ data }) => data);
+  }
+
+  pollUserStatus(projectId, engine, databaseId, userId) {
+    return this.Poller.poll(
+      `/cloud/project/${projectId}/database/${engine}/${databaseId}/user/${userId}`,
+      {},
+      {
+        namespace: `databases_${databaseId}_user_${userId}`,
+        interval: 2000,
+        method: 'get',
+        successRule: (user) => !new User(user).isProcessing(),
+      },
+    );
+  }
+
+  stopPollingUserStatus(databaseId, userId) {
+    this.Poller.kill({ namespace: `databases_${databaseId}_user_${userId}` });
   }
 
   addUser(projectId, engine, databaseId, user) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
@@ -19,22 +19,25 @@ export default /* @ngInject */ ($stateProvider) => {
             projectId,
             database.engine,
             database.id,
-          ).then((users) => {
-            const mappedUsers = map(users, (u) => new User(u));
-            mappedUsers.forEach((u) => {
-              if (u.isProcessing()) {
+          ).then((users) =>
+            map(users, (u) => {
+              const user = new User(u);
+              if (user.isProcessing()) {
                 DatabaseService.pollUserStatus(
                   projectId,
                   database.engine,
                   database.id,
-                  u.id,
+                  user.id,
                 ).then((userInfos) => {
-                  u.updateData({ ...userInfos, rolesArray: userInfos.roles });
+                  user.updateData({
+                    ...userInfos,
+                    rolesArray: userInfos.roles,
+                  });
                 });
               }
-            });
-            return mappedUsers;
-          }),
+              return user;
+            }),
+          ),
         addUser: /* @ngInject */ (
           $state,
           database,
@@ -193,8 +196,8 @@ export default /* @ngInject */ ($stateProvider) => {
         guideUrl: () => null,
         hideRolesMatrix: () => true,
         onDestroy: /* @ngInject */ (DatabaseService, users, database) => () =>
-          users.forEach((u) =>
-            DatabaseService.stopPollingUserStatus(database.id, u.id),
+          users.forEach((user) =>
+            DatabaseService.stopPollingUserStatus(database.id, user.id),
           ),
       },
     },


### PR DESCRIPTION
PUD-823

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | PUD-823
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

As requested by customers, add the polling of user status in the user tab for databases