### PR TITLE
fix: refresh nutanix dashboard after redeploy

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/confirm/controller.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/confirm/controller.js
@@ -35,7 +35,7 @@ export default class RedeployConfirmController {
     )
       .then(() => {
         this.isRedeploying = false;
-        return this.goToNutanixGeneralInfo();
+        return this.goToNutanixGeneralInfo(null, null, true);
       })
       .then(() => {
         return this.atInternet.trackPage({

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/routing.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/routing.js
@@ -13,8 +13,8 @@ export default /* @ngInject */ ($stateProvider) => {
         $state,
         Alerter,
         serviceName,
-      ) => (message = false, type = STATUS_DONE) => {
-        const reload = message && type === STATUS_DONE;
+      ) => (message = false, type = STATUS_DONE, stateReload = false) => {
+        const reload = (message && type === STATUS_DONE) || stateReload;
         const promise = $state.go(
           'nutanix.dashboard.general-info',
           {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix-redeploy`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8623
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Refreshing the Nutanix cluster dashboard after performing the redeploy

## Related

<!-- Link dependencies of this PR -->
