### PR TITLE
Revert "feat(details): add statistics"

### DIFF
--- a/packages/manager/modules/cloud-connect/src/cloud-connect.service.js
+++ b/packages/manager/modules/cloud-connect/src/cloud-connect.service.js
@@ -507,4 +507,22 @@ export default class CloudConnectService {
       CloudConnectService.clearCache(cacheName);
     });
   }
+
+  loadStatistics(cloudConnectId, interfaceId, type, period) {
+    const options = {
+      period,
+      type,
+    };
+
+    return this.$http
+      .get(
+        `/ovhCloudConnect/${cloudConnectId}/interface/${interfaceId}/statistics`,
+        { params: options },
+      )
+      .then((statistics) => {
+        const stats = statistics.data || [];
+        return stats.map(({ timestamp, value }) => [timestamp * 1000, value]);
+      })
+      .catch(() => []);
+  }
 }

--- a/packages/manager/modules/cloud-connect/src/details/details.module.js
+++ b/packages/manager/modules/cloud-connect/src/details/details.module.js
@@ -7,6 +7,7 @@ import overview from './overview';
 import routing from './details.routing';
 import serviceKeys from './service-keys';
 import tasks from './tasks';
+import statistics from './statistics';
 
 const moduleName = 'ovhCloudConnectDetails';
 
@@ -17,6 +18,7 @@ angular
     overview,
     serviceKeys,
     tasks,
+    statistics,
   ])
   .config(routing)
   .component('cloudConnectDetails', component)

--- a/packages/manager/modules/cloud-connect/src/details/statistics/index.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/index.js
@@ -1,0 +1,36 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import 'oclazyload';
+import 'ovh-api-services';
+import ngOvhCloudUniverseComponents from '@ovh-ux/ng-ovh-cloud-universe-components';
+
+const moduleName = 'ovhCloudConnectStatisticsDetailsLazyLoading';
+
+angular
+  .module(moduleName, [
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'oc.lazyLoad',
+    'ovh-api-services',
+    ngOvhCloudUniverseComponents,
+  ])
+  .config(
+    /* @ngInject */ ($stateProvider) => {
+      $stateProvider.state('cloud-connect.details.statistics.**', {
+        url: '/statistics',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+          return import('./statistics.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+    },
+  );
+
+export default moduleName;

--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.component.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.component.js
@@ -1,0 +1,10 @@
+import controller from './statistics.controller';
+import template from './template.html';
+
+export default {
+  bindings: {
+    cloudConnect: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.constant.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.constant.js
@@ -1,0 +1,131 @@
+export const PERIOD = {
+  HOURLY: 'hourly',
+  DAILY: 'daily',
+  MONTHLY: 'monthly',
+};
+
+export const TYPE = {
+  LIGHT: 'light',
+  LIGHT_IN: 'light:in',
+  LIGHT_OUT: 'light:out',
+  TRAFFIC: 'traffic',
+  TRAFFIC_DOWN: 'traffic:download',
+  TRAFFIC_UP: 'traffic:upload',
+  ERROR: 'error',
+  ERROR_DOWN: 'error:download',
+  ERROR_UP: 'error:upload',
+};
+
+export const PERIOD_ENUM = ['hourly', 'daily', 'weekly'];
+
+export const TYPE_ENUM = ['error', 'light', 'traffic'];
+
+export const TYPE_LABELS = {
+  down: 'down',
+  up: 'up',
+};
+
+export const LABELS = {
+  traffic_unit: 'bytes/s',
+  light_unit: 'dbm',
+  error_unit: 'error/s',
+  id_port: 'ID Port',
+  download: 'download',
+  upload: 'upload',
+  in: 'in',
+  out: 'out',
+};
+
+export const STATISTICS = {
+  colors: [
+    {
+      borderColor: '#33acff',
+      backgroundColor: 'rgba(51, 172, 255, 0.1)',
+    },
+    {
+      borderColor: '#354291',
+      backgroundColor: 'rgba(53, 66, 145, 0.1)',
+    },
+    {
+      borderColor: '#fd8c06',
+      backgroundColor: 'rgba(253, 140, 6, 0.1)',
+    },
+    {
+      borderColor: '#24b994',
+      backgroundColor: 'rgba(36, 185, 148, 0.1)',
+    },
+    {
+      borderColor: '#b92463',
+      backgroundColor: 'rgba(185, 36, 99, 0.1)',
+    },
+    {
+      borderColor: '#5a2d7a',
+      backgroundColor: 'rgba(90, 45, 122, 0.1)',
+    },
+    {
+      borderColor: '#0d618c',
+      backgroundColor: 'rgba(13, 97, 140, 0.1)',
+    },
+    {
+      borderColor: '#e53232',
+      backgroundColor: 'rgba(229, 50, 50, 0.1)',
+    },
+  ],
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    legend: {
+      position: 'bottom',
+      display: true,
+    },
+    elements: {
+      line: {
+        fill: false,
+        tension: 0,
+        borderWidth: 1,
+      },
+      point: {
+        radius: 0,
+      },
+    },
+    tooltips: {
+      mode: 'label',
+      intersect: false,
+    },
+    scales: {
+      yAxes: [
+        {
+          display: true,
+          type: 'linear',
+          position: 'left',
+          scaleLabel: {
+            display: true,
+          },
+          gridLines: {
+            drawBorder: true,
+            display: false,
+          },
+        },
+      ],
+      xAxes: [
+        {
+          type: 'time',
+          position: 'bottom',
+          gridLines: {
+            drawBorder: true,
+            display: false,
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default {
+  PERIOD,
+  PERIOD_ENUM,
+  STATISTICS,
+  TYPE,
+  TYPE_ENUM,
+  TYPE_LABELS,
+};

--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.controller.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.controller.js
@@ -1,0 +1,194 @@
+import get from 'lodash/get';
+import map from 'lodash/map';
+
+import {
+  LABELS,
+  PERIOD,
+  PERIOD_ENUM,
+  STATISTICS,
+  TYPE,
+  TYPE_ENUM,
+  TYPE_LABELS,
+} from './statistics.constant';
+
+export default class CloudConnectStatisticsCtrl {
+  /* @ngInject */
+  constructor($q, CucCloudMessage, cloudConnectService) {
+    this.$q = $q;
+    this.CucCloudMessage = CucCloudMessage;
+    this.cloudConnectService = cloudConnectService;
+    this.LABELS = LABELS;
+    this.PERIOD = PERIOD;
+    this.STATISTICS = STATISTICS;
+    this.TYPE = TYPE;
+    this.TYPE_LABELS = TYPE_LABELS;
+  }
+
+  $onInit() {
+    this.periodOptions = PERIOD_ENUM;
+    this.typeOptions = TYPE_ENUM;
+
+    this.graphType = this.TYPE.TRAFFIC;
+    this.graphPeriod = this.PERIOD.DAILY;
+
+    this.trafficLoader = {
+      series: [],
+      data: [],
+    };
+
+    this.displayedGraph = this.TYPE.TRAFFIC;
+    this.colors = this.STATISTICS.colors;
+    this.options = {
+      ...this.STATISTICS.options,
+    };
+    this.options.scales.yAxes[0].ticks = {
+      beginAtZero: true,
+    };
+
+    this.lightOptions = {
+      ...this.STATISTICS.options,
+    };
+
+    this.isLoading = false;
+    this.loadGraphs();
+  }
+
+  loadGraphs() {
+    switch (this.graphType) {
+      case this.TYPE.LIGHT:
+        this.displayedGraph = this.TYPE.LIGHT;
+        this.loadLightGraph();
+        break;
+      case this.TYPE.ERROR:
+        this.loadErrorGraph();
+        this.displayedGraph = this.TYPE.ERROR;
+        break;
+      default:
+        this.loadTrafficGraph();
+        this.displayedGraph = this.TYPE.TRAFFIC;
+        break;
+    }
+  }
+
+  loadInterfacesStatistics(type) {
+    let propDown = '';
+    let propUp = '';
+    switch (type) {
+      case this.TYPE.LIGHT:
+        propDown = this.TYPE.LIGHT_IN;
+        propUp = this.TYPE.LIGHT_OUT;
+        break;
+      case this.TYPE.ERROR:
+        propDown = this.TYPE.ERROR_DOWN;
+        propUp = this.TYPE.ERROR_UP;
+        break;
+      default:
+        propDown = this.TYPE.TRAFFIC_DOWN;
+        propUp = this.TYPE.TRAFFIC_UP;
+        break;
+    }
+
+    this.cloudConnect.interfaceList.forEach((interfaceId) => {
+      return this.$q
+        .all({
+          down: this.loadStatistics(
+            this.cloudConnect.id,
+            interfaceId,
+            propDown,
+            this.graphPeriod,
+          ),
+          up: this.loadStatistics(
+            this.cloudConnect.id,
+            interfaceId,
+            propUp,
+            this.graphPeriod,
+          ),
+        })
+        .then((stats) => {
+          if (stats.down.length > 0 || stats.up.length > 0) {
+            this.updateStats(type, interfaceId, stats);
+            this.isLoading = false;
+          }
+        });
+    });
+  }
+
+  // Load error statistics
+  loadErrorGraph() {
+    this.series = [];
+    this.data = [];
+    this.isLoading = true;
+
+    // Update options
+    this.options.scales.yAxes[0].scaleLabel.labelString = this.LABELS.error_unit;
+
+    this.loadInterfacesStatistics(this.TYPE.ERROR);
+  }
+
+  // Load light statistics
+  loadLightGraph() {
+    this.series = [];
+    this.data = [];
+    this.isLoading = true;
+
+    // Update options
+    this.lightOptions.scales.yAxes[0].scaleLabel.labelString = this.LABELS.light_unit;
+
+    this.loadInterfacesStatistics(this.TYPE.LIGHT);
+  }
+
+  // Load traffic statistics
+  loadTrafficGraph() {
+    this.series = [];
+    this.data = [];
+    this.isLoading = true;
+
+    // Update options
+    this.options.scales.yAxes[0].scaleLabel.labelString = this.LABELS.traffic_unit;
+
+    this.loadInterfacesStatistics(this.TYPE.TRAFFIC);
+  }
+
+  updateStats(type, interfaceId, stats) {
+    let serieLabels = null;
+    const dataProperties = [this.TYPE_LABELS.down, this.TYPE_LABELS.up];
+    switch (type) {
+      case this.TYPE.LIGHT:
+        serieLabels = [
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.in}`,
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.out}`,
+        ];
+        break;
+      case this.TYPE.ERROR:
+        serieLabels = [
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.download}`,
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.upload}`,
+        ];
+        break;
+      default:
+        serieLabels = [
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.download}`,
+          `${this.LABELS.id_port} ${interfaceId} - ${this.LABELS.upload}`,
+        ];
+        break;
+    }
+
+    serieLabels.forEach((label) => {
+      this.series.push(label);
+    });
+
+    this.labels = map(get(stats, dataProperties[0]), (value) => value[0]);
+    dataProperties.forEach((prop) => {
+      this.data.push(map(get(stats, prop), (value) => value[1].value));
+    });
+  }
+
+  loadStatistics(connectId, interfaceId, type, period) {
+    return this.cloudConnectService.loadStatistics(
+      connectId,
+      interfaceId,
+      type,
+      period,
+    );
+  }
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.module.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.module.js
@@ -1,0 +1,16 @@
+import angular from 'angular';
+
+import component from './statistics.component';
+import routing from './statistics.routing';
+
+import '../../style.scss';
+
+const moduleName = 'ovhCloudConnectDetailsStatistics';
+
+angular
+  .module(moduleName, [])
+  .config(routing)
+  .component('cloudConnectDetailsStatistics', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.routing.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.routing.js
@@ -1,0 +1,10 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('cloud-connect.details.statistics', {
+    url: '/statistics',
+    component: 'cloudConnectDetailsStatistics',
+    resolve: {
+      breadcrumb: /* @ngInject */ ($translate) =>
+        $translate.instant('cloud_connect_statistics'),
+    },
+  });
+};

--- a/packages/manager/modules/cloud-connect/src/details/statistics/template.html
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/template.html
@@ -1,0 +1,97 @@
+<section>
+    <form class="form-horizontal">
+        <div class="form-group">
+            <label
+                for="graphType"
+                class="col-xs-3 col-md-2 control-label text-left"
+                data-translate="cloud_connect_stats_type"
+            ></label>
+            <div class="col-xs-9 col-md-4 clearfix">
+                <select
+                    id="graphType"
+                    name="graphType"
+                    class="form-control"
+                    data-ng-disabled="$ctrl.isGraphLoading"
+                    data-ng-change="$ctrl.loadGraphs()"
+                    data-ng-model="$ctrl.graphType"
+                    data-ng-options="'cloud_connect_stats_type_' + type | translate for type in $ctrl.typeOptions"
+                ></select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label
+                for="graphPeriod"
+                class="col-xs-3 col-md-2 control-label text-left"
+                data-translate="cloud_connect_stats_period"
+            ></label>
+            <div class="col-xs-9 col-md-4 clearfix">
+                <select
+                    id="graphPeriod"
+                    name="graphPeriod"
+                    class="form-control"
+                    data-ng-disabled="$ctrl.isGraphLoading"
+                    data-ng-change="$ctrl.loadGraphs()"
+                    data-ng-model="$ctrl.graphPeriod"
+                    data-ng-options="'cloud_connect_stats_period_' + period | translate for period in $ctrl.periodOptions"
+                ></select>
+            </div>
+        </div>
+    </form>
+    <div>
+        <oui-header
+            data-heading="{{::'cloud_connect_stats_type_traffic' | translate}}"
+            data-ng-if="$ctrl.displayedGraph === $ctrl.TYPE.TRAFFIC"
+        ></oui-header>
+        <oui-header
+            data-heading="{{::'cloud_connect_stats_type_error' | translate}}"
+            data-ng-if="$ctrl.displayedGraph === $ctrl.TYPE.ERROR"
+        ></oui-header>
+        <oui-header
+            data-heading="{{::'cloud_connect_stats_type_light' | translate}}"
+            data-ng-if="$ctrl.displayedGraph === $ctrl.TYPE.LIGHT"
+        ></oui-header>
+
+        <oui-tile-definition data-ng-if="$ctrl.isLoading">
+            <oui-tile-description>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+                <oui-skeleton data-randomized></oui-skeleton>
+            </oui-tile-description>
+        </oui-tile-definition>
+
+        <div data-ng-if="!$ctrl.isLoading">
+            <div data-ng-if="$ctrl.data.length > 0" class="statistics-graph">
+                <canvas
+                    id="line"
+                    class="chart chart-line"
+                    data-chart-series="$ctrl.series"
+                    data-chart-colors="$ctrl.colors"
+                    data-chart-data="$ctrl.data"
+                    data-chart-labels="$ctrl.labels"
+                    data-chart-options="$ctrl.options"
+                    data-ng-if="$ctrl.displayedGraph === $ctrl.TYPE.TRAFFIC || $ctrl.displayedGraph === $ctrl.TYPE.ERROR"
+                >
+                </canvas>
+                <canvas
+                    id="line"
+                    class="chart chart-line"
+                    data-chart-series="$ctrl.series"
+                    data-chart-colors="$ctrl.colors"
+                    data-chart-data="$ctrl.data"
+                    data-chart-labels="$ctrl.labels"
+                    data-chart-options="$ctrl.lightOptions"
+                    data-ng-if="$ctrl.displayedGraph === $ctrl.TYPE.LIGHT"
+                >
+                </canvas>
+            </div>
+            <div
+                data-ng-if="$ctrl.data.length == 0"
+                data-translate="cloud_connect_stats_no_data"
+            ></div>
+        </div>
+    </div>
+</section>

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_de_DE.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_de_DE.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statistiken",
+  "cloud_connect_stats_type": "Typ",
+  "cloud_connect_stats_type_light": "Licht",
+  "cloud_connect_stats_type_traffic": "Traffic",
+  "cloud_connect_stats_type_error": "Fehler",
+  "cloud_connect_stats_period": "Frequenz",
+  "cloud_connect_stats_period_hourly": "Stündlich",
+  "cloud_connect_stats_period_daily": "Täglich",
+  "cloud_connect_stats_period_weekly": "Wöchentlich",
+  "cloud_connect_stats_no_data": "Keine Daten gefunden"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_en_GB.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_en_GB.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statistics",
+  "cloud_connect_stats_type": "Type",
+  "cloud_connect_stats_type_light": "Light",
+  "cloud_connect_stats_type_traffic": "Traffic",
+  "cloud_connect_stats_type_error": "Error",
+  "cloud_connect_stats_period": "Frequency",
+  "cloud_connect_stats_period_hourly": "Hourly",
+  "cloud_connect_stats_period_daily": "Daily",
+  "cloud_connect_stats_period_weekly": "Weekly",
+  "cloud_connect_stats_no_data": "No data found"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_es_ES.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_es_ES.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Estadísticas",
+  "cloud_connect_stats_type": "Tipo",
+  "cloud_connect_stats_type_light": "Luz",
+  "cloud_connect_stats_type_traffic": "Tráfico",
+  "cloud_connect_stats_type_error": "Error",
+  "cloud_connect_stats_period": "Periodicidad",
+  "cloud_connect_stats_period_hourly": "Cada hora",
+  "cloud_connect_stats_period_daily": "Diariamente",
+  "cloud_connect_stats_period_weekly": "Semanalmente",
+  "cloud_connect_stats_no_data": "No hay datos"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_fr_CA.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statistiques",
+  "cloud_connect_stats_type": "Type",
+  "cloud_connect_stats_type_light": "Lumière",
+  "cloud_connect_stats_type_traffic": "Trafic",
+  "cloud_connect_stats_type_error": "Erreur",
+  "cloud_connect_stats_period": "Périodicité",
+  "cloud_connect_stats_period_hourly": "Toutes les heures",
+  "cloud_connect_stats_period_daily": "Journalier",
+  "cloud_connect_stats_period_weekly": "Hebdomadaire",
+  "cloud_connect_stats_no_data": "Aucune donnée trouvée"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_fr_FR.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statistiques",
+  "cloud_connect_stats_type": "Type",
+  "cloud_connect_stats_type_light": "Lumière",
+  "cloud_connect_stats_type_traffic": "Trafic",
+  "cloud_connect_stats_type_error": "Erreur",
+  "cloud_connect_stats_period": "Périodicité",
+  "cloud_connect_stats_period_hourly": "Toutes les heures",
+  "cloud_connect_stats_period_daily": "Journalier",
+  "cloud_connect_stats_period_weekly": "Hebdomadaire",
+  "cloud_connect_stats_no_data": "Aucune donnée trouvée"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_it_IT.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_it_IT.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statistiche",
+  "cloud_connect_stats_type": "Tipo",
+  "cloud_connect_stats_type_light": "Luce",
+  "cloud_connect_stats_type_traffic": "Traffico",
+  "cloud_connect_stats_type_error": "Errore",
+  "cloud_connect_stats_period": "Periodicità",
+  "cloud_connect_stats_period_hourly": "Ogni ora",
+  "cloud_connect_stats_period_daily": "Giornaliera",
+  "cloud_connect_stats_period_weekly": "Settimanale",
+  "cloud_connect_stats_no_data": "Nessun dato trovato"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_pl_PL.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Statystyki",
+  "cloud_connect_stats_type": "Typ",
+  "cloud_connect_stats_type_light": "Światło",
+  "cloud_connect_stats_type_traffic": "Transfer",
+  "cloud_connect_stats_type_error": "Błąd",
+  "cloud_connect_stats_period": "Częstotliwość zbierania danych",
+  "cloud_connect_stats_period_hourly": "Co godzinę",
+  "cloud_connect_stats_period_daily": "Codziennie",
+  "cloud_connect_stats_period_weekly": "Co tydzień",
+  "cloud_connect_stats_no_data": "Brak danych"
+}

--- a/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/translations/Messages_pt_PT.json
@@ -1,0 +1,12 @@
+{
+  "cloud_connect_stats_title": "Estatísticas",
+  "cloud_connect_stats_type": "Tipo",
+  "cloud_connect_stats_type_light": "Luz",
+  "cloud_connect_stats_type_traffic": "Tráfego",
+  "cloud_connect_stats_type_error": "Erro",
+  "cloud_connect_stats_period": "Periodicidade",
+  "cloud_connect_stats_period_hourly": "De hora em hora",
+  "cloud_connect_stats_period_daily": "Diário ",
+  "cloud_connect_stats_period_weekly": "Semanal ",
+  "cloud_connect_stats_no_data": "Nenhum dado encontrado"
+}

--- a/packages/manager/modules/cloud-connect/src/details/template.html
+++ b/packages/manager/modules/cloud-connect/src/details/template.html
@@ -21,6 +21,11 @@
         <oui-header-tabs-item data-state="cloud-connect.details.tasks"
             ><span data-translate="cloud_connect_tasks"></span
         ></oui-header-tabs-item>
+        <oui-header-tabs-item
+            data-ng-if="$ctrl.cloudConnect.isDirectService()"
+            data-state="cloud-connect.details.statistics"
+            ><span data-translate="cloud_connect_statistics"></span>
+        </oui-header-tabs-item>
     </oui-header-tabs>
 </oui-header>
 <div data-ui-view></div>

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_de_DE.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_de_DE.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Konfigurieren",
   "cloud_connect_service_keys": "Serviceschlüssel",
-  "cloud_connect_tasks": "Tasks"
+  "cloud_connect_tasks": "Tasks",
+  "cloud_connect_statistics": "Statistiken"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_en_GB.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configure",
   "cloud_connect_service_keys": "Service keys",
-  "cloud_connect_tasks": "Tasks"
+  "cloud_connect_tasks": "Tasks",
+  "cloud_connect_statistics": "Statistics"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_es_ES.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_es_ES.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configurar",
   "cloud_connect_service_keys": "Claves de servicio",
-  "cloud_connect_tasks": "Tareas"
+  "cloud_connect_tasks": "Tareas",
+  "cloud_connect_statistics": "Estadísticas"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_fr_CA.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configurer",
   "cloud_connect_service_keys": "Clés de service",
-  "cloud_connect_tasks": "Tâches"
+  "cloud_connect_tasks": "Tâches",
+  "cloud_connect_statistics": "Statistiques"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_fr_FR.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configurer",
   "cloud_connect_service_keys": "Clés de service",
-  "cloud_connect_tasks": "Tâches"
+  "cloud_connect_tasks": "Tâches",
+  "cloud_connect_statistics": "Statistiques"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_it_IT.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_it_IT.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configura",
   "cloud_connect_service_keys": "Chiavi di servizio",
-  "cloud_connect_tasks": "Operazioni"
+  "cloud_connect_tasks": "Operazioni",
+  "cloud_connect_statistics": "Statistiche"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_pl_PL.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHCloud Connect",
   "cloud_connect_overview": "Konfiguruj",
   "cloud_connect_service_keys": "Klucze usługi",
-  "cloud_connect_tasks": "Zadania"
+  "cloud_connect_tasks": "Zadania",
+  "cloud_connect_statistics": "Statystyki"
 }

--- a/packages/manager/modules/cloud-connect/src/details/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/cloud-connect/src/details/translations/Messages_pt_PT.json
@@ -3,5 +3,6 @@
   "cloud_connect_guides_main": "OVHcloud Connect",
   "cloud_connect_overview": "Configurar",
   "cloud_connect_service_keys": "Chaves de serviço",
-  "cloud_connect_tasks": "Tarefas"
+  "cloud_connect_tasks": "Tarefas",
+  "cloud_connect_statistics": "Estatísticas"
 }

--- a/packages/manager/modules/cloud-connect/src/style.scss
+++ b/packages/manager/modules/cloud-connect/src/style.scss
@@ -10,4 +10,8 @@ cloud-connect-details {
       display: none;
     }
   }
+
+  .statistics-graph {
+    height: 230px;
+  }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-423
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

This reverts commit b4ab59831847ec641461230a7b3dd53dbb24023d.
This feature adds a new tab to display statistics for OVHcloud Connect.

