### PR TITLE
fix(hosting.ftp): prevent empty primary ftp login

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/ftp/hosting-ftp.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/ftp/hosting-ftp.controller.js
@@ -152,7 +152,9 @@ angular.module('App').controller(
             user.ssh = user.serviceManagementCredentials.ssh;
             user.sshUrl = `ssh://${user.serviceManagementCredentials.ssh.user}@${user.serviceManagementCredentials.ssh.url}:${user.serviceManagementCredentials.ssh.port}/`;
 
-            this.primaryUser = user.isPrimaryAccount ? user : null;
+            if (user.isPrimaryAccount) {
+              this.primaryUser = user;
+            }
           });
           /* eslint-enable no-param-reassign */
 


### PR DESCRIPTION
ref: MANAGER-8015

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8015
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

primaryUser variable was set to user when retrieving primary user information by incorrectly set to null when retrieving non primary user information. Fix is : when retrieving non primary user information, primaryUser variable is not updated.