### PR TITLE
feat PUD-1153 (pci.storage.databases):  add input rules visualisation for add, fork and edit pages

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.constants.js
@@ -1,4 +1,4 @@
-export const NAME_PATTERN = /^([a-zA-Z0-9_.-]{3,40})$/;
+export const NAME_PATTERN = /^([a-zA-Z0-9_.-]*)$/;
 export const MIN_NAME_LENGTH = 3;
 export const MAX_NAME_LENGTH = 40;
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.constants.js
@@ -1,4 +1,4 @@
-export const NAME_PATTERN = /^([a-zA-Z0-9_.-]*)$/;
+export const NAME_PATTERN = /^([\w.-]*)$/;
 export const MIN_NAME_LENGTH = 3;
 export const MAX_NAME_LENGTH = 40;
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -4,7 +4,11 @@ import get from 'lodash/get';
 import map from 'lodash/map';
 import sortBy from 'lodash/sortBy';
 
-import { NAME_PATTERN, MAX_NAME_LENGTH } from './add.constants';
+import {
+  NAME_PATTERN,
+  MAX_NAME_LENGTH,
+  MIN_NAME_LENGTH,
+} from './add.constants';
 
 export default class {
   /* @ngInject */
@@ -23,7 +27,9 @@ export default class {
     this.DatabaseService = DatabaseService;
     this.Poller = Poller;
     this.NAME_PATTERN = NAME_PATTERN;
+    this.MIN_NAME_LENGTH = MIN_NAME_LENGTH;
     this.MAX_NAME_LENGTH = MAX_NAME_LENGTH;
+    this.regexp = new RegExp(this.NAME_PATTERN);
   }
 
   $onInit() {
@@ -50,6 +56,10 @@ export default class {
       name: this.$translate.instant('pci_database_common_none'),
     };
     this.trackDatabases('configuration', 'page');
+  }
+
+  checkPattern(value) {
+    return this.regexp.test(value);
   }
 
   acceptLab(accepted) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -29,7 +29,6 @@ export default class {
     this.NAME_PATTERN = NAME_PATTERN;
     this.MIN_NAME_LENGTH = MIN_NAME_LENGTH;
     this.MAX_NAME_LENGTH = MAX_NAME_LENGTH;
-    this.regexp = new RegExp(this.NAME_PATTERN);
   }
 
   $onInit() {
@@ -59,7 +58,7 @@ export default class {
   }
 
   checkPattern(value) {
-    return this.regexp.test(value);
+    return this.NAME_PATTERN.test(value);
   }
 
   acceptLab(accepted) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -128,18 +128,18 @@
                 required
             />
             <div class="oui-password__rules" id="database-name-rules">
-                <input-rule
+                <pci-storage-database-input-rule
                     valid="$ctrl.model.name.length >= $ctrl.MIN_NAME_LENGTH"
                     data-label="{{:: 'pci_database_add_name_min_rule' | translate: {min: $ctrl.MIN_NAME_LENGTH} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="$ctrl.model.name.length < $ctrl.MAX_NAME_LENGTH"
                     data-label="{{:: 'pci_database_add_name_max_rule' | translate: {max: $ctrl.MAX_NAME_LENGTH} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="$ctrl.checkPattern($ctrl.model.name)"
                     data-label="{{:: 'pci_database_add_name_pattern_rule' | translate }}"
-                ></input-rule>
+                ></pci-storage-database-input-rule>
             </div>
         </oui-field>
         <oui-message

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -115,7 +115,6 @@
         <oui-field
             data-size="l"
             data-label="{{:: 'pci_database_add_name' | translate }}"
-            data-help-text="{{:: 'pci_database_add_name_help_text' | translate }}"
         >
             <input
                 class="oui-input"
@@ -125,10 +124,24 @@
                 data-ng-model="$ctrl.model.name"
                 data-ng-pattern="$ctrl.NAME_PATTERN"
                 data-ng-maxlength="$ctrl.MAX_NAME_LENGTH"
+                data-ng-model-options="{ allowInvalid: true }"
                 required
             />
+            <div class="oui-password__rules" id="database-name-rules">
+                <input-rule
+                    valid="$ctrl.model.name.length >= $ctrl.MIN_NAME_LENGTH"
+                    data-label="{{:: 'pci_database_add_name_min_rule' | translate: {min: $ctrl.MIN_NAME_LENGTH} }}"
+                ></input-rule>
+                <input-rule
+                    valid="$ctrl.model.name.length < $ctrl.MAX_NAME_LENGTH"
+                    data-label="{{:: 'pci_database_add_name_max_rule' | translate: {max: $ctrl.MAX_NAME_LENGTH} }}"
+                ></input-rule>
+                <input-rule
+                    valid="$ctrl.checkPattern($ctrl.model.name)"
+                    data-label="{{:: 'pci_database_add_name_pattern_rule' | translate }}"
+                ></input-rule>
+            </div>
         </oui-field>
-
         <oui-message
             data-ng-if="!($ctrl.model.flavor.supportsPublicNetwork && $ctrl.model.flavor.supportsPrivateNetwork)"
             data-type="info"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.module.js
@@ -13,6 +13,7 @@ import orderCommand from '../components/order-command';
 import orderReview from '../components/order-review';
 import plansList from '../components/plans-list';
 import regionsList from '../../../../../components/project/regions-list';
+import inputRule from '../components/input-rule';
 import routing from './add.routing';
 
 const moduleName = 'ovhManagerPciStoragesDatabasesAdd';
@@ -30,6 +31,7 @@ angular
     orderReview,
     plansList,
     regionsList,
+    inputRule,
   ])
   .config(routing)
   .component('pciProjectStoragesDatabasesAdd', component)

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
@@ -13,7 +13,6 @@
   "pci_database_add_select_flavor": "Sélectionnez le modèle des nœuds",
   "pci_database_add_step5_title": "Configurez vos options",
   "pci_database_add_name": "Nommez votre service de base de données",
-  "pci_database_add_name_help_text": "Le nom doit comporter au moins 3 caractères",
   "pci_database_add_network_mode_label": "Type de réseau",
   "pci_database_add_network_mode_public": "Public",
   "pci_database_add_network_mode_private": "Privé",
@@ -30,5 +29,8 @@
   "pci_database_add_create_database": "Créer un service de base de données",
   "pci_database_add_create_database_processing": "Le service est en cours de création",
   "pci_database_add_create_database_success": "Votre service est en cours de création et sera disponible dans quelques minutes.",
-  "pci_database_add_create_database_error": "Une erreur est survenue lors de la création de votre service. Veuillez retenter l’opération ultérieurement : {{message}}"
+  "pci_database_add_create_database_error": "Une erreur est survenue lors de la création de votre service. Veuillez retenter l’opération ultérieurement : {{message}}",
+  "pci_database_add_name_min_rule": "Au moins {{min}} caractères",
+  "pci_database_add_name_max_rule": "Maximum {{max}} caractères",
+  "pci_database_add_name_pattern_rule": "Doit uniquement contenir des nombres, lettres, underscores, tirets ou points."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/index.js
@@ -7,7 +7,7 @@ const moduleName = 'ovhManagerPciStoragesDatabasesInputRule';
 
 angular
   .module(moduleName, ['oui'])
-  .component('inputRule', component)
+  .component('pciStorageDatabaseInputRule', component)
   .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/index.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+import '@ovh-ux/ui-kit';
+
+import component from './input-rule.component';
+
+const moduleName = 'ovhManagerPciStoragesDatabasesInputRule';
+
+angular
+  .module(moduleName, ['oui'])
+  .component('inputRule', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.component.js
@@ -1,4 +1,3 @@
-import controller from './input-rule.controller';
 import template from './input-rule.html';
 
 export default {
@@ -6,6 +5,5 @@ export default {
     valid: '<',
     label: '@',
   },
-  controller,
   template,
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.component.js
@@ -1,0 +1,11 @@
+import controller from './input-rule.controller';
+import template from './input-rule.html';
+
+export default {
+  bindings: {
+    valid: '<',
+    label: '@',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.controller.js
@@ -1,0 +1,1 @@
+export default class PciInputRuleController {}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.controller.js
@@ -1,1 +1,0 @@
-export default class PciInputRuleController {}

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/input-rule/input-rule.html
@@ -1,0 +1,10 @@
+<span class="oui-password-rule">
+    <span
+        class="oui-icon"
+        ng-class="{
+        'oui-icon-error': !$ctrl.valid,
+        'oui-icon-success': $ctrl.valid
+    }"
+    ></span>
+    <span data-ng-bind="$ctrl.label"></span>
+</span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
@@ -19,6 +19,11 @@ export default class {
     this.pattern = NAME_PATTERN;
     this.minNameLength = MIN_NAME_LENGTH;
     this.maxNameLength = MAX_NAME_LENGTH;
+    this.regexp = new RegExp(this.pattern);
+  }
+
+  checkPattern(value) {
+    return this.regexp.test(value);
   }
 
   edit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.controller.js
@@ -19,11 +19,10 @@ export default class {
     this.pattern = NAME_PATTERN;
     this.minNameLength = MIN_NAME_LENGTH;
     this.maxNameLength = MAX_NAME_LENGTH;
-    this.regexp = new RegExp(this.pattern);
   }
 
   checkPattern(value) {
-    return this.regexp.test(value);
+    return this.pattern.test(value);
   }
 
   edit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
@@ -28,18 +28,18 @@
                 autofocus
             />
             <div class="oui-password__rules" id="databasename-rules">
-                <input-rule
+                <pci-storage-database-input-rule
                     valid="editName.databaseName.$viewValue.length >= $ctrl.minNameLength"
                     data-label="{{:: 'pci_databases_general_information_edit_name_min_rule' | translate: {min: $ctrl.minNameLength} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="editName.databaseName.$viewValue.length < $ctrl.maxNameLength"
                     data-label="{{:: 'pci_databases_general_information_edit_name_max_rule' | translate: {max: $ctrl.maxNameLength} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="$ctrl.checkPattern(editName.databaseName.$viewValue)"
                     data-label="{{:: 'pci_databases_general_information_edit_name_pattern_rule' | translate }}"
-                ></input-rule>
+                ></pci-storage-database-input-rule>
             </div>
         </oui-field>
     </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.html
@@ -27,6 +27,20 @@
                 required
                 autofocus
             />
+            <div class="oui-password__rules" id="databasename-rules">
+                <input-rule
+                    valid="editName.databaseName.$viewValue.length >= $ctrl.minNameLength"
+                    data-label="{{:: 'pci_databases_general_information_edit_name_min_rule' | translate: {min: $ctrl.minNameLength} }}"
+                ></input-rule>
+                <input-rule
+                    valid="editName.databaseName.$viewValue.length < $ctrl.maxNameLength"
+                    data-label="{{:: 'pci_databases_general_information_edit_name_max_rule' | translate: {max: $ctrl.maxNameLength} }}"
+                ></input-rule>
+                <input-rule
+                    valid="$ctrl.checkPattern(editName.databaseName.$viewValue)"
+                    data-label="{{:: 'pci_databases_general_information_edit_name_pattern_rule' | translate }}"
+                ></input-rule>
+            </div>
         </oui-field>
     </oui-modal>
 </form>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/edit-name.module.js
@@ -2,11 +2,12 @@ import angular from 'angular';
 
 import component from './edit-name.component';
 import routing from './edit-name.routing';
+import inputRule from '../../../components/input-rule';
 
 const moduleName = 'ovhManagerPciStoragesDatabaseGeneralInformationName';
 
 angular
-  .module(moduleName, [])
+  .module(moduleName, [inputRule])
   .config(routing)
   .component('ovhManagerPciProjectDatabaseGeneralInformationName', component)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/edit-name/translations/Messages_fr_FR.json
@@ -5,5 +5,8 @@
   "pci_databases_general_information_edit_name_description": "Modifie le nom affiché dans l’en-tête",
   "pci_databases_general_information_edit_name_label": "Nom",
   "pci_databases_general_information_edit_name_success": "Le nom de votre service a été mis à jour.",
-  "pci_databases_general_information_edit_name_error": "Une erreur est survenue lors du renommage de votre service : {{ message }}"
+  "pci_databases_general_information_edit_name_error": "Une erreur est survenue lors du renommage de votre service : {{ message }}",
+  "pci_databases_general_information_edit_name_min_rule": "Au moins {{min}} caractère",
+  "pci_databases_general_information_edit_name_max_rule": "Maximum {{max}} caractères",
+  "pci_databases_general_information_edit_name_pattern_rule": "Doit uniquement contenir des nombres, lettres, underscores, tirets ou points."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
@@ -1,6 +1,6 @@
 export const ADD_USER_FORM_RULES = {
   name: {
-    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,}$/,
+    pattern: /^\w[\w.-]*$/,
     min: 1,
     max: 32,
   },

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.constants.js
@@ -1,6 +1,7 @@
 export const ADD_USER_FORM_RULES = {
   name: {
-    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,31}$/,
+    pattern: /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,}$/,
+    min: 1,
     max: 32,
   },
   keys: {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -8,7 +8,6 @@ export default class {
     this.$translate = $translate;
     this.DatabaseService = DatabaseService;
     this.inputRules = ADD_USER_FORM_RULES;
-    this.regexp = new RegExp(this.inputRules.name.pattern);
   }
 
   $onInit() {
@@ -30,7 +29,7 @@ export default class {
   }
 
   checkPattern(value) {
-    return this.regexp.test(value);
+    return this.inputRules.name.pattern.test(value);
   }
 
   getUserFromModel() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -8,6 +8,7 @@ export default class {
     this.$translate = $translate;
     this.DatabaseService = DatabaseService;
     this.inputRules = ADD_USER_FORM_RULES;
+    this.regexp = new RegExp(this.inputRules.name.pattern);
   }
 
   $onInit() {
@@ -26,6 +27,10 @@ export default class {
     if (this.isRolesReadOnly) {
       this.model.selectedRoles = [];
     }
+  }
+
+  checkPattern(value) {
+    return this.regexp.test(value);
   }
 
   getUserFromModel() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
@@ -21,18 +21,18 @@
             required
         />
         <div class="oui-password__rules" id="username-rules">
-            <input-rule
+            <pci-storage-database-input-rule
                 valid="addUserForm.username.$viewValue.length >= $ctrl.inputRules.name.min"
                 data-label="{{:: 'pci_databases_users_add_username_min_rule' | translate: {min: $ctrl.inputRules.name.min} }}"
-            ></input-rule>
-            <input-rule
+            ></pci-storage-database-input-rule>
+            <pci-storage-database-input-rule
                 valid="addUserForm.username.$viewValue.length < $ctrl.inputRules.name.max"
                 data-label="{{:: 'pci_databases_users_add_username_max_rule' | translate: {max: $ctrl.inputRules.name.max} }}"
-            ></input-rule>
-            <input-rule
+            ></pci-storage-database-input-rule>
+            <pci-storage-database-input-rule
                 valid="$ctrl.checkPattern(addUserForm.username.$viewValue)"
                 data-label="{{:: 'pci_databases_users_add_username_pattern_rule' | translate }}"
-            ></input-rule>
+            ></pci-storage-database-input-rule>
         </div>
     </oui-field>
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
@@ -3,7 +3,7 @@
     data-on-click="$ctrl.goBack()"
 ></oui-back-button>
 
-<form novalidate>
+<form name="addUserForm" novalidate>
     <h2 data-translate="pci_databases_users_add"></h2>
     <oui-field
         data-label="{{:: 'pci_databases_users_add_username_label' | translate }}"
@@ -16,9 +16,24 @@
             name="username"
             ng-model="$ctrl.model.username"
             data-ng-pattern="$ctrl.inputRules.name.pattern"
+            data-ng-minlength="$ctrl.inputRules.name.min"
             data-ng-maxlength="$ctrl.inputRules.name.max"
             required
         />
+        <div class="oui-password__rules" id="username-rules">
+            <input-rule
+                valid="addUserForm.username.$viewValue.length >= $ctrl.inputRules.name.min"
+                data-label="{{:: 'pci_databases_users_add_username_min_rule' | translate: {min: $ctrl.inputRules.name.min} }}"
+            ></input-rule>
+            <input-rule
+                valid="addUserForm.username.$viewValue.length < $ctrl.inputRules.name.max"
+                data-label="{{:: 'pci_databases_users_add_username_max_rule' | translate: {max: $ctrl.inputRules.name.max} }}"
+            ></input-rule>
+            <input-rule
+                valid="$ctrl.checkPattern(addUserForm.username.$viewValue)"
+                data-label="{{:: 'pci_databases_users_add_username_pattern_rule' | translate }}"
+            ></input-rule>
+        </div>
     </oui-field>
 
     <div ng-if="!$ctrl.isRolesReadOnly">

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.module.js
@@ -6,6 +6,7 @@ import 'angular-translate';
 import addUserComponent from './add.component';
 import password from '../../../components/password';
 import tagsInput from '../../../components/tags-input';
+import inputRule from '../../../components/input-rule';
 import routing from './add.routing';
 
 const moduleName = 'ovhManagerPciStoragesDatabaseUsersAdd';
@@ -17,6 +18,7 @@ angular
     'ui.router',
     password,
     tagsInput,
+    inputRule,
   ])
   .config(routing)
   .component('ovhManagerPciProjectDatabaseUsersAdd', addUserComponent)

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/translations/Messages_fr_FR.json
@@ -15,5 +15,8 @@
   "pci_databases_users_add_keys_button_label": "Ajouter une clé",
   "pci_databases_users_add_categories_button_label": "Ajouter une catégorie",
   "pci_databases_users_add_commands_button_label": "Ajouter une commande",
-  "pci_databases_users_add_channels_button_label": "Ajouter un channel"
+  "pci_databases_users_add_channels_button_label": "Ajouter un channel",
+  "pci_databases_users_add_username_min_rule": "Au moins {{min}} caractère",
+  "pci_databases_users_add_username_max_rule": "Maximum {{max}} caractères",
+  "pci_databases_users_add_username_pattern_rule": "Doit être composé de caractères alphanumériques, points (.), underscores (_) ou tirets ( - ), ne doit pas commencer par un tiret ( - ) ou un point (.)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.controller.js
@@ -19,6 +19,11 @@ export default class {
     this.pattern = NAME_PATTERN;
     this.minNameLength = MIN_NAME_LENGTH;
     this.maxNameLength = MAX_NAME_LENGTH;
+    this.regexp = new RegExp(this.pattern);
+  }
+
+  checkPattern(value) {
+    return this.regexp.test(value);
   }
 
   edit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.controller.js
@@ -19,11 +19,10 @@ export default class {
     this.pattern = NAME_PATTERN;
     this.minNameLength = MIN_NAME_LENGTH;
     this.maxNameLength = MAX_NAME_LENGTH;
-    this.regexp = new RegExp(this.pattern);
   }
 
   checkPattern(value) {
-    return this.regexp.test(value);
+    return this.pattern.test(value);
   }
 
   edit() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.html
@@ -26,18 +26,18 @@
                 autofocus
             />
             <div class="oui-password__rules" id="databasename-rules">
-                <input-rule
+                <pci-storage-database-input-rule
                     valid="editName.databaseName.$viewValue.length >= $ctrl.minNameLength"
                     data-label="{{:: 'pci_databases_edit_name_min_rule' | translate: {min: $ctrl.minNameLength} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="editName.databaseName.$viewValue.length < $ctrl.maxNameLength"
                     data-label="{{:: 'pci_databases_edit_name_max_rule' | translate: {max: $ctrl.maxNameLength} }}"
-                ></input-rule>
-                <input-rule
+                ></pci-storage-database-input-rule>
+                <pci-storage-database-input-rule
                     valid="$ctrl.checkPattern(editName.databaseName.$viewValue)"
                     data-label="{{:: 'pci_databases_edit_name_pattern_rule' | translate }}"
-                ></input-rule>
+                ></pci-storage-database-input-rule>
             </div>
         </oui-field>
     </oui-modal>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.html
@@ -25,6 +25,20 @@
                 required
                 autofocus
             />
+            <div class="oui-password__rules" id="databasename-rules">
+                <input-rule
+                    valid="editName.databaseName.$viewValue.length >= $ctrl.minNameLength"
+                    data-label="{{:: 'pci_databases_edit_name_min_rule' | translate: {min: $ctrl.minNameLength} }}"
+                ></input-rule>
+                <input-rule
+                    valid="editName.databaseName.$viewValue.length < $ctrl.maxNameLength"
+                    data-label="{{:: 'pci_databases_edit_name_max_rule' | translate: {max: $ctrl.maxNameLength} }}"
+                ></input-rule>
+                <input-rule
+                    valid="$ctrl.checkPattern(editName.databaseName.$viewValue)"
+                    data-label="{{:: 'pci_databases_edit_name_pattern_rule' | translate }}"
+                ></input-rule>
+            </div>
         </oui-field>
     </oui-modal>
 </form>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/edit-name.module.js
@@ -3,10 +3,12 @@ import angular from 'angular';
 import component from './edit-name.component';
 import routing from './edit-name.routing';
 
+import inputRule from '../components/input-rule';
+
 const moduleName = 'ovhManagerPciStoragesDatabaseName';
 
 angular
-  .module(moduleName, [])
+  .module(moduleName, [inputRule])
   .config(routing)
   .component('ovhManagerPciProjectDatabaseName', component)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/edit-name/translations/Messages_fr_FR.json
@@ -5,5 +5,8 @@
   "pci_databases_edit_name_description": "Modifie le nom affiché dans l’en-tête",
   "pci_databases_edit_name_label": "Nom",
   "pci_databases_edit_name_success": "Le nom de votre service a été mis à jour.",
-  "pci_databases_edit_name_error": "Une erreur est survenue lors du renommage de votre service : {{ message }}"
+  "pci_databases_edit_name_error": "Une erreur est survenue lors du renommage de votre service : {{ message }}",
+  "pci_databases_edit_name_min_rule": "Au moins {{min}} caractère",
+  "pci_databases_edit_name_max_rule": "Maximum {{max}} caractères",
+  "pci_databases_edit_name_pattern_rule": "Doit uniquement contenir des nombres, lettres, underscores, tirets ou points."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.constants.js
@@ -1,7 +1,0 @@
-export const NAME_PATTERN = /^([a-zA-Z0-9_.-]{3,40})$/;
-export const MAX_NAME_LENGTH = 40;
-
-export default {
-  NAME_PATTERN,
-  MAX_NAME_LENGTH,
-};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
@@ -5,7 +5,11 @@ import map from 'lodash/map';
 import clone from 'lodash/clone';
 import sortBy from 'lodash/sortBy';
 
-import { NAME_PATTERN, MAX_NAME_LENGTH } from './fork.constants';
+import {
+  NAME_PATTERN,
+  MIN_NAME_LENGTH,
+  MAX_NAME_LENGTH,
+} from '../add/add.constants';
 
 export default class {
   /* @ngInject */
@@ -26,7 +30,9 @@ export default class {
     this.DatabaseService = DatabaseService;
     this.Poller = Poller;
     this.NAME_PATTERN = NAME_PATTERN;
+    this.MIN_NAME_LENGTH = MIN_NAME_LENGTH;
     this.MAX_NAME_LENGTH = MAX_NAME_LENGTH;
+    this.regexp = new RegExp(this.NAME_PATTERN);
   }
 
   $onInit() {
@@ -71,6 +77,10 @@ export default class {
     this.orderData = null;
     this.prepareOrderData();
     this.trackDatabases('configuration_fork', 'page');
+  }
+
+  checkPattern(value) {
+    return this.regexp.test(value);
   }
 
   getAvailableNetworks(region) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
@@ -32,7 +32,6 @@ export default class {
     this.NAME_PATTERN = NAME_PATTERN;
     this.MIN_NAME_LENGTH = MIN_NAME_LENGTH;
     this.MAX_NAME_LENGTH = MAX_NAME_LENGTH;
-    this.regexp = new RegExp(this.NAME_PATTERN);
   }
 
   $onInit() {
@@ -80,7 +79,7 @@ export default class {
   }
 
   checkPattern(value) {
-    return this.regexp.test(value);
+    return this.NAME_PATTERN.test(value);
   }
 
   getAvailableNetworks(region) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
@@ -101,18 +101,18 @@
             required
         />
         <div class="oui-password__rules" id="database-fork-name-rules">
-            <input-rule
+            <pci-storage-database-input-rule
                 valid="$ctrl.model.name.length >= $ctrl.MIN_NAME_LENGTH"
                 data-label="{{:: 'pci_database_fork_name_min_rule' | translate: {min: $ctrl.MIN_NAME_LENGTH} }}"
-            ></input-rule>
-            <input-rule
+            ></pci-storage-database-input-rule>
+            <pci-storage-database-input-rule
                 valid="$ctrl.model.name.length < $ctrl.MAX_NAME_LENGTH"
                 data-label="{{:: 'pci_database_fork_name_max_rule' | translate: {max: $ctrl.MAX_NAME_LENGTH} }}"
-            ></input-rule>
-            <input-rule
+            ></pci-storage-database-input-rule>
+            <pci-storage-database-input-rule
                 valid="$ctrl.checkPattern($ctrl.model.name)"
                 data-label="{{:: 'pci_database_fork_name_pattern_rule' | translate }}"
-            ></input-rule>
+            ></pci-storage-database-input-rule>
         </div>
     </oui-field>
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
@@ -86,7 +86,6 @@
     <oui-field
         data-size="l"
         data-label="{{:: 'pci_database_fork_name' | translate }}"
-        data-help-text="{{:: 'pci_database_fork_name_help_text' | translate }}"
     >
         <input
             class="oui-input"
@@ -95,10 +94,26 @@
             name="name"
             data-ng-model="$ctrl.model.name"
             data-ng-pattern="$ctrl.NAME_PATTERN"
+            data-ng-minlength="$ctrl.MIN_NAME_LENGTH"
             data-ng-maxlength="$ctrl.MAX_NAME_LENGTH"
             data-ng-change="$ctrl.prepareOrderData()"
+            data-ng-model-options="{ allowInvalid: true }"
             required
         />
+        <div class="oui-password__rules" id="database-fork-name-rules">
+            <input-rule
+                valid="$ctrl.model.name.length >= $ctrl.MIN_NAME_LENGTH"
+                data-label="{{:: 'pci_database_fork_name_min_rule' | translate: {min: $ctrl.MIN_NAME_LENGTH} }}"
+            ></input-rule>
+            <input-rule
+                valid="$ctrl.model.name.length < $ctrl.MAX_NAME_LENGTH"
+                data-label="{{:: 'pci_database_fork_name_max_rule' | translate: {max: $ctrl.MAX_NAME_LENGTH} }}"
+            ></input-rule>
+            <input-rule
+                valid="$ctrl.checkPattern($ctrl.model.name)"
+                data-label="{{:: 'pci_database_fork_name_pattern_rule' | translate }}"
+            ></input-rule>
+        </div>
     </oui-field>
 
     <oui-message

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.module.js
@@ -13,6 +13,7 @@ import orderCommand from '../components/order-command';
 import orderReview from '../components/order-review';
 import plansList from '../components/plans-list';
 import regionsList from '../../../../../components/project/regions-list';
+import inputRule from '../components/input-rule';
 import routing from './fork.routing';
 
 const moduleName = 'ovhManagerPciStoragesDatabasesFork';
@@ -30,6 +31,7 @@ angular
     orderReview,
     plansList,
     regionsList,
+    inputRule,
   ])
   .config(routing)
   .component('pciProjectStoragesDatabasesFork', component)

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/translations/Messages_fr_FR.json
@@ -28,5 +28,8 @@
   "pci_database_fork_create_database": "Créer un service de base de données",
   "pci_database_fork_create_database_processing": "Le service est en cours de création",
   "pci_database_fork_create_database_success": "Votre service est en cours de création et sera disponible dans quelques minutes.",
-  "pci_database_fork_create_database_error": "Une erreur est survenue lors de la création de votre service. Veuillez retenter l’opération ultérieurement : {{message}}"
+  "pci_database_fork_create_database_error": "Une erreur est survenue lors de la création de votre service. Veuillez retenter l’opération ultérieurement : {{message}}",
+  "pci_database_fork_name_min_rule": "Au moins {{min}} caractère",
+  "pci_database_fork_name_max_rule": "Maximum {{max}} caractères",
+  "pci_database_fork_name_pattern_rule": "Doit uniquement contenir des nombres, lettres, underscores, tirets ou points."
 }


### PR DESCRIPTION
PUD-1153

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/aiven-ga1-pud`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #PUD-1153
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
Add input rules visualisation for those pages:
- add a cluster
- change cluster name from list
- change cluster name from cluster details
- fork
