### PR TITLE
build(*): bump ng-ovh-api-wrappers to version 4.0.9

### DIFF
--- a/packages/manager/apps/anthos/package.json
+++ b/packages/manager/apps/anthos/package.json
@@ -28,7 +28,7 @@
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-mondial-relay": "^8.1.0",

--- a/packages/manager/apps/cda/package.json
+++ b/packages/manager/apps/cda/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.1.2",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.9",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.1.2",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.3",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.2",

--- a/packages/manager/apps/dbaas-logs/package.json
+++ b/packages/manager/apps/dbaas-logs/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.1.2",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.9",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.3",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -62,7 +62,7 @@
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.10",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-browser-alert": "^2.0.3",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contacts": "^4.0.6",

--- a/packages/manager/apps/email-domain/package.json
+++ b/packages/manager/apps/email-domain/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/manager-email-domain": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.0.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/apps/email-pro/package.json
+++ b/packages/manager/apps/email-pro/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/manager-emailpro": "^2.0.0 || ^3.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.0.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.3",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/apps/enterprise-cloud-database/package.json
+++ b/packages/manager/apps/enterprise-cloud-database/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/manager-enterprise-cloud-database": "^0.2.0 || ^1.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-http": "^5.0.3",

--- a/packages/manager/apps/exchange/package.json
+++ b/packages/manager/apps/exchange/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.3",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -29,7 +29,7 @@
     "@ovh-ux/manager-preloader": "^1.2.1",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.3",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/manager-trusted-nic": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.3",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.9",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/metrics/package.json
+++ b/packages/manager/apps/metrics/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-server-sidebar": "^2.0.0 || ^3.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.9",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-nasha": "^1.0.0 || ^2.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.1.0 || ^2.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.2",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/netapp/package.json
+++ b/packages/manager/apps/netapp/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/apps/office/package.json
+++ b/packages/manager/apps/office/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-office": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.3",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-overthebox": "^5.0.0 || ^6.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.2",
     "@ovh-ux/ng-ovh-contracts": "^4.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.2",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contacts": "^4.0.6",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -43,7 +43,7 @@
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.10",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contacts": "^4.0.6",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",

--- a/packages/manager/apps/sharepoint/package.json
+++ b/packages/manager/apps/sharepoint/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-preloader": "^1.1.0",
     "@ovh-ux/manager-sharepoint": "^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.4",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.3",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -28,7 +28,7 @@
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.1.2",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.2",
     "@ovh-ux/ng-ovh-contracts": "^4.0.4",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.3",

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-support": "^0.6.0 || ^0.7.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.2",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -44,7 +44,7 @@
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.10",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-browser-alert": "^2.0.3",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.3",
     "@ovh-ux/ng-ovh-contact": "^5.0.5",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -28,7 +28,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-veeam-cloud-connect": "^1.0.0 || ^2.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.2",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-veeam-enterprise": "^0.3.0 || ^1.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.2",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.2",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/manager-product-offers": "^4.0.0 || ^5.0.0",
     "@ovh-ux/manager-vps": "^1.0.0 || ^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.3",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.0.0",
     "@ovh-ux/manager-vrack": "^0.7.0 || ^1.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.4",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.3",

--- a/packages/manager/apps/web-paas/package.json
+++ b/packages/manager/apps/web-paas/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-web-paas": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-webpack-dev-server": "^2.8.2",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -46,7 +46,7 @@
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.10",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.3",

--- a/packages/manager/modules/account-sidebar/package.json
+++ b/packages/manager/modules/account-sidebar/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-order-tracking": "^1.1.1 || ^2.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.4",

--- a/packages/manager/modules/billing/package.json
+++ b/packages/manager/modules/billing/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-models": "^1.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^1.0.1 || ^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-contacts": "^4.0.6",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.3",
     "@ovh-ux/ng-ovh-order-tracking": "^1.1.1 || ^2.0.0",

--- a/packages/manager/modules/hub/package.json
+++ b/packages/manager/modules/hub/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",
     "@ovh-ux/ng-ovh-order-tracking": "^1.1.1 || ^2.0.0",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",

--- a/packages/manager/modules/ng-layout-helpers/package.json
+++ b/packages/manager/modules/ng-layout-helpers/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.6",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-translate-async-loader": "^2.1.3",
     "@ovh-ux/ui-kit": "^5.0.0",
     "angular": "^1.7.9",

--- a/packages/manager/modules/notifications-sidebar/package.json
+++ b/packages/manager/modules/notifications-sidebar/package.json
@@ -18,7 +18,7 @@
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.7.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-translate-async-loader": "^2.1.2",
     "@ovh-ux/ui-kit": "^5.0.0",
     "@uirouter/angularjs": "^1.0.23",

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.6",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-mondial-relay": "^8.1.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^6.0.0 || ^7.0.0",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -40,7 +40,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-telecom-styles": "^4.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.2",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",

--- a/packages/manager/modules/support/package.json
+++ b/packages/manager/modules/support/package.json
@@ -19,7 +19,7 @@
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.5",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-translate-async-loader": "^2.1.3",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.5",
     "@ovh-ux/ui-kit": "^5.0.0",

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "4.0.8",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.9",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.0.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,12 +3017,12 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@ovh-ux/ng-ovh-api-wrappers@^4.0.4", "@ovh-ux/ng-ovh-api-wrappers@^4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-api-wrappers/-/ng-ovh-api-wrappers-4.0.8.tgz#f95c8ce909f7baa59f8fd85949801e7d74bf6dbd"
-  integrity sha512-V1x01nBs+bmTKD8PV69StlHU9v4CeA4lqLIB/oom2PmQIcsSRhhaiwFE5JCui7fDi0+A8sZSg4EUDMie/M3QQg==
+"@ovh-ux/ng-ovh-api-wrappers@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-api-wrappers/-/ng-ovh-api-wrappers-4.0.9.tgz#062b50f039d3e6b820d1b1a5dd279654b148b845"
+  integrity sha512-+v1NZx4xMged64VCxBs3tQzCimScSfIicColVoP6MIByEw9g8Lt6DHtnpJk1M2RnGQVxhJbE5KpDVADadhnBhA==
   dependencies:
-    lodash "^4.17.20"
+    lodash "^4.17.21"
 
 "@ovh-ux/rollup-plugin-less-inject@^1.0.5":
   version "1.0.5"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7878
| License          | BSD 3-Clause

## Description

bump @ovh-ux/ng-ovh-api-wrappers to version 4.0.9