### PR TITLE
feat(hosting.dashboard): remove ftp link

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
@@ -20,7 +20,6 @@
   "hosting_state_info_BLOQUED": "infos sur l'état bloqué",
   "hosting_state_info_title": "Accéder aux guides (nouvelle fenêtre)",
   "hosting_dashboard_service_home": "Accès au cluster",
-  "hosting_dashboard_service_home_ftp": "Accès FTP au cluster",
   "hosting_dashboard_service_home_ftp_newtab": "Accès FTP au cluster (nouvel onglet)",
   "hosting_dashboard_service_home_http": "Accès HTTP au cluster",
   "hosting_dashboard_service_home_http_newtab": "Accès HTTP au cluster (nouvel onglet)",

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -747,16 +747,6 @@
                         ></span>
                     </oui-tile-button>
                     <oui-tile-button
-                        aria-label="{{ ::'hosting_dashboard_service_home_ftp_newtab' | translate }}"
-                        href="{{ ftpUrl }}"
-                        external
-                        on-click="$ctrl.sendTrackClick('web::hosting::go-to-ftp-access')"
-                    >
-                        <span
-                            data-translate="hosting_dashboard_service_home_ftp"
-                        ></span>
-                    </oui-tile-button>
-                    <oui-tile-button
                         aria-label="{{ ::'hosting_dashboard_service_home_http_newtab' | translate }}"
                         href="{{ httpUrl }}"
                         external


### PR DESCRIPTION
ref: DTRSD-43496

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/webhosting-sftp-doc`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DTRSD-43496
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

In webhosting manager, FTP link to the hosting is removed from useful link. The goal is to push customer to use SFTP instead of FTP (more secure protocol). SFTP link is not added to useful link since browser do not support it.

## Related

- #5988
- #5991
- #5989
- #5992