### PR TITLE
fix PUD-1111 (pci.storage.databases):  add tooltip for default db suppression action

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/databases.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/databases.html
@@ -19,12 +19,21 @@
             data-searchable
             data-filterable
         ></oui-datagrid-column>
-        <oui-action-menu
-            data-compact
-            data-placement="end"
-            ng-if="!$row.default"
-        >
-            <oui-action-menu-item data-on-click="$ctrl.deleteDatabase($row)">
+        <oui-action-menu data-compact data-placement="end">
+            <oui-action-menu-item
+                disabled
+                oui-tooltip
+                title="{{:: 'pci_databases_databases_tab_delete_defaultdb' | translate}}"
+                ng-if="$row.default"
+            >
+                <span
+                    data-translate="pci_databases_databases_tab_delete_link"
+                ></span>
+            </oui-action-menu-item>
+            <oui-action-menu-item
+                data-on-click="$ctrl.deleteDatabase($row)"
+                ng-if="!$row.default"
+            >
                 <span
                     data-translate="pci_databases_databases_tab_delete_link"
                 ></span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_de_DE.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Datenbanken",
   "pci_databases_databases_tab_name": "Name",
   "pci_databases_databases_tab_add": "Datenbank erstellen",
-  "pci_databases_databases_tab_delete_link": "Löschen"
+  "pci_databases_databases_tab_delete_link": "Löschen",
+  "pci_databases_databases_tab_delete_defaultdb": "Die Standarddatenbank kann nicht gelöscht werden."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_en_GB.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Databases",
   "pci_databases_databases_tab_name": "Name",
   "pci_databases_databases_tab_add": "Create a database",
-  "pci_databases_databases_tab_delete_link": "Delete"
+  "pci_databases_databases_tab_delete_link": "Delete",
+  "pci_databases_databases_tab_delete_defaultdb": "You cannot delete the default database."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_es_ES.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Bases de datos",
   "pci_databases_databases_tab_name": "Nombre",
   "pci_databases_databases_tab_add": "Crear una base de datos",
-  "pci_databases_databases_tab_delete_link": "Eliminar"
+  "pci_databases_databases_tab_delete_link": "Eliminar",
+  "pci_databases_databases_tab_delete_defaultdb": "No es posible eliminar la base de datos por defecto."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_fr_CA.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Bases de données",
   "pci_databases_databases_tab_name": "Nom",
   "pci_databases_databases_tab_add": "Créer une base de données",
-  "pci_databases_databases_tab_delete_link": "Supprimer"
+  "pci_databases_databases_tab_delete_link": "Supprimer",
+  "pci_databases_databases_tab_delete_defaultdb": "Vous ne pouvez pas supprimer la base de données par défaut."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_fr_FR.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Bases de données",
   "pci_databases_databases_tab_name": "Nom",
   "pci_databases_databases_tab_add": "Créer une base de données",
-  "pci_databases_databases_tab_delete_link": "Supprimer"
+  "pci_databases_databases_tab_delete_link": "Supprimer",
+  "pci_databases_databases_tab_delete_defaultdb": "Vous ne pouvez pas supprimer la base de données par défaut."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_it_IT.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Database",
   "pci_databases_databases_tab_name": "Nome",
   "pci_databases_databases_tab_add": "Crea un database",
-  "pci_databases_databases_tab_delete_link": "Elimina"
+  "pci_databases_databases_tab_delete_link": "Elimina",
+  "pci_databases_databases_tab_delete_defaultdb": "Non è possibile eliminare il database predefinito."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_pl_PL.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Bazy danych",
   "pci_databases_databases_tab_name": "Nazwa",
   "pci_databases_databases_tab_add": "Utwórz bazę danych",
-  "pci_databases_databases_tab_delete_link": "Usuń"
+  "pci_databases_databases_tab_delete_link": "Usuń",
+  "pci_databases_databases_tab_delete_defaultdb": "Nie można usunąć domyślnej bazy danych."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/translations/Messages_pt_PT.json
@@ -2,5 +2,6 @@
   "pci_databases_databases_tab_title": "Bases de dados",
   "pci_databases_databases_tab_name": "Nome",
   "pci_databases_databases_tab_add": "Criar uma base de dados",
-  "pci_databases_databases_tab_delete_link": "Eliminar"
+  "pci_databases_databases_tab_delete_link": "Eliminar",
+  "pci_databases_databases_tab_delete_defaultdb": "Não é possível eliminar a base de dados predefinida."
 }


### PR DESCRIPTION
PUD-1111

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1111
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Add a tooltip on the disabled suppress action for the default database

### :flags: Translations

- [x] TRANS-40432