### PR TITLE
fix(domain.mx-autoconfig): get region based constants

### DIFF
--- a/packages/manager/modules/exchange/src/domain/mx-autoconfig/domain-mx-autoconfig.controller.js
+++ b/packages/manager/modules/exchange/src/domain/mx-autoconfig/domain-mx-autoconfig.controller.js
@@ -5,7 +5,7 @@ export default class ExchangeDomainMxAutoconfigCtrl {
     wucExchange,
     ExchangeDomains,
     EXCHANGE_MX_CONFIG,
-    constants,
+    coreConfig,
     messaging,
     navigation,
     $translate,
@@ -16,7 +16,7 @@ export default class ExchangeDomainMxAutoconfigCtrl {
       wucExchange,
       ExchangeDomains,
       EXCHANGE_MX_CONFIG,
-      constants,
+      coreConfig,
       messaging,
       navigation,
       $translate,
@@ -34,10 +34,10 @@ export default class ExchangeDomainMxAutoconfigCtrl {
       .then((data) => {
         this.domainDiag = data;
 
-        if (constants.target === 'CA') {
-          this.domainDiag.mx.spam = EXCHANGE_MX_CONFIG.CA.spam;
-        } else if (constants.target === 'EU') {
+        if (coreConfig.isRegion('EU')) {
           this.domainDiag.mx.spam = EXCHANGE_MX_CONFIG.EU.spam;
+        } else if (coreConfig.isRegion('CA')) {
+          this.domainDiag.mx.spam = EXCHANGE_MX_CONFIG.CA.spam;
         }
 
         if (this.domainDiag.isOvhDomain) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2021-w43`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-35881
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

get region based constants
