### PR TITLE
Fix/manager 8780: add missed is-trusted-zone param

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.component.js
@@ -4,6 +4,7 @@ import template from './add.html';
 export default {
   bindings: {
     pciFeatures: '<',
+    isTrustedZone: '<',
     catalogEndpoint: '<',
     addInstanceSuccessMessage: '<',
     addInstancesSuccessMessage: '<',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-7953`
| Bug fix?         | fix
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8780
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. Add missed param to display the pci trusted zone info banner