### PR TITLE
refactor: remove initShell from monoliths

### DIFF
--- a/packages/manager/apps/dedicated/client/app/index.js
+++ b/packages/manager/apps/dedicated/client/app/index.js
@@ -9,7 +9,6 @@ import {
   findAvailableLocale,
   detectUserLocale,
 } from '@ovh-ux/manager-config';
-import { useShellClient } from '@ovh-ux/shell';
 
 attachPreloader(findAvailableLocale(detectUserLocale()));
 
@@ -19,9 +18,6 @@ fetchConfiguration('dedicated').then((environment) => {
   if (environment.getMessage()) {
     displayMessage(environment.getMessage(), environment.getUserLanguage());
   }
-
-  const shellClient = useShellClient();
-  shellClient.routing.init();
 
   import(`./config-${environment.getRegion()}`)
     .catch(() => {})

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -92,7 +92,6 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.4",
     "@ovh-ux/ng-ui-router-layout": "^4.0.3",
     "@ovh-ux/ng-ui-router-line-progress": "^1.2.5",
-    "@ovh-ux/shell": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ufrontend": "^1.1.3 || ^2.0.0",
     "@ovh-ux/ui-kit": "^5.1.2",
     "@uirouter/angularjs": "^1.0.23",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -74,7 +74,6 @@
     "@ovh-ux/ng-ui-router-layout": "^4.0.3",
     "@ovh-ux/ng-ui-router-line-progress": "^1.2.5",
     "@ovh-ux/ng-ui-router-title": "^3.0.2",
-    "@ovh-ux/shell": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ufrontend": "^1.1.3 || ^2.0.0",
     "@ovh-ux/ui-kit": "^5.1.2",
     "@uirouter/angularjs": "^1.0.23",

--- a/packages/manager/apps/telecom/src/app/index.js
+++ b/packages/manager/apps/telecom/src/app/index.js
@@ -9,7 +9,6 @@ import {
   findAvailableLocale,
   detectUserLocale,
 } from '@ovh-ux/manager-config';
-import { useShellClient } from '@ovh-ux/shell';
 
 attachPreloader(findAvailableLocale(detectUserLocale()));
 
@@ -19,9 +18,6 @@ fetchConfiguration('telecom').then((environment) => {
   if (environment.getMessage()) {
     displayMessage(environment.getMessage(), environment.getUserLanguage());
   }
-
-  const shellClient = useShellClient();
-  shellClient.routing.init();
 
   import(`./config-${environment.getRegion()}`)
     .catch(() => {})

--- a/packages/manager/apps/web/client/app/index.js
+++ b/packages/manager/apps/web/client/app/index.js
@@ -9,7 +9,6 @@ import {
   findAvailableLocale,
   detectUserLocale,
 } from '@ovh-ux/manager-config';
-import { useShellClient } from '@ovh-ux/shell';
 
 attachPreloader(findAvailableLocale(detectUserLocale()));
 
@@ -19,9 +18,6 @@ fetchConfiguration('web').then((environment) => {
   if (environment.getMessage()) {
     displayMessage(environment.getMessage(), environment.getUserLanguage());
   }
-
-  const shellClient = useShellClient();
-  shellClient.routing.init();
 
   import(`./config-${environment.getRegion()}`)
     .catch(() => {})

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -70,7 +70,6 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.4",
     "@ovh-ux/ng-ui-router-layout": "^4.0.3",
     "@ovh-ux/ng-ui-router-line-progress": "^1.2.5",
-    "@ovh-ux/shell": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ufrontend": "^1.1.3 || ^2.0.0",
     "@ovh-ux/ui-kit": "^5.1.2",
     "@uirouter/angularjs": "^1.0.23",


### PR DESCRIPTION
ref: MANAGER-8166

Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/manager-shell-config`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8166
| License          | BSD 3-Clause

## Description

Remove initShell usage from following packages:
* @ovh-ux/manager-dedicated
* @ovh-ux/manager-web
* @ovh-ux/manager-telecom