### PR TITLE
ci(workflows): use `actions/setup-node@v2` for publishing gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
       - name: Install


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~ (not applicable)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Support LTS Node.js v16.

### :green_circle: Continuous Integration

e6b3b7d - ci(workflows): use `actions/setup-node@v2` for publishing gh-pages

see: https://github.com/actions/setup-node/releases/tag/v2.2.0

## Related

- #5985

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
