### PR TITLE
fix PUD-1103 (pci.storage.databases): Fix the polling of users status

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
@@ -1,5 +1,5 @@
 <oui-back-button
-    data-previous-page="{{:: 'pci_projects_project_users_title' | translate }}"
+    data-previous-page="{{:: 'pci_databases_users_title' | translate }}"
     data-on-click="$ctrl.goBack()"
 ></oui-back-button>
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/index.js
@@ -2,24 +2,28 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
-const moduleName = 'ovhManagerPciStoragesDatabaseUsersLazyLoading';
+import '@ovh-ux/manager-core';
 
-angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
-  /* @ngInject */ ($stateProvider) => {
-    $stateProvider.state(
-      'pci.projects.project.storages.databases.dashboard.users.**',
-      {
-        url: '/users',
-        lazyLoad: ($transition$) => {
-          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+const moduleName = 'ovhManagerPciStoragesDatabasesUsersLazyloading';
 
-          return import('./users.module').then((mod) =>
-            $ocLazyLoad.inject(mod.default || mod),
-          );
+angular
+  .module(moduleName, ['ui.router', 'ovhManagerCore', 'oc.lazyLoad'])
+  .config(
+    /* @ngInject */ ($stateProvider) => {
+      $stateProvider.state(
+        'pci.projects.project.storages.databases.dashboard.users.**',
+        {
+          url: '/users',
+          lazyLoad: ($transition$) => {
+            const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+            return import('./users.module').then((mod) =>
+              $ocLazyLoad.inject(mod.default || mod),
+            );
+          },
         },
-      },
-    );
-  },
-);
+      );
+    },
+  );
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_de_DE.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Benutzer und Rollen",
+  "pci_databases_users_username_label": "Benutzername",
+  "pci_databases_users_description_label": "Beschreibung",
+  "pci_databases_users_role_label": "Rollen",
+  "pci_databases_users_createdAt_label": "Erstellungsdatum",
+  "pci_databases_users_status_label": "Status",
+  "pci_databases_users_status_creating": "Wird erstellt",
+  "pci_databases_users_status_ok": "Aktiviert",
+  "pci_databases_users_status_deleting": "Wird gelöscht",
+  "pci_databases_users_status_deleted": "Gelöscht",
+  "pci_databases_users_status_updating": "Wird aktualisiert",
+  "pci_databases_users_status_ready": "Aktiviert",
+  "pci_databases_users_status_error": "Fehler",
+  "pci_databases_users_status_error_inconsistent_spec": "Fehler",
+  "pci_databases_users_status_pending": "Ausstehend",
+  "pci_databases_users_modify_password_action_label": "Passwort neu generieren",
+  "pci_databases_users_show_key_action_label": "Zugriffsschlüssel anzeigen",
+  "pci_databases_users_show_cert_action_label": "Zertifikat anzeigen",
+  "pci_databases_users_show_user_informations_action_label": "Details anzeigen",
+  "pci_databases_users_delete_action_label": "Löschen",
+  "pci_databases_users_add_action_label": "Benutzer hinzufügen"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_en_GB.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Users &amp; Roles",
+  "pci_databases_users_username_label": "Username",
+  "pci_databases_users_description_label": "Description",
+  "pci_databases_users_role_label": "Roles",
+  "pci_databases_users_createdAt_label": "Creation date",
+  "pci_databases_users_status_label": "Status",
+  "pci_databases_users_status_creating": "Creating...",
+  "pci_databases_users_status_ok": "Enabled",
+  "pci_databases_users_status_deleting": "Deleting...",
+  "pci_databases_users_status_deleted": "Deleted",
+  "pci_databases_users_status_updating": "Updating...",
+  "pci_databases_users_status_ready": "Enabled",
+  "pci_databases_users_status_error": "Error",
+  "pci_databases_users_status_error_inconsistent_spec": "Error",
+  "pci_databases_users_status_pending": "Queued",
+  "pci_databases_users_modify_password_action_label": "Reset the password",
+  "pci_databases_users_show_key_action_label": "Show access key",
+  "pci_databases_users_show_cert_action_label": "View certificate",
+  "pci_databases_users_show_user_informations_action_label": "View details",
+  "pci_databases_users_delete_action_label": "Delete",
+  "pci_databases_users_add_action_label": "Add user"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_es_ES.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Usuarios y roles",
+  "pci_databases_users_username_label": "Nombre de usuario",
+  "pci_databases_users_description_label": "Descripción",
+  "pci_databases_users_role_label": "Roles",
+  "pci_databases_users_createdAt_label": "Fecha de creación",
+  "pci_databases_users_status_label": "Estado",
+  "pci_databases_users_status_creating": "Creando...",
+  "pci_databases_users_status_ok": "Activado",
+  "pci_databases_users_status_deleting": "Eliminando...",
+  "pci_databases_users_status_deleted": "Eliminado",
+  "pci_databases_users_status_updating": "Actualizando...",
+  "pci_databases_users_status_ready": "Activado",
+  "pci_databases_users_status_error": "En error",
+  "pci_databases_users_status_error_inconsistent_spec": "En error",
+  "pci_databases_users_status_pending": "Pendiente",
+  "pci_databases_users_modify_password_action_label": "Regenerar la contraseña",
+  "pci_databases_users_show_key_action_label": "Mostrar la clave de acceso",
+  "pci_databases_users_show_cert_action_label": "Mostrar el certificado",
+  "pci_databases_users_show_user_informations_action_label": "Mostrar la información",
+  "pci_databases_users_delete_action_label": "Eliminar",
+  "pci_databases_users_add_action_label": "Añadir un usuario"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_CA.json
@@ -1,0 +1,24 @@
+{
+  "pci_databases_users_title": "Users & Roles",
+  "pci_databases_users_username_label": "Nom d'utilisateur",
+  "pci_databases_users_description_label": "Description",
+  "pci_databases_users_role_label": "Rôles",
+  "pci_databases_users_createdAt_label": "Date de création",
+  "pci_databases_users_status_label": "Statut",
+  "pci_databases_users_status_creating": "Création en cours",
+  "pci_databases_users_status_ok": "Activé",
+  "pci_databases_users_status_deleting": "Suppression en cours",
+  "pci_databases_users_status_deleted": "Supprimé",
+  "pci_databases_users_status_updating": "Mise à jour en cours",
+  "pci_databases_users_status_ready": "Activé",
+  "pci_databases_users_status_error": "En erreur",
+  "pci_databases_users_status_error_inconsistent_spec": "En erreur",
+  "pci_databases_users_status_pending": "En attente",
+
+  "pci_databases_users_modify_password_action_label": "Régénérer le mot de passe",
+  "pci_databases_users_show_key_action_label": "Afficher la clé d'accès",
+  "pci_databases_users_show_cert_action_label": "Afficher le certificat",
+  "pci_databases_users_show_user_informations_action_label": "Afficher les informations",
+  "pci_databases_users_delete_action_label": "Supprimer",
+  "pci_databases_users_add_action_label": "Ajouter un utilisateur"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
@@ -19,10 +19,6 @@
   "pci_databases_users_show_key_action_label": "Afficher la clé d'accès",
   "pci_databases_users_show_cert_action_label": "Afficher le certificat",
   "pci_databases_users_show_user_informations_action_label": "Afficher les informations",
-
-  "pci_databases_users_password_message_infos": "Le nouveau mot de passe de l'utilisateur {{ user }} est <code>{{ password }}</code>.",
-  "pci_databases_users_password_message_success": "Le mot de passe de l'utilisateur {{ user }} a été regénéré.",
-  "pci_databases_users_password_message_error": "Une erreur est survenue lors de la génération du mot de passe de l'utilisateur {{ user }} : {{ message }}.",
   "pci_databases_users_delete_action_label": "Supprimer",
   "pci_databases_users_add_action_label": "Ajouter un utilisateur"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
@@ -1,0 +1,28 @@
+{
+  "pci_databases_users_title": "Users & Roles",
+  "pci_databases_users_username_label": "Nom d'utilisateur",
+  "pci_databases_users_description_label": "Description",
+  "pci_databases_users_role_label": "Rôles",
+  "pci_databases_users_createdAt_label": "Date de création",
+  "pci_databases_users_status_label": "Status",
+  "pci_databases_users_status_creating": "Création en cours",
+  "pci_databases_users_status_ok": "Activé",
+  "pci_databases_users_status_deleting": "Suppression en cours",
+  "pci_databases_users_status_deleted": "Supprimé",
+  "pci_databases_users_status_updating": "Mise à jour en cours",
+  "pci_databases_users_status_ready": "Activé",
+  "pci_databases_users_status_error": "En erreur",
+  "pci_databases_users_status_error_inconsistent_spec": "En erreur",
+  "pci_databases_users_status_pending": "En attente",
+
+  "pci_databases_users_modify_password_action_label": "Régénérer le mot de passe",
+  "pci_databases_users_show_key_action_label": "Afficher la clé d'accès",
+  "pci_databases_users_show_cert_action_label": "Afficher le certificat",
+  "pci_databases_users_show_user_informations_action_label": "Afficher les informations",
+
+  "pci_databases_users_password_message_infos": "Le nouveau mot de passe de l'utilisateur {{ user }} est <code>{{ password }}</code>.",
+  "pci_databases_users_password_message_success": "Le mot de passe de l'utilisateur {{ user }} a été regénéré.",
+  "pci_databases_users_password_message_error": "Une erreur est survenue lors de la génération du mot de passe de l'utilisateur {{ user }} : {{ message }}.",
+  "pci_databases_users_delete_action_label": "Supprimer",
+  "pci_databases_users_add_action_label": "Ajouter un utilisateur"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_fr_FR.json
@@ -4,7 +4,7 @@
   "pci_databases_users_description_label": "Description",
   "pci_databases_users_role_label": "Rôles",
   "pci_databases_users_createdAt_label": "Date de création",
-  "pci_databases_users_status_label": "Status",
+  "pci_databases_users_status_label": "Statut",
   "pci_databases_users_status_creating": "Création en cours",
   "pci_databases_users_status_ok": "Activé",
   "pci_databases_users_status_deleting": "Suppression en cours",

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_it_IT.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Utenti e ruoli",
+  "pci_databases_users_username_label": "Nome utente",
+  "pci_databases_users_description_label": "Descrizione",
+  "pci_databases_users_role_label": "Ruoli",
+  "pci_databases_users_createdAt_label": "Data di creazione",
+  "pci_databases_users_status_label": "Stato",
+  "pci_databases_users_status_creating": "Creazione in corso...",
+  "pci_databases_users_status_ok": "Attivato",
+  "pci_databases_users_status_deleting": "Eliminazione in corso...",
+  "pci_databases_users_status_deleted": "Eliminato ",
+  "pci_databases_users_status_updating": "Aggiornamento in corso...",
+  "pci_databases_users_status_ready": "Attivato",
+  "pci_databases_users_status_error": "In errore",
+  "pci_databases_users_status_error_inconsistent_spec": "In errore",
+  "pci_databases_users_status_pending": "In attesa",
+  "pci_databases_users_modify_password_action_label": "Rigenera la password",
+  "pci_databases_users_show_key_action_label": "Mostra la chiave di accesso",
+  "pci_databases_users_show_cert_action_label": "Visualizza il certificato",
+  "pci_databases_users_show_user_informations_action_label": "Mostra le informazioni",
+  "pci_databases_users_delete_action_label": "Elimina",
+  "pci_databases_users_add_action_label": "Aggiungi un utente"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_pl_PL.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Użytkownicy &amp; Role",
+  "pci_databases_users_username_label": "Nazwa użytkownika",
+  "pci_databases_users_description_label": "Opis",
+  "pci_databases_users_role_label": "Role",
+  "pci_databases_users_createdAt_label": "Data utworzenia",
+  "pci_databases_users_status_label": "Status",
+  "pci_databases_users_status_creating": "Trwa tworzenie",
+  "pci_databases_users_status_ok": "Aktywny",
+  "pci_databases_users_status_deleting": "Trwa usuwanie",
+  "pci_databases_users_status_deleted": "Usunięty",
+  "pci_databases_users_status_updating": "Trwa aktualizacja",
+  "pci_databases_users_status_ready": "Aktywny",
+  "pci_databases_users_status_error": "Błąd",
+  "pci_databases_users_status_error_inconsistent_spec": "Błąd",
+  "pci_databases_users_status_pending": "Oczekujące",
+  "pci_databases_users_modify_password_action_label": "Wygeneruj ponownie hasło",
+  "pci_databases_users_show_key_action_label": "Wyświetl klucz dostępu",
+  "pci_databases_users_show_cert_action_label": "Wyświetl certyfikat",
+  "pci_databases_users_show_user_informations_action_label": "Wyświetl informacje",
+  "pci_databases_users_delete_action_label": "Usuń",
+  "pci_databases_users_add_action_label": "Dodaj użytkownika"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/translations/Messages_pt_PT.json
@@ -1,0 +1,23 @@
+{
+  "pci_databases_users_title": "Utilizadores e funções",
+  "pci_databases_users_username_label": "Nome do utilizador",
+  "pci_databases_users_description_label": "Descrição",
+  "pci_databases_users_role_label": "Funções",
+  "pci_databases_users_createdAt_label": "Data de criação",
+  "pci_databases_users_status_label": "Estado",
+  "pci_databases_users_status_creating": "Criação em curso",
+  "pci_databases_users_status_ok": "Ativado",
+  "pci_databases_users_status_deleting": "Eliminação em curso",
+  "pci_databases_users_status_deleted": "Eliminado",
+  "pci_databases_users_status_updating": "Atualização em curso",
+  "pci_databases_users_status_ready": "Ativado",
+  "pci_databases_users_status_error": "Erro",
+  "pci_databases_users_status_error_inconsistent_spec": "Erro",
+  "pci_databases_users_status_pending": "Em espera",
+  "pci_databases_users_modify_password_action_label": "Gerar nova palavra-passe",
+  "pci_databases_users_show_key_action_label": "Mostrar a chave de acesso",
+  "pci_databases_users_show_cert_action_label": "Mostrar o certificado",
+  "pci_databases_users_show_user_informations_action_label": "Apresentar as informações",
+  "pci_databases_users_delete_action_label": "Eliminar",
+  "pci_databases_users_add_action_label": "Adicionar um utilizador"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.component.js
@@ -13,6 +13,8 @@ export default {
     goToShowKey: '<',
     goToShowCert: '<',
     users: '<',
+    stopPollingUsersStatus: '<',
+    stopPollingDatabaseStatus: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.component.js
@@ -1,0 +1,19 @@
+import controller from './users.controller';
+import template from './users.html';
+
+export default {
+  bindings: {
+    projectId: '<',
+    database: '<',
+    trackDashboard: '<',
+    goToAddUser: '<',
+    goToDeleteUser: '<',
+    goToModifyPassword: '<',
+    goToUserInformations: '<',
+    goToShowKey: '<',
+    goToShowCert: '<',
+    users: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.controller.js
@@ -1,0 +1,70 @@
+import some from 'lodash/some';
+import isFeatureActivated from '../../features.constants';
+
+export default class UsersCtrl {
+  /* @ngInject */
+  constructor($translate, CucCloudMessage) {
+    this.CucCloudMessage = CucCloudMessage;
+    this.$translate = $translate;
+  }
+
+  $onInit() {
+    this.messageContainer =
+      'pci.projects.project.storages.databases.dashboard.users';
+    this.loadMessages();
+    this.trackDashboard('users', 'page');
+    this.isRolesAvailable = some(this.users, (user) => !!user.roles);
+    this.showCertOption = isFeatureActivated('showCert', this.database.engine);
+    this.showKeyOption = isFeatureActivated('showKey', this.database.engine);
+    this.showUserInformationOption = isFeatureActivated(
+      'showUserInformations',
+      this.database.engine,
+    );
+  }
+
+  loadMessages() {
+    this.CucCloudMessage.unSubscribe(this.messageContainer);
+    this.messageHandler = this.CucCloudMessage.subscribe(
+      this.messageContainer,
+      { onMessage: () => this.refreshMessages() },
+    );
+  }
+
+  refreshMessages() {
+    this.messages = this.messageHandler.getMessages();
+  }
+
+  trackAndAddUser() {
+    this.trackDashboard('users::add_a_user');
+    this.goToAddUser();
+  }
+
+  trackAndDeleteUser(user) {
+    this.trackDashboard('users::options_menu::delete_user');
+    this.goToDeleteUser(user);
+  }
+
+  trackAndModifyPassword(user) {
+    this.trackDashboard('users::options_menu::modify_password');
+    this.goToModifyPassword(user);
+  }
+
+  trackAndShowKey(user) {
+    this.trackDashboard('users::options_menu::show_key');
+    this.goToShowKey(user);
+  }
+
+  trackAndShowCert(user) {
+    this.trackDashboard('users::options_menu::delete_user');
+    this.goToShowCert(user);
+  }
+
+  trackAndShowUserInformations(user) {
+    this.trackDashboard('users::options_menu::delete_user');
+    this.goToUserInformations(user);
+  }
+
+  isDisabledOrPending($row) {
+    return $row.isProcessing() || this.database.isProcessing();
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.controller.js
@@ -67,4 +67,9 @@ export default class UsersCtrl {
   isDisabledOrPending($row) {
     return $row.isProcessing() || this.database.isProcessing();
   }
+
+  $onDestroy() {
+    this.stopPollingUsersStatus();
+    this.stopPollingDatabaseStatus();
+  }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.html
@@ -108,7 +108,10 @@
                 data-disabled="$ctrl.database.isProcessing()"
                 data-on-click="$ctrl.trackAndAddUser()"
             >
-                <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
+                <span
+                    class="oui-icon oui-icon-add pr-1"
+                    aria-hidden="true"
+                ></span>
                 <span
                     data-translate="pci_databases_users_add_action_label"
                 ></span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.html
@@ -1,0 +1,118 @@
+<div class="container-fluid px-0 mt-3" data-ui-view>
+    <!-- error messages -->
+    <cui-message-container
+        data-messages="$ctrl.messages"
+    ></cui-message-container>
+
+    <h2 data-translate="pci_databases_users_title"></h2>
+
+    <oui-datagrid
+        data-rows="$ctrl.users"
+        data-columns-parameters="[
+        {
+            name: 'roles',
+            hidden: !$ctrl.isRolesAvailable
+        }]"
+    >
+        <oui-datagrid-column
+            title=":: 'pci_databases_users_username_label' | translate"
+            data-property="username"
+            data-type="string"
+            data-searchable
+            data-filterable
+            data-sortable="asc"
+        >
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-title=":: 'pci_databases_users_role_label' | translate"
+            data-property="roles"
+        >
+            <span
+                class="d-block"
+                data-ng-repeat="role in $row.roles track by role.id"
+                data-ng-bind="::role.description || role.name"
+            ></span>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-title=":: 'pci_databases_users_createdAt_label' | translate"
+            data-property="createdAt"
+            data-sortable
+        >
+            <span data-ng-bind="$row.createdAt | date: 'medium'"></span>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-title=":: 'pci_databases_users_status_label' | translate"
+            data-property="status"
+        >
+            <span
+                class="oui-badge"
+                data-ng-class="{
+                    'oui-badge_success': !$row.isProcessing(),
+                    'oui-badge_warning': $row.isProcessing(),
+                }"
+            >
+                <span
+                    data-ng-bind=":: 'pci_databases_users_status_' + $row.status.toLowerCase() | translate"
+                ></span>
+            </span>
+        </oui-datagrid-column>
+
+        <oui-action-menu data-compact data-placement="end">
+            <oui-action-menu-item
+                data-ng-if="$ctrl.showUserInformationOption"
+                data-disabled="$ctrl.isDisabledOrPending($row)"
+                data-on-click="$ctrl.trackAndShowUserInformations($row)"
+            >
+                <span
+                    data-translate="pci_databases_users_show_user_informations_action_label"
+                ></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item
+                data-ng-if="$ctrl.showCertOption"
+                data-disabled="$ctrl.isDisabledOrPending($row)"
+                data-on-click="$ctrl.trackAndShowCert($row)"
+            >
+                <span
+                    data-translate="pci_databases_users_show_cert_action_label"
+                ></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item
+                data-ng-if="$ctrl.showKeyOption"
+                data-disabled="$ctrl.isDisabledOrPending($row)"
+                data-on-click="$ctrl.trackAndShowKey($row)"
+            >
+                <span
+                    data-translate="pci_databases_users_show_key_action_label"
+                ></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item
+                data-on-click="$ctrl.trackAndModifyPassword($row)"
+                data-disabled="$ctrl.isDisabledOrPending($row)"
+            >
+                <span
+                    data-translate="pci_databases_users_modify_password_action_label"
+                ></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item
+                data-on-click="$ctrl.trackAndDeleteUser($row)"
+                data-disabled="$ctrl.isDisabledOrPending($row)"
+            >
+                <span
+                    data-translate="pci_databases_users_delete_action_label"
+                ></span>
+            </oui-action-menu-item>
+        </oui-action-menu>
+
+        <oui-datagrid-topbar>
+            <oui-button
+                data-disabled="$ctrl.database.isProcessing()"
+                data-on-click="$ctrl.trackAndAddUser()"
+            >
+                <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
+                <span
+                    data-translate="pci_databases_users_add_action_label"
+                ></span>
+            </oui-button>
+        </oui-datagrid-topbar>
+    </oui-datagrid>
+</div>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.module.js
@@ -1,31 +1,30 @@
 import angular from 'angular';
-import '@uirouter/angularjs';
-import '@ovh-ux/ng-translate-async-loader';
-import 'angular-translate';
 
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@ovh-ux/ui-kit';
+
+import component from './users.component';
+import routing from './users.routing';
 import addUser from './add';
 import deleteUser from './delete';
+import informations from './informations';
 import modifyPassword from './modify-password';
 import showSecret from './show-secret';
-import informations from './informations';
-import routing from './users.routing';
-import users from '../../../../../../components/project/users';
 
-const moduleName = 'ovhManagerPciStoragesDatabaseUsers';
+const moduleName = 'ovhManagerPciStoragesDatabasesUsers';
 
 angular
   .module(moduleName, [
-    'ngTranslateAsyncLoader',
-    'pascalprecht.translate',
-    'ovh-api-services',
-    'ui.router',
+    'ngOvhCloudUniverseComponents',
+    'oui',
     addUser,
     deleteUser,
-    modifyPassword,
-    users,
-    showSecret,
     informations,
+    modifyPassword,
+    showSecret,
   ])
-  .config(routing);
+  .config(routing)
+  .component('ovhManagerPciStoragesDatabaseUsersComponent', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/users.routing.js
@@ -141,6 +141,21 @@ export default /* @ngInject */ ($stateProvider) => {
           }
           return promise;
         },
+        stopPollingUsersStatus: /* @ngInject */ (
+          DatabaseService,
+          databaseId,
+          users,
+        ) => () => {
+          users.forEach((user) =>
+            DatabaseService.stopPollingUserStatus(databaseId, user.id),
+          );
+        },
+        stopPollingDatabaseStatus: /* @ngInject */ (
+          DatabaseService,
+          databaseId,
+        ) => () => {
+          DatabaseService.stopPollingDatabaseStatus(databaseId);
+        },
       },
       atInternet: {
         ignore: true,


### PR DESCRIPTION
PUD-1103

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1103
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix the polling of users status on databases tab "users", use specific database tracking

### :flags: Translations

- [x] TRANS-40387
