### PR TITLE
feat(netapp): gray snap btn if we have only default snap rule

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
@@ -94,7 +94,8 @@
             policies="$ctrl.snapshotPolicies"
             selected="$ctrl.policyId"
         ></snapshot-policies>
-        <oui-button variant="primary" on-click="$ctrl.changePolicy()">
+        <oui-button data-disabled="$ctrl.snapshotPolicies.length === 1" variant="primary"
+                    on-click="$ctrl.changePolicy()">
             <span
                 data-translate="netapp_volumes_snapshots_policies_apply"
             ></span>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-8208`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8224
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
If customer has only the default snap policy rule, we have to gray the apply snapshot policy btn.

## Related

- [ ] TRANS-xxxx