### PR TITLE
feat(account-sidebar, dedicated): change of url to status-ovhcloud

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -241,7 +241,7 @@ export default (containerEl, environment) => {
       UNIVERS: configConstants.UNIVERS,
       TOP_GUIDES: configConstants.TOP_GUIDES,
       vmsUrl: configConstants.vmsUrl,
-      travauxUrl: configConstants.travauxUrl,
+      statusUrl: configConstants.statusUrl,
       aapiHeaderName: 'X-Ovh-Session',
       vrackUrl: configConstants.vrackUrl,
       REDIRECT_URLS: configConstants.REDIRECT_URLS,

--- a/packages/manager/apps/dedicated/client/app/config/constants.config.js
+++ b/packages/manager/apps/dedicated/client/app/config/constants.config.js
@@ -5,7 +5,7 @@ const constants = {
     RENEW_URL:
       'https://eu.ovh.com/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
     vmsUrl: 'http://travaux.ovh.net/vms/',
-    travauxUrl: 'http://travaux.ovh.net/',
+    statusUrl: 'https://www.status-ovhcloud.com/',
     UNIVERS: 'dedicated',
     SECTIONS_UNIVERSE_MAP: {
       sd: ['server'],
@@ -747,7 +747,7 @@ const constants = {
     RENEW_URL:
       'https://ca.ovh.com/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
     vmsUrl: 'http://status.ovh.net/vms/',
-    travauxUrl: 'http://status.ovh.net/',
+    statusUrl: 'https://www.status-ovhcloud.com/',
     UNIVERS: 'dedicated',
     SECTIONS_UNIVERSE_MAP: {
       sd: ['server'],
@@ -1110,7 +1110,7 @@ const constants = {
   },
   US: {
     RENEW_URL: '/cgi-bin/order/renew.cgi?domainChooser={serviceName}',
-    travauxUrl: 'https://status.us.ovhcloud.com/',
+    statusUrl: 'https://status.us.ovhcloud.com/',
     vrackUrl: 'https://us.ovhcloud.com/manager/cloud/index.html#/vrack',
     UNIVERS: 'dedicated',
     SECTIONS_UNIVERSE_MAP: {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.controller.js
@@ -45,7 +45,7 @@ export default class DedicatedServerDashboard {
     this.servicesStateLinks = {
       weathermap: WEATHERMAP_URL[this.user.country],
       vms: this.constants.vmsUrl,
-      travaux: this.constants.travauxUrl,
+      status: this.constants.statusUrl,
     };
 
     this.infoServer = {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
@@ -473,7 +473,7 @@
                                 <li class="oui-list__item">
                                     <a
                                         class="oui-list__link oui-button_ghost"
-                                        href="{{:: $ctrl.servicesStateLinks.travaux }}"
+                                        href="{{:: $ctrl.servicesStateLinks.status }}"
                                         target="_blank"
                                         rel="noopener"
                                     >

--- a/packages/manager/modules/core/src/redirection/redirection.constants.js
+++ b/packages/manager/modules/core/src/redirection/redirection.constants.js
@@ -36,7 +36,7 @@ export default {
       SN: `${helpRoot}/fr-sn`,
       TN: `${helpRoot}/fr-tn`,
     },
-    tasks: 'http://travaux.ovh.net/',
+    tasks: 'https://www.status-ovhcloud.com/',
     expressOrder: {
       DE: 'https://www.ovh.de/order/express/#/new/express/resume',
       EN: 'https://www.ovh.co.uk/order/express/',
@@ -75,7 +75,7 @@ export default {
       WE: `${helpRoot}/en`,
       WS: `${helpRoot}/es`,
     },
-    tasks: 'http://travaux.ovh.net/',
+    tasks: 'https://www.status-ovhcloud.com/',
     expressOrder: {
       ASIA: 'https://ca.ovh.com/asia/order/express/',
       AU: 'https://ca.ovh.com/au/order/express/',


### PR DESCRIPTION
 Change of URL from travaux to status-ovhcloud
 ref: MANAGER-6669

Signed-off-by: Anoop <anooparveti@gmail.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-6669
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Change of URL from Travaux to status-ovhcloud

## Related

<!-- Link dependencies of this PR -->
