### PR TITLE
feat MANAGER-8477 (pci.storage.databases): change unit for minutes in metrics tab

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "pci_database_metrics_title": "Métriques",
   "pci_databases_metrics_title": "Métriques",
-  "pci_databases_metrics_refresh_label": "Auto-Refresh (1M)",
+  "pci_databases_metrics_refresh_label": "Auto-Refresh (1 min.)",
   "pci_databases_metrics_range_label": "Time range",
   "pci_databases_metrics_range_label_1H": "1H",
   "pci_databases_metrics_range_label_1D": "1D",


### PR DESCRIPTION
MANAGER-8477

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/aiven-ga1-pud`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8477
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Change "1M" to "1 min." in metrics tab