### PR TITLE
fix(storage.databases): fix nodes polling

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/database.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/database.class.js
@@ -87,10 +87,7 @@ export default class Database extends Base {
   }
 
   setNodes(nodes) {
-    nodes.forEach((node) => {
-      const nodeObj = this.getNode(node.id);
-      return nodeObj ? nodeObj.updateData(node) : this.addNode(node);
-    });
+    this.nodes = nodes;
   }
 
   getEngineFromList(engines) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.routing.js
@@ -159,8 +159,8 @@ export default /* @ngInject */ ($stateProvider) => {
             projectId,
             database.engine,
             database.id,
-          )
-            .then((databaseInfo) => {
+          ).then(
+            (databaseInfo) => {
               CucCloudMessage.flushMessages(`${stateName}-${databaseInfo.id}`);
               CucCloudMessage.success(
                 $translate.instant(
@@ -172,11 +172,19 @@ export default /* @ngInject */ ($stateProvider) => {
               return getNodes(database).then((nodes) =>
                 database.setNodes(nodes),
               );
-            })
-            .finally(() => {
-              return pollNodesStatus();
-            });
+            },
+            null,
+            () => {
+              getNodes(database).then((nodes) => {
+                database.setNodes(nodes);
+              });
+            },
+          );
         }
+        getNodes(database).then((nodes) => {
+          database.setNodes(nodes);
+          pollNodesStatus();
+        });
       },
       pollNodesStatus: /* @ngInject */ (
         $translate,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     |no
| Breaking change? |no
| Tickets          | Fix #PUD-1085
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fetch nodes information during cluster status polling to avoid having inconsistent data.
Change the setNodes function so it does not keep old nodes in memory
Fetch the nodes information once if the status is ready to keep data in sync
