### PR TITLE
fix(hosting.cron): implement polling

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/cron/CRON.html
+++ b/packages/manager/apps/web/client/app/hosting/cron/CRON.html
@@ -1,154 +1,153 @@
-<div data-ng-controller="HostingCronsCtrl as $ctrl">
-    <div class="row">
-        <div class="col-md-9">
-            <div data-ovh-alert="{{alerts.main}}"></div>
+<div class="row">
+    <div class="col-md-9">
+        <div data-ovh-alert="{{alerts.main}}"></div>
 
-            <div
-                class="alert alert-info"
-                role="alert"
-                data-ng-if="!displayTabs.cron"
-            >
-                <div>
-                    <p
-                        class="mb-3"
-                        data-translate="hosting_change_offer_for_service"
-                    ></p>
-                    <button
-                        class="btn btn-info"
-                        type="button"
-                        data-translate="hosting_dashboard_service_change_offer"
-                        data-ui-sref="app.hosting.dashboard.upgrade({ productId: hosting.serviceName })"
-                    ></button>
-                </div>
-            </div>
-
-            <div
-                class="alert alert-info"
-                role="alert"
-                data-ng-if="displayTabs.cron && hosting.offer === 'START_10_M'"
-            >
-                <div>
-                    <p
-                        class="mb-3"
-                        data-translate="hosting_change_offer_for_service_start10m"
-                    ></p>
-                    <button
-                        class="btn btn-info"
-                        type="button"
-                        data-translate="hosting_dashboard_service_change_offer"
-                        data-ui-sref="app.hosting.dashboard.upgrade({ productId: hosting.serviceName })"
-                    ></button>
-                </div>
-            </div>
-
-            <div
-                data-ng-if="displayTabs.cron && hosting.offer !== 'START_10_M'"
-            >
-                <h2 data-translate="hosting_tab_menu_crons"></h2>
-
-                <div class="mb-4" data-ng-if="$ctrl.guide">
-                    <span
-                        class="fa fa-life-ring mr-2"
-                        aria-hidden="true"
-                    ></span>
-                    <span data-translate="hosting_tab_CRON_guide_help"></span>
-                    <a
-                        data-ng-href="{{:: $ctrl.guide}}"
-                        target="_blank"
-                        title="{{hosting_guide_help}} {{ 'common_newtab' | translate }}"
-                    >
-                        <span data-translate="hosting_guide_help"></span>
-                        <span
-                            class="fa fa-external-link"
-                            aria-hidden="true"
-                        ></span>
-                    </a>
-                </div>
-
-                <oui-datagrid
-                    data-rows-loader="$ctrl.getCrons($config)"
-                    data-row-loader="$ctrl.getCron($row)"
-                    data-empty-placeholder="{{:: 'hosting_tab_CRON_table_empty' | translate }}"
-                >
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_command' | translate"
-                        data-property="command"
-                        data-type="string"
-                        data-searchable
-                    >
-                    </oui-datagrid-column>
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_description' | translate"
-                        data-property="description"
-                        data-type="string"
-                        data-searchable
-                    >
-                    </oui-datagrid-column>
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_frequency' | translate"
-                        data-property="frequency"
-                    >
-                    </oui-datagrid-column>
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_language' | translate"
-                        data-property="displayedLanguage"
-                    >
-                    </oui-datagrid-column>
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_status' | translate"
-                        data-property="status"
-                    >
-                        <span
-                            class="oui-badge"
-                            data-ng-class="{
-                                'oui-badge_success': $row.status === 'enabled',
-                                'oui-badge_error': $row.status === 'disabled',
-                                'oui-badge_warning': $row.status === 'suspended'
-                            }"
-                            data-ng-bind=":: 'hosting_tab_CRON_table_status_' + $row.status | translate"
-                        >
-                        </span>
-                    </oui-datagrid-column>
-                    <oui-datagrid-column
-                        data-title=":: 'hosting_tab_CRON_table_header_email' | translate"
-                        data-property="email"
-                        data-type="string"
-                        data-searchable
-                    >
-                        <span
-                            data-translate="{{:: 'hosting_tab_CRON_email_' +  $row.email }}"
-                        ></span>
-                    </oui-datagrid-column>
-                    <oui-action-menu data-compact data-placement="end">
-                        <oui-action-menu-item
-                            data-on-click="$ctrl.modifyCron($row)"
-                        >
-                            <span
-                                data-translate="hosting_tab_CRON_edit_task"
-                            ></span>
-                        </oui-action-menu-item>
-                        <oui-action-menu-item
-                            data-on-click="$ctrl.deleteCron($row)"
-                        >
-                            <span
-                                data-translate="hosting_tab_CRON_delete_task"
-                            ></span>
-                        </oui-action-menu-item>
-                    </oui-action-menu>
-                </oui-datagrid>
+        <div
+            class="alert alert-info"
+            role="alert"
+            data-ng-if="!displayTabs.cron"
+        >
+            <div>
+                <p
+                    class="mb-3"
+                    data-translate="hosting_change_offer_for_service"
+                ></p>
+                <button
+                    class="btn btn-info"
+                    type="button"
+                    data-translate="hosting_dashboard_service_change_offer"
+                    data-ui-sref="app.hosting.dashboard.upgrade({ productId: hosting.serviceName })"
+                ></button>
             </div>
         </div>
 
         <div
-            class="col-md-3 mt-5 mt-lg-0"
-            data-ng-if="displayTabs.cron && hosting.offer !== 'START_10_M'"
+            class="alert alert-info"
+            role="alert"
+            data-ng-if="displayTabs.cron && hosting.offer === 'START_10_M'"
         >
-            <button
-                class="btn btn-block btn-default"
-                type="button"
-                data-translate="hosting_tab_CRON_configuration_create_title_button"
-                data-ng-click="setAction('cron/add-or-edit/hosting-cron-add-or-edit',{})"
-            ></button>
+            <div>
+                <p
+                    class="mb-3"
+                    data-translate="hosting_change_offer_for_service_start10m"
+                ></p>
+                <button
+                    class="btn btn-info"
+                    type="button"
+                    data-translate="hosting_dashboard_service_change_offer"
+                    data-ui-sref="app.hosting.dashboard.upgrade({ productId: hosting.serviceName })"
+                ></button>
+            </div>
         </div>
+
+        <div data-ng-if="displayTabs.cron && hosting.offer !== 'START_10_M'">
+            <h2 data-translate="hosting_tab_menu_crons"></h2>
+
+            <div class="mb-4" data-ng-if="$ctrl.guide">
+                <span class="fa fa-life-ring mr-2" aria-hidden="true"></span>
+                <span data-translate="hosting_tab_CRON_guide_help"></span>
+                <a
+                    data-ng-href="{{:: $ctrl.guide}}"
+                    target="_blank"
+                    title="{{hosting_guide_help}} {{ 'common_newtab' | translate }}"
+                >
+                    <span data-translate="hosting_guide_help"></span>
+                    <span class="fa fa-external-link" aria-hidden="true"></span>
+                </a>
+            </div>
+
+            <oui-datagrid
+                data-rows="$ctrl.crons"
+                data-row-loader="$ctrl.getCron($row)"
+                data-empty-placeholder="{{:: 'hosting_tab_CRON_table_empty' | translate }}"
+            >
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_command' | translate"
+                    data-property="command"
+                    data-type="string"
+                    data-searchable
+                >
+                    <span data-ng-bind="$value"></span>
+                    <oui-spinner
+                        data-size="s"
+                        data-ng-if="!isCronStatusCreated($row.state)"
+                    ></oui-spinner>
+                </oui-datagrid-column>
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_description' | translate"
+                    data-property="description"
+                    data-type="string"
+                    data-searchable
+                >
+                </oui-datagrid-column>
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_frequency' | translate"
+                    data-property="frequency"
+                >
+                </oui-datagrid-column>
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_language' | translate"
+                    data-property="displayedLanguage"
+                >
+                </oui-datagrid-column>
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_status' | translate"
+                    data-property="status"
+                >
+                    <span
+                        class="oui-badge"
+                        data-ng-class="{
+                                'oui-badge_success': $row.status === 'enabled',
+                                'oui-badge_error': $row.status === 'disabled',
+                                'oui-badge_warning': $row.status === 'suspended'
+                            }"
+                        data-ng-bind=":: 'hosting_tab_CRON_table_status_' + $row.status | translate"
+                    >
+                    </span>
+                </oui-datagrid-column>
+                <oui-datagrid-column
+                    data-title=":: 'hosting_tab_CRON_table_header_email' | translate"
+                    data-property="email"
+                    data-type="string"
+                    data-searchable
+                >
+                    <span
+                        data-translate="{{:: 'hosting_tab_CRON_email_' +  $row.email }}"
+                    ></span>
+                </oui-datagrid-column>
+                <oui-action-menu
+                    disabled="!isCronStatusCreated($row.state)"
+                    data-compact
+                    data-placement="end"
+                >
+                    <oui-action-menu-item
+                        data-on-click="$ctrl.modifyCron($row)"
+                    >
+                        <span
+                            data-translate="hosting_tab_CRON_edit_task"
+                        ></span>
+                    </oui-action-menu-item>
+                    <oui-action-menu-item
+                        data-on-click="$ctrl.deleteCron($row)"
+                    >
+                        <span
+                            data-translate="hosting_tab_CRON_delete_task"
+                        ></span>
+                    </oui-action-menu-item>
+                </oui-action-menu>
+            </oui-datagrid>
+        </div>
+    </div>
+
+    <div
+        class="col-md-3 mt-5 mt-lg-0"
+        data-ng-if="displayTabs.cron && hosting.offer !== 'START_10_M'"
+    >
+        <button
+            class="btn btn-block btn-default"
+            type="button"
+            data-translate="hosting_tab_CRON_configuration_create_title_button"
+            data-ng-click="setAction('cron/add-or-edit/hosting-cron-add-or-edit',{})"
+        ></button>
     </div>
 </div>

--- a/packages/manager/apps/web/client/app/hosting/cron/cron.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/cron/cron.routing.js
@@ -5,6 +5,8 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/cron',
     template,
     controller: 'HostingCronsCtrl',
+    controllerAs: '$ctrl',
+
     resolve: {
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('hosting_cron'),

--- a/packages/manager/apps/web/client/app/hosting/cron/hosting-cron.constants.js
+++ b/packages/manager/apps/web/client/app/hosting/cron/hosting-cron.constants.js
@@ -3,12 +3,42 @@ export const LANGUAGES = {
   PHP: 'PHP',
 };
 
+export const TASK_MAPPING = {
+  'cron/create': 'createCron',
+  'cron/update': 'editCron',
+  'cron/delete': 'deleteCron',
+};
+
+export const POLLING_EVENTS_ERROR = {
+  delete: 'hostingDomain.deleteCron.error',
+  edit: 'hostingDomain.editCron.error',
+  create: 'hostingDomain.createCron.error',
+};
+
+export const POLLING_EVENTS_DONE = {
+  delete: 'hostingDomain.deleteCron.done',
+  edit: 'hostingDomain.editCron.done',
+  create: 'hostingDomain.createCron.done',
+};
+
+export const POLLING_EVENTS_MESSAGE_DISPLAY = {
+  [POLLING_EVENTS_ERROR.delete]: 'hosting_tab_CRON_configuration_delete_fail',
+  [POLLING_EVENTS_ERROR.edit]: 'hosting_tab_CRON_edit_error',
+  [POLLING_EVENTS_ERROR.create]: 'hosting_tab_CRON_save_error',
+};
+
 export const PATTERN = /\d+(_\d)?/;
 
 export const OTHER = 'other';
 
+export const STATUS_CREATED = 'created';
+
 export default {
   LANGUAGES,
+  POLLING_EVENTS_ERROR,
+  POLLING_EVENTS_DONE,
+  POLLING_EVENTS_MESSAGE_DISPLAY,
   PATTERN,
   OTHER,
+  STATUS_CREATED,
 };

--- a/packages/manager/apps/web/client/app/hosting/cron/hosting-cron.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/cron/hosting-cron.controller.js
@@ -2,11 +2,20 @@ import get from 'lodash/get';
 import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
+import {
+  TASK_MAPPING,
+  POLLING_EVENTS_MESSAGE_DISPLAY,
+  POLLING_EVENTS_ERROR,
+  POLLING_EVENTS_DONE,
+  STATUS_CREATED,
+} from './hosting-cron.constants';
 
 export default class HostingCronsCtrl {
   /* @ngInject */
   constructor(
+    $rootScope,
     $scope,
+    $q,
     $stateParams,
     $timeout,
     $translate,
@@ -16,7 +25,9 @@ export default class HostingCronsCtrl {
     HostingCron,
     WucUser,
   ) {
+    this.$rootScope = $rootScope;
     this.$scope = $scope;
+    this.$q = $q;
     this.$stateParams = $stateParams;
     this.$timeout = $timeout;
     this.$translate = $translate;
@@ -30,19 +41,39 @@ export default class HostingCronsCtrl {
   $onInit() {
     this.atInternet.trackPage({ name: 'web::hosting::cron' });
 
-    this.crons = {
-      details: [],
-    };
+    this.crons = [];
     this.guide = null;
-    this.search = {
-      text: null,
-    };
-    this.hasResult = false;
-    this.loading = {
-      cron: false,
-      init: true,
+
+    // POLLING
+    Object.values(POLLING_EVENTS_DONE).forEach((e) => {
+      this.$scope.$on(e, () => {
+        this.onPollingSuccess();
+      });
+    });
+
+    Object.values(POLLING_EVENTS_ERROR).forEach((e) => {
+      this.$scope.$on(e, (event, err) => {
+        this.onPollingError(POLLING_EVENTS_MESSAGE_DISPLAY[e], err);
+      });
+    });
+
+    // refresh cron table display after cron create/update/delete
+    this.$scope.$on('hosting.tabs.crons.refresh', () => {
+      this.updateCronsList();
+    });
+
+    // kill polling when leaving page
+    this.$scope.$on('$destroy', () => {
+      this.HostingCron.killAllPolling();
+    });
+
+    this.$scope.isCronStatusCreated = (state) => {
+      return state === STATUS_CREATED;
     };
 
+    // INIT PAGE
+    this.startPolling();
+    this.updateCronsList();
     return this.getGuides();
   }
 
@@ -52,6 +83,15 @@ export default class HostingCronsCtrl {
         this.guide = guides.hostingCron;
       }
     });
+  }
+
+  updateCronsList() {
+    const newCrons = [];
+    this.HostingCron.getCrons(this.$stateParams.productId).then((crons) => {
+      crons.map((e) => newCrons.push({ id: e }));
+    });
+
+    this.crons = newCrons;
   }
 
   getCrons({ criteria }) {
@@ -93,6 +133,46 @@ export default class HostingCronsCtrl {
 
   deleteCron(cron) {
     return this.$scope.setAction('cron/delete/hosting-cron-delete', cron);
+  }
+
+  startPolling() {
+    const taskTypes = Object.keys(TASK_MAPPING);
+    const tasksPendingAll = [];
+
+    taskTypes.forEach((e) => {
+      const tasksPending = this.Hosting.getTaskIds(
+        this.$stateParams.productId,
+        e,
+      );
+      tasksPendingAll.push(tasksPending);
+    });
+
+    this.$q.all(tasksPendingAll).then((tasks) => {
+      taskTypes.forEach((name, key) => {
+        if (tasks[key].length > 0) {
+          const tasksFiltered = tasks[key];
+          this.HostingCron.pollRequest({
+            taskIds: tasksFiltered,
+            namespace: TASK_MAPPING[name],
+            serviceName: this.$stateParams.productId,
+          });
+        }
+      });
+    });
+  }
+
+  onPollingSuccess() {
+    this.$rootScope.$broadcast('hosting.tabs.crons.refresh');
+    this.Alerter.resetMessage(this.$scope.alerts.main);
+  }
+
+  onPollingError(message, err) {
+    this.$rootScope.$broadcast('hosting.tabs.crons.refresh');
+    this.Alerter.alertFromSWS(
+      this.$translate.instant(message),
+      get(err, 'data', err),
+      this.$scope.alerts.main,
+    );
   }
 }
 

--- a/packages/manager/apps/web/client/app/hosting/dashboard/hosting.service.js
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/hosting.service.js
@@ -362,6 +362,24 @@ import union from 'lodash/union';
       }
 
       /**
+       * Get task ids
+       * @param {string} serviceName
+       * @param {string} fn
+       */
+      getTaskIds(serviceName, fn) {
+        return this.$http
+          .get(`/hosting/web/${serviceName}/tasks`, {
+            rootPath: 'apiv6',
+            params: {
+              function: fn,
+            },
+          })
+          .then((response) => {
+            return response.data;
+          });
+      }
+
+      /**
        * Flush Cdn
        * @param {string} serviceName
        */


### PR DESCRIPTION
ref: MANAGER-3741

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-3741
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The goal of this PR is to block actions on webhosting cron when there is already one ongoing action. Currently user can update cron with ongoing action and resulting API call will fail.
I also remove HostingCronsCtrl controller from routing file state because it is already linked in CRON.html. It was duplicating function calls after broadcast.
Code is similar to multisite polling (see PR https://github.com/ovh/manager/pull/5884)

<!-- Link dependencies of this PR -->
