### PR TITLE
fix PUD-1134 (pci.storage.databases): correctly download certificate and key for Kafka users

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/show-secret/show-secret.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/show-secret/show-secret.controller.js
@@ -14,7 +14,7 @@ export default class {
   downloadSecret() {
     this.trackDashboard(`users::show_secret::download_${this.type.label}`);
     this.CucControllerHelper.constructor.downloadContent({
-      fileContent: this.secretKeyAndAccess[this.type],
+      fileContent: this.secretKeyAndAccess[this.type.label],
       fileName: this.type.filename,
     });
   }


### PR DESCRIPTION
PUD-1134

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1134
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix the content of key/certificate files for Kafka users.