### PR TITLE
feat(account-sidebar): change of url from travaux to status-ovhcloud

### DIFF
--- a/packages/manager/modules/core/src/redirection/redirection.constants.js
+++ b/packages/manager/modules/core/src/redirection/redirection.constants.js
@@ -36,7 +36,7 @@ export default {
       SN: `${helpRoot}/fr-sn`,
       TN: `${helpRoot}/fr-tn`,
     },
-    tasks: 'http://travaux.ovh.net/',
+    tasks: 'https://www.status-ovhcloud.com/',
   },
   CA: {
     guides: {
@@ -59,7 +59,7 @@ export default {
       WE: `${helpRoot}/en`,
       WS: `${helpRoot}/es`,
     },
-    tasks: 'http://travaux.ovh.net/',
+    tasks: 'https://www.status-ovhcloud.com/',
   },
   US: {
     guides: {


### PR DESCRIPTION
 Change of URL from travaux to status-ovhcloud for Status and Incidents
 ref: MANAGER-6669

Signed-off-by: Anoop <anooparveti@gmail.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix # MANAGER-6669
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Change of URL from travaux to status-ovhcloud 

## Related

<!-- Link dependencies of this PR -->
