### PR TITLE
Fix PUD-1060 (pci.storage.databases): reflect backend changes

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/replication.class.js
@@ -30,10 +30,10 @@ export default class ServiceIntegration {
   setServicesNames(replications) {
     this.integrationNameSource = find(replications, {
       id: this.sourceIntegration,
-    })?.destinationServiceName;
+    })?.sourceServiceName;
     this.integrationNameTarget = find(replications, {
       id: this.targetIntegration,
-    })?.destinationServiceName;
+    })?.sourceServiceName;
   }
 
   updateData({

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
@@ -646,8 +646,8 @@ export default class DatabaseService {
       .post(
         `/cloud/project/${projectId}/database/${engine}/${databaseId}/integration`,
         {
-          sourceServiceId: databaseId,
-          destinationServiceId: service.id,
+          sourceServiceId: service.id,
+          destinationServiceId: databaseId,
         },
       )
       .then(({ data }) => data);
@@ -674,7 +674,17 @@ export default class DatabaseService {
     return this.$http
       .post(
         `/cloud/project/${projectId}/database/${engine}/${databaseId}/replication`,
-        replication,
+        {
+          sourceIntegration: replication.sourceIntegration,
+          targetIntegration: replication.targetIntegration,
+          emitHeartbeats: replication.emitHeartbeats,
+          enabled: replication.enabled,
+          replicationPolicyClass: replication.replicationPolicyClass,
+          syncGroupOffsets: replication.syncGroupOffsets,
+          syncInterval: replication.syncInterval,
+          topicExcludeList: replication.topicExcludeList,
+          topics: replication.topics,
+        },
       )
       .then(({ data }) => data);
   }
@@ -683,7 +693,15 @@ export default class DatabaseService {
     return this.$http
       .put(
         `/cloud/project/${projectId}/database/${engine}/${databaseId}/replication/${replication.id}`,
-        replication,
+        {
+          emitHeartbeats: replication.emitHeartbeats,
+          enabled: replication.enabled,
+          replicationPolicyClass: replication.replicationPolicyClass,
+          syncGroupOffsets: replication.syncGroupOffsets,
+          syncInterval: replication.syncInterval,
+          topicExcludeList: replication.topicExcludeList,
+          topics: replication.topics,
+        },
       )
       .then(({ data }) => data);
   }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.html
@@ -24,7 +24,7 @@
                     model="$ctrl.model.sourceIntegration"
                     name="source"
                     items="$ctrl.readyServiceIntegrationList"
-                    match="destinationServiceName"
+                    match="sourceServiceName"
                     on-change="$ctrl.checkTargetAndSourceValidity()"
                     disabled="$ctrl.isUpdate"
                     required
@@ -41,7 +41,7 @@
                     model="$ctrl.model.targetIntegration"
                     name="target"
                     items="$ctrl.readyServiceIntegrationList"
-                    match="destinationServiceName"
+                    match="sourceServiceName"
                     on-change="$ctrl.checkTargetAndSourceValidity()"
                     disabled="$ctrl.isUpdate"
                     required
@@ -177,7 +177,7 @@
             size="l"
             variant="primary"
             icon-right="oui-icon-arrow-right"
-            disabled="$ctrl.addOrEditReplicationForm.$invalid || $ctrl.invalidTargetSource"
+            disabled="$ctrl.addOrEditReplicationForm.$invalid || $ctrl.invalidTargetSource || $ctrl.processing"
         >
             <span
                 ng-if="$ctrl.isUpdate"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/replications.routing.js
@@ -62,7 +62,7 @@ export default /* @ngInject */ ($stateProvider) => {
           ).then((integrations) =>
             map(integrations, (i) => {
               const serviceIntegration = new ServiceIntegration(i);
-              serviceIntegration.setDestinationServiceName(kafkaServicesList);
+              serviceIntegration.setSourceServiceName(kafkaServicesList);
               return serviceIntegration;
             }),
           ),

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.html
@@ -24,7 +24,7 @@
     >
         <oui-datagrid-column
             data-title=":: 'pci_databases_service_integration_tab_kafka_service' | translate"
-            data-property="destinationServiceName"
+            data-property="sourceServiceName"
             data-sortable="asc"
             data-type="string"
             data-searchable

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/service-integration.routing.js
@@ -46,7 +46,7 @@ export default /* @ngInject */ ($stateProvider) => {
           ).then((integrations) => {
             const serviceIntegrations = map(integrations, (i) => {
               const serviceIntegration = new ServiceIntegration(i);
-              serviceIntegration.setDestinationServiceName(kafkaServicesList);
+              serviceIntegration.setSourceServiceName(kafkaServicesList);
               return serviceIntegration;
             });
             serviceIntegrations.forEach((i) => {
@@ -84,7 +84,7 @@ export default /* @ngInject */ ($stateProvider) => {
             (kafkaService) =>
               !serviceIntegrationList.find(
                 (integration) =>
-                  integration.destinationServiceId === kafkaService.id,
+                  integration.sourceServiceId === kafkaService.id,
               ),
           ),
         replicationsList: /* @ngInject */ (


### PR DESCRIPTION
PUD-1060

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-819`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | PUD-1060
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

As seen in staging environment, some things change between mocked api and real data:

- Endpoint getIpRestrictions does not exist for mirror maker, remove the call in general information
- In service integration model, kafka is now source and mirrormaker the destination (was mm as source and kafka as destination)
- Endpoint add a replication does not accept a null id anymore
- Endpoint edit replication does not accept source & target properties anymore
