### PR TITLE
fix(dedicated-cloud.user): nsx right not displayed in user list

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
@@ -137,7 +137,6 @@
         <oui-datagrid-column
             data-title=":: 'dedicatedCloud_USER_nsx' | translate"
             data-ng-if="$ctrl.nsxOptions === 'enabled'"
-            data-name="nsx"
         >
             <span data-translate="common_yes" data-ng-if="$row.nsxRight">
             </span>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8603
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

PCC : Fix nsx interface right not displayed in user list

Before:
![Capture d’écran 2022-01-19 à 15 32 12](https://user-images.githubusercontent.com/666182/150151410-855a2eb6-1de2-4083-b767-f81343cc9b72.png)

After:
![Capture d’écran 2022-01-19 à 15 22 43](https://user-images.githubusercontent.com/666182/150149595-5157d0e5-57a3-4bc4-a4f0-8af2b516fe60.png)

## Related
