### PR TITLE
fix(hosting.multisite): webhosting multisite polling

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/MULTISITE.html
+++ b/packages/manager/apps/web/client/app/hosting/multisite/MULTISITE.html
@@ -198,7 +198,7 @@
                                 ></span>
                                 <oui-spinner
                                     data-size="s"
-                                    data-ng-if="hosting.isCloudWeb && domain.status === HOSTING_STATUS.UPDATING"
+                                    data-ng-if="domain.status === HOSTING_STATUS.UPDATING"
                                 ></oui-spinner>
                             </td>
                             <td data-ng-bind="domain.path"></td>
@@ -266,6 +266,7 @@
                                     data-linkedpopover-remote="true"
                                     data-linkedpopover-title="{{ 'common_actions' | translate }}"
                                     data-domain-index="{{$index}}"
+                                    data-ng-disabled="domain.status === HOSTING_STATUS.UPDATING"
                                 >
                                     <span
                                         class="oui-icon oui-icon-ellipsis"

--- a/packages/manager/apps/web/client/app/hosting/multisite/multisite.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/multisite.routing.js
@@ -3,7 +3,6 @@ import template from './MULTISITE.html';
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.hosting.dashboard.multisite', {
     url: '/multisite',
-    controller: 'HostingTabDomainsCtrl',
     template,
     resolve: {
       breadcrumb: /* @ngInject */ ($translate) =>


### PR DESCRIPTION
ref: MANAGER-3738

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-3738
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

The goal of this PR is to block actions on multisite when there is already one ongoing action. Currently user can update multisite with ongoing action and resulting API call will fail.
I also remove HostingTabDomainsCtrl controller from routing file state because it is already linked in MULTISITE.html. It was duplicating function calls after broadcast.
