### PR TITLE
feat(storage.databases): PUD-1084 - add modal to alert user about existing integrations before delete

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.component.js
@@ -1,0 +1,16 @@
+import controller from './confirm-delete.controller';
+import template from './confirm-delete.html';
+
+const component = {
+  bindings: {
+    database: '<',
+    goBack: '<',
+    projectId: '<',
+    trackDatabases: '<',
+    linkedServices: '<',
+  },
+  template,
+  controller,
+};
+
+export default component;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.controller.js
@@ -1,0 +1,44 @@
+import get from 'lodash/get';
+
+export default class {
+  /* @ngInject */
+  constructor($translate, DatabaseService) {
+    this.$translate = $translate;
+    this.DatabaseService = DatabaseService;
+  }
+
+  $onInit() {
+    this.processing = false;
+    this.trackDatabases('table::options_menu::delete_database', 'page');
+  }
+
+  deleteService() {
+    this.trackDatabases('table::options_menu::delete_database_validate');
+    this.processing = true;
+    return this.DatabaseService.deleteDatabase(
+      this.projectId,
+      this.database.engine,
+      this.database.id,
+    )
+      .then(() =>
+        this.goBack(
+          this.$translate.instant(
+            'pci_database_confirm_delete_success_message',
+          ),
+        ),
+      )
+      .catch((error) =>
+        this.goBack(
+          this.$translate.instant('pci_database_confirm_delete_error_message', {
+            message: get(error, 'data.message'),
+          }),
+          'error',
+        ),
+      );
+  }
+
+  cancel() {
+    this.trackDatabases('table::options_menu::delete_database_cancel');
+    this.goBack();
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
@@ -23,5 +23,5 @@
         data-translate="pci_database_confirm_delete_description_2"
         data-translate-values="{serviceName: $ctrl.database.description}"
     ></p>
-    <b data-translate="pci_database_confirm_delete_description_3"></b>
+    <strong data-translate="pci_database_confirm_delete_description_3"></strong>
 </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
@@ -1,0 +1,27 @@
+<oui-modal
+    data-type="warning"
+    data-on-dismiss="$ctrl.cancel()"
+    data-primary-label="{{:: 'pci_database_confirm_delete_confirm' | translate}}"
+    data-primary-action="$ctrl.deleteService()"
+    data-secondary-action="$ctrl.cancel()"
+    data-secondary-label="{{:: 'pci_database_confirm_delete_cancel' | translate}}"
+    data-loading="$ctrl.processing"
+    data-heading="{{:: 'pci_database_confirm_delete' | translate}}"
+>
+    <oui-message type="warning">
+        <p
+            data-translate="pci_database_confirm_delete_description_1"
+            data-translate-values="{serviceName: $ctrl.database.description}"
+        ></p>
+        <ul>
+            <li ng-repeat="service in $ctrl.linkedServices">
+                {{service.description}}
+            </li>
+        </ul>
+    </oui-message>
+    <p
+        data-translate="pci_database_confirm_delete_description_2"
+        data-translate-values="{serviceName: $ctrl.database.description}"
+    ></p>
+    <b data-translate="pci_database_confirm_delete_description_3"></b>
+</oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.html
@@ -14,7 +14,7 @@
             data-translate-values="{serviceName: $ctrl.database.description}"
         ></p>
         <ul>
-            <li ng-repeat="service in $ctrl.linkedServices">
+            <li ng-repeat="service in $ctrl.linkedServices track by $index">
                 {{service.description}}
             </li>
         </ul>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.module.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+
+import component from './confirm-delete.component';
+import routing from './confirm-delete.routing';
+
+const moduleName = 'ovhManagerPciStoragesDatabaseConfirmDelete';
+
+angular
+  .module(moduleName, [])
+  .config(routing)
+  .component('ovhManagerPciProjectDatabaseConfirmDelete', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/confirm-delete.routing.js
@@ -1,0 +1,28 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state(
+    'pci.projects.project.storages.databases.confirm-delete',
+    {
+      url: '/confirm-delete',
+      views: {
+        modal: {
+          component: 'ovhManagerPciProjectDatabaseConfirmDelete',
+        },
+      },
+      params: {
+        database: null,
+        linkedServices: [],
+      },
+      layout: 'modal',
+      resolve: {
+        breadcrumb: () => null,
+        database: /* @ngInject */ ($transition$) =>
+          $transition$.params().database,
+        linkedServices: /* @ngInject */ ($transition$) =>
+          $transition$.params().linkedServices,
+      },
+      atInternet: {
+        ignore: true,
+      },
+    },
+  );
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/index.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerPciStoragesDatabaseConfirmDeleteLazyloading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state(
+      'pci.projects.project.storages.databases.confirm-delete.**',
+      {
+        url: '/confirm-delete',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./confirm-delete.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      },
+    );
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/confirm-delete/translations/Messages_fr_FR.json
@@ -1,0 +1,10 @@
+{
+  "pci_database_confirm_delete_confirm": "Confirmer",
+  "pci_database_confirm_delete_cancel": "Annuler",
+  "pci_database_confirm_delete": "Supprimer votre service",
+  "pci_database_confirm_delete_description_1": "Le ou les services suivants sont associés au service {{serviceName}} que vous souhaitez supprimer :",
+  "pci_database_confirm_delete_description_2": "Êtes-vous sûr de vouloir supprimer le service {{serviceName}} ?",
+  "pci_database_confirm_delete_description_3": "Cela entrainera la suppression de l'association (réplication ou intégration).",
+  "pci_database_confirm_delete_success_message": "Votre service a bien été supprimé.",
+  "pci_database_confirm_delete_error_message": "Une erreur est survenue lors de la suppression de votre service: {{message}}"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.component.js
@@ -8,6 +8,7 @@ export default {
     databaseLink: '<',
     goToDatabase: '<',
     goToDeleteDatabase: '<',
+    goToConfirmDeleteDatabase: '<',
     goToEditName: '<',
     goToUpgradePlan: '<',
     goToUpgradeVersion: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.controller.js
@@ -1,17 +1,24 @@
+import find from 'lodash/find';
 import capitalize from 'lodash/capitalize';
 import { getCriteria } from '../../project.utils';
-import { ENGINE_LOGOS } from './databases.constants';
+import { ENGINE_LOGOS, DATABASE_TYPES } from './databases.constants';
 
 const optionsMenuTrackPrefix = 'table::options_menu:';
 
 export default class {
   /* @ngInject */
-  constructor($translate, CucCloudMessage, ovhManagerRegionService) {
+  constructor(
+    $translate,
+    CucCloudMessage,
+    ovhManagerRegionService,
+    DatabaseService,
+  ) {
     this.$translate = $translate;
     this.capitalize = capitalize;
     this.CucCloudMessage = CucCloudMessage;
     this.ovhManagerRegionService = ovhManagerRegionService;
     this.ENGINE_LOGOS = ENGINE_LOGOS;
+    this.DatabaseService = DatabaseService;
   }
 
   $onInit() {
@@ -40,7 +47,30 @@ export default class {
 
   deleteDatabase(database) {
     this.trackDatabases(`${optionsMenuTrackPrefix}delete_database`);
-    this.goToDeleteDatabase(database);
+    if (
+      [DATABASE_TYPES.KAFKA, DATABASE_TYPES.KAFKA_MIRROR_MAKER].includes(
+        database.engine,
+      )
+    ) {
+      this.DatabaseService.getIntegrations(
+        this.projectId,
+        database.engine,
+        database.id,
+      ).then((integrations) => {
+        const linkedServices = integrations.map((integration) =>
+          database.engine === DATABASE_TYPES.KAFKA
+            ? find(this.databases, { id: integration.destinationServiceId })
+            : find(this.databases, { id: integration.sourceServiceId }),
+        );
+        if (linkedServices.length > 0) {
+          this.goToConfirmDeleteDatabase(database, linkedServices);
+        } else {
+          this.goToDeleteDatabase(database);
+        }
+      });
+    } else {
+      this.goToDeleteDatabase(database);
+    }
   }
 
   renameDatabase(database) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.controller.js
@@ -52,7 +52,7 @@ export default class {
         database.engine,
       )
     ) {
-      this.DatabaseService.getIntegrations(
+      return this.DatabaseService.getIntegrations(
         this.projectId,
         database.engine,
         database.id,
@@ -63,14 +63,12 @@ export default class {
             : find(this.databases, { id: integration.sourceServiceId }),
         );
         if (linkedServices.length > 0) {
-          this.goToConfirmDeleteDatabase(database, linkedServices);
-        } else {
-          this.goToDeleteDatabase(database);
+          return this.goToConfirmDeleteDatabase(database, linkedServices);
         }
+        return this.goToDeleteDatabase(database);
       });
-    } else {
-      this.goToDeleteDatabase(database);
     }
+    return this.goToDeleteDatabase(database);
   }
 
   renameDatabase(database) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.module.js
@@ -17,6 +17,7 @@ import node from './components/node';
 import onboarding from './onboarding';
 import routing from './databases.routing';
 import service from './database.service';
+import confirmDelete from './confirm-delete';
 
 import './index.scss';
 
@@ -33,6 +34,7 @@ angular
     ngOvhSwimmingPoll,
     node,
     onboarding,
+    confirmDelete,
     'ngTranslateAsyncLoader',
     'pascalprecht.translate',
     'ngOvhCloudUniverseComponents',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.routing.js
@@ -119,7 +119,14 @@ export default /* @ngInject */ ($stateProvider) => {
             })
           : promise;
       },
-
+      goToConfirmDeleteDatabase: /* @ngInject */ ($state) => (
+        database,
+        linkedServices,
+      ) =>
+        $state.go('pci.projects.project.storages.databases.confirm-delete', {
+          database,
+          linkedServices,
+        }),
       goToDeleteDatabase: /* @ngInject */ ($state, projectId) => (database) =>
         $state.go('pci.projects.project.storages.databases.delete', {
           projectId,


### PR DESCRIPTION
PUD-1084

| Question         | Answer
| ---------------- | ---
| Branch?          | `PUD-819`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #PUD-1084
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Add a modal to confirm deletion when service is a part of at least one integration.