### PR TITLE
feat(config): allow jest to use local config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ['<rootDir>/packages/components', '<rootDir>/packages/manager'],
+  projects: ['<rootDir>/packages/manager/apps/shell/jest.config.js'],
   setupFilesAfterEnv: ['<rootDir>/jest/mocks/jest.setup.js'],
   collectCoverageFrom: ['packages/**/*.{js,jsx,ts,tsx}', '!packages/**/*.d.ts'],
   testMatch: [

--- a/packages/manager/apps/shell/jest.config.js
+++ b/packages/manager/apps/shell/jest.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+const rootConfig = require('../../../../jest.config.js');
+
+rootConfig.moduleNameMapper = {
+  ...rootConfig.moduleNameMapper,
+  '^@/(.*)$': `${path.dirname(__filename)}/src/$1`,
+};
+
+module.exports = rootConfig;

--- a/packages/manager/apps/shell/src/notifications-sidebar/Notifications/Notification/Badge.jsx
+++ b/packages/manager/apps/shell/src/notifications-sidebar/Notifications/Notification/Badge.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import useNotifications from '../../../core/notifications';
+import useNotifications from '@/core/notifications';
 
 import style from './notification.module.scss';
 

--- a/packages/manager/apps/shell/src/notifications-sidebar/NotificationsSidebar.jsx
+++ b/packages/manager/apps/shell/src/notifications-sidebar/NotificationsSidebar.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { groupBy } from 'lodash-es';
 
-import useNotifications from '../core/notifications';
-import useDate from '../helpers/useDate';
+import useNotifications from '@/core/notifications';
+import useDate from '@/helpers/useDate';
 
 import Notifications from './Notifications/Notifications.jsx';
 import { MAX_NOTIFICATIONS } from './constants';

--- a/packages/manager/apps/shell/src/shell/header.jsx
+++ b/packages/manager/apps/shell/src/shell/header.jsx
@@ -1,9 +1,9 @@
 import React, { Suspense } from 'react';
-import Navbar from '../navbar/navbar.jsx';
-import AccountSidebar from '../account-sidebar';
-import NotificationsSidebar from '../notifications-sidebar';
-import { NotificationsProvider } from '../core/notifications';
-import ApplicationContext from '../context';
+import Navbar from '@/navbar/navbar.jsx';
+import AccountSidebar from '@/account-sidebar';
+import NotificationsSidebar from '@/notifications-sidebar';
+import { NotificationsProvider } from '@/core/notifications';
+import ApplicationContext from '@/context';
 
 function ShellHeader() {
   return (


### PR DESCRIPTION
ref:MANAGER-7849

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/manager-shell
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| License          | BSD 3-Clause


## Description

Currently, jest only uses root configuration. But for some projects, we will need more granular configuration to fit the project. Such as here, where we define aliases in our Vite project which cannot be defined in root config. 

