### PR TITLE
fix(sign-up): send ovh subsidiary on first call on /rules

### DIFF
--- a/packages/manager/modules/sign-up/src/form/form.controller.js
+++ b/packages/manager/modules/sign-up/src/form/form.controller.js
@@ -76,6 +76,7 @@ export default class SignUpFormCtrl {
     const ruleParams = merge(
       {
         action: this.action,
+        ovhSubsidiary: SignUpFormCtrl.getOvhSubsidiaryFromUrl(),
       },
       this.model,
     );
@@ -133,6 +134,23 @@ export default class SignUpFormCtrl {
 
         return error;
       });
+  }
+
+  /**
+   * Get ovhSubsidiary value from which account must be created, from signup url
+   * @return {String} ovhSubsidiary
+   */
+  static getOvhSubsidiaryFromUrl() {
+    const ovhSubsidiaryUrlParameter = window.location.hash
+      ?.substring(1)
+      .split('&')
+      .find((parameter) => {
+        const [key] = parameter.split('=');
+
+        return key === 'ovhSubsidiary';
+      });
+
+    return ovhSubsidiaryUrlParameter?.split('=')[1];
   }
 
   /**


### PR DESCRIPTION
ref: DTRSD-61671

Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-61671
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Sending ovhSubsidiary on step 2 loading.
This will directly populate the corresponding country and language on Account creation form step 2.
