### PR TITLE
Feat PUD-1046 (pci.storage.databases): Reflect changes from backend

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/engines.constants.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/engines.constants.js
@@ -13,7 +13,7 @@ export const ENGINES_NAMES = {
   kafka: 'Kafka',
   redis: 'Redis',
   opensearch: 'OpenSearch',
-  kafkamirrormaker: 'Kafka MirrorMaker',
+  kafkaMirrorMaker: 'Kafka MirrorMaker',
 };
 
 export default {

--- a/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
@@ -9,7 +9,7 @@ export default class ServiceIntegration {
     topicExcludeList,
     syncGroupOffsets,
     syncInterval,
-    heartbeatsEmit,
+    emitHeartbeats,
     replicationPolicyClass,
     enabled,
   }) {
@@ -21,7 +21,7 @@ export default class ServiceIntegration {
       topicExcludeList,
       syncGroupOffsets,
       syncInterval,
-      heartbeatsEmit,
+      emitHeartbeats,
       replicationPolicyClass,
       enabled,
     });
@@ -44,7 +44,7 @@ export default class ServiceIntegration {
     topicExcludeList,
     syncGroupOffsets,
     syncInterval,
-    heartbeatsEmit,
+    emitHeartbeats,
     replicationPolicyClass,
     enabled,
   }) {
@@ -56,7 +56,7 @@ export default class ServiceIntegration {
       topicExcludeList,
       syncGroupOffsets,
       syncInterval,
-      heartbeatsEmit,
+      emitHeartbeats,
       replicationPolicyClass,
       enabled,
     });

--- a/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
@@ -3,8 +3,8 @@ import find from 'lodash/find';
 export default class ServiceIntegration {
   constructor({
     id,
-    sourceService,
-    targetService,
+    sourceIntegration,
+    targetIntegration,
     topics,
     topicExcludeList,
     syncGroupOffsets,
@@ -15,8 +15,8 @@ export default class ServiceIntegration {
   }) {
     this.updateData({
       id,
-      sourceService,
-      targetService,
+      sourceIntegration,
+      targetIntegration,
       topics,
       topicExcludeList,
       syncGroupOffsets,
@@ -28,18 +28,18 @@ export default class ServiceIntegration {
   }
 
   setServicesNames(replications) {
-    this.serviceNameSource = find(replications, {
-      id: this.sourceService,
+    this.integrationNameSource = find(replications, {
+      id: this.sourceIntegration,
     })?.serviceName;
-    this.serviceNameTarget = find(replications, {
-      id: this.targetService,
+    this.integrationNameTarget = find(replications, {
+      id: this.targetIntegration,
     })?.serviceName;
   }
 
   updateData({
     id,
-    sourceService,
-    targetService,
+    sourceIntegration,
+    targetIntegration,
     topics,
     topicExcludeList,
     syncGroupOffsets,
@@ -50,8 +50,8 @@ export default class ServiceIntegration {
   }) {
     Object.assign(this, {
       id,
-      sourceService,
-      targetService,
+      sourceIntegration,
+      targetIntegration,
       topics,
       topicExcludeList,
       syncGroupOffsets,

--- a/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
@@ -30,10 +30,10 @@ export default class ServiceIntegration {
   setServicesNames(replications) {
     this.integrationNameSource = find(replications, {
       id: this.sourceIntegration,
-    })?.serviceName;
+    })?.destinationServiceName;
     this.integrationNameTarget = find(replications, {
       id: this.targetIntegration,
-    })?.serviceName;
+    })?.destinationServiceName;
   }
 
   updateData({

--- a/packages/manager/modules/pci/src/components/project/storages/databases/serviceIntegration.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/serviceIntegration.class.js
@@ -2,21 +2,36 @@ import find from 'lodash/find';
 import Base from './base.class';
 
 export default class ServiceIntegration extends Base {
-  constructor({ id, serviceId, status, type }) {
+  constructor({ id, sourceServiceId, destinationServiceId, status, type }) {
     super();
     this.updateData({
       id,
-      serviceId,
+      sourceServiceId,
+      destinationServiceId,
       status,
       type,
     });
   }
 
-  setServiceName(serviceList) {
-    this.serviceName = find(serviceList, { id: this.serviceId })?.description;
+  setSourceServiceName(serviceList) {
+    this.sourceServiceName = find(serviceList, {
+      id: this.sourceServiceId,
+    })?.description;
   }
 
-  updateData({ id, serviceId, status, type }) {
-    Object.assign(this, { id, serviceId, status, type });
+  setDestinationServiceName(serviceList) {
+    this.destinationServiceName = find(serviceList, {
+      id: this.destinationServiceId,
+    })?.description;
+  }
+
+  updateData({ id, sourceServiceId, destinationServiceId, status, type }) {
+    Object.assign(this, {
+      id,
+      sourceServiceId,
+      destinationServiceId,
+      status,
+      type,
+    });
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/engines-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/engines-list/translations/Messages_fr_FR.json
@@ -8,5 +8,5 @@
   "pci_database_engines_list_description_redis": "Système de stockage de données clé-valeur en mémoire",
   "pci_database_engines_list_description_mongodb": "Système de gestion de base de données orienté documents",
   "pci_database_engines_list_description_opensearch": "Moteur de recherche et d'analyse distribuée. Fork d'Elasticsearch 7.10.2 et de Kibana 7.10.2",
-  "pci_database_engines_list_description_kafkamirrormaker": "Système de réplication de données entre deux Kafka"
+  "pci_database_engines_list_description_kafkaMirrorMaker": "Système de réplication de données entre deux Kafka"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
@@ -635,7 +635,8 @@ export default class DatabaseService {
       .post(
         `/cloud/project/${projectId}/database/${engine}/${databaseId}/integration`,
         {
-          serviceId: service.id,
+          sourceServiceId: databaseId,
+          destinationServiceId: service.id,
         },
       )
       .then(({ data }) => data);

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
@@ -68,13 +68,13 @@ export default class {
   prepareModel() {
     return {
       id: this.model.id,
-      sourceService: this.model.sourceService.id,
-      targetService: this.model.targetService.id,
+      sourceIntegration: this.model.sourceIntegration.id,
+      targetIntegration: this.model.targetIntegration.id,
       topics: this.model.topics,
       topicExcludeList: this.model.topicExcludeList,
       syncInterval: this.model.syncInterval,
       syncGroupOffsets: this.model.syncGroupOffsets,
-      heartbeatsEmit: this.model.heartbeatsEmit,
+      emitHeartbeats: this.model.emitHeartbeats,
       replicationPolicyClass: this.model.replicationPolicyClass,
       enabled: this.model.enabled,
     };

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
@@ -40,8 +40,8 @@ export default class {
       replicationPolicyClass: this.isUpdate
         ? this.replication.replicationPolicyClass
         : null,
-      heartbeatsEmit: this.isUpdate
-        ? this.replication.heartbeatsEmit
+      emitHeartbeats: this.isUpdate
+        ? this.replication.emitHeartbeats
         : DEFAULT_VALUES.heartbeat,
       enabled: this.isUpdate ? this.replication.enabled : DEFAULT_VALUES.status,
     };

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
@@ -19,14 +19,14 @@ export default class {
     this.invalidTargetSource = false;
     this.model = {
       id: this.isUpdate ? this.replication.id : null,
-      sourceService: this.isUpdate
+      sourceIntegration: this.isUpdate
         ? find(this.readyServiceIntegrationList, {
-            id: this.replication.sourceService,
+            id: this.replication.sourceIntegration,
           })
         : null,
-      targetService: this.isUpdate
+      targetIntegration: this.isUpdate
         ? find(this.readyServiceIntegrationList, {
-            id: this.replication.targetService,
+            id: this.replication.targetIntegration,
           })
         : null,
       topics: this.isUpdate ? this.replication.topics : [],
@@ -60,9 +60,9 @@ export default class {
 
   checkTargetAndSourceValidity() {
     this.invalidTargetSource =
-      this.model.targetService &&
-      this.model.sourceService &&
-      this.model.targetService.id === this.model.sourceService.id;
+      this.model.targetIntegration &&
+      this.model.sourceIntegration &&
+      this.model.targetIntegration.id === this.model.sourceIntegration.id;
   }
 
   prepareModel() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
@@ -141,11 +141,11 @@
                 class="d-inline-block"
                 size="m"
             >
-                <oui-switch model="$ctrl.model.heartbeatsEmit" name="heartbeat">
+                <oui-switch model="$ctrl.model.emitHeartbeats" name="heartbeat">
                 </oui-switch>
                 <strong
                     >{{'pci_databases_replications_add_edit_heartbeat_' +
-                    $ctrl.model.heartbeatsEmit | translate }}</strong
+                    $ctrl.model.emitHeartbeats | translate }}</strong
                 >
             </oui-field>
             <oui-field

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
@@ -24,7 +24,7 @@
                     model="$ctrl.model.sourceIntegration"
                     name="source"
                     items="$ctrl.readyServiceIntegrationList"
-                    match="serviceName"
+                    match="destinationServiceName"
                     on-change="$ctrl.checkTargetAndSourceValidity()"
                     disabled="$ctrl.isUpdate"
                     required
@@ -41,7 +41,7 @@
                     model="$ctrl.model.targetIntegration"
                     name="target"
                     items="$ctrl.readyServiceIntegrationList"
-                    match="serviceName"
+                    match="destinationServiceName"
                     on-change="$ctrl.checkTargetAndSourceValidity()"
                     disabled="$ctrl.isUpdate"
                     required

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
@@ -21,7 +21,7 @@
                 ng-class="{'oui-field_error': $ctrl.invalidTargetSource}"
             >
                 <oui-select
-                    model="$ctrl.model.sourceService"
+                    model="$ctrl.model.sourceIntegration"
                     name="source"
                     items="$ctrl.readyServiceIntegrationList"
                     match="serviceName"
@@ -38,7 +38,7 @@
                 ng-class="{'oui-field_error': $ctrl.invalidTargetSource}"
             >
                 <oui-select
-                    model="$ctrl.model.targetService"
+                    model="$ctrl.model.targetIntegration"
                     name="target"
                     items="$ctrl.readyServiceIntegrationList"
                     match="serviceName"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.html
@@ -25,7 +25,7 @@
     >
         <oui-datagrid-column
             data-title=":: 'pci_databases_replications_tab_source' | translate"
-            data-property="serviceNameSource"
+            data-property="integrationNameSource"
             data-sortable="asc"
             data-type="string"
             data-searchable
@@ -33,7 +33,7 @@
         ></oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_databases_replications_tab_target' | translate"
-            data-property="serviceNameTarget"
+            data-property="integrationNameTarget"
             data-sortable="asc"
             data-type="string"
             data-searchable

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.routing.js
@@ -62,7 +62,7 @@ export default /* @ngInject */ ($stateProvider) => {
           ).then((integrations) =>
             map(integrations, (i) => {
               const serviceIntegration = new ServiceIntegration(i);
-              serviceIntegration.setServiceName(kafkaServicesList);
+              serviceIntegration.setDestinationServiceName(kafkaServicesList);
               return serviceIntegration;
             }),
           ),

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.controller.js
@@ -26,8 +26,8 @@ export default class ServiceIntegrationCtrl {
   isServiceIntegrationDeletable(integration) {
     return (
       integration.statusGroup !== STATUS.READY ||
-      find(this.replicationsList, { sourceService: integration.id }) ||
-      find(this.replicationsList, { targetService: integration.id })
+      find(this.replicationsList, { sourceIntegration: integration.id }) ||
+      find(this.replicationsList, { targetIntegration: integration.id })
     );
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.html
@@ -24,7 +24,7 @@
     >
         <oui-datagrid-column
             data-title=":: 'pci_databases_service_integration_tab_kafka_service' | translate"
-            data-property="serviceName"
+            data-property="destinationServiceName"
             data-sortable="asc"
             data-type="string"
             data-searchable

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.routing.js
@@ -46,7 +46,7 @@ export default /* @ngInject */ ($stateProvider) => {
           ).then((integrations) => {
             const serviceIntegrations = map(integrations, (i) => {
               const serviceIntegration = new ServiceIntegration(i);
-              serviceIntegration.setServiceName(kafkaServicesList);
+              serviceIntegration.setDestinationServiceName(kafkaServicesList);
               return serviceIntegration;
             });
             serviceIntegrations.forEach((i) => {
@@ -81,7 +81,10 @@ export default /* @ngInject */ ($stateProvider) => {
           serviceIntegrationList,
         ) =>
           kafkaServicesList.filter(
-            (k) => !serviceIntegrationList.find((i) => i.serviceId === k.id),
+            (k) =>
+              !serviceIntegrationList.find(
+                (i) => i.destinationServiceId === k.id,
+              ),
           ),
         replicationsList: /* @ngInject */ (
           DatabaseService,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.constants.js
@@ -14,7 +14,7 @@ export const ENGINE_LOGOS = {
   postgresql: ASSET_POSTGRE_SQL,
   redis: ASSET_REDIS,
   opensearch: ASSET_OPEN_SEARCH,
-  kafkamirrormaker: ASSET_KAFKA,
+  kafkaMirrorMaker: ASSET_KAFKA,
 };
 
 export const DATABASES_GUIDES_URL =
@@ -27,7 +27,7 @@ export const DATABASE_TYPES = {
   REDIS: 'redis',
   KAFKA: 'kafka',
   OPEN_SEARCH: 'opensearch',
-  KAFKA_MIRROR_MAKER: 'kafkamirrormaker',
+  KAFKA_MIRROR_MAKER: 'kafkaMirrorMaker',
 };
 
 export const SHELL_NAMES = {
@@ -37,7 +37,7 @@ export const SHELL_NAMES = {
   redis: 'redis',
   kafka: 'kafka',
   opensearch: 'opensearch',
-  kafkamirrormaker: 'kafkamirrormaker',
+  kafkaMirrorMaker: 'kafkaMirrorMaker',
 };
 
 export const SECRET_TYPE = {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-973` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #PUD-1046
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Some changes have been made in the backend, we need to reflect them in the frontend:

- engine name is now kafkaMirrorMaker (was kafkamirrormaker)
- integration model has changed: we now have both sourceServiceId and destinationServiceId (was serviceId)
- replication model has changed: we now have sourceIntegration and targetIntegration (was sourceService and targetService)
- replication model has changed: we now have emitHeartbeats (was heartbeatsEmit)

## Related

```
PUD-833 <-- PUD-819
               ^
               |-- PUD-975 <-- PUD-972 
				^
				|-- PUD-969
				|-- PUD-973 -- PUD-1046
				|-- PUD-1007
```
[PUD-833](https://github.com/ovh/manager/pull/5605)
[PUD-819](https://github.com/ovh/manager/pull/5747)
[PUD-975](https://github.com/ovh/manager/pull/5765)
[PUD-972](https://github.com/ovh/manager/pull/5748)
[PUD-969](https://github.com/ovh/manager/pull/5774)
[PUD-973](https://github.com/ovh/manager/pull/5749)
[PUD-1007](https://github.com/ovh/manager/pull/5769)
[PUD-1046](https://github.com/ovh/manager/pull/5865)
