### PR TITLE
fix(pci.object-storage): disable next btn until customer select a region

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
@@ -72,12 +72,14 @@
     </oui-step-form>
 
     <oui-step-form
+        data-name="storage_container_add_region"
         data-header="{{:: 'pci_projects_project_storages_containers_add_region_title' | translate }}"
         data-navigation="$ctrl.container.region"
         data-on-focus="$ctrl.onRegionsFocus()"
         data-on-submit="$ctrl.onRegionChange()"
         data-editable="!$ctrl.isLoading"
-        name="storage_container_add_region"
+        data-valid="$ctrl.container.region"
+        data-prevent-next
     >
         <pci-project-regions-list
             data-ng-if="$ctrl.archive || $ctrl.currrentStep > 0"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-7953`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8784
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. don't allow customers to go to next step if region is not selected