### PR TITLE
fix(pci): ip reverse delete

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip/reverse/ip-ip-reverse.service.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/reverse/ip-ip-reverse.service.js
@@ -44,7 +44,7 @@ export default class IpReverse {
     return this.OvhApiIp.Reverse()
       .v6()
       .delete({
-        ip: window.encodeURIComponent(ipBlock),
+        ip: ipBlock,
         ipReverse: ip,
       }).$promise;
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-54444
| License          | BSD 3-Clause

## Description

fix ip reverse delete (ipBlock url encoded twice)