### PR TITLE
Feat/manager 8475: add missed trad and banner service name for block-storage

### DIFF
--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_de_DE.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Wartung von Public Cloud mit Auswirkung auf die Verwaltung Ihres Dienstes.",
-  "pci_projects_maintenance_banner_info_link": "Mehr erfahren."
+  "pci_projects_maintenance_banner_info_link": "Mehr erfahren.",
+  "pci_projects_maintenance_banner_info_project_page": "Wartungsarbeiten: Dies betrifft mindestens einen der Dienste, die mit Ihrem Projekt {{projectName}} verbundenen sind.",
+  "pci_projects_maintenance_banner_info_list_page": "Wartungsarbeiten: Mindestens eine Ihrer Dienste {{productName}} ist betroffen.",
+  "pci_projects_maintenance_banner_info_product_page": "Wartungsarbeiten: Ihr Dienst {{productServiceName}} ist gerade von Wartungsarbeiten betroffen."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_en_GB.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Public Cloud maintenance with impact on your service management.",
-  "pci_projects_maintenance_banner_info_link": "Find out more."
+  "pci_projects_maintenance_banner_info_link": "Find out more.",
+  "pci_projects_maintenance_banner_info_project_page": "Maintenance: at least one of the services associated with your {{projectName}} project is affected.",
+  "pci_projects_maintenance_banner_info_list_page": "Maintenance: at least one of your {{productName}} services is affected.",
+  "pci_projects_maintenance_banner_info_product_page": "Maintenance: your {{productServiceName}} service is affected by maintenance."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_es_ES.json
@@ -1,7 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Mantenimiento de Public Cloud que afecta a la gestión de su servicio.",
   "pci_projects_maintenance_banner_info_link": "Más información.",
-  "pci_projects_maintenance_banner_info_project_page": "Mantenimiento: al menos uno de los servicios asociados al proyecto {{projectName}} se ha visto afectado.",
-  "pci_projects_maintenance_banner_info_list_page": "Mantenimiento: al menos uno de sus servicios {{productName}} se ha visto afectado.",
-  "pci_projects_maintenance_banner_info_product_page": "Mantenimiento: el servicio {{productServiceName}} se ha visto afectado por una operación de mantenimiento."
+  "pci_projects_maintenance_banner_info_project_page": "Mantenimiento: al menos uno de los servicios asociados al proyecto {{projectName}} está afectado.",
+  "pci_projects_maintenance_banner_info_list_page": "Mantenimiento: al menos uno de sus servicios {{productName}} está afectado.",
+  "pci_projects_maintenance_banner_info_product_page": "Mantenimiento: el servicio {{productServiceName}} está afectado por una operación de mantenimiento."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_es_ES.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Mantenimiento de Public Cloud que afecta a la gestión de su servicio.",
-  "pci_projects_maintenance_banner_info_link": "Más información."
+  "pci_projects_maintenance_banner_info_link": "Más información.",
+  "pci_projects_maintenance_banner_info_project_page": "Mantenimiento: al menos uno de los servicios asociados al proyecto {{projectName}} se ha visto afectado.",
+  "pci_projects_maintenance_banner_info_list_page": "Mantenimiento: al menos uno de sus servicios {{productName}} se ha visto afectado.",
+  "pci_projects_maintenance_banner_info_product_page": "Mantenimiento: el servicio {{productServiceName}} se ha visto afectado por una operación de mantenimiento."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_fr_CA.json
@@ -1,4 +1,6 @@
 {
-  "pci_projects_maintenance_banner_info": "Maintenance Public Cloud avec impact sur le management de votre service.",
+  "pci_projects_maintenance_banner_info_project_page": "Maintenance : au moins un des services associé à votre projet {{projectName}} est impacté.",
+  "pci_projects_maintenance_banner_info_list_page": "Maintenance : au moins un de vos services {{productName}} est impacté.",
+  "pci_projects_maintenance_banner_info_product_page": "Maintenance : votre service {{productServiceName}} est impacté par une maintenance.",
   "pci_projects_maintenance_banner_info_link": "En savoir plus."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_it_IT.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Manutenzione Public Cloud con impatto sulla gestione del tuo servizio.",
-  "pci_projects_maintenance_banner_info_link": "Scopri di più"
+  "pci_projects_maintenance_banner_info_link": "Scopri di più",
+  "pci_projects_maintenance_banner_info_project_page": "Manutenzione: l’operazione ha impatto su almeno uno dei servizi associati al progetto {{projectName}}.",
+  "pci_projects_maintenance_banner_info_list_page": "Manutenzione: l’operazione ha impatto su almeno uno dei servizi {{productName}}.",
+  "pci_projects_maintenance_banner_info_product_page": "Manutenzione: il servizio {{productServiceName}} è interessato da un intervento di manutenzione."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_pl_PL.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Planowe prace modernizacyjne na usłudze Public Cloud ograniczające czasowo zarządzanie usługą.",
-  "pci_projects_maintenance_banner_info_link": "Dowiedz się więcej."
+  "pci_projects_maintenance_banner_info_link": "Dowiedz się więcej.",
+  "pci_projects_maintenance_banner_info_project_page": "Konserwacja: dotyczy co najmniej jednej z usług przypisanych do Twojego projektu {{projectName}}.",
+  "pci_projects_maintenance_banner_info_list_page": "Konserwacja: dotyczy co najmniej jednej z Twoich usług {{productName}}.",
+  "pci_projects_maintenance_banner_info_product_page": "Konserwacja: dotyczy Twojej usługi {{productServiceName}}."
 }

--- a/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/components/pci-maintenance-banner/translations/Messages_pt_PT.json
@@ -1,4 +1,7 @@
 {
   "pci_projects_maintenance_banner_info": "Manutenção do Public Cloud com impacto na gestão do seu serviço.",
-  "pci_projects_maintenance_banner_info_link": "Saber mais"
+  "pci_projects_maintenance_banner_info_link": "Saber mais",
+  "pci_projects_maintenance_banner_info_project_page": "Manutenção: pelo menos um dos serviços associados ao seu projeto {{projectName}} foi afetado.",
+  "pci_projects_maintenance_banner_info_list_page": "Manutenção: pelo menos um dos seus serviços {{productName}} foi afetado.",
+  "pci_projects_maintenance_banner_info_product_page": "Manutenção: o seu serviço {{productServiceName}} foi afetado por uma manutenção."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/block/edit/edit.html
@@ -8,7 +8,7 @@
         data-customer-regions="$ctrl.customerRegions"
         data-product-regions="$ctrl.storagesRegions"
         data-is-dashboard-page="true"
-        data-product-service-name="$ctrl.instance.name"
+        data-product-service-name="$ctrl.editStorage.name"
         data-product-region="$ctrl.editStorage.region"
     ></pci-maintenance-banner>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/2022-w07`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8475
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1 - Get missed trad
2 - Add missed service name on block storage maintenance banner  

### :flags: Translations
- [x] TRANS-41520