### PR TITLE
feat(hosting.multisite.add): select ssl by default

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.controller.js
@@ -77,7 +77,7 @@ angular
         countryIp: null,
         firewall: 'NONE',
         ownLog: null,
-        ssl: false,
+        ssl: true,
         runtime: null,
       };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix MANAGER-7521
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

When adding a multi-site to a webhosting, SSL option is now selected by default. It is more secure for user to have an SSL attached to its site, so selecting this option by default prevents the user to have insecure settings by mistake.
CX recommendation was to invert the wording ("Disable SSL" instead of "SSL") but as seen with Richard Lenaert, SSL selection by default seems more intuitive for the user and more coherent with the rest of the UI (tooltips, other multisite dialogs...).

