### PR TITLE
fix PUD-1179 (pci.storage.databases): disable actions if cluster is not ready

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/acl/acl.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/acl/acl.html
@@ -31,13 +31,20 @@
             data-searchable
             data-filterable
         ></oui-datagrid-column>
-        <oui-action-menu data-compact data-placement="end">
+        <oui-action-menu
+            data-compact
+            data-placement="end"
+            data-disabled="!$ctrl.database.isActive()"
+        >
             <oui-action-menu-item data-on-click="$ctrl.delete($row)">
                 <span data-translate="pci_databases_acl_tab_delete"></span>
             </oui-action-menu-item>
         </oui-action-menu>
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.goToAddAcl()">
+            <oui-button
+                data-disabled="!$ctrl.database.isActive()"
+                data-on-click="$ctrl.goToAddAcl()"
+            >
                 <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
                 <span data-translate="pci_databases_acl_tab_add"></span>
             </oui-button>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/databases.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/databases/databases.html
@@ -24,14 +24,20 @@
             data-placement="end"
             ng-if="!$row.default"
         >
-            <oui-action-menu-item data-on-click="$ctrl.deleteDatabase($row)">
+            <oui-action-menu-item
+                data-on-click="$ctrl.deleteDatabase($row)"
+                data-disabled="!$ctrl.database.isActive()"
+            >
                 <span
                     data-translate="pci_databases_databases_tab_delete_link"
                 ></span>
             </oui-action-menu-item>
         </oui-action-menu>
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.addDatabase()">
+            <oui-button
+                data-on-click="$ctrl.addDatabase()"
+                data-disabled="!$ctrl.database.isActive()"
+            >
                 <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
                 <span data-translate="pci_databases_databases_tab_add"></span>
             </oui-button>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/indexes/indexes.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/indexes/indexes.html
@@ -31,6 +31,7 @@
                 <button
                     class="oui-button oui-button_s oui-button_secondary"
                     data-ng-click="$ctrl.deletePattern($row)"
+                    data-disabled="!$ctrl.database.isActive()"
                 >
                     <span
                         class="oui-icon oui-icon-bin"
@@ -40,7 +41,10 @@
             </div>
         </oui-datagrid-column>
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.trackAndCreatePattern()">
+            <oui-button
+                data-on-click="$ctrl.trackAndCreatePattern()"
+                data-disabled="!$ctrl.database.isActive()"
+            >
                 <span
                     class="oui-icon oui-icon-add pr-1"
                     aria-hidden="true"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/topics/topics.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/topics/topics.html
@@ -70,7 +70,11 @@
         >
             <span>delete</span>
         </oui-datagrid-column>
-        <oui-action-menu data-compact data-placement="end">
+        <oui-action-menu
+            data-compact
+            data-placement="end"
+            data-disabled="!$ctrl.database.isActive()"
+        >
             <oui-action-menu-item data-on-click="$ctrl.deleteTopic($row)">
                 <span
                     data-translate="pci_databases_topics_tab_delete_link"
@@ -78,7 +82,10 @@
             </oui-action-menu-item>
         </oui-action-menu>
         <oui-datagrid-topbar>
-            <oui-button data-on-click="$ctrl.addTopic()">
+            <oui-button
+                data-on-click="$ctrl.addTopic()"
+                data-disabled="!$ctrl.database.isActive()"
+            >
                 <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i>
                 <span data-translate="pci_databases_topics_tab_add"></span>
             </oui-button>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/useracl/useracl.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/useracl/useracl.html
@@ -20,6 +20,7 @@
         data-label="{{ ::'pci_databases_useracl_tab_activate_acl' | translate }}"
     >
         <oui-switch
+            data-disabled="!$ctrl.database.isActive()"
             model="$ctrl.database.aclsEnabled"
             name="oui-switch"
             on-change="$ctrl.trackAndSetAclState(modelValue)"


### PR DESCRIPTION
PUD-1179

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/aiven-ga1-pud`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1179
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Disable actions if cluster is not in ready state

## Related

<!-- Link dependencies of this PR -->
