### PR TITLE
fix: sanitize ssh link

### DIFF
--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -110,11 +110,11 @@ import wucExpiration from './components/expiration';
 import wucOvhFileReader from './components/ovhFileReader';
 import wucProgressBarElementCounter from './components/progressBarElementCounter';
 import wucServiceStatus from './components/service-status';
-
 import './css/source.less';
 import './css/source.scss';
 
 import { TRACKING } from './at-internet.constants';
+import { SANITIZATION } from './constants';
 
 export default (containerEl, environment) => {
   const config = getConfig(environment.getRegion());
@@ -285,6 +285,7 @@ export default (containerEl, environment) => {
         set(OvhHttpProvider, 'returnErrorKey', 'data'); // By default, request return error.data
       },
     ])
+
     .config([
       '$compileProvider',
       '$logProvider',
@@ -292,6 +293,7 @@ export default (containerEl, environment) => {
       ($compileProvider, $logProvider, constants) => {
         // Debug mode and logs are disabled in production
         $compileProvider.debugInfoEnabled(!constants.prodMode);
+        $compileProvider.aHrefSanitizationWhitelist(SANITIZATION.regex);
         $logProvider.debugEnabled(!constants.prodMode);
       },
     ])

--- a/packages/manager/apps/web/client/app/constants.js
+++ b/packages/manager/apps/web/client/app/constants.js
@@ -1,0 +1,7 @@
+export const SANITIZATION = {
+  regex: /^\s*(https?|s?ftp|mailto|tel|file|data|ssh):/i,
+};
+
+export default {
+  SANITIZATION,
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8012
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

In webhosting app, FTP page, issue is : SSH links points to "unsafe:ssh://ssh.cluster031.hosting.ovh.net/" instead of "ssh://ssh.cluster031.hosting.ovh.net/". 
Fix is to add ssh in the list of url prefixes authorized by angularjs.

