### PR TITLE
fix(storage.databases): PUD-985: add tracking on success or error when adding a replication

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/replications/add-edit/add-edit.controller.js
@@ -118,15 +118,17 @@ export default class {
       this.database.id,
       this.prepareModel(),
     )
-      .then(() =>
-        this.goBack({
+      .then(() => {
+        this.trackDashboard('replication_flows::create_validated', 'page');
+        return this.goBack({
           textHtml: this.$translate.instant(
             'pci_databases_replications_add_success_message',
           ),
-        }),
-      )
-      .catch((err) =>
-        this.goBack(
+        });
+      })
+      .catch((err) => {
+        this.trackDashboard('replication_flows::create_error', 'page');
+        return this.goBack(
           this.$translate.instant(
             'pci_databases_replications_add_error_message',
             {
@@ -134,7 +136,7 @@ export default class {
             },
           ),
           'error',
-        ),
-      );
+        );
+      });
   }
 }


### PR DESCRIPTION
PUD-985

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/PUD-819`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-985
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Add tracking on success or error when adding a replication