### PR TITLE
fix(netapp): use cucBytes to get right value and unit

### DIFF
--- a/packages/manager/apps/netapp/package.json
+++ b/packages/manager/apps/netapp/package.json
@@ -30,6 +30,7 @@
     "@ovh-ux/manager-netapp": "^0.0.0 || ^1.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
     "@ovh-ux/manager-preloader": "^1.1.0",
+    "@ovh-ux/manager-filters": "^0.1.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.10",

--- a/packages/manager/modules/netapp/package.json
+++ b/packages/manager/modules/netapp/package.json
@@ -25,6 +25,7 @@
     "@ovh-ux/manager-core": "^11.0.0",
     "@ovh-ux/manager-models": "^1.11.1",
     "@ovh-ux/manager-ng-layout-helpers": "^2.0.0",
+    "@ovh-ux/manager-filters": "^0.1.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",

--- a/packages/manager/modules/netapp/src/dashboard/module.js
+++ b/packages/manager/modules/netapp/src/dashboard/module.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import '@ovh-ux/manager-core';
+import '@ovh-ux/manager-filters';
 import '@uirouter/angularjs';
 import 'angular-translate';
 import '@ovh-ux/ng-ovh-utils';
@@ -21,6 +22,7 @@ angular
     'ngOvhFeatureFlipping',
     'ovhManagerBilling',
     'ovhManagerCore',
+    'ovhManagerFilters',
     'ovhManagerAdvices',
     'ngAtInternet',
     'pascalprecht.translate',

--- a/packages/manager/modules/netapp/src/dashboard/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/template.html
@@ -59,7 +59,7 @@
                     </oui-tile-definition>
                     <oui-tile-definition
                         term="{{:: 'netapp_dashboard_information_quota' | translate }}"
-                        description="{{ 'netapp_dashboard_information_quota_formatted' | translate:{quota: $ctrl.storage.quota } }}"
+                        description="{{ $ctrl.storage.quota | bytes:'GB':false:0 }}"
                     >
                     </oui-tile-definition>
                 </oui-tile>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-8208`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-7916
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
Use bytes filter to convert storage capacity to right unit value
