### PR TITLE
fix(web.domain): display propagation info on non-dismissable banner

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dns/DNS.html
+++ b/packages/manager/apps/web/client/app/domain/dns/DNS.html
@@ -7,6 +7,12 @@
         <div class="col-md-9">
             <div data-ovh-alert="{{alerts.main}}"></div>
 
+            <oui-message
+                type="success"
+                data-ng-if="$ctrl.displayPropagationInfo"
+            >
+                <span data-translate="domain_tab_DNS_update_success"></span>
+            </oui-message>
             <div
                 class="alert alert-danger"
                 role="alert"

--- a/packages/manager/apps/web/client/app/domain/dns/domain-dns.controller.js
+++ b/packages/manager/apps/web/client/app/domain/dns/domain-dns.controller.js
@@ -100,7 +100,7 @@ export default class DomainDnsCtrl {
           isUsed: true,
           toDelete: false,
         }).length;
-        this.displayPropogationInfo(tabDns.dns);
+        this.checkPendingPropagation(tabDns.dns);
         return this.$q.all(
           map(tabDns.dns, (nameServer) =>
             this.Domain.getNameServerStatus(
@@ -239,14 +239,9 @@ export default class DomainDnsCtrl {
     this.editMode = false;
   }
 
-  displayPropogationInfo(dnsServers) {
-    if (dnsServers.some((server) => server.toDelete || !server.isUsed)) {
-      this.Alerter.success(
-        this.$translate.instant('domain_tab_DNS_update_success'),
-        this.$scope.alerts.main,
-      );
-    } else {
-      this.Alerter.resetMessage(this.$scope.alerts.main);
-    }
+  checkPendingPropagation(dnsServers) {
+    this.displayPropagationInfo = dnsServers.some(
+      (server) => server.toDelete || !server.isUsed,
+    );
   }
 }


### PR DESCRIPTION
 | Question         | Answer
| ---------------- | ---
| Branch?          |  `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8259
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Displaying propagation info on non-dismissable banner in DNS Server page

## Related

<!-- Link dependencies of this PR -->
