### PR TITLE
feat(hosting.offer): implement detach start10M

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/dashboard/hosting.constant.js
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/hosting.constant.js
@@ -46,4 +46,5 @@ angular
     OK: 'ok',
     CHECK: 'check',
     DOING: 'doing',
-  });
+  })
+  .constant('DETACHABLE_PRODUCT_NAMES', ['start10m-addon-v1']);

--- a/packages/manager/apps/web/client/app/hosting/dashboard/hosting.service.js
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/hosting.service.js
@@ -30,6 +30,7 @@ import union from 'lodash/union';
         HOSTING,
         HOSTING_UPGRADES,
         HOSTING_OPERATION_STATUS,
+        DETACHABLE_PRODUCT_NAMES,
         OvhHttp,
         Poll,
       ) {
@@ -42,6 +43,7 @@ import union from 'lodash/union';
         this.HOSTING = HOSTING;
         this.HOSTING_UPGRADES = HOSTING_UPGRADES;
         this.HOSTING_OPERATION_STATUS = HOSTING_OPERATION_STATUS;
+        this.DETACHABLE_PRODUCT_NAMES = DETACHABLE_PRODUCT_NAMES;
         this.OvhHttp = OvhHttp;
         this.Poll = Poll;
 
@@ -442,6 +444,21 @@ import union from 'lodash/union';
             rootPath: 'apiv6',
           },
         );
+      }
+
+      /**
+       * Check if service can be detached
+       * @param {string} serviceName
+       */
+      isServiceDetachable(serviceName) {
+        return this.getServiceInfos(serviceName)
+          .then(({ serviceId }) => {
+            return this.$http.get(`/services/${serviceId}`);
+          })
+          .then(({ data }) => {
+            const productName = data.resource.product.name;
+            return this.DETACHABLE_PRODUCT_NAMES.includes(productName);
+          });
       }
 
       /**

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
@@ -148,7 +148,6 @@
   "hosting_dashboard_service_cdn": "Option CDN",
   "hosting_dashboard_service_cdn_customer_has_cdn_v1_banner_msg": "L’option Shared CDN pour vos hébergements évolue ! De nouvelles fonctionnalités sont disponibles.",
   "hosting_dashboard_service_cdn_customer_has_cdn_v1_banner_msg_link_upgrade": "Migrer votre CDN",
-  "hosting_dashboard_service_cdn_customer_has_cdn_v1_badge_new": "Nouveau",
   "hosting_dashboard_service_cdn_customer_has_cdn_v1_new_offers": "OVHcloud vous recommande les nouvelles offres CDN",
   "hosting_dashboard_service_web": "Sites web",
   "hosting_dashboard_service_privatesql": "Base de données privée",

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
@@ -32,7 +32,6 @@ export default class HostingGeneralInformationsCtrl {
     hostingSSLCertificate,
     OvhApiScreenshot,
     user,
-    ovhManagerProductOffersActionService,
   ) {
     this.$q = $q;
     this.$scope = $scope;
@@ -56,7 +55,6 @@ export default class HostingGeneralInformationsCtrl {
     this.hostingSSLCertificate = hostingSSLCertificate;
     this.OvhApiScreenshot = OvhApiScreenshot;
     this.user = user;
-    this.ovhManagerProductOffersActionService = ovhManagerProductOffersActionService;
 
     this.CDN_ADVANCED = CDN_ADVANCED;
     this.CDN_VERSION_V1 = HOSTING_CDN_ORDER_CDN_VERSION_V1;
@@ -69,7 +67,7 @@ export default class HostingGeneralInformationsCtrl {
     this.isCdnInDeleteAtExpiration =
       this.$scope.cdnServiceInfo?.renew.mode === 'deleteAtExpiration';
     this.defaultRuntime = null;
-    this.isAvailableOfferOrPlanDetach = false;
+    this.isAvailableOfferOrDetach = false;
     this.contactManagementLink = this.coreConfig.isRegion('EU')
       ? this.coreURLBuilder.buildURL('dedicated', '#/contacts/services', {
           serviceName: this.serviceName,
@@ -121,7 +119,7 @@ export default class HostingGeneralInformationsCtrl {
         this.getScreenshot(),
         this.retrievingSSLCertificate(),
         this.isAvailableOffer(this.serviceName),
-        this.isAvailablePlanDetach(this.serviceName),
+        this.isAvailableDetach(this.serviceName),
       ])
       .then(() => this.HostingRuntimes.getDefault(this.serviceName))
       .then((runtime) => {
@@ -245,24 +243,19 @@ export default class HostingGeneralInformationsCtrl {
   isAvailableOffer(productId) {
     return this.Hosting.getAvailableOffer(productId).then((offers) => {
       if (offers.length > 0) {
-        this.isAvailableOfferOrPlanDetach = true;
+        this.isAvailableOfferOrDetach = true;
       }
     });
   }
 
-  isAvailablePlanDetach(productId) {
-    return this.Hosting.getServiceInfos(productId)
-      .then(({ serviceId }) => {
-        this.serviceId = serviceId;
-        return this.ovhManagerProductOffersActionService.getAvailableDetachPlancodes(
-          serviceId,
-        );
-      })
-      .then((offers) => {
-        if (offers.length > 0) {
-          this.isAvailableOfferOrPlanDetach = true;
+  isAvailableDetach(serviceName) {
+    return this.Hosting.isServiceDetachable(serviceName).then(
+      (isDetachable) => {
+        if (isDetachable) {
+          this.isAvailableOfferOrDetach = true;
         }
-      });
+      },
+    );
   }
 
   changeOffer() {

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -648,7 +648,7 @@
                             ></span>
                         </oui-tile-description>
                         <oui-action-menu
-                            data-ng-if="$ctrl.isAvailableOfferOrPlanDetach"
+                            data-ng-if="$ctrl.isAvailableOfferOrDetach"
                             data-compact
                             data-placement="end"
                         >

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -369,15 +369,6 @@
                     >
                         <oui-tile-description>
                             <span
-                                data-ng-if=""
-                            >
-                                <span
-                                    class="oui-badge oui-badge_s oui-badge_new"
-                                    data-translate="hosting_dashboard_service_cdn_customer_has_cdn_v1_badge_new"
-                                ></span
-                                ><br/>
-                            </span>
-                            <span
                                 data-ng-bind="::hosting.hasCdn ? ('common_yes' | translate) : ('common_no' | translate)"
                             ></span>
                             <span data-ng-if="hosting.hasCdn">
@@ -386,9 +377,11 @@
                                     data-ng-if="isUpgradable && cdnProperties.version === '2013v1'"
                                 >
                                     <span> - </span>
-                                    <span class="fa fa-exclamation-triangle text-warning"
-                                          aria-hidden="true"
-                                          data-oui-tooltip="{{:: 'hosting_dashboard_service_cdn_customer_has_cdn_v1_new_offers' | translate }}"></span>
+                                    <span
+                                        class="fa fa-exclamation-triangle text-warning"
+                                        aria-hidden="true"
+                                        data-oui-tooltip="{{:: 'hosting_dashboard_service_cdn_customer_has_cdn_v1_new_offers' | translate }}"
+                                    ></span>
                                 </span>
                             </span>
                             <oui-spinner
@@ -401,19 +394,28 @@
                                 data-ng-if="flushCdnState === 'doing'"
                             ></span>
 
-                            <div data-ng-if="hosting.hasCdn && $ctrl.isCdnInDeleteAtExpiration">
+                            <div
+                                data-ng-if="hosting.hasCdn && $ctrl.isCdnInDeleteAtExpiration"
+                            >
                                 <p class="m-0">
-                                    <small data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate"
-                                           data-translate-values="{ endEngagementDate: '<b>' + (cdnServiceInfo.expirationDate | date) + '</b>' }">
+                                    <small
+                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate"
+                                        data-translate-values="{ endEngagementDate: '<b>' + (cdnServiceInfo.expirationDate | date) + '</b>' }"
+                                    >
                                     </small>
                                 </p>
                                 <button
                                     type="button"
                                     class="oui-button oui-button_s oui-button_ghost oui-button_icon-right"
-                                    data-ng-click="$ctrl.onCancelTerminateCdn()">
+                                    data-ng-click="$ctrl.onCancelTerminateCdn()"
+                                >
                                     <span
-                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate_link"></span>
-                                    <span class="oui-icon oui-icon-arrow-right" aria-hidden="true"></span>
+                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate_link"
+                                    ></span>
+                                    <span
+                                        class="oui-icon oui-icon-arrow-right"
+                                        aria-hidden="true"
+                                    ></span>
                                 </button>
                             </div>
                         </oui-tile-description>
@@ -646,7 +648,7 @@
                             ></span>
                         </oui-tile-description>
                         <oui-action-menu
-                            data-ng-if="$ctrl.availableOffers.length > 0"
+                            data-ng-if="$ctrl.isAvailableOfferOrPlanDetach"
                             data-compact
                             data-placement="end"
                         >

--- a/packages/manager/apps/web/client/app/hosting/offer/upgrade/hosting-offer-upgrade.constants.js
+++ b/packages/manager/apps/web/client/app/hosting/offer/upgrade/hosting-offer-upgrade.constants.js
@@ -2,8 +2,6 @@ export const OFFERS_NAME_MAPPING = {
   perso2014: 'PERSO_2014',
 };
 
-export const DETACHABLE_OFFERS = ['START_10_M'];
-
 export const DETACH_DEFAULT_OPTIONS = {
   type: 'detach',
   durationCode: 'P12M',
@@ -14,6 +12,5 @@ export const DETACH_DEFAULT_OPTIONS = {
 
 export default {
   OFFERS_NAME_MAPPING,
-  DETACHABLE_OFFERS,
   DETACH_DEFAULT_OPTIONS,
 };

--- a/packages/manager/apps/web/client/app/hosting/offer/upgrade/hosting-offer-upgrade.constants.js
+++ b/packages/manager/apps/web/client/app/hosting/offer/upgrade/hosting-offer-upgrade.constants.js
@@ -1,0 +1,19 @@
+export const OFFERS_NAME_MAPPING = {
+  perso2014: 'PERSO_2014',
+};
+
+export const DETACHABLE_OFFERS = ['START_10_M'];
+
+export const DETACH_DEFAULT_OPTIONS = {
+  type: 'detach',
+  durationCode: 'P12M',
+  durationText: '12m',
+  pricingMode: 'default',
+  quantity: 1,
+};
+
+export default {
+  OFFERS_NAME_MAPPING,
+  DETACHABLE_OFFERS,
+  DETACH_DEFAULT_OPTIONS,
+};


### PR DESCRIPTION
ref: WEB-11147

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Feat #WEB-11147
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

With the purchase of a domain name, customer can activate a free hosting offer, called start10m. 
As of now, customer cannot upgrade this offer to a standard one (ex: perso2014). This PR aim is to give the possibility to perform such action.
Technically, it is not the same process as a classical upgrade (is is a detach operation, using different api calls) but it must appear similar to the customer.
After testing, we encountered an issue: there is a distinction between legacy and "new" start10m offers : for now, legacy cannot be detached, so we limit the detach of start10m to "new" offers (start10m-addon-v1).
