### PR TITLE
fix(web.domain): display domain status in single line

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -1,4 +1,4 @@
-<div ui-view>
+<div ui-view class="general-information">
     <div data-ovh-alert="{{alerts.main}}"></div>
     <oui-message
         type="warning"
@@ -44,7 +44,7 @@
                             >
                                 <span data-ng-bind="::allDomDomain.name"></span>
                                 <span
-                                    class="oui-badge {{::!allDomDomain.isTerminated ? 'oui-badge_success' : 'oui-badge_error'}}"
+                                    class="oui-badge domain-status-tag {{::!allDomDomain.isTerminated ? 'oui-badge_success' : 'oui-badge_error'}}"
                                     data-ng-bind="::(!allDomDomain.isTerminated ? 'domain_dashboard_general_information_domain_automatic_renewal' : 'domain_dashboard_general_information_domain_terminated') | translate"
                                 ></span>
                             </li>

--- a/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.state.js
+++ b/packages/manager/apps/web/client/app/domain/general-informations/domain-general-informations.state.js
@@ -1,6 +1,8 @@
 import isEmpty from 'lodash/isEmpty';
 import template from './GENERAL_INFORMATIONS.html';
 
+import './general-information.styles.scss';
+
 const commonResolves = {
   availableOptions: /* @ngInject */ (
     $q,

--- a/packages/manager/apps/web/client/app/domain/general-informations/general-information.styles.scss
+++ b/packages/manager/apps/web/client/app/domain/general-informations/general-information.styles.scss
@@ -1,0 +1,5 @@
+.general-information {
+  .domain-status-tag {
+    word-break: normal;
+  }
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-7596`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8323
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Fix to display the domain status in single line

## Related

<!-- Link dependencies of this PR -->
