### PR TITLE
feat(ai-training-notebooks): add possibility to attach ssh keys

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.controller.js
@@ -13,6 +13,7 @@ export default class NotebookAddController {
 
     // Stepper config object
     this.stepper = {
+      notebookSshKeys: { name: 'notebook_ssh_keys', display: null },
       notebookSettings: { name: 'notebook_settings', display: null },
       notebookEditors: { name: 'notebook_editors', display: null },
       notebookFrameworks: { name: 'notebook_frameworks', display: null },
@@ -37,6 +38,7 @@ export default class NotebookAddController {
       mountPath: '',
       nbResources: NOTEBOOK_RESOURCES.NB_RESOURCES,
       volumes: [],
+      sshPublicKeys: [],
       selected: {
         editor: null,
         framework: {
@@ -101,7 +103,7 @@ export default class NotebookAddController {
 
   static convertNotebookModel(notebookModel) {
     const { name, nbResources } = notebookModel;
-    const { labels, volumes, selected } = notebookModel;
+    const { labels, volumes, selected, sshPublicKeys } = notebookModel;
     const { editor, framework, region, resource, privacy } = selected;
 
     return {
@@ -119,6 +121,7 @@ export default class NotebookAddController {
       ),
       volumes: NotebookAddController.buildVolumesBody(volumes),
       unsecureHttp: NOTEBOOK_PRIVACY_SETTINGS.PUBLIC === privacy,
+      sshPublicKeys,
     };
   }
 
@@ -223,6 +226,16 @@ export default class NotebookAddController {
     }
 
     return this.$translate.instant('pci_notebook_add_resources_title');
+  }
+
+  getSshKeysHeader(display) {
+    if (display === false) {
+      return this.$translate.instant('pci_notebook_add_ssh_keys_selected', {
+        quantity: this.notebookModel.sshPublicKeys.length,
+      });
+    }
+
+    return this.$translate.instant('pci_notebook_add_ssh_keys');
   }
 
   getAttachContainerHeader(display) {

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.html
@@ -193,7 +193,7 @@
         data-loading="$ctrl.isAdding"
     >
         <notebook-review
-            data-ng-if="stepReview.display && !$ctrl.stepper.notebookAttach.display"
+            data-ng-if="stepReview.display && !$ctrl.stepper.notebookSshKeys.display"
             data-project-id="$ctrl.projectId"
             data-convert-notebook-model="$ctrl.constructor.convertNotebookModel"
             data-display-notebook-review="stepReview.display"

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.html
@@ -164,6 +164,22 @@
         ></notebook-attach>
     </oui-step-form>
 
+    <!--Notebook add public ssh keys-->
+    <oui-step-form
+        data-ng-init="stepSshKeys = $ctrl.stepper.notebookSshKeys"
+        data-name="{{:: stepSshKeys.name}}"
+        data-header="{{ $ctrl.getSshKeysHeader(stepSshKeys.display) }}"
+        data-on-focus="stepSshKeys.display = true"
+        data-on-submit="stepSshKeys.display = false"
+        data-prevent-next="true"
+    >
+        <notebook-ssh-keys
+            data-project-id="$ctrl.projectId"
+            data-display-notebook-ssh-keys="stepSshKeys.display"
+            data-notebook-model="$ctrl.notebookModel"
+        ></notebook-ssh-keys>
+    </oui-step-form>
+
     <!--Notebook Review-->
     <oui-step-form
         data-ng-init="stepReview = $ctrl.stepper.notebookReview"

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/add.module.js
@@ -14,6 +14,7 @@ import notebookPrivacySettings from './components/notebook-privacy-settings';
 import notebookResources from './components/notebook-resources';
 import notebookAttach from './components/notebook-attach';
 import notebookReview from './components/notebook-review';
+import notebookSshKeys from './components/notebook-ssh-keys';
 import ovhManagerPciStoragesContainers from '../../storages/containers';
 
 const moduleName = 'ovhManagerPciNotebooksAdd';
@@ -30,6 +31,7 @@ angular
     notebookResources,
     notebookAttach,
     notebookReview,
+    notebookSshKeys,
     ovhManagerPciStoragesContainers,
   ])
   .config(routing)

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/index.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/index.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
+
+import component from './notebook-ssh-keys.component';
+
+const moduleName = 'ovhManagerPciProjectNotebooksNotebookSshKeys';
+
+angular
+  .module(moduleName, ['oui', 'pascalprecht.translate'])
+  .component('notebookSshKeys', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.component.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.component.js
@@ -1,0 +1,13 @@
+import controller from './notebook-ssh-keys.controller';
+import template from './notebook-ssh-keys.html';
+
+export default {
+  bindings: {
+    notebookModel: '<',
+    displayNotebookSshKeys: '<',
+    projectId: '<',
+  },
+  require: {},
+  controller,
+  template,
+};

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.component.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.component.js
@@ -7,7 +7,6 @@ export default {
     displayNotebookSshKeys: '<',
     projectId: '<',
   },
-  require: {},
   controller,
   template,
 };

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
@@ -1,0 +1,95 @@
+import { NOTEBOOK_SSH_KEYS } from '../../notebook.constants';
+
+export default class NotebookSshKeysController {
+  /* @ngInject */
+  constructor(coreConfig, NotebookService) {
+    this.NOTEBOOK_SSH_KEYS_CONSTANTS = NOTEBOOK_SSH_KEYS;
+    this.NotebookService = NotebookService;
+
+    this.coreConfig = coreConfig;
+    // Option set by user indicating if he wants to add ssh keys
+    this.enabledSshPublicKey = false;
+    // List of ssh keys added by user
+    this.addedSshKeys = [];
+    // Saved ssh keys in public cloud
+    this.savedKeys = [];
+    // All available names for saved ssh keys
+    this.allKeyNames = [];
+  }
+
+  $onInit() {
+    this.populateSavedSshKeys();
+  }
+
+  canAddNewSshPublicKey() {
+    const allSshKeys = this.getAllSshKeys();
+    return (
+      allSshKeys.length === this.addedSshKeys.length &&
+      allSshKeys.length <= this.NOTEBOOK_SSH_KEYS_CONSTANTS.MAX
+    );
+  }
+
+  addNewSshPublicKey() {
+    this.addedSshKeys.push({
+      disabled: false,
+      model: null,
+      keyName: this.NOTEBOOK_SSH_KEYS_CONSTANTS.CUSTOM_SELECT,
+    });
+  }
+
+  onSshPublickeysDeleteBtnClick(index) {
+    this.addedSshKeys.splice(index, 1);
+  }
+
+  changeEnabledSshPublicKey(enabledSshPublicKey) {
+    this.enabledSshPublicKey = enabledSshPublicKey;
+    if (!this.enabledSshPublicKey) {
+      this.addedSshKeys = [];
+    } else {
+      this.addNewSshPublicKey();
+    }
+  }
+
+  // Return all non empty ssh keys
+  getAllSshKeys() {
+    return this.addedSshKeys
+      .map((sshKey) => sshKey.model)
+      .filter(
+        (sshKeyModel) =>
+          sshKeyModel && sshKeyModel.length > 0 && sshKeyModel.trim(),
+      );
+  }
+
+  changeSavedSshKey(index) {
+    // Get the select key name from the index
+    const newSshKeyName = this.addedSshKeys[index].keyName;
+    // Find the selected key by name
+    if (newSshKeyName === this.NOTEBOOK_SSH_KEYS_CONSTANTS.CUSTOM_SELECT) {
+      this.addedSshKeys[index].model = null;
+      this.addedSshKeys[index].disabled = false;
+    } else {
+      const newSshKey = this.savedKeys.filter(
+        (x) => x.name === newSshKeyName,
+      )[0].publicKey;
+      this.addedSshKeys[index].model = newSshKey;
+      this.addedSshKeys[index].disabled = true;
+    }
+    this.textareaChanged();
+  }
+
+  populateSavedSshKeys() {
+    this.NotebookService.getSavedSshKeys(this.projectId).then(
+      ({ data: keys }) => {
+        this.savedKeys = keys;
+        this.allKeyNames = [
+          this.NOTEBOOK_SSH_KEYS_CONSTANTS.CUSTOM_SELECT,
+        ].concat(this.savedKeys.map((x) => x.name));
+      },
+    );
+  }
+
+  textareaChanged() {
+    this.notebookModel.sshPublicKeys = this.getAllSshKeys();
+    console.log(this.notebookModel);
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
@@ -78,18 +78,15 @@ export default class NotebookSshKeysController {
   }
 
   populateSavedSshKeys() {
-    this.NotebookService.getSavedSshKeys(this.projectId).then(
-      ({ data: keys }) => {
-        this.savedKeys = keys;
-        this.allKeyNames = [
-          this.NOTEBOOK_SSH_KEYS_CONSTANTS.CUSTOM_SELECT,
-        ].concat(this.savedKeys.map((x) => x.name));
-      },
-    );
+    this.NotebookService.getSavedSshKeys(this.projectId).then((keys) => {
+      this.savedKeys = keys;
+      this.allKeyNames = [
+        this.NOTEBOOK_SSH_KEYS_CONSTANTS.CUSTOM_SELECT,
+      ].concat(this.savedKeys.map((x) => x.name));
+    });
   }
 
   textareaChanged() {
     this.notebookModel.sshPublicKeys = this.getAllSshKeys();
-    console.log(this.notebookModel);
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.controller.js
@@ -2,12 +2,11 @@ import { NOTEBOOK_SSH_KEYS } from '../../notebook.constants';
 
 export default class NotebookSshKeysController {
   /* @ngInject */
-  constructor(coreConfig, NotebookService) {
+  constructor(NotebookService) {
     this.NOTEBOOK_SSH_KEYS_CONSTANTS = NOTEBOOK_SSH_KEYS;
     this.NotebookService = NotebookService;
 
-    this.coreConfig = coreConfig;
-    // Option set by user indicating if he wants to add ssh keys
+    // Option indicating if the user wants to add ssh keys
     this.enabledSshPublicKey = false;
     // List of ssh keys added by user
     this.addedSshKeys = [];

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.html
@@ -1,0 +1,96 @@
+<div data-ng-if="$ctrl.displayNotebookSshKeys">
+    <oui-message type="info" dismissable="true">
+        <span
+            class="d-block"
+            data-translate="pci_projects_project_training_notebook_add_select_ssh_tips_1"
+        ></span>
+    </oui-message>
+    <oui-field
+        data-size="xl"
+        data-label="{{:: 'pci_projects_project_training_notebook_add_select_ssh_default_select' | translate  }}"
+    >
+        <oui-switch
+            data-model="$ctrl.enabledSshPublicKey"
+            name="enabledSshPublicKey"
+            on-change="$ctrl.changeEnabledSshPublicKey(modelValue)"
+        >
+        </oui-switch>
+    </oui-field>
+    <div class="oui-field__control" data-ng-if="$ctrl.enabledSshPublicKey">
+        <div class="oui-inline-adder mb-2">
+            <div
+                class="oui-inline-adder__form"
+                data-ng-repeat="sshKey in $ctrl.addedSshKeys track by $index"
+            >
+                <fieldset class="oui-inline-adder__fieldset">
+                    <legend
+                        data-ng-bind=":: 'pci_projects_project_training_notebook_add_select_ssh_legend' | translate"
+                    ></legend>
+                    <div class="oui-inline-adder__row">
+                        <div class="oui-inline-adder__field">
+                            <oui-field
+                                data-size="m"
+                                data-label="{{:: 'pci_projects_project_training_notebook_add_select_ssh_name_tips' | translate  }}"
+                                data-ng-if="$ctrl.allKeyNames.length > 0"
+                            >
+                                <oui-select
+                                    id="savedKeyName"
+                                    name="savedKeyName"
+                                    data-model="$ctrl.addedSshKeys[$index].keyName"
+                                    data-items="$ctrl.allKeyNames"
+                                    on-change="$ctrl.changeSavedSshKey($index)"
+                                >
+                                </oui-select>
+                            </oui-field>
+                            <oui-field
+                                data-label="{{:: 'pci_projects_project_training_notebook_add_select_ssh_input_tips' | translate  }}"
+                            >
+                                <textarea
+                                    type="textarea"
+                                    class="oui-input"
+                                    placeholder="{{:: $ctrl.NOTEBOOK_SSH_KEYS_CONSTANTS.PLACEHOLDER }}"
+                                    name="sshPublicKey"
+                                    rows="{{:: $ctrl.NOTEBOOK_SSH_KEYS_CONSTANTS.NB_ROWS }}"
+                                    data-ng-model="$ctrl.addedSshKeys[$index].model"
+                                    data-ng-required
+                                    data-ng-disabled="$ctrl.addedSshKeys[$index].disabled"
+                                    data-ng-change="$ctrl.textareaChanged()"
+                                />
+                            </oui-field>
+                        </div>
+                    </div>
+                </fieldset>
+                <footer class="oui-inline-adder__footer">
+                    <button
+                        type="button"
+                        class="oui-inline-adder__action oui-button oui-button_primary oui-button_s"
+                        data-translate-attr="{title: 'dedicated_server_install_image_config_http_header_delete'}"
+                        data-ng-click="$ctrl.onSshPublickeysDeleteBtnClick($index)"
+                        data-ng-disabled="$ctrl.addedSshKeys.length === 1"
+                    >
+                        <span
+                            class="oui-icon oui-icon-trash"
+                            aria-hidden="true"
+                        ></span>
+                    </button>
+                </footer>
+            </div>
+        </div>
+        <oui-button
+            data-icon-left="oui-icon-plus"
+            data-variant="secondary"
+            data-disabled="!$ctrl.canAddNewSshPublicKey()"
+            data-on-click="$ctrl.addNewSshPublicKey()"
+        >
+            <span
+                data-translate="pci_projects_project_training_notebook_add_select_ssh_add"
+            ></span>
+        </oui-button>
+        <div class="oui-field__control py-2">
+            <span
+                data-translate="pci_projects_project_training_notebook_add_select_ssh_quantity"
+                data-translate-values="{ numberOfSshKeys: $ctrl.getAllSshKeys().length, maxSshKeys: $ctrl.NOTEBOOK_SSH_KEYS_CONSTANTS.MAX}"
+            ></span>
+        </div>
+    </div>
+</div>

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/notebook-ssh-keys.html
@@ -24,7 +24,7 @@
             >
                 <fieldset class="oui-inline-adder__fieldset">
                     <legend
-                        data-ng-bind=":: 'pci_projects_project_training_notebook_add_select_ssh_legend' | translate"
+                        data-translate="pci_projects_project_training_notebook_add_select_ssh_legend"
                     ></legend>
                     <div class="oui-inline-adder__row">
                         <div class="oui-inline-adder__field">
@@ -34,7 +34,6 @@
                                 data-ng-if="$ctrl.allKeyNames.length > 0"
                             >
                                 <oui-select
-                                    id="savedKeyName"
                                     name="savedKeyName"
                                     data-model="$ctrl.addedSshKeys[$index].keyName"
                                     data-items="$ctrl.allKeyNames"
@@ -64,7 +63,7 @@
                     <button
                         type="button"
                         class="oui-inline-adder__action oui-button oui-button_primary oui-button_s"
-                        data-translate-attr="{title: 'dedicated_server_install_image_config_http_header_delete'}"
+                        data-translate-attr="{title: 'pci_projects_project_training_notebook_add_select_ssh_delete_message'}"
                         data-ng-click="$ctrl.onSshPublickeysDeleteBtnClick($index)"
                         data-ng-disabled="$ctrl.addedSshKeys.length === 1"
                     >

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_de_DE.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "SSH-Schlüssel hinzufügen (optional)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Wenn Sie einen öffentlichen SSH-Schlüssel hinzufügen, können Sie anschließend remote per SSH- oder SCP-Protokoll auf das Notebook zugreifen.",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Den zu verwendenden öffentlichen SSH-Schlüssel angeben (optional)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Den Namen des Schlüssels aus den bereits gespeicherten Schlüsseln auswählen",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Inhalt des öffentlichen SSH-Schlüssels",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Einen neuen öffentlichen SSH Schlüssel hinzufügen",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} SSH-Schlüssel",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Öffentlicher SSH-Schlüssel",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Den hinzugefügten SSH-Schlüssel löschen"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_en_GB.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Attach SSH public keys (optional)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "By attaching an SSH public key, you can then access the notebook remotely via SSH or SCP protocol",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Enter the SSH public key to use (optional)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Choose key name from saved keys",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "SSH public key content",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Add a new SSH public key",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{numberOfSshKeys}}/{{maxSshKeys}} SSH keys",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Public SSH key",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Delete the attached SSH key"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_es_ES.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Asociar claves públicas SSH (opcional)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Asociar una clave pública SSH le permitirá acceder a distancia al notebook a través del protocolo SSH o SCP.",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Introducir la clave pública SSH que desea utilizar (opcional)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Elegir el nombre de la clave entre las claves guardadas",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenido de la clave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Añadir una nueva clave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }}/{{ maxSshKeys }} clave(s) SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Clave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Eliminar la clave SSH asociada"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_CA.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Attacher des clés publiques ssh (optionnel)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Attacher une clé publique ssh vous permet par la suite d'accéder à distance au notebook via le protocole ssh ou scp",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Renseigner la clé publique ssh à utiliser (optionnel)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Choisir le nom de la clé parmi celles enregistrées",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenu de la clé publique ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Clé publique SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Supprimer la clé ssh attachée"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
@@ -1,0 +1,10 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Attacher des clés publiques ssh (optionnel)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Attacher une clé publique ssh vous permet par la suite d'accéder à distance au notebook via le protocole ssh ou scp",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Renseigner la clé publique ssh à utiliser (optionnel)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenu de la clé publique ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Clé publique SSH"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
@@ -2,7 +2,7 @@
   "pci_projects_project_training_notebook_add_select_ssh": "Attacher des clés publiques ssh (optionnel)",
   "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Attacher une clé publique ssh vous permet par la suite d'accéder à distance au notebook via le protocole ssh ou scp",
   "pci_projects_project_training_notebook_add_select_ssh_default_select": "Renseigner la clé publique ssh à utiliser (optionnel)",
-  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Choisir le nom de la clé parmis celles enregistrées",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Choisir le nom de la clé parmi celles enregistrées",
   "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenu de la clé publique ssh",
   "pci_projects_project_training_notebook_add_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
   "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_fr_FR.json
@@ -6,5 +6,6 @@
   "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenu de la clé publique ssh",
   "pci_projects_project_training_notebook_add_select_ssh_add": "Ajouter une nouvelle clé publique ssh",
   "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} clé(s) ssh",
-  "pci_projects_project_training_notebook_add_select_ssh_legend": "Clé publique SSH"
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Clé publique SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Supprimer la clé ssh attachée"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_it_IT.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Associa chiavi pubbliche SSH (opzionale)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "L’associazione di una chiave pubblica SSH permette di accedere da remoto al notebook tramite il protocollo SSH o SCP.",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Inserisci la chiave pubblica SSH da utilizzare (opzionale)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Scegli il nome della chiave tra quelle salvate",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Contenuto della chiave pubblica SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Aggiungi una nuova chiave pubblica SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }}/{{ maxSshKeys }} chiavi SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Chiave pubblica SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Elimina la chiave SSH associata"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_pl_PL.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Przypisz publiczne klucze SSH (opcjonalnie)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Przypisanie publicznego klucza SSH pozwala na zdalny dostęp do notebooka za pomocą protokołu SSH lub SCP",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Wpisz publiczny klucz SSH, którego chcesz użyć (opcjonalnie)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Wybierz nazwę klucza spośród zarejestrowanych nazw",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Zawartość publicznego klucza SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Dodaj nowy publiczny klucz SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{numberOfSshKeys}} / {{maxSshKeys}} kluczy SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Publiczny klucz SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Usuń przypisany klucz SSH"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-ssh-keys/translations/Messages_pt_PT.json
@@ -1,0 +1,11 @@
+{
+  "pci_projects_project_training_notebook_add_select_ssh": "Associar chaves públicas SSH (opcional)",
+  "pci_projects_project_training_notebook_add_select_ssh_tips_1": "Associar uma chave pública SSH permite-lhe aceder remotamente ao notebook através do protocolo SSH ou SCP",
+  "pci_projects_project_training_notebook_add_select_ssh_default_select": "Inserir a chave pública SSH a utilizar (opcional)",
+  "pci_projects_project_training_notebook_add_select_ssh_name_tips": "Selecionar o nome da chave entre as que estão registadas",
+  "pci_projects_project_training_notebook_add_select_ssh_input_tips": "Conteúdo da chave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_add": "Adicionar uma nova chave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_quantity": "{{ numberOfSshKeys }} / {{ maxSshKeys }} chave(s) SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_legend": "Chave pública SSH",
+  "pci_projects_project_training_notebook_add_select_ssh_delete_message": "Eliminar a chave SSH associada"
+}

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/notebook.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/notebook.constants.js
@@ -22,8 +22,16 @@ export const NOTEBOOK_ATTACH_STORAGE = {
   MAX_VOLUMES: 10,
 };
 
+export const NOTEBOOK_SSH_KEYS = {
+  MAX: 10,
+  CUSTOM_SELECT: '-',
+  PLACEHOLDER: 'ssh-rsa AAAAB3...',
+  NB_ROWS: 5,
+};
+
 export default {
   NOTEBOOK_LABELS,
   NOTEBOOK_PRIVACY_SETTINGS,
   NOTEBOOK_RESOURCES,
+  NOTEBOOK_SSH_KEYS,
 };

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_de_DE.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Ein Notebook erstellen",
   "pci_notebook_add_notebook_create_pending": "Das Notebook wird erstellt...",
   "pci_notebook_add_notebook_create_success": "Ihr Notebook wurde erstellt.",
-  "pci_notebook_add_notebook_create_error": "Bei der Erstellung des Notebooks ist ein Fehler aufgetreten: {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Bei der Erstellung des Notebooks ist ein Fehler aufgetreten: {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Öffentliche SSH-Schlüssel hinzufügen",
+  "pci_notebook_add_ssh_keys_selected": "Hinzugefügte öffentliche SSH-Schlüssel: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_en_GB.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Create a notebook",
   "pci_notebook_add_notebook_create_pending": "Creating notebook...",
   "pci_notebook_add_notebook_create_success": "Your notebook has been created.",
-  "pci_notebook_add_notebook_create_error": "An error has occurred creating the notebook: {{message}}."
+  "pci_notebook_add_notebook_create_error": "An error has occurred creating the notebook: {{message}}.",
+  "pci_notebook_add_ssh_keys": "Attach SSH public keys",
+  "pci_notebook_add_ssh_keys_selected": "Attached SSH public keys: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_es_ES.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Crear un notebook",
   "pci_notebook_add_notebook_create_pending": "Creando el notebook...",
   "pci_notebook_add_notebook_create_success": "Su notebook se ha creado correctamente.",
-  "pci_notebook_add_notebook_create_error": "Error al crear el notebook: {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Error al crear el notebook: {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Asociar claves públicas SSH",
+  "pci_notebook_add_ssh_keys_selected": "Claves públicas SSH asociadas: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_fr_CA.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Créer un notebook",
   "pci_notebook_add_notebook_create_pending": "Le notebook est en cours de creation…",
   "pci_notebook_add_notebook_create_success": "Votre notebook a été créé avec succès.",
-  "pci_notebook_add_notebook_create_error": "Erreur lors de la création du notebook : {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Erreur lors de la création du notebook : {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Attacher des clés publiques ssh",
+  "pci_notebook_add_ssh_keys_selected": "Clés publiques ssh attachées : {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_fr_FR.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Créer un notebook",
   "pci_notebook_add_notebook_create_pending": "Le notebook est en cours de creation…",
   "pci_notebook_add_notebook_create_success": "Votre notebook a été créé avec succès.",
-  "pci_notebook_add_notebook_create_error": "Erreur lors de la création du notebook : {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Erreur lors de la création du notebook : {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Attacher des clés publiques ssh",
+  "pci_notebook_add_ssh_keys_selected": "Clés publiques ssh attachées : {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_it_IT.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Crea un notebook",
   "pci_notebook_add_notebook_create_pending": "Creazione del notebook in corso...",
   "pci_notebook_add_notebook_create_success": "Il notebook è stato creato correttamente.",
-  "pci_notebook_add_notebook_create_error": "Errore durante la creazione del notebook: {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Errore durante la creazione del notebook: {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Associa chiavi pubbliche SSH",
+  "pci_notebook_add_ssh_keys_selected": "Chiavi pubbliche SSH associate: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_pl_PL.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Stwórz notebook",
   "pci_notebook_add_notebook_create_pending": "Trwa tworzenie notebooka...",
   "pci_notebook_add_notebook_create_success": "Twój notebook został utworzony.",
-  "pci_notebook_add_notebook_create_error": "Wystąpił błąd podczas tworzenia notebooka: {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Wystąpił błąd podczas tworzenia notebooka: {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Przypisz publiczne klucze SSH",
+  "pci_notebook_add_ssh_keys_selected": "Przypisane publiczne klucze SSH: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/translations/Messages_pt_PT.json
@@ -24,5 +24,7 @@
   "pci_notebook_add_notebook_create": "Criar um notebook",
   "pci_notebook_add_notebook_create_pending": "O notebook está a ser criado...",
   "pci_notebook_add_notebook_create_success": "O seu notebook foi criado com sucesso.",
-  "pci_notebook_add_notebook_create_error": "Ocorreu um erro aquando da criação do notebook: {{ message }}."
+  "pci_notebook_add_notebook_create_error": "Ocorreu um erro aquando da criação do notebook: {{ message }}.",
+  "pci_notebook_add_ssh_keys": "Associar chaves públicas SSH",
+  "pci_notebook_add_ssh_keys_selected": "Chaves públicas SSH associadas: {{quantity}}"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/general-information.html
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/general-information.html
@@ -34,6 +34,18 @@
                     </oui-tile-description>
                 </oui-tile-definition>
 
+                <!--SSH URL-->
+                <oui-tile-definition
+                    data-term="{{:: 'pci_notebooks_general_information_info_notebook_ssh_url' | translate }}"
+                    ng-if="$ctrl.notebook.status.sshUrl"
+                >
+                    <oui-tile-description>
+                        <oui-clipboard
+                            data-model="$ctrl.notebook.status.sshUrl"
+                        ></oui-clipboard>
+                    </oui-tile-description>
+                </oui-tile-definition>
+
                 <!--Container-->
                 <oui-tile-definition
                     data-term="{{:: 'pci_notebooks_general_information_info_notebook_container' | translate }}"

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_de_DE.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Überwachung des Verbrauchs",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Zugang zu Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Ressourcen",
-  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM pro Ressource"
+  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM pro Ressource",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "SSH Zugang"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_en_GB.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Usage monitoring",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Go to Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Resources",
-  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM per resource"
+  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM per resource",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "SSH access"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_es_ES.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Seguimiento del consumo",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Acceder a Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Recursos",
-  "pci_notebooks_general_information_resources_info": "GPU, CPU y RAM por recurso"
+  "pci_notebooks_general_information_resources_info": "GPU, CPU y RAM por recurso",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Acceso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_fr_CA.json
@@ -2,6 +2,7 @@
   "pci_notebooks_general_information_info_title": "Informations générales",
   "pci_notebooks_general_information_info_notebook_name": "Nom du notebook",
   "pci_notebooks_general_information_info_notebook_editor_code": "Live-code editor",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Accès SSH",
   "pci_notebooks_general_information_info_notebook_container": "Conteneurs attachés",
   "pci_notebooks_general_information_info_notebook_container_total": "{{ xContainer }} conteneur(s)",
   "pci_notebooks_general_information_info_notebook_container_swift_total": "{{ xContainer }} conteneur(s) Swift",

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_fr_FR.json
@@ -2,6 +2,7 @@
   "pci_notebooks_general_information_info_title": "Informations générales",
   "pci_notebooks_general_information_info_notebook_name": "Nom du notebook",
   "pci_notebooks_general_information_info_notebook_editor_code": "Live-code editor",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Accès SSH",
   "pci_notebooks_general_information_info_notebook_container": "Conteneurs attachés",
   "pci_notebooks_general_information_info_notebook_container_total": "{{ xContainer }} conteneur(s)",
   "pci_notebooks_general_information_info_notebook_container_swift_total": "{{ xContainer }} conteneur(s) Swift",

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_it_IT.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Controllo dei consumi",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Accedi a Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Risorse",
-  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM per risorsa"
+  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM per risorsa",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Accesso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_pl_PL.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Monitorowanie zużycia",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Dostęp do Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Zasoby",
-  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM dla zasobu"
+  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM dla zasobu",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Dostęp SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/dashboard/general-information/translations/Messages_pt_PT.json
@@ -37,5 +37,6 @@
   "pci_notebooks_general_information_resources_monitoring": "Seguimento do consumo",
   "pci_notebooks_general_information_resources_monitoring_access_to_graph": "Aceder ao Graph Dashboard",
   "pci_notebooks_general_information_resources_quantity": "Recursos",
-  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM por recurso"
+  "pci_notebooks_general_information_resources_info": "GPU/CPU/RAM por recurso",
+  "pci_notebooks_general_information_info_notebook_ssh_url": "Acesso SSH"
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
@@ -152,6 +152,8 @@ export default class NotebookService {
   }
 
   getSavedSshKeys(serviceName) {
-    return this.$http.get(`/cloud/project/${serviceName}/sshkey`);
+    return this.$http
+      .get(`/cloud/project/${serviceName}/sshkey`)
+      .then(({ data }) => data);
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebooks.service.js
@@ -150,4 +150,8 @@ export default class NotebookService {
       .post(`/cloud/project/${serviceName}/ai/authorization`)
       .then(({ data }) => data);
   }
+
+  getSavedSshKeys(serviceName) {
+    return this.$http.get(`/cloud/project/${serviceName}/sshkey`);
+  }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MLS-2321
| License          | BSD 3-Clause

## Description

On AI Notebooks add the possibility to attach an ssh key when submiting a new notebook

### :flags: Translations

- [x] TRANS-41400
