### PR TITLE
fix(software-update): upgrading status is async

### DIFF
--- a/packages/manager/modules/anthos/src/dashboard/general-information/general-information.routing.js
+++ b/packages/manager/modules/anthos/src/dashboard/general-information/general-information.routing.js
@@ -23,8 +23,12 @@ export default /* @ngInject */ ($stateProvider) => {
       packInfo: /* @ngInject */ (AnthosTenantsService, serviceInfo) =>
         AnthosTenantsService.getPackInfo(serviceInfo),
 
-      goBack: /* @ngInject */ ($state, goToTenant) => (message, type) =>
-        goToTenant(message, type, $state.$current.parent.name),
+      goBack: /* @ngInject */ ($state, goToTenant) => (
+        message,
+        type,
+        stateToGo = $state.$current.parent.name,
+        stateParams = {},
+      ) => goToTenant(message, type, stateToGo, stateParams),
 
       goToRenameService: /* @ngInject */ ($state, serviceName) => () =>
         $state.go('anthos.dashboard.general-information.rename-service', {

--- a/packages/manager/modules/anthos/src/dashboard/general-information/software-update/software-update.constants.js
+++ b/packages/manager/modules/anthos/src/dashboard/general-information/software-update/software-update.constants.js
@@ -1,7 +1,10 @@
 export const TRACKING_CHUNK = 'update-software';
 export const TRACKING_PREFIX = 'anthos-update-software';
+export const UPDATE_KEY =
+  'anthos_tenant_dashboard_general_information_software_update';
 
 export default {
   TRACKING_CHUNK,
   TRACKING_PREFIX,
+  UPDATE_KEY,
 };

--- a/packages/manager/modules/anthos/src/dashboard/general-information/software-update/software-update.controller.js
+++ b/packages/manager/modules/anthos/src/dashboard/general-information/software-update/software-update.controller.js
@@ -1,4 +1,5 @@
-import { TRACKING_PREFIX } from './software-update.constants';
+import { TENANT_STATUS } from '../../../anthos.constants';
+import { TRACKING_PREFIX, UPDATE_KEY } from './software-update.constants';
 
 export default class SoftwareUpdateController {
   /* @ngInject */
@@ -30,21 +31,23 @@ export default class SoftwareUpdateController {
       serviceName,
       selectedVersion,
     )
-      .then(() => {
-        const successVerbatim = this.$translate.instant(
-          'anthos_tenant_dashboard_general_information_software_update_success',
-        );
-        this.goBack(successVerbatim, 'success');
-      })
+      .then(() =>
+        this.goBack(
+          this.$translate.instant(`${UPDATE_KEY}_success`),
+          'success',
+          'anthos.dashboard',
+          {
+            patchTenantStatus: TENANT_STATUS.UPGRADING,
+          },
+        ),
+      )
       .catch(() => {
-        const errorVerbatim = this.$translate.instant(
-          'anthos_tenant_dashboard_general_information_software_update_error',
-        );
-        this.displayAlerterMessage('error', errorVerbatim);
-      })
-      .finally(() => {
         this.isUpdating = false;
         this.selectedVersion = null;
+        this.displayAlerterMessage(
+          'error',
+          this.$translate.instant(`${UPDATE_KEY}_error`),
+        );
       });
   }
 

--- a/packages/manager/modules/anthos/src/dashboard/routing.js
+++ b/packages/manager/modules/anthos/src/dashboard/routing.js
@@ -6,17 +6,31 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('anthos.dashboard', {
     url: '/:serviceName',
     component: 'anthosDashboard',
+    params: {
+      patchTenantStatus: { value: '' },
+    },
     resolve: {
       breadcrumb: /* @ngInject */ (serviceName) => serviceName,
 
       serviceName: /* @ngInject */ ($transition$) =>
         $transition$.params().serviceName,
 
+      patchTenantStatus: /* @ngInject */ ($transition$) =>
+        $transition$.params().patchTenantStatus,
+
       alertId: () => 'anthos_dashboard',
 
-      tenant: /* @ngInject */ (serviceName, AnthosTenantsService) => {
+      tenant: /* @ngInject */ (
+        serviceName,
+        patchTenantStatus,
+        AnthosTenantsService,
+      ) => {
         return AnthosTenantsService.getTenantDetails(serviceName).then(
-          (tenant) => new Tenant(tenant),
+          (data) => {
+            const tenant = new Tenant(data);
+            if (patchTenantStatus) tenant.status = patchTenantStatus;
+            return tenant;
+          },
         );
       },
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/anthos-m4`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8536
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

After updating the software version, the status of the tenant is not updated immediately on the back end but a few milliseconds later, leaving a 50/50 chance the user interface is out of sync with the actual data. This fix is an attempt to visually "patch" the user interface so that the client is not aware of this API behaviour

What this fix does it makes the user interface goes back from the /software-update page to the dashboard page after the operation of updating the software succeed. It sends an additional `patchTenantStatus` state parameter so that the original tenant status is overridden by this one, thus setting the status as it is supposed to be when fetched from the API

Open to discussion if anyone has a better idea on how we can handle this