### PR TITLE
feat: add `pageUrl`

### DIFF
--- a/packages/components/ng-at-internet-ui-router-plugin/src/index.js
+++ b/packages/components/ng-at-internet-ui-router-plugin/src/index.js
@@ -32,6 +32,13 @@ angular
             const ignore = options && options.ignore;
             const trackPage = {};
             if (atInternetUiRouterPlugin.isStateTrackEnabled() && !ignore) {
+              trackPage.pageUrl = encodeURIComponent(
+                transition.router.stateService.href(
+                  state.name,
+                  transition.params(),
+                  { absolute: true },
+                ),
+              );
               trackPage.name = state.name;
               if (options) {
                 if (options.rename) {

--- a/packages/components/ng-at-internet/src/constants.js
+++ b/packages/components/ng-at-internet/src/constants.js
@@ -25,6 +25,17 @@ export const AT_INTERNET_CUSTOM_VARS = {
   },
 
   /**
+   * Url for the tracking hit
+   */
+  pageUrl: {
+    path: {
+      default: 'site.11',
+      US: 'site.10',
+    },
+    format: '[%s]',
+  },
+
+  /**
    * Referrer site
    */
 

--- a/packages/components/ng-at-internet/src/provider.js
+++ b/packages/components/ng-at-internet/src/provider.js
@@ -350,7 +350,10 @@ export default /* @ngInject */ function(AT_INTERNET_CUSTOM_VARS) {
         if (isAtInternetTagAvailable()) {
           updateData(pageData);
           if (pageData.name) {
-            pageData.customVars = getCustomVarsWithDefaults(pageDataParam);
+            pageData.customVars = getCustomVarsWithDefaults({
+              pageUrl: encodeURIComponent(window.location.href),
+              ...pageDataParam,
+            });
             atinternetTag.page.send(pageData);
             logDebugInfos('atinternet.trackpage: ', pageData);
           } else {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-7481
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Add pageUrl to trackPage. There are 2 cases handled
1.) When the trackPage is triggered in the ng-at-internet-ui-router-plugin module, when the transition to a new state happens, the target url is built and passed as the pageUrl
2.) When no pageUrl is passed to trackPage (in cases where trackPage is called directly in the code, when no transition occurs), the current active url is taken as the pageUrl