### PR TITLE
feat(dedicated-cloud.user): change username displayed field to login

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
@@ -69,7 +69,7 @@
     >
         <oui-datagrid-column
             data-title=":: 'dedicatedCloud_USER_name' | translate"
-            data-property="name"
+            data-property="login"
         >
         </oui-datagrid-column>
         <oui-datagrid-column


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8604
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

PCC : Changing username field displayed to login to handle federation users (with @ domain) in user list.

Before:
![Capture d’écran 2022-01-19 à 15 32 16](https://user-images.githubusercontent.com/666182/150151562-0f3be683-32a3-4460-927b-4d78f9e83466.png)

After:
![Capture d’écran 2022-01-19 à 15 25 39](https://user-images.githubusercontent.com/666182/150150109-a1ac2f1c-f3aa-4ae2-afeb-c4d3e7490680.png)

## Related

