### PR TITLE
fix(server.dashboard.upgrade): use the right service id

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/upgrade/upgrade.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/upgrade/upgrade.controller.js
@@ -86,9 +86,11 @@ export default class {
   orderOption() {
     this.orderInProgress = true;
     const renewDetails = this.getRenewDetails(this.selectedUpgradeOption);
+    const upgradePlanServiceId =
+      this.selectedUpgradeOption.serviceId || this.optionId;
     return this.$http
       .post(
-        `/services/${this.optionId}/upgrade/${this.selectedUpgradeOption.planCode}/execute`,
+        `/services/${upgradePlanServiceId}/upgrade/${this.selectedUpgradeOption.planCode}/execute`,
         {
           duration: renewDetails.duration,
           pricingMode: renewDetails.pricingMode,


### PR DESCRIPTION
wrong service id is used during dedicated storage upgrade

ref: MANAGER-7896

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/hgv2`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-7896
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
