### PR TITLE
build(deps): add missing `@ovh-ux/ng-ovh-contracts` dependency

### DIFF
--- a/packages/manager/apps/anthos/package.json
+++ b/packages/manager/apps/anthos/package.json
@@ -29,6 +29,7 @@
     "@ovh-ux/ng-at-internet": "^5.8.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^4.0.10",
+    "@ovh-ux/ng-ovh-contracts": "^4.0.5",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.4",
     "@ovh-ux/ng-ovh-http": "^5.0.3",
     "@ovh-ux/ng-ovh-payment-method": "^9.1.1",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [ ] ~~Commits are signed-off~~ (not applicable)
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~ (not applicable)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Solve following error:

```sh
@ovh-ux/manager-anthos-app: ERROR in /home/manager/packages/manager/modules/product-offers/src/index.js
@ovh-ux/manager-anthos-app: Module not found: Error: Can't resolve '@ovh-ux/ng-ovh-contracts' in '/home/manager/packages/manager/modules/product-offers/src'
```

### :construction_worker: Build

36d6a0d - build(deps): add missing `@ovh-ux/ng-ovh-contracts` dependency

uses: `npx lerna add @ovh-ux/ng-ovh-contracts --scope=@ovh-ux/manager-anthos-app`

## Related

- #6195

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
