### PR TITLE
fix(netapp.volumes.snapshots): grayed apply policy btn for default snap

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/controller.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/controller.js
@@ -12,6 +12,10 @@ export default class NetAppVolumesDashboardSnapshotsController {
     this.policyId = this.currentPolicy.id;
   }
 
+  isApplicablePolicy() {
+    return this.snapshots?.length && !this.snapshots[0].isDefault;
+  }
+
   changePolicy() {
     this.trackClick('apply-policy');
     return this.applyPolicy(this.policyId)

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
@@ -94,7 +94,7 @@
             policies="$ctrl.snapshotPolicies"
             selected="$ctrl.policyId"
         ></snapshot-policies>
-        <oui-button variant="primary" on-click="$ctrl.changePolicy()">
+        <oui-button variant="primary" disabled="$ctrl.isApplicablePolicy()" on-click="$ctrl.changePolicy()">
             <span
                 data-translate="netapp_volumes_snapshots_policies_apply"
             ></span>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-8208`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8224
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. disable "apply policy" button if snapshots contains only the default one