### PR TITLE
fix(storage.databases): MANAGER-8032: Service name not limited in edition

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
@@ -1,4 +1,9 @@
 import get from 'lodash/get';
+import {
+  NAME_PATTERN,
+  MIN_LENGTH,
+  MAX_LENGTH,
+} from '../../databases/create-database/create-database.constants';
 
 export default class {
   /* @ngInject */
@@ -11,6 +16,9 @@ export default class {
     this.isEditing = false;
     this.name = this.database.description;
     this.trackDashboard('general_information::modify_name', 'page');
+    this.pattern = NAME_PATTERN;
+    this.minNameLength = MIN_LENGTH;
+    this.maxNameLength = MAX_LENGTH;
   }
 
   edit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
@@ -21,6 +21,9 @@
                 name="databaseName"
                 class="oui-input"
                 data-ng-model="$ctrl.name"
+                data-minlength="$ctrl.minNameLength"
+                data-ng-maxlength="$ctrl.maxNameLength"
+                data-ng-pattern="$ctrl.pattern"
                 required
                 autofocus
             />

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
@@ -21,7 +21,7 @@
                 name="databaseName"
                 class="oui-input"
                 data-ng-model="$ctrl.name"
-                data-minlength="$ctrl.minNameLength"
+                data-ng-minlength="$ctrl.minNameLength"
                 data-ng-maxlength="$ctrl.maxNameLength"
                 data-ng-pattern="$ctrl.pattern"
                 required


### PR DESCRIPTION
MANAGER-8032

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-819`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8032
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Add controls to database name during edition

## Related

<!-- Link dependencies of this PR -->
