### PR TITLE
fix(storage.databases): MANAGER-8013: Change message when no kafka to integrate

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/translations/Messages_fr_FR.json
@@ -3,7 +3,7 @@
   "pci_databases_service_integration_tab_descritpion": "L’intégration de services vous permet de connecter différentes solutions Kafka.",
   "pci_databases_service_integration_tab_kafka_service": "Service Kafka",
   "pci_databases_service_integration_tab_add_kafka": "Ajouter un Kafka",
-  "pci_databases_service_integration_tab_no_kafka_service": "Vous ne pouvez pas ajouter un Kafka car vous n'avez plus d'autre service Kafka disponible à connecter.",
+  "pci_databases_service_integration_tab_no_kafka_service": "Vous ne pouvez pas ajouter un Kafka car vous n'avez pas ou plus de service Kafka disponible à connecter.",
   "pci_databases_service_integration_tab_unknown_service": "Service non trouvé",
   "pci_databases_service_integration_tab_service_ready": "L'intégration de votre service Kafka est prête"
 }


### PR DESCRIPTION
MANAGER-8013

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-819`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8013
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Changed the message when no kafka to integrate to avoid confusion

## Related

<!-- Link dependencies of this PR -->
