### PR TITLE
feat(netapp.order): order by size and display item horizontally

### DIFF
--- a/packages/manager/modules/netapp/src/order/template.html
+++ b/packages/manager/modules/netapp/src/order/template.html
@@ -45,24 +45,23 @@
             valid="$ctrl.plan"
         >
             <div class="row mb-2">
-                <div class="col-md-3">
-                    <oui-select-picker
-                        data-ng-repeat="plan in $ctrl.highlightedPlans track by $index"
-                        name="size"
-                        model="$ctrl.plan"
-                        label="{{:: 'netapp_order_size_label' | translate:{'size': plan.size} }}"
-                        on-change="$ctrl.onPlanChange(modelValue)"
-                        values="[plan]"
-                    >
-                        <oui-select-picker-footer>
-                            <ovh-manager-catalog-price
-                                price="plan.defaultPrice.price"
-                                interval-unit="{{ plan.defaultPrice.intervalUnit }}"
-                            >
-                            </ovh-manager-catalog-price>
-                        </oui-select-picker-footer>
-                    </oui-select-picker>
-                </div>
+                <oui-select-picker
+                    class="col-md-4 col-lg-3 mb-3"
+                    data-ng-repeat="plan in $ctrl.highlightedPlans | orderBy: 'size' track by $index"
+                    name="size"
+                    model="$ctrl.plan"
+                    label="{{:: 'netapp_order_size_label' | translate:{'size': plan.size} }}"
+                    on-change="$ctrl.onPlanChange(modelValue)"
+                    values="[plan]"
+                >
+                    <oui-select-picker-footer>
+                        <ovh-manager-catalog-price
+                            price="plan.defaultPrice.price"
+                            interval-unit="{{ plan.defaultPrice.intervalUnit }}"
+                        >
+                        </ovh-manager-catalog-price>
+                    </oui-select-picker-footer>
+                </oui-select-picker>
             </div>
             <div class="row mb-2">
                 <div class="col-md-3">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-8208`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8709
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. Order storages by size
2. Display storages horizontally
