### PR TITLE
ci(commitlint): allow `sync` and `release` as type-enum

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,9 @@
+const typeEnum = require('@commitlint/config-angular-type-enum');
+const types = [...typeEnum.value(), 'sync', 'release'];
+
+module.exports = {
+  extends: ['@commitlint/config-angular'],
+  rules: {
+    'type-enum': [2, 'always', types],
+  },
+};

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@commitlint/config-angular"
-  ]
-}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8860
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

Following commit message will now be allowed:

```txt
sync: master to develop
release: <release_name>
```

### :green_circle: Continuous Integration

247c919 - ci(commitlint): allow `sync` and `release` as type-enum

## Related

#6543

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>