### PR TITLE
build(ovh-shell): fix the dev script and add dev:watch

### DIFF
--- a/packages/components/ovh-shell/package.json
+++ b/packages/components/ovh-shell/package.json
@@ -15,7 +15,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc -w"
+    "dev": "tsc",
+    "dev:watch": "tsc -w"
   },
   "dependencies": {
     "@ovh-ux/manager-config": "^5.0.0 || ^6.0.0",


### PR DESCRIPTION
Signed-off-by: Jisay <jean-christophe.alleman@corp.ovh.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | -
| License          | BSD 3-Clause

## Description

Replace `dev` scrtipt with `dev:watch` script and fix `dev`script by removing the watch flag in order to be able to use `start:dev` on applications.