### PR TITLE
feat(ai-training-jobs): add possibility to attach ssh keys

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
@@ -181,6 +181,27 @@
                         </oui-tile-description>
                     </dl>
                 </div>
+
+                <div class="oui-tile__item" ng-if="$ctrl.job.status.sshUrl">
+                    <dl class="oui-tile__definition">
+                        <dt class="oui-tile__term">
+                            <span
+                                data-translate="pci_projects_project_training_jobs_ssh_url"
+                            ></span>
+                            <button
+                                type="button"
+                                class="oui-popover-button"
+                                data-oui-popover="{{ 'pci_projects_project_training_jobs_ssh_url_help' | translate }}"
+                            ></button>
+                        </dt>
+
+                        <oui-tile-description>
+                            <oui-clipboard
+                                data-model="$ctrl.job.status.sshUrl"
+                            ></oui-clipboard>
+                        </oui-tile-description>
+                    </dl>
+                </div>
             </oui-tile>
         </div>
         <div class="col-md-4">

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_de_DE.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Informationen",
   "pci_projects_project_training_jobs_info_title_actions": "Aktionen",
   "pci_projects_project_training_job_logs_text_pre_running": "Der Auftrag wurde noch nicht gestartet... Der Tab wird automatisch aktualisiert, sobald der Auftrag gestartet wurde.",
-  "pci_projects_project_training_jobs_resubmit": "Neu starten"
+  "pci_projects_project_training_jobs_resubmit": "Neu starten",
+  "pci_projects_project_training_jobs_ssh_url": "SSH Zugang"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_en_GB.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Info",
   "pci_projects_project_training_jobs_info_title_actions": "Actions",
   "pci_projects_project_training_job_logs_text_pre_running": "The job is still waiting to start... The tab will refresh automatically once the job has started.",
-  "pci_projects_project_training_jobs_resubmit": "Relaunch"
+  "pci_projects_project_training_jobs_resubmit": "Relaunch",
+  "pci_projects_project_training_jobs_ssh_url": "SSH access"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_es_ES.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Información",
   "pci_projects_project_training_jobs_info_title_actions": "Acciones",
   "pci_projects_project_training_job_logs_text_pre_running": "El job todavía está en espera de arranque... La pestaña se actualizará automáticamente cuando el job comience.",
-  "pci_projects_project_training_jobs_resubmit": "Reanudar"
+  "pci_projects_project_training_jobs_resubmit": "Reanudar",
+  "pci_projects_project_training_jobs_ssh_url": "Acceso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_CA.json
@@ -14,6 +14,7 @@
   "pci_projects_project_training_jobs_price": "Coût du job",
   "pci_projects_project_training_jobs_price_estimate": "Estimation sur le temps d'éxecution du job",
   "pci_projects_project_training_jobs_access_url": "Accès HTTP",
+  "pci_projects_project_training_jobs_ssh_url": "Accès SSH",
   "pci_projects_project_training_jobs_access_url_link": "Accès",
   "pci_projects_project_training_jobs_resource_usage_url": "Détails sur les ressources",
   "pci_projects_project_training_jobs_resource_usage_url_link": "Usage des ressources",

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_fr_FR.json
@@ -14,6 +14,7 @@
   "pci_projects_project_training_jobs_price": "Coût du job",
   "pci_projects_project_training_jobs_price_estimate": "Estimation sur le temps d'éxecution du job",
   "pci_projects_project_training_jobs_access_url": "Accès HTTP",
+  "pci_projects_project_training_jobs_ssh_url": "Accès SSH",
   "pci_projects_project_training_jobs_access_url_link": "Accès",
   "pci_projects_project_training_jobs_resource_usage_url": "Détails sur les ressources",
   "pci_projects_project_training_jobs_resource_usage_url_link": "Usage des ressources",

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_it_IT.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Info",
   "pci_projects_project_training_jobs_info_title_actions": "Azioni",
   "pci_projects_project_training_job_logs_text_pre_running": "Il job è ancora in attesa di avvio... la scheda si raffredderà automaticamente una volta che il job avrà inizio.",
-  "pci_projects_project_training_jobs_resubmit": "Riavvia"
+  "pci_projects_project_training_jobs_resubmit": "Riavvia",
+  "pci_projects_project_training_jobs_ssh_url": "Accesso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_pl_PL.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Informacje",
   "pci_projects_project_training_jobs_info_title_actions": "Operacje",
   "pci_projects_project_training_job_logs_text_pre_running": "Zadanie oczekuje na uruchomienie... Zakładka odświeży się automatycznie po rozpoczęciu zadania.",
-  "pci_projects_project_training_jobs_resubmit": "Uruchom ponownie"
+  "pci_projects_project_training_jobs_resubmit": "Uruchom ponownie",
+  "pci_projects_project_training_jobs_ssh_url": "Dostęp SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/translations/Messages_pt_PT.json
@@ -27,5 +27,6 @@
   "pci_projects_project_training_jobs_info_title_6": "Informações",
   "pci_projects_project_training_jobs_info_title_actions": "Ações",
   "pci_projects_project_training_job_logs_text_pre_running": "O job ainda está a aguardar o arranque... O separador será automaticamente atualizado assim que o job começar.",
-  "pci_projects_project_training_jobs_resubmit": "Relançar"
+  "pci_projects_project_training_jobs_resubmit": "Relançar",
+  "pci_projects_project_training_jobs_ssh_url": "Acesso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -354,7 +354,6 @@ export default class PciTrainingJobsSubmitController {
   populateSavedSshKeys() {
     this.PciProjectTrainingService.getSavedSshKeys(this.projectId).then(
       ({ data: keys }) => {
-        console.log(keys);
         this.savedKeys = keys;
         this.allKeyNames = [this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT].concat(
           this.savedKeys.map((x) => x.name),

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -17,7 +17,6 @@ export default class PciTrainingJobsSubmitController {
     PciProjectTrainingService,
     PciProjectTrainingJobService,
     PciProjectStorageContainersService,
-    OvhApiCloudProjectSshKey,
     atInternet,
     coreConfig,
   ) {
@@ -27,7 +26,6 @@ export default class PciTrainingJobsSubmitController {
     this.PciProjectTrainingService = PciProjectTrainingService;
     this.PciProjectTrainingJobService = PciProjectTrainingJobService;
     this.PciProjectStorageContainersService = PciProjectStorageContainersService;
-    this.OvhApiCloudProjectSshKey = OvhApiCloudProjectSshKey;
     this.atInternet = atInternet;
   }
 
@@ -354,15 +352,14 @@ export default class PciTrainingJobsSubmitController {
   }
 
   populateSavedSshKeys() {
-    this.OvhApiCloudProjectSshKey.v6()
-      .query({
-        serviceName: this.projectId,
-      })
-      .$promise.then((keys) => {
+    this.PciProjectTrainingService.getSavedSshKeys(this.projectId).then(
+      ({ data: keys }) => {
+        console.log(keys);
         this.savedKeys = keys;
         this.allKeyNames = [this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT].concat(
           this.savedKeys.map((x) => x.name),
         );
-      });
+      },
+    );
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -103,7 +103,7 @@ export default class PciTrainingJobsSubmitController {
     this.emptyData = this.containers.length === 0;
     this.filterContainers();
 
-    // Option set by user indicating if he wants to add ssh keys
+    // Option indicating if the user wants to add ssh keys
     this.enabledSshPublicKey = false;
     // List of ssh keys added by user
     this.addedSshKeys = [];
@@ -352,7 +352,7 @@ export default class PciTrainingJobsSubmitController {
   }
 
   populateSavedSshKeys() {
-    this.PciProjectTrainingService.getSavedSshKeys(this.projectId).then(
+    return this.PciProjectTrainingService.getSavedSshKeys(this.projectId).then(
       ({ data: keys }) => {
         this.savedKeys = keys;
         this.allKeyNames = [this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT].concat(

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -7,11 +7,8 @@ import { nameGenerator } from '../../../data-processing/data-processing.utils';
 import {
   DISCORD_URL,
   DOC_DOCKER_BUILD_URL,
-  JOB_MAX_SSH_KEYS,
+  JOB_SSH_KEYS_CONSTANTS,
 } from '../../training.constants';
-
-export const CUSTOM_SELECT = '-';
-export const PLACEHOLDER_SSH_KEY = 'ssh-rsa AAAAB3...';
 
 export default class PciTrainingJobsSubmitController {
   /* @ngInject */
@@ -24,8 +21,7 @@ export default class PciTrainingJobsSubmitController {
     atInternet,
     coreConfig,
   ) {
-    this.JOB_MAX_SSH_KEYS = JOB_MAX_SSH_KEYS;
-    this.PLACEHOLDER_SSH_KEY = PLACEHOLDER_SSH_KEY;
+    this.JOB_SSH_KEYS_CONSTANTS = JOB_SSH_KEYS_CONSTANTS;
     this.coreConfig = coreConfig;
     this.$translate = $translate;
     this.PciProjectTrainingService = PciProjectTrainingService;
@@ -306,7 +302,7 @@ export default class PciTrainingJobsSubmitController {
     const allSshKeys = this.getAllSshKeys();
     return (
       allSshKeys.length === this.addedSshKeys.length &&
-      allSshKeys.length <= this.JOB_MAX_SSH_KEYS
+      allSshKeys.length <= this.JOB_SSH_KEYS_CONSTANTS.MAX
     );
   }
 
@@ -314,7 +310,7 @@ export default class PciTrainingJobsSubmitController {
     this.addedSshKeys.push({
       disabled: false,
       model: null,
-      keyName: CUSTOM_SELECT,
+      keyName: this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT,
     });
   }
 
@@ -345,7 +341,7 @@ export default class PciTrainingJobsSubmitController {
     // Get the select key name from the index
     const newSshKeyName = this.addedSshKeys[index].keyName;
     // Find the selected key by name
-    if (newSshKeyName === CUSTOM_SELECT) {
+    if (newSshKeyName === this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT) {
       this.addedSshKeys[index].model = null;
       this.addedSshKeys[index].disabled = false;
     } else {
@@ -364,7 +360,7 @@ export default class PciTrainingJobsSubmitController {
       })
       .$promise.then((keys) => {
         this.savedKeys = keys;
-        this.allKeyNames = [CUSTOM_SELECT].concat(
+        this.allKeyNames = [this.JOB_SSH_KEYS_CONSTANTS.CUSTOM_SELECT].concat(
           this.savedKeys.map((x) => x.name),
         );
       });

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -7,7 +7,7 @@ import { nameGenerator } from '../../../data-processing/data-processing.utils';
 import {
   DISCORD_URL,
   DOC_DOCKER_BUILD_URL,
-  JOB_SSH_KEYS_CONSTANTS,
+  JOB_SSH_KEYS,
 } from '../../training.constants';
 
 export default class PciTrainingJobsSubmitController {
@@ -21,7 +21,7 @@ export default class PciTrainingJobsSubmitController {
     atInternet,
     coreConfig,
   ) {
-    this.JOB_SSH_KEYS_CONSTANTS = JOB_SSH_KEYS_CONSTANTS;
+    this.JOB_SSH_KEYS_CONSTANTS = JOB_SSH_KEYS;
     this.coreConfig = coreConfig;
     this.$translate = $translate;
     this.PciProjectTrainingService = PciProjectTrainingService;

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -11,6 +11,7 @@ import {
 } from '../../training.constants';
 
 export const CUSTOM_SELECT = '-';
+export const PLACEHOLDER_SSH_KEY = 'ssh-rsa AAAAB3...';
 
 export default class PciTrainingJobsSubmitController {
   /* @ngInject */
@@ -24,6 +25,7 @@ export default class PciTrainingJobsSubmitController {
     coreConfig,
   ) {
     this.JOB_MAX_SSH_KEYS = JOB_MAX_SSH_KEYS;
+    this.PLACEHOLDER_SSH_KEY = PLACEHOLDER_SSH_KEY;
     this.coreConfig = coreConfig;
     this.$translate = $translate;
     this.PciProjectTrainingService = PciProjectTrainingService;
@@ -311,7 +313,6 @@ export default class PciTrainingJobsSubmitController {
   addNewSshPublicKey() {
     this.addedSshKeys.push({
       disabled: false,
-      placeHolder: 'ssh-rsa AAAAB3...',
       model: null,
       keyName: CUSTOM_SELECT,
     });
@@ -333,8 +334,11 @@ export default class PciTrainingJobsSubmitController {
   // Return all non empty ssh keys
   getAllSshKeys() {
     return this.addedSshKeys
-      .map((x) => x.model)
-      .filter((x) => x && x.length !== 0 && x.trim());
+      .map((sshKey) => sshKey.model)
+      .filter(
+        (sshKeyModel) =>
+          sshKeyModel && sshKeyModel.length > 0 && sshKeyModel.trim(),
+      );
   }
 
   changeSavedSshKey(index) {

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
@@ -421,7 +421,7 @@
                     >
                         <fieldset class="oui-inline-adder__fieldset">
                             <legend
-                                data-ng-bind=":: 'pci_projects_project_training_jobs_submit_select_ssh_legend' | translate"
+                                data-translate="pci_projects_project_training_jobs_submit_select_ssh_legend"
                             ></legend>
                             <div class="oui-inline-adder__row">
                                 <div class="oui-inline-adder__field">
@@ -431,7 +431,6 @@
                                         data-ng-if="$ctrl.allKeyNames.length > 0"
                                     >
                                         <oui-select
-                                            id="savedKeyName"
                                             name="savedKeyName"
                                             data-model="$ctrl.addedSshKeys[$index].keyName"
                                             data-items="$ctrl.allKeyNames"
@@ -460,7 +459,7 @@
                             <button
                                 type="button"
                                 class="oui-inline-adder__action oui-button oui-button_primary oui-button_s"
-                                data-translate-attr="{title: 'dedicated_server_install_image_config_http_header_delete'}"
+                                data-translate-attr="{title: 'pci_projects_project_training_jobs_submit_select_ssh_delete_message'}"
                                 data-ng-click="$ctrl.onSshPublickeysDeleteBtnClick($index)"
                                 data-ng-disabled="$ctrl.addedSshKeys.length === 1"
                             >

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
@@ -445,9 +445,9 @@
                                         <textarea
                                             type="textarea"
                                             class="oui-input"
-                                            placeholder="{{:: $ctrl.PLACEHOLDER_SSH_KEY }}"
+                                            placeholder="{{:: $ctrl.JOB_SSH_KEYS_CONSTANTS.PLACEHOLDER }}"
                                             name="sshPublicKey"
-                                            rows="5"
+                                            rows="{{:: $ctrl.JOB_SSH_KEYS_CONSTANTS.NB_ROWS }}"
                                             data-ng-model="$ctrl.addedSshKeys[$index].model"
                                             data-ng-required
                                             data-ng-disabled="$ctrl.addedSshKeys[$index].disabled"
@@ -485,7 +485,7 @@
                 <div class="oui-field__control pt-2 pb-2">
                     <span
                         data-translate="pci_projects_project_training_jobs_submit_select_ssh_quantity"
-                        data-translate-values="{ numberOfSshKeys: $ctrl.getAllSshKeys().length, maxSshKeys: $ctrl.JOB_MAX_SSH_KEYS}"
+                        data-translate-values="{ numberOfSshKeys: $ctrl.getAllSshKeys().length, maxSshKeys: $ctrl.JOB_SSH_KEYS_CONSTANTS.MAX}"
                     ></span>
                 </div>
             </div>

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
@@ -420,11 +420,9 @@
                         data-ng-repeat="sshKey in $ctrl.addedSshKeys track by $index"
                     >
                         <fieldset class="oui-inline-adder__fieldset">
-                            <legend>
-                                {{::
-                                'pci_projects_project_training_jobs_submit_select_ssh_legend'
-                                | translate }}
-                            </legend>
+                            <legend
+                                data-ng-bind=":: 'pci_projects_project_training_jobs_submit_select_ssh_legend' | translate"
+                            ></legend>
                             <div class="oui-inline-adder__row">
                                 <div class="oui-inline-adder__field">
                                     <oui-field
@@ -447,7 +445,7 @@
                                         <textarea
                                             type="textarea"
                                             class="oui-input"
-                                            placeholder="{{:: $ctrl.addedSshKeys[$index].placeHolder }}"
+                                            placeholder="{{:: $ctrl.PLACEHOLDER_SSH_KEY }}"
                                             name="sshPublicKey"
                                             rows="5"
                                             data-ng-model="$ctrl.addedSshKeys[$index].model"
@@ -464,7 +462,7 @@
                                 class="oui-inline-adder__action oui-button oui-button_primary oui-button_s"
                                 data-translate-attr="{title: 'dedicated_server_install_image_config_http_header_delete'}"
                                 data-ng-click="$ctrl.onSshPublickeysDeleteBtnClick($index)"
-                                data-ng-disabled="$ctrl.addedSshKeys.length == 1"
+                                data-ng-disabled="$ctrl.addedSshKeys.length === 1"
                             >
                                 <span
                                     class="oui-icon oui-icon-trash"

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
@@ -389,6 +389,109 @@
                 </div>
             </div>
         </oui-step-form>
+        <oui-step-form
+            data-header="{{ :: 'pci_projects_project_training_jobs_submit_select_ssh' | translate }}"
+            data-editable="!$ctrl.isSubmit"
+        >
+            <oui-message type="info" dismissable="true">
+                <span
+                    class="d-block"
+                    data-translate="pci_projects_project_training_jobs_submit_select_ssh_tips_1"
+                ></span>
+            </oui-message>
+            <oui-field
+                data-size="xl"
+                data-label="{{:: 'pci_projects_project_training_jobs_submit_select_ssh_default_select' | translate  }}"
+            >
+                <oui-switch
+                    data-model="$ctrl.enabledSshPublicKey"
+                    name="enabledSshPublicKey"
+                    on-change="$ctrl.changeEnabledSshPublicKey(modelValue)"
+                >
+                </oui-switch>
+            </oui-field>
+            <div
+                class="oui-field__control"
+                data-ng-if="$ctrl.enabledSshPublicKey"
+            >
+                <div class="oui-inline-adder mb-2">
+                    <div
+                        class="oui-inline-adder__form"
+                        data-ng-repeat="sshKey in $ctrl.addedSshKeys track by $index"
+                    >
+                        <fieldset class="oui-inline-adder__fieldset">
+                            <legend>
+                                {{::
+                                'pci_projects_project_training_jobs_submit_select_ssh_legend'
+                                | translate }}
+                            </legend>
+                            <div class="oui-inline-adder__row">
+                                <div class="oui-inline-adder__field">
+                                    <oui-field
+                                        data-size="m"
+                                        data-label="{{:: 'pci_projects_project_training_jobs_submit_select_ssh_name_tips' | translate  }}"
+                                        data-ng-if="$ctrl.allKeyNames.length > 0"
+                                    >
+                                        <oui-select
+                                            id="savedKeyName"
+                                            name="savedKeyName"
+                                            data-model="$ctrl.addedSshKeys[$index].keyName"
+                                            data-items="$ctrl.allKeyNames"
+                                            on-change="$ctrl.changeSavedSshKey($index)"
+                                        >
+                                        </oui-select>
+                                    </oui-field>
+                                    <oui-field
+                                        data-label="{{:: 'pci_projects_project_training_jobs_submit_select_ssh_input_tips' | translate  }}"
+                                    >
+                                        <textarea
+                                            type="textarea"
+                                            class="oui-input"
+                                            placeholder="{{:: $ctrl.addedSshKeys[$index].placeHolder }}"
+                                            name="sshPublicKey"
+                                            rows="5"
+                                            data-ng-model="$ctrl.addedSshKeys[$index].model"
+                                            data-ng-required
+                                            data-ng-disabled="$ctrl.addedSshKeys[$index].disabled"
+                                        />
+                                    </oui-field>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <footer class="oui-inline-adder__footer">
+                            <button
+                                type="button"
+                                class="oui-inline-adder__action oui-button oui-button_primary oui-button_s"
+                                data-translate-attr="{title: 'dedicated_server_install_image_config_http_header_delete'}"
+                                data-ng-click="$ctrl.onSshPublickeysDeleteBtnClick($index)"
+                                data-ng-disabled="$ctrl.addedSshKeys.length == 1"
+                            >
+                                <span
+                                    class="oui-icon oui-icon-trash"
+                                    aria-hidden="true"
+                                ></span>
+                            </button>
+                        </footer>
+                    </div>
+                </div>
+                <oui-button
+                    data-icon-left="oui-icon-plus"
+                    data-variant="secondary"
+                    data-disabled="!$ctrl.canAddNewSshPublicKey()"
+                    data-on-click="$ctrl.addNewSshPublicKey()"
+                >
+                    <span
+                        data-translate="pci_projects_project_training_jobs_submit_select_ssh_add"
+                    ></span>
+                </oui-button>
+                <div class="oui-field__control pt-2 pb-2">
+                    <span
+                        data-translate="pci_projects_project_training_jobs_submit_select_ssh_quantity"
+                        data-translate-values="{ numberOfSshKeys: $ctrl.getAllSshKeys().length, maxSshKeys: $ctrl.JOB_MAX_SSH_KEYS}"
+                    ></span>
+                </div>
+            </div>
+        </oui-step-form>
 
         <oui-step-form
             data-header="{{:: 'pci_projects_project_training_jobs_submit_select_config' | translate  }}"
@@ -537,7 +640,6 @@
                 </div>
             </div>
         </oui-step-form>
-
         <oui-step-form
             data-header="{{:: 'pci_projects_project_training_jobs_submit_validation' | translate  }}"
             data-submit-text="{{:: 'pci_projects_project_training_jobs_list_submit_button' | translate  }}"

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.html
@@ -482,7 +482,7 @@
                         data-translate="pci_projects_project_training_jobs_submit_select_ssh_add"
                     ></span>
                 </oui-button>
-                <div class="oui-field__control pt-2 pb-2">
+                <div class="oui-field__control py-2">
                     <span
                         data-translate="pci_projects_project_training_jobs_submit_select_ssh_quantity"
                         data-translate-values="{ numberOfSshKeys: $ctrl.getAllSshKeys().length, maxSshKeys: $ctrl.JOB_SSH_KEYS_CONSTANTS.MAX}"

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_de_DE.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Ein individuelles Image erstellen",
-  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lesen &amp; Schreiben &amp; Löschen"
+  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lesen &amp; Schreiben &amp; Löschen",
+  "pci_projects_project_training_jobs_ssh_url_help": "Mit dem SSH-Zugang können Sie sich von jedem SSH-Client aus mit dem Auftrag verbinden. Dazu werden die öffentlichen Schlüssel verwendet, die bei dem Start des Auftrags mitgeteilt werden.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Öffentliche SSH-Schlüssel hinzufügen (optional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Wenn Sie einen öffentlichen SSH-Schlüssel hinzufügen, können Sie anschließend remote per SSH- oder SCP-Protokoll auf den Auftrag zugreifen.",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Den zu verwendenden öffentlichen SSH-Schlüssel angeben (optional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Den Namen des Schlüssels aus den bereits gespeicherten Schlüsseln auswählen",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Inhalt des öffentlichen SSH-Schlüssels",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Einen neuen öffentlichen SSH-Schlüssel hinzufügen",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} SSH-Schlüssel",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Öffentlicher SSH-Schlüssel",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Den hinzugefügten SSH-Schlüssel löschen"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_en_GB.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_resource_price_by_ressource": "{{price}}/unit. ex. VAT/hour",
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
-  "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Create Custom Image"
+  "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Create Custom Image",
+  "pci_projects_project_training_jobs_ssh_url_help": "SSH access enables you to connect to the job from any SSH client via the public keys provided when the job was launched.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Attach SSH public keys (optional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "By attaching an SSH public key, you can then access the job remotely via SSH or SCP protocol",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Enter the SSH public key to use (optional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Choose key name from saved keys",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "SSH public key content",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Add a new SSH public key",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{numberOfSshKeys}}/{{maxSshKeys}} SSH keys",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Public SSH key",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Delete the attached SSH key"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_es_ES.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Crear una imagen personalizada",
-  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lectura, escritura y eliminación"
+  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lectura, escritura y eliminación",
+  "pci_projects_project_training_jobs_ssh_url_help": "El acceso SSH permite conectarse al job desde cualquier cliente SSH a través de las claves públicas proporcionadas durante el lanzamiento del job.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Asociar claves públicas SSH (opcional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Asociar una clave pública SSH le permitirá acceder a distancia al job a través del protocolo SSH o SCP.",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Introducir la clave pública SSH que desea utilizar (opcional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Elegir el nombre de la clave entre las claves guardadas",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenido de la clave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Añadir una nueva clave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }}/{{ maxSshKeys }} clave(s) SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Eliminar la clave SSH asociada"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_CA.json
@@ -37,6 +37,7 @@
   "pci_projects_project_training_jobs_submit_select_command_tile_title": "Commande spécifique",
   "pci_projects_project_training_jobs_submit_select_command_tile_command": "Arguments",
   "pci_projects_project_training_jobs_access_url_help": "L'accès HTTP permet d'être redirigé depuis votre navigateur vers le port 80 du conteneur si celui-ci est toujours en cours d'exécution. Pour accéder à l'interface web vous aurez besoin de vous identifier.",
+  "pci_projects_project_training_jobs_ssh_url_help": "L'accès SSH permet de se connecter sur le job depuis n'importe quel client SSH via les clés publiques fournies au lancement du job.",
   "pci_projects_project_training_jobs_submit_select_image_tips_help": "Les images hébergées sur une registry privé ou public sont acceptées (GitHub, GitLab, DockerHub, ...)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Créer une image personnalisée",
   "pci_projects_project_training_jobs_submit_data_container": "Conteneur",
@@ -67,5 +68,14 @@
   "pci_projects_project_training_jobs_submitresources_proposed_private_bandwidth": "Réseau Privé {{ bandwidth }}/s",
   "pci_projects_project_training_jobs_submitresources_proposed_resource_price_by_ressource": "{{ price }}/unité. HT/heure",
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
-  "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)"
+  "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Attacher des clés publiques SSH (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique SSH vous permet par la suite d'accéder à distance au job via le protocole SSH ou SCP",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Renseigner la clé publique SSH à utiliser (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Supprimer la clé SSH attachée"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -70,7 +70,7 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_ssh": "Attacher des clés publiques SSH (optionnel)",
-  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique SSH vous permet par la suite d'accéder à distance au notebook via le protocole SSH ou SCP",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique SSH vous permet par la suite d'accéder à distance au job via le protocole SSH ou SCP",
   "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Renseigner la clé publique SSH à utiliser (optionnel)",
   "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
   "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique SSH",

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -76,5 +76,6 @@
   "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique SSH",
   "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique SSH",
   "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) SSH",
-  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique SSH"
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Supprimer la clé ssh attachée"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -67,5 +67,13 @@
   "pci_projects_project_training_jobs_submitresources_proposed_private_bandwidth": "Réseau Privé {{ bandwidth }}/s",
   "pci_projects_project_training_jobs_submitresources_proposed_resource_price_by_ressource": "{{ price }}/unité. HT/heure",
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
-  "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)"
+  "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Attacher des clés publiques ssh (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique ssh vous permet par la suite d'accéder à distance au notebook via le protocole ssh ou scp",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Renseigner la clé publique ssh à utiliser (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique ssh",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique ssh"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -68,12 +68,12 @@
   "pci_projects_project_training_jobs_submitresources_proposed_resource_price_by_ressource": "{{ price }}/unité. HT/heure",
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
-  "pci_projects_project_training_jobs_submit_select_ssh": "Attacher des clés publiques ssh (optionnel)",
-  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique ssh vous permet par la suite d'accéder à distance au notebook via le protocole ssh ou scp",
-  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Renseigner la clé publique ssh à utiliser (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Attacher des clés publiques SSH (optionnel)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Attacher une clé publique SSH vous permet par la suite d'accéder à distance au notebook via le protocole SSH ou SCP",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Renseigner la clé publique SSH à utiliser (optionnel)",
   "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
-  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique ssh",
-  "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
-  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",
-  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique ssh"
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenu de la clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -37,6 +37,7 @@
   "pci_projects_project_training_jobs_submit_select_command_tile_title": "Commande spécifique",
   "pci_projects_project_training_jobs_submit_select_command_tile_command": "Arguments",
   "pci_projects_project_training_jobs_access_url_help": "L'accès HTTP permet d'être redirigé depuis votre navigateur vers le port 80 du conteneur si celui-ci est toujours en cours d'exécution. Pour accéder à l'interface web vous aurez besoin de vous identifier.",
+  "pci_projects_project_training_jobs_ssh_url_help": "L'accès SSH permet de se connecter sur le job depuis n'importe quel client SSH via les clés publiques fournies au lancement du job.",
   "pci_projects_project_training_jobs_submit_select_image_tips_help": "Les images hébergées sur une registry privé ou public sont acceptées (GitHub, GitLab, DockerHub, ...)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Créer une image personnalisée",
   "pci_projects_project_training_jobs_submit_data_container": "Conteneur",

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_fr_FR.json
@@ -77,5 +77,5 @@
   "pci_projects_project_training_jobs_submit_select_ssh_add": "Ajouter une nouvelle clé publique SSH",
   "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) SSH",
   "pci_projects_project_training_jobs_submit_select_ssh_legend": "Clé publique SSH",
-  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Supprimer la clé ssh attachée"
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Supprimer la clé SSH attachée"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_it_IT.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Creare un'immagine personalizzata",
-  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lettura, scrittura ed eliminazione"
+  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Lettura, scrittura ed eliminazione",
+  "pci_projects_project_training_jobs_ssh_url_help": "L'accesso SSH permette di accedere al job da qualsiasi client SSH tramite le chiavi pubbliche fornite all’avvio del job.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Associa chiavi pubbliche SSH (opzionale)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "L’associazione di una chiave pubblica SSH permette di accedere da remoto al job tramite il protocollo SSH o SCP.",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Inserisci la chiave pubblica SSH da utilizzare (opzionale)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Scegli il nome della chiave tra quelle salvate",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Contenuto della chiave pubblica SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Aggiungi una nuova chiave pubblica SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }}/{{ maxSshKeys }} chiavi SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Chiave pubblica SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Elimina la chiave SSH associata"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pl_PL.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Utwórz spersonalizowany obraz",
-  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Odczyt, Zapis oraz Usuwanie"
+  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Odczyt, Zapis oraz Usuwanie",
+  "pci_projects_project_training_jobs_ssh_url_help": "Dostęp SSH pozwala na logowanie się do zadania z poziomu dowolnego klienta SSH za pomocą publicznych kluczy dostarczonych w momencie uruchamiania zadania.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Przypisz publiczne klucze SSH (opcjonalnie)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Przypisanie publicznego klucza SSH pozwala na zdalny dostęp do zadania za pomocą protokołu SSH lub SCP",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Wpisz publiczny klucz SSH, którego chcesz użyć (opcjonalnie)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Wybierz nazwę klucza spośród zarejestrowanych nazw",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Zawartość publicznego klucza SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Dodaj nowy publiczny klucz SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{numberOfSshKeys}} / {{maxSshKeys}} kluczy SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Publiczny klucz SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Usuń przypisany klucz SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/translations/Messages_pt_PT.json
@@ -67,5 +67,15 @@
   "pci_projects_project_training_jobs_submitresources_proposed_type_gpu": " (GPU)",
   "pci_projects_project_training_jobs_submitresources_proposed_type_cpu": " (CPU)",
   "pci_projects_project_training_jobs_submit_select_image_custom_doc": "Criar uma imagem personalizada",
-  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Leitura, escrita e eliminação"
+  "pci_projects_project_training_jobs_submit_data_permission_RWD": "Leitura, escrita e eliminação",
+  "pci_projects_project_training_jobs_ssh_url_help": "O acesso SSH permite ligar-se ao job a partir de qualquer cliente SSH através das chaves públicas fornecidas no lançamento do job.",
+  "pci_projects_project_training_jobs_submit_select_ssh": "Associar chaves públicas SSH (opcional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_tips_1": "Associar uma chave pública SSH permite-lhe aceder remotamente ao job através do protocolo SSH ou SCP",
+  "pci_projects_project_training_jobs_submit_select_ssh_default_select": "Inserir a chave pública SSH a utilizar (opcional)",
+  "pci_projects_project_training_jobs_submit_select_ssh_name_tips": "Selecionar o nome da chave entre as que estão registadas",
+  "pci_projects_project_training_jobs_submit_select_ssh_input_tips": "Conteúdo da chave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_add": "Adicionar uma nova chave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} chave(s) SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_legend": "Chave pública SSH",
+  "pci_projects_project_training_jobs_submit_select_ssh_delete_message": "Eliminar a chave SSH associada"
 }

--- a/packages/manager/modules/pci/src/projects/project/training/training.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.constants.js
@@ -2,7 +2,7 @@ export const GUIDE_URL = 'https://docs.ovh.com/gb/en/ai-training';
 export const DISCORD_URL = 'https://discord.com/invite/vXVurFfwe9';
 export const DOC_DOCKER_BUILD_URL =
   'https://docs.ovh.com/gb/en/ai-training/build-use-custom-image/';
-export const JOB_SSH_KEYS_CONSTANTS = {
+export const JOB_SSH_KEYS = {
   MAX: 10,
   CUSTOM_SELECT: '-',
   PLACEHOLDER: 'ssh-rsa AAAAB3...',
@@ -13,5 +13,5 @@ export default {
   GUIDE_URL,
   DISCORD_URL,
   DOC_DOCKER_BUILD_URL,
-  JOB_SSH_KEYS_CONSTANTS,
+  JOB_SSH_KEYS,
 };

--- a/packages/manager/modules/pci/src/projects/project/training/training.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.constants.js
@@ -1,5 +1,6 @@
 export const GUIDE_URL = 'https://docs.ovh.com/gb/en/ai-training';
 export const DISCORD_URL = 'https://discord.com/invite/vXVurFfwe9';
+export const JOB_MAX_SSH_KEYS = 10;
 export const DOC_DOCKER_BUILD_URL =
   'https://docs.ovh.com/gb/en/ai-training/build-use-custom-image/';
 
@@ -7,4 +8,5 @@ export default {
   GUIDE_URL,
   DISCORD_URL,
   DOC_DOCKER_BUILD_URL,
+  JOB_MAX_SSH_KEYS,
 };

--- a/packages/manager/modules/pci/src/projects/project/training/training.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.constants.js
@@ -1,12 +1,17 @@
 export const GUIDE_URL = 'https://docs.ovh.com/gb/en/ai-training';
 export const DISCORD_URL = 'https://discord.com/invite/vXVurFfwe9';
-export const JOB_MAX_SSH_KEYS = 10;
 export const DOC_DOCKER_BUILD_URL =
   'https://docs.ovh.com/gb/en/ai-training/build-use-custom-image/';
+export const JOB_SSH_KEYS_CONSTANTS = {
+  MAX: 10,
+  CUSTOM_SELECT: '-',
+  PLACEHOLDER: 'ssh-rsa AAAAB3...',
+  NB_ROWS: 5,
+};
 
 export default {
   GUIDE_URL,
   DISCORD_URL,
   DOC_DOCKER_BUILD_URL,
-  JOB_MAX_SSH_KEYS,
+  JOB_SSH_KEYS_CONSTANTS,
 };

--- a/packages/manager/modules/pci/src/projects/project/training/training.service.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.service.js
@@ -129,4 +129,8 @@ export default class PciProjectTrainingService {
   getJobCliCommand(serviceName, job) {
     return this.$http.post(`/cloud/project/${serviceName}/ai/job/command`, job);
   }
+
+  getSavedSshKeys(serviceName) {
+    return this.$http.get(`/cloud/project/${serviceName}/sshkey`);
+  }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MLS-2250
| License          | BSD 3-Clause

## Description

On AI Training add the possibility to attach an ssh key when submiting a new job

### :flags: Translations

- [x] TRANS-41398