### PR TITLE
feat(telecom/xdsl/notification): add allowIncident & downThreshold in notification

### DIFF
--- a/packages/manager/apps/telecom/src/components/notification/notification-list.html
+++ b/packages/manager/apps/telecom/src/components/notification/notification-list.html
@@ -73,6 +73,26 @@
                         ></span>
                     </tuc-col-sort>
                 </th>
+                <th scope="col">
+                    <tuc-col-sort
+                        data-field-name="allowIncident"
+                        data-title="{{:: 'table_sort' | translate}}"
+                    >
+                        <span
+                            data-ng-bind=":: 'components_notification_allowIncident' | translate"
+                        ></span>
+                    </tuc-col-sort>
+                </th>
+                <th scope="col">
+                    <tuc-col-sort
+                        data-field-name="downThreshold"
+                        data-title="{{:: 'table_sort' | translate}}"
+                    >
+                        <span
+                            data-ng-bind=":: 'components_notification_downThreshold' | translate"
+                        ></span>
+                    </tuc-col-sort>
+                </th>
                 <th scope="col"></th>
             </tr>
         </thead>
@@ -93,6 +113,9 @@
                     data-ng-if="!element.editMode"
                     data-title="{{ 'components_notification_type' | translate }}"
                 >
+                    <em
+                        data-ng-class="{'fa fa-mobile': element.type === 'sms', 'fa fa-envelope-o': element.type === 'mail'}"
+                    ></em>
                     <span
                         data-ng-bind="'components_notification_' + element.type | translate"
                     ></span>
@@ -103,7 +126,10 @@
                     data-ng-if="!element.editMode"
                     data-title="{{ 'components_notification_account' | translate }}"
                 >
-                    <span data-ng-bind=":: element.smsAccount"></span>
+                    <span
+                        data-ng-bind=":: element.smsAccount"
+                        data-ng-if="element.type === 'sms' "
+                    ></span>
                 </td>
                 <!-- Contact -->
                 <td
@@ -123,6 +149,25 @@
                         data-ng-bind="'components_notification_' + element.frequency |
                         translate"
                     ></span>
+                </td>
+                <!-- allowIncident -->
+                <td
+                    class="form-group"
+                    data-ng-if="!element.editMode"
+                    data-title="{{ 'components_notification_allowIncident' | translate }}"
+                >
+                    <span
+                        data-ng-bind="'components_notification_' + element.allowIncident |
+                        translate"
+                    ></span>
+                </td>
+                <!-- downThreshold -->
+                <td
+                    class="form-group"
+                    data-ng-if="!element.editMode"
+                    data-title="{{ 'components_notification_downThreshold' | translate }}"
+                >
+                    <span data-ng-bind="element.downThreshold"></span>
                 </td>
                 <!-- Buttons -->
                 <td
@@ -228,6 +273,36 @@
                             >{{fre.label | translate}}</option
                         >
                     </select>
+                </td>
+                <!-- allowIncident (edit mode)-->
+                <td
+                    data-title="{{ 'components_notification_allowIncident' | translate }}"
+                    data-ng-if="element.editMode"
+                    class="form-group"
+                >
+                    <select
+                        class="form-control"
+                        data-ng-model="element.allowIncident"
+                    >
+                        <option
+                            data-ng-repeat="fre in NotificationListCtrl.allowIncident"
+                            value="{{fre.name}}"
+                            >{{fre.label | translate}}</option
+                        >
+                    </select>
+                </td>
+                <!-- downThreshold (edit mode)-->
+                <td
+                    data-title="{{ 'components_notification_downThreshold' | translate }}"
+                    data-ng-if="element.editMode"
+                    class="form-group"
+                >
+                    <oui-numeric
+                        min="NotificationListCtrl.downThreshold.min"
+                        max="NotificationListCtrl.downThreshold.max"
+                        model="element.downThreshold"
+                    >
+                    </oui-numeric>
                 </td>
 
                 <!-- Buttons (edit mode)-->

--- a/packages/manager/apps/telecom/src/components/notification/notification.component.js
+++ b/packages/manager/apps/telecom/src/components/notification/notification.component.js
@@ -34,6 +34,8 @@ angular.module('managerApp').component('notificationList', {
         {
           frequency: self.frequencies[0].name,
           type: self.types[0].name,
+          allowIncident: self.allowIncident[0].name,
+          downThreshold: self.downThreshold.model * 60,
           xdslService: self.xdslService,
           smsAccount: self.accounts.length === 1 ? self.accounts[0] : null,
           id: new Date().getTime(),
@@ -210,6 +212,15 @@ angular.module('managerApp').component('notificationList', {
         { name: '1h', label: 'components_notification_1h' },
         { name: '6h', label: 'components_notification_6h' },
       ];
+
+      // allowIncident choices
+      self.allowIncident = [
+        { name: 'true', label: 'components_notification_true' },
+        { name: 'false', label: 'components_notification_false' },
+      ];
+
+      // downThreshold choices
+      self.downThreshold = { min: 2, max: 35791394, model: 15 };
 
       // get the SMS accounts and the SMS remaining credits by accounts
       iceberg('/sms')

--- a/packages/manager/apps/telecom/src/components/notification/notification.service.js
+++ b/packages/manager/apps/telecom/src/components/notification/notification.service.js
@@ -8,6 +8,8 @@ angular.module('managerApp').service('NotificationElement', () => {
     this.xdslService = element.xdslService;
     this.editMode = editMode === true;
     this.id = element.id;
+    this.allowIncident = element.allowIncident;
+    this.downThreshold = element.downThreshold / 60;
   };
 
   NotificationElement.prototype = {
@@ -21,6 +23,8 @@ angular.module('managerApp').service('NotificationElement', () => {
       return (
         this.frequency &&
         this.type &&
+        this.allowIncident &&
+        this.downThreshold &&
         (this.isValidEmail() || this.isValidSms())
       );
     },
@@ -28,6 +32,8 @@ angular.module('managerApp').service('NotificationElement', () => {
       const data = {
         frequency: this.frequency,
         type: this.type,
+        allowIncident: this.allowIncident,
+        downThreshold: this.downThreshold * 60,
       };
       switch (this.type) {
         case 'sms':

--- a/packages/manager/apps/telecom/src/components/notification/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/components/notification/translations/Messages_fr_FR.json
@@ -15,5 +15,9 @@
   "components_notification_5m": "Toutes les 5 minutes",
   "components_notification_1h": "Toutes les heures",
   "components_notification_6h": "Toutes les 6 heures",
-  "components_notification_sms_detail_warning": "Attention, le compte {{smsAccount}} n'a plus de crédit pour l'envoi de nouveaux SMS."
+  "components_notification_sms_detail_warning": "Attention, le compte {{smsAccount}} n'a plus de crédit pour l'envoi de nouveaux SMS.",
+  "components_notification_allowIncident": "Notification des incidents",
+  "components_notification_downThreshold": "Délai avant notification (en minutes)",
+  "components_notification_true": "Oui",
+  "components_notification_false": "Non"
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Hyenne <hyenne.guillaume@neuf.fr>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7960
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I added to the xdsl monitoring alerts (notification) the management of "allowIncident" and "downThreshold" which is available in the API but not used in the manager.

![Screenshot_PR_notification](https://user-images.githubusercontent.com/67371070/140303347-a9eaa5e0-1b50-4380-b002-c7b623e376f3.png)

## Related

### :flags: Translations

- [ ] ~~TRANS-41022~~
