### PR TITLE
fix PUD-1260 (pci.storage.databases): connection pool wrong port display

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/pool.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/pool.class.js
@@ -11,6 +11,7 @@ export default class Pool {
     uri,
     userId,
     userName,
+    port,
   }) {
     Object.assign(this, {
       databaseId,
@@ -24,6 +25,7 @@ export default class Pool {
       uri,
       userId,
       userName,
+      port,
     });
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/pools/information/information.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/pools/information/information.html
@@ -21,7 +21,7 @@
                 ></dt>
                 <dd
                     class="col-sm-9 my-auto"
-                    data-ng-bind="$ctrl.database.port"
+                    data-ng-bind="$ctrl.pool.port"
                 ></dd>
             </div>
             <div class="row my-2 py-2 border-top">


### PR DESCRIPTION
PUD-1260

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1260
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

In the manager, the connection pools for postgresql are currently taking the port from the service information while it should take it from the connection pool
