### PR TITLE
feat(overthebox.details): display service id into infos

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -385,7 +385,7 @@
                             >
                             </strong>
                             <oui-tile-button
-                                data-ng-href="{{:: $ctrl.guidesLink }}"
+                                data-href="{{:: $ctrl.guidesLink }}"
                                 external
                             >
                                 <span

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -138,6 +138,21 @@
                     <div class="oui-tile__item">
                         <div class="oui-tile__definition">
                             <strong
+                                class="oui-tile__term d-block"
+                                data-translate="overTheBox_serviceId"
+                            ></strong>
+                            <div class="oui-tile__description">
+                                <span
+                                    class="d-block mb-2"
+                                    data-ng-bind="$ctrl.serviceName"
+                                >
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="oui-tile__item">
+                        <div class="oui-tile__definition">
+                            <strong
                                 class="oui-tile__term"
                                 data-ng-class="{ 'text-warning': !$ctrl.device.deviceId }"
                             >
@@ -367,10 +382,18 @@
                     </div>
                     <div class="oui-tile__definition">
                         <div class="oui-tile__definition">
-                            <strong class="oui-tile__term d-block" data-translate="overthebox_detail_links">
+                            <strong
+                                class="oui-tile__term d-block"
+                                data-translate="overthebox_detail_links"
+                            >
                             </strong>
-                            <oui-tile-button data-ng-href="{{:: $ctrl.guidesLink }}" external>
-                                <span data-translate="overTheBox_detail_link_guide"></span>
+                            <oui-tile-button
+                                data-ng-href="{{:: $ctrl.guidesLink }}"
+                                external
+                            >
+                                <span
+                                    data-translate="overTheBox_detail_link_guide"
+                                ></span>
                             </oui-tile-button>
                         </div>
                     </div>

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -141,13 +141,10 @@
                                 class="oui-tile__term d-block"
                                 data-translate="overTheBox_serviceId"
                             ></strong>
-                            <div class="oui-tile__description">
-                                <span
-                                    class="d-block mb-2"
-                                    data-ng-bind="$ctrl.serviceName"
-                                >
-                                </span>
-                            </div>
+                            <div
+                                class="oui-tile__description d-block mb-2"
+                                data-ng-bind="$ctrl.serviceName"
+                            ></div>
                         </div>
                     </div>
                     <div class="oui-tile__item">

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -139,7 +139,7 @@
                         <div class="oui-tile__definition">
                             <strong
                                 class="oui-tile__term d-block"
-                                data-translate="overTheBox_serviceId"
+                                data-translate="overTheBox_service_id"
                             ></strong>
                             <div
                                 class="oui-tile__description d-block mb-2"

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -85,5 +85,5 @@
   "overTheBox_reverse_dns": "Reverse DNS",
   "overTheBox_detail_link_guide": "Guides",
   "overthebox_detail_links": "Liens",
-  "overTheBox_serviceId": "Identifiant du service :"
+  "overTheBox_service_id": "Identifiant du service :"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -84,5 +84,6 @@
   "overTheBox_last_seen_minutes_ago": "Il y a {{lastSeenDiff}} environ",
   "overTheBox_reverse_dns": "Reverse DNS",
   "overTheBox_detail_link_guide": "Guides",
-  "overthebox_detail_links": "Liens"
+  "overthebox_detail_links": "Liens",
+  "overTheBox_serviceId": "Identifiant du service :"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-429
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Into detail information, display service id with a label to be more clear for customer


