### PR TITLE
fix(storage.databases): MANAGER-8008: hide user info message if no user

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.html
@@ -5,7 +5,7 @@
         ></cui-message-container>
     </div>
     <oui-message
-        data-ng-if="$ctrl.newDatabases[$ctrl.database.id]"
+        data-ng-if="$ctrl.isFeatureActivated('usersTab') && $ctrl.newDatabases[$ctrl.database.id]"
         data-type="info"
         data-dismissable
     >


### PR DESCRIPTION
MANAGER-8008

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-819`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8008
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Hide message asking to regenerate password if the engine does not support users.

## Related

<!-- Link dependencies of this PR -->
