### PR TITLE
Feat/searchable mac address

### DIFF
--- a/packages/manager/apps/telecom/src/components/telecom/telephony/sidebar/telephony-sidebar.service.js
+++ b/packages/manager/apps/telecom/src/components/telecom/telephony/sidebar/telephony-sidebar.service.js
@@ -16,7 +16,7 @@ angular
 
     function addServiceMenuItems(services, options, billingAccountSubSection) {
       services.forEach((service) => {
-        SidebarMenu.addMenuItem(
+        const item = SidebarMenu.addMenuItem(
           {
             id: service.serviceName,
             title: service.getDisplayedName(),
@@ -32,6 +32,13 @@ angular
           },
           billingAccountSubSection,
         );
+
+        const { associatedDeviceMac } = service;
+
+        if (associatedDeviceMac) {
+          item.addSearchKey(associatedDeviceMac);
+          item.addSearchKey(service.getRawAssociatedDeviceMac());
+        }
       });
     }
 

--- a/packages/manager/modules/telecom-universe-components/src/telecom/voip/service/voip-service.factory.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/voip/service/voip-service.factory.js
@@ -48,6 +48,7 @@ export default () => {
       this.getPublicOffer = options.getPublicOffer;
       this.offers = options.offers;
       this.simultaneousLines = options.simultaneousLines;
+      this.associatedDeviceMac = options.associatedDeviceMac;
     }
 
     /* ===================================
@@ -94,6 +95,22 @@ export default () => {
         this.getPublicOffer.name !== '' &&
         this.getPublicOffer.description !== 'The Service has an error'
       );
+    }
+
+    /**
+     *  @ngdoc method
+     *  @name managerApp.object:TucVoipService#getRawAssociatedDeviceMac
+     *  @propertyOf managerApp.object:TucVoipService
+     *
+     *  @description
+     *  Get the <i>associatedDeviceMac</i> of the service as lower cased raw value, i.e. without ":".
+     *
+     *  @return {String}
+     */
+    getRawAssociatedDeviceMac() {
+      return this.associatedDeviceMac
+        ? this.associatedDeviceMac.replace(/:/g, '').toLowerCase()
+        : '';
     }
 
     /* -----  End of Some Helpers  ------ */


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-7266
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

The `associatedDeviceMac` of the `TucVoipService` service is now searchable through 
- The Telephony item of the sidebar menu (v6),
- The (beta) global search of the Telecom app.

![feat_searchable-mac-address-2](https://user-images.githubusercontent.com/3984480/140943654-91105eae-efd1-4acf-bb79-c1cc4af26b5b.png)
![feat_searchable-mac-address-1](https://user-images.githubusercontent.com/3984480/140943658-d2a52278-e483-42f2-bff8-70ab72b6045e.png)

