### PR TITLE
fix(web.domain, dedicated.services): all-dom termination enhancements

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_FR.json
@@ -839,6 +839,6 @@
   "domain_dashboard_general_information_domain_terminated": "Résiliation demandée",
   "domain_dashboard_general_information_domain_automatic_renewal": "Renouvellement automatique",
   "domain_dashboard_general_information_alldom_termination_info": "Votre pack expirera le {{ expirationDate }}. Les domaines non résiliés inclus dans celui-ci seront <strong>renouvelés gratuitement jusqu’à l’expiration définitive de votre pack.</strong> Au-delà de cette date, vos domaines non résiliés seront facturés individuellement.",
-  "domain_dashboard_general_information_alldom_renewal_link": "Renouveler mon pack",
+  "domain_dashboard_general_information_alldom_renewal_link": "Annuler la résiliation du pack",
   "domain_dashboard_general_information_alldom_termination_warning_close": "fermer"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -8,7 +8,7 @@
     >
         <div
             data-translate="domain_dashboard_general_information_alldom_termination_info"
-            data-translate-values="{'expirationDate': ($ctrl.allDomInfos.expiration | date:'longDate') }"
+            data-translate-values="{'expirationDate': '<strong>' + ($ctrl.allDomInfos.expiration | date:'longDate') + '</strong>' }"
         ></div>
         <a href="{{ ::$ctrl.actions.manageAlldom.href }}">
             <span

--- a/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/autoRenew/actions/terminate-all-dom/translations/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "autorenew_all_dom_terminate_title": "Vous avez demandé la résiliation de votre pack alldom",
   "autorenew_all_dom_terminate_effect_on_domains": "Attention, la résiliation de ce pack n'entraîne pas la résiliation des domaines qui y sont attachés.",
-  "autorenew_all_dom_terminate_domain_renewal_info": "Les domaines non résiliés inclus dans votre pack seront renouvelés gratuitment jusqu'a l'expiration definitive de votre pack.",
+  "autorenew_all_dom_terminate_domain_renewal_info": "Les domaines non résiliés inclus dans votre pack seront renouvelés gratuitment jusqu'a l'expiration definitive de votre pack. Au-delà de cette date, vos domaines non résiliés seront facturés individuellement.",
   "autorenew_all_dom_terminate_choose_option": "Veuillez sélectionner les noms de domaines que vous souhaitez résilier ci-dessous :",
   "autorenew_all_dom_terminate_select_all_dom": "Pack Alldom",
   "autorenew_all_dom_terminate_select_all_domains": "Tout sélectionner",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-7596`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix [#MANAGER-8280](https://projects.dsi.ovh/browse/MANAGER-8280), [#MANAGER-8304](https://projects.dsi.ovh/browse/MANAGER-8304), [#MANAGER-8305](https://projects.dsi.ovh/browse/MANAGER-8305)
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

1. Change of display text for 'Cancel All dom termination' link
2. Addition of individual domain renewal info in the warning banner while All dom termination
3. Highlighting the expiration date of All dom pack in the warning banner in domain page

## Related

<!-- Link dependencies of this PR -->
