### PR TITLE
fix(hosting): warn when `php` version is EOL

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_de_DE.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Inaktiv",
   "hosting_dashboard_email_offer_get_error": "Es ist unmöglich, die E-Mail-Adresse wiederherzustellen.",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Mehr"
+  "hosting_dashboard_tabs_dropdown": "Mehr",
+  "hosting_dashboard_php_support_SUPPORTED": "Sie verwenden eine aktuelle PHP-Version. Sie nutzen die neuesten Sicherheitsupdates."
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_en_GB.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Disabled",
   "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "More"
+  "hosting_dashboard_tabs_dropdown": "More",
+  "hosting_dashboard_php_support_SUPPORTED": "You are currently using a recent PHP version. You have the latest security updates."
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_es_ES.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Inactivo",
   "hosting_dashboard_email_offer_get_error": "No se ha podido cargar la dirección de correo.",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Más"
+  "hosting_dashboard_tabs_dropdown": "Más",
+  "hosting_dashboard_php_support_SUPPORTED": "Actualmente está utilizando una versión de PHP reciente. Dispone de las últimas actualizaciones de seguridad."
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_CA.json
@@ -35,6 +35,7 @@
   "hosting_dashboard_disk_usage_total": "Espace utilisé :",
   "hosting_dashboard_disk_usage_configuration": "{{t0}} sont alloués à la configuration du serveur",
   "hosting_dashboard_trafic_usage": "Traffic utilisé",
+  "hosting_dashboard_php_support_SUPPORTED": "Vous utilisez actuellement une version de PHP récente. Vous disposez des dernières mises à jour de sécurité.",
   "hosting_dashboard_php_support_SECURITY_FIXES": "Vous utilisez actuellement une version de PHP qui n'évoluera plus. Seules les failles de sécurité seront corrigées. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_END_OF_LIFE": "Vous utilisez actuellement une version de PHP qui n'est plus maintenue. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_BETA": "Version beta",

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
@@ -35,6 +35,7 @@
   "hosting_dashboard_disk_usage_total": "Espace utilisé :",
   "hosting_dashboard_disk_usage_configuration": "{{t0}} sont alloués à la configuration du serveur",
   "hosting_dashboard_trafic_usage": "Traffic utilisé",
+  "hosting_dashboard_php_support_SUPPORTED": "Vous utilisez actuellement une version de PHP récente. Vous disposez des dernières mises à jour de sécurité.",
   "hosting_dashboard_php_support_SECURITY_FIXES": "Vous utilisez actuellement une version de PHP qui n'évoluera plus. Seules les failles de sécurité seront corrigées. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_END_OF_LIFE": "Vous utilisez actuellement une version de PHP qui n'est plus maintenue. Vous pouvez mettre à jour cette version en utilisant le bouton \"modifier la configuration\" situé sur la droite. Le changement de version peut impacter le fonctionnement de vos sites Web.",
   "hosting_dashboard_php_support_BETA": "Version beta",

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_it_IT.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Disattivo",
   "hosting_dashboard_email_offer_get_error": "Impossibile recuperare l’indirizzo email",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Più"
+  "hosting_dashboard_tabs_dropdown": "Più",
+  "hosting_dashboard_php_support_SUPPORTED": "Al momento stai utilizzando una versione di PHP recente. Disponi degli ultimi aggiornamenti di sicurezza."
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pl_PL.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Nieaktywny",
   "hosting_dashboard_email_offer_get_error": "Nie można pobrać adresu e-mail",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Więcej"
+  "hosting_dashboard_tabs_dropdown": "Więcej",
+  "hosting_dashboard_php_support_SUPPORTED": "Aktualnie korzystasz z najnowszej wersji PHP. Dostępne są najnowsze aktualizacje bezpieczeństwa."
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pt_PT.json
@@ -1373,5 +1373,6 @@
   "hosting_dashboard_service_common_inactive": "Inativo",
   "hosting_dashboard_email_offer_get_error": "Não é possível recuperar o endereço de e-mail",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Mais"
+  "hosting_dashboard_tabs_dropdown": "Mais",
+  "hosting_dashboard_php_support_SUPPORTED": "Está a utilizar uma versão de PHP recente. Dispõe das últimas atualizações de segurança."
 }

--- a/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -232,13 +232,12 @@
                                 data-ng-bind="::ovhConfig.engineVersion"
                             ></span>
                             <span
-                                class="fa fa-exclamation-triangle"
                                 aria-hidden="true"
                                 data-ng-class="{
-                                    'text-warning': phpVersionSupport.support === 'SECURITY_FIXES',
-                                    'text-danger': phpVersionSupport.support === 'END_OF_LIFE'
-                                  }"
-                                data-ng-if="phpVersionSupport.support && phpVersionSupport.support !== 'SUPPORTED'"
+                                        'fa fa-check-circle text-success': phpVersionSupport.support === 'SUPPORTED',
+                                        'fa fa-exclamation-triangle text-warning': phpVersionSupport.support === 'SECURITY_FIXES',
+                                        'fa fa-exclamation-triangle text-danger': phpVersionSupport.support === 'END_OF_LIFE',
+                                     }"
                                 data-oui-tooltip="{{:: 'hosting_dashboard_php_support_'+ phpVersionSupport.support | translate }}"
                                 data-oui-tooltip-placement="bottom"
                             >
@@ -368,14 +367,12 @@
                         data-term="{{:: 'hosting_dashboard_service_cdn' | translate }}"
                     >
                         <oui-tile-description>
-                            <span
-                                data-ng-if=""
-                            >
+                            <span data-ng-if="">
                                 <span
                                     class="oui-badge oui-badge_s oui-badge_new"
                                     data-translate="hosting_dashboard_service_cdn_customer_has_cdn_v1_badge_new"
                                 ></span
-                                ><br/>
+                                ><br />
                             </span>
                             <span
                                 data-ng-bind="::hosting.hasCdn ? ('common_yes' | translate) : ('common_no' | translate)"
@@ -386,9 +383,11 @@
                                     data-ng-if="isUpgradable && cdnProperties.version === '2013v1'"
                                 >
                                     <span> - </span>
-                                    <span class="fa fa-exclamation-triangle text-warning"
-                                          aria-hidden="true"
-                                          data-oui-tooltip="{{:: 'hosting_dashboard_service_cdn_customer_has_cdn_v1_new_offers' | translate }}"></span>
+                                    <span
+                                        class="fa fa-exclamation-triangle text-warning"
+                                        aria-hidden="true"
+                                        data-oui-tooltip="{{:: 'hosting_dashboard_service_cdn_customer_has_cdn_v1_new_offers' | translate }}"
+                                    ></span>
                                 </span>
                             </span>
                             <oui-spinner
@@ -401,19 +400,28 @@
                                 data-ng-if="flushCdnState === 'doing'"
                             ></span>
 
-                            <div data-ng-if="hosting.hasCdn && $ctrl.isCdnInDeleteAtExpiration">
+                            <div
+                                data-ng-if="hosting.hasCdn && $ctrl.isCdnInDeleteAtExpiration"
+                            >
                                 <p class="m-0">
-                                    <small data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate"
-                                           data-translate-values="{ endEngagementDate: '<b>' + (cdnServiceInfo.expirationDate | date) + '</b>' }">
+                                    <small
+                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate"
+                                        data-translate-values="{ endEngagementDate: '<b>' + (cdnServiceInfo.expirationDate | date) + '</b>' }"
+                                    >
                                     </small>
                                 </p>
                                 <button
                                     type="button"
                                     class="oui-button oui-button_s oui-button_ghost oui-button_icon-right"
-                                    data-ng-click="$ctrl.onCancelTerminateCdn()">
+                                    data-ng-click="$ctrl.onCancelTerminateCdn()"
+                                >
                                     <span
-                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate_link"></span>
-                                    <span class="oui-icon oui-icon-arrow-right" aria-hidden="true"></span>
+                                        data-translate="hosting_dashboard_config_tile_options_cdn_cancel_terminate_link"
+                                    ></span>
+                                    <span
+                                        class="oui-icon oui-icon-arrow-right"
+                                        aria-hidden="true"
+                                    ></span>
                                 </button>
                             </div>
                         </oui-tile-description>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Ticket             | MANAGER-8769
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Customer is warn when php version is EOL, he should also be warn when he use a stable version

### :flags: Translations

- [x] TRANS-41727