### PR TITLE
Fix/billing order id filter

### DIFF
--- a/packages/manager/modules/billing/src/main/history/billing-main-history.html
+++ b/packages/manager/modules/billing/src/main/history/billing-main-history.html
@@ -66,8 +66,8 @@
             title=":: 'billing_main_history_table_order_id' | translate"
             property="orderId"
             searchable
-            type="string"
-            type-options="$ctrl.stringColumnOptions"
+            type="number"
+            type-options="$ctrl.numberColumnOptions"
             sortable
             filterable
         >

--- a/packages/manager/modules/ng-layout-helpers/src/list/constants.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/constants.js
@@ -8,7 +8,10 @@ export const STRING_COLUMN_OPTIONS = [
   'isNot',
 ];
 
+export const NUMBER_COLUMN_OPTIONS = ['is'];
+
 export default {
   DEFAULT_NUMBER_OF_COLUMNS,
+  NUMBER_COLUMN_OPTIONS,
   STRING_COLUMN_OPTIONS,
 };

--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.controller.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.controller.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import map from 'lodash/map';
 
-import { STRING_COLUMN_OPTIONS } from './constants';
+import { NUMBER_COLUMN_OPTIONS, STRING_COLUMN_OPTIONS } from './constants';
 
 export default class ListLayoutCtrl {
   /* @ngInject */
@@ -23,6 +23,10 @@ export default class ListLayoutCtrl {
 
     this.stringColumnOptions = {
       operators: STRING_COLUMN_OPTIONS,
+    };
+
+    this.numberColumnOptions = {
+      operators: NUMBER_COLUMN_OPTIONS,
     };
   }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7878
| License          | BSD 3-Clause

## Description

"like" operator won't work anymore with incoming iceberg type checking on numbers, orderId is type long