### PR TITLE
fix(filter): avoid double url encoding with iceberg filters

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
@@ -75,11 +75,11 @@ export default /* @ngInject */ ($stateProvider) => {
             reference.map((val) => {
               switch (comparator.toUpperCase()) {
                 case 'CONTAINS':
-                  return `%25${val}%25`;
+                  return `%${val}%`;
                 case 'STARTSWITH':
-                  return `${val}%25`;
+                  return `${val}%`;
                 case 'ENDSWITH':
-                  return `%25${val}`;
+                  return `%${val}`;
                 default:
                   return val;
               }

--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
@@ -23,11 +23,11 @@ export const mapFilterForIceberg = (comparator, reference) =>
   reference.map((val) => {
     switch (comparator.toUpperCase()) {
       case 'CONTAINS':
-        return `%25${val}%25`;
+        return `%${val}%`;
       case 'STARTSWITH':
-        return `${val}%25`;
+        return `${val}%`;
       case 'ENDSWITH':
-        return `%25${val}`;
+        return `%${val}`;
       default:
         return val;
     }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | relates to MANAGER-7878
| License          | BSD 3-Clause

## Description

avoid double encodeURIComponent of "%" symbol
ng-ovh-api-wrappers is now url encoding values (to avoid passing reserved characters such as comma ",")