### PR TITLE
feat(dedicated-cloud.user): handle active directory users and groups

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.controller.js
@@ -57,6 +57,8 @@ export default class {
       (user) => {
         set(user, 'state', user.state.toUpperCase());
         set(user, 'activationState', user.activationState.toUpperCase());
+        set(user, 'loginUsername', user.login.split('@')[0]);
+        set(user, 'loginDomain', user.login.split('@')[1]);
         return user;
       },
     );

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/dedicatedCloud-user.html
@@ -69,8 +69,30 @@
     >
         <oui-datagrid-column
             data-title=":: 'dedicatedCloud_USER_name' | translate"
-            data-property="name"
         >
+            <span
+                data-ng-if="!$row.activeDirectoryId"
+                data-ng-bind="$row.login"
+            >
+            </span>
+            <span data-ng-if="$row.activeDirectoryId">
+                <span data-ng-if="$row.activeDirectoryType === 'group'">
+                    <span class="fa fa-users" aria-hidden="true"></span>
+                    <span data-ng-bind="$row.loginUsername"> </span>
+                    <span
+                        class="font-italic text-muted"
+                        data-ng-bind="'('+$row.loginDomain+')'"
+                    >
+                    </span>
+                </span>
+                <span data-ng-if="$row.activeDirectoryType !== 'group'">
+                    <span data-ng-bind="$row.loginUsername"> </span
+                    ><span
+                        class="font-italic text-muted"
+                        data-ng-bind="'@'+$row.loginDomain"
+                    ></span>
+                </span>
+            </span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'dedicatedCloud_USER_firstname' | translate"
@@ -212,6 +234,7 @@
                 ></span>
             </oui-action-menu-item>
             <oui-action-menu-item
+                data-ng-if="!$row.activeDirectoryId"
                 data-on-click="$ctrl.passwordReset($row, $ctrl.passwordPolicy)"
                 ><span
                     data-translate="dedicatedCloud_USER_change_password"

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/delete/dedicatedCloud-user-delete.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/delete/dedicatedCloud-user-delete.html
@@ -7,7 +7,7 @@
     <div data-wizard-step>
         <span
             data-translate="dedicatedCloud_USER_delete_message"
-            data-translate-values="{ t0: $ctrl.user.name }"
+            data-translate-values="{ t0: $ctrl.user.login }"
         ></span>
     </div>
 </div>

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/rights/dedicatedCloud-user-rights.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/user/rights/dedicatedCloud-user-rights.html
@@ -7,7 +7,7 @@
         <oui-back-button data-on-click="$ctrl.goBack()">
             <span
                 data-translate="dedicatedCloud_USER_rights_management_by_datacenter"
-                data-translate-values="{ t0: $ctrl.selectedUser.name }"
+                data-translate-values="{ t0: $ctrl.selectedUser.login }"
             ></span>
         </oui-back-button>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8833
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

PCC : Changing username field in user list.
Switching to login field handling federation users and groups (with @ domain) in user list.

Normal users are displayed as before.
Federation users are displayed with `user@domain` format
Federation groups are displayed with `groupname (domain)` format

Before:

<img width="222" alt="Capture d’écran 2022-02-07 à 22 55 30" src="https://user-images.githubusercontent.com/666182/152880674-b49f194d-51a8-4363-953f-fc4c48c0dc7d.png">

After:

<img width="283" alt="Capture d’écran 2022-02-12 à 22 28 08" src="https://user-images.githubusercontent.com/666182/153729037-3c5c4093-bba2-4d80-bb06-239e64297648.png">

## Related

Will overlap #6333 
