### PR TITLE
fix(hosted-private-cloud): display correct private bandwidth

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.component.js
@@ -6,6 +6,7 @@ export default {
     cluster: '<',
     goToUpgradePrivateBandwidth: '<',
     onError: '&?',
+    privateBandwidthPlanCode: '<',
     privateBandwidthServiceId: '<',
   },
   controller,

--- a/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.controller.js
+++ b/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.controller.js
@@ -1,4 +1,5 @@
 import isFunction from 'lodash/isFunction';
+import parseInt from 'lodash/parseInt';
 import { IPFO } from './network-tile.constants';
 
 export default class NutanixNetworkTileController {
@@ -36,15 +37,6 @@ export default class NutanixNetworkTileController {
         });
     }
 
-    this.loadingBandwidth = true;
-    this.loadBandwidth()
-      .then((res) => {
-        this.specifications = res;
-      })
-      .finally(() => {
-        this.loadingBandwidth = false;
-      });
-
     this.loadingBandwidthOptions = true;
     this.loadBandwidthOptions()
       .then((res) => {
@@ -61,6 +53,19 @@ export default class NutanixNetworkTileController {
       .finally(() => {
         this.loadingUpgradeOptions = false;
       });
+    this.setPrivateBandwidth();
+  }
+
+  setPrivateBandwidth() {
+    this.privatebandwidth = {
+      value:
+        parseInt(
+          this.privateBandwidthPlanCode
+            .split('-')
+            .find((ele) => /^\d+$/.test(ele)),
+        ) / 1000,
+      unit: 'Gbps',
+    };
   }
 
   loadVrack(vRackServiceName) {
@@ -83,12 +88,6 @@ export default class NutanixNetworkTileController {
         ...data,
       }))
       .catch((error) => this.handleError(error));
-  }
-
-  loadBandwidth() {
-    return this.NutanixService.getBandwidth(
-      this.cluster.getFirstNode(),
-    ).catch((error) => this.handleError(error));
   }
 
   loadBandwidthOptions() {

--- a/packages/manager/modules/nutanix/src/dashboard/component/network-tile/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/component/network-tile/template.html
@@ -1,12 +1,11 @@
 <oui-tile
     class="h-100"
     data-heading="{{:: 'nutanix_cluster_network_title' | translate }}"
-    data-loading="$ctrl.loadingVrack || $ctrl.loadingIpLb ||
-        $ctrl.loadingBandwidth || $ctrl.loadingBandwidthOptions"
+    data-loading="$ctrl.loadingVrack || $ctrl.loadingIpLb || $ctrl.loadingBandwidthOptions"
 >
     <!-- Private Bandwidth -->
     <oui-tile-definition
-        data-ng-if="$ctrl.specifications.vrack.bandwidth"
+        data-ng-if="$ctrl.privateBandwidthPlanCode"
         data-term="{{:: 'nutanix_cluster_bandwidth_private' | translate }}"
     >
         <oui-tile-description>
@@ -17,7 +16,7 @@
                         class="oui-icon oui-icon-arrow-up font-inherit"
                     ></span>
                     <span
-                        data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
+                        data-ng-bind="$ctrl.privatebandwidth | serverBandwidth"
                     ></span>
                     <span
                         data-translate="nutanix_cluster_bandwidth_outgoing"
@@ -34,7 +33,7 @@
                         class="oui-icon oui-icon-arrow-down font-inherit"
                     ></span>
                     <span
-                        data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
+                        data-ng-bind="$ctrl.privatebandwidth | serverBandwidth"
                     ></span>
                     <span
                         data-translate="nutanix_cluster_bandwidth_incoming"

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/controller.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/controller.js
@@ -14,7 +14,7 @@ export default class NutanixGeneralInfoCtrl {
   $onInit() {
     this.loadServcesDetails();
     this.technicalDetails = this.getTechnicalDetails();
-    this.setPrivateBandwidthServiceId();
+    this.setPrivateBandwidthDetails();
     this.clusterRedeploying = this.cluster.status === CLUSTER_STATUS.DEPLOYING;
   }
 
@@ -36,10 +36,16 @@ export default class NutanixGeneralInfoCtrl {
     );
   }
 
-  setPrivateBandwidthServiceId() {
-    this.privateBandwidthServiceId = this.clusterAddOns.find((addOn) =>
-      addOn.billing?.plan?.code?.startsWith(PRIVATE_BANDWIDTH_SERVICE_PREFIX),
-    )?.serviceId;
+  setPrivateBandwidthDetails() {
+    const addOn = this.clusterAddOns.find((clusterAddOn) =>
+      clusterAddOn.billing?.plan?.code?.startsWith(
+        PRIVATE_BANDWIDTH_SERVICE_PREFIX,
+      ),
+    );
+    if (addOn) {
+      this.privateBandwidthServiceId = addOn.serviceId;
+      this.privateBandwidthPlanCode = addOn.billing.plan.code;
+    }
   }
 
   trackClick(trackText) {

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
@@ -204,6 +204,7 @@
             cluster="$ctrl.cluster"
             on-error="$ctrl.handleError(error)"
             go-to-upgrade-private-bandwidth="$ctrl.goToUpgradePrivateBandwidth"
+            private-bandwidth-plan-code="$ctrl.privateBandwidthPlanCode"
             private-bandwidth-service-id="$ctrl.privateBandwidthServiceId"
         >
         </nutanix-network-tile>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8745
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Fix to display correct private bandwidth on nutanix cluster dashboard

## Related

<!-- Link dependencies of this PR -->
