### PR TITLE
feat(instances.add): display banner when flavor selected is eol

### DIFF
--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
@@ -7,6 +7,7 @@ import map from 'lodash/map';
 import mapValues from 'lodash/mapValues';
 import omit from 'lodash/omit';
 import some from 'lodash/some';
+import includes from 'lodash/includes';
 
 import Flavor from './flavor.class';
 import FlavorGroup from './flavor-group.class';
@@ -92,6 +93,15 @@ export default class FlavorsList {
             ),
             frequency: get(CPU_FREQUENCY, resource.type),
             groupName: resource.groupName.replace(/-flex/, ''),
+            legacy: includes(
+              get(
+                find(catalog.addons, {
+                  invoiceName: resource.name,
+                }),
+                'blobs.tags',
+              ),
+              'legacy',
+            ),
           });
         });
       });

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -136,6 +136,16 @@ export default class PciInstancesAddController {
 
   onFlavorCategorySelect(flavor, category) {
     this.selectedCategory = category;
+    if (flavor.legacy) {
+      this.CucCloudMessage.warning(
+        this.$translate.instant(
+          'pci_projects_project_instances_add_flavor_selected_legacy',
+        ),
+        'pci.projects.project.instances.add',
+      );
+    } else {
+      this.messages = [];
+    }
   }
 
   onRegionFocus() {

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.module.js
@@ -4,6 +4,7 @@ import '@ovh-ux/ng-translate-async-loader';
 import '@ovh-ux/ng-ovh-cloud-universe-components';
 import 'angular-translate';
 import 'ovh-api-services';
+import '@ovh-ux/manager-filters';
 
 import './add.less';
 
@@ -20,6 +21,7 @@ const moduleName = 'ovhManagerPciInstancesAdd';
 
 angular
   .module(moduleName, [
+    'ovhManagerFilters',
     'ngTranslateAsyncLoader',
     'ngOvhCloudUniverseComponents',
     'pascalprecht.translate',

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Empfohlen",
   "pci_projects_project_instances_add_privateNetwork_description": "Die Public Cloud Instanzen verfügen standardmäßig über ein öffentliches Netzwerk. Sie können ihnen ein privates Netzwerk hinzufügen. ",
   "pci_projects_project_instances_add_privateNetwork_add": "Privates Netzwerk erstellen",
-  "pci_projects_project_instances_add_instance_is_iops": "Das automatische Backup wird nur für die Daten auf der lokalen Festplatte Ihrer Instanz ausgeführt. Die Daten auf den NVMe-Festplatten werden nicht gesichert."
+  "pci_projects_project_instances_add_instance_is_iops": "Das automatische Backup wird nur für die Daten auf der lokalen Festplatte Ihrer Instanz ausgeführt. Die Daten auf den NVMe-Festplatten werden nicht gesichert.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "Das gewählte Modell ist veraltet. Seine Verfügbarkeit kann nicht garantiert werden."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Recommended",
   "pci_projects_project_instances_add_privateNetwork_description": "Public Cloud instances have a public network by default. You can add a private network.",
   "pci_projects_project_instances_add_privateNetwork_add": "Add Private Network",
-  "pci_projects_project_instances_add_instance_is_iops": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up."
+  "pci_projects_project_instances_add_instance_is_iops": "The automatic backup applies strictly to data on your instance’s local disk. NVMe drive data will not be backed up.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "The selected model is deprecated. Availability cannot be guaranteed."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
   "pci_projects_project_instances_add_privateNetwork_description": "Por defecto las instancias Public Cloud disponen de una red pública, pero es posible añadir una red privada.",
   "pci_projects_project_instances_add_privateNetwork_add": "Crear una red privada",
-  "pci_projects_project_instances_add_instance_is_iops": "La copia de seguridad automática solo se aplica a los datos del disco local de su instancia. No se realizarán copias de seguridad de los datos de los discos NVMe."
+  "pci_projects_project_instances_add_instance_is_iops": "La copia de seguridad automática solo se aplica a los datos del disco local de su instancia. No se realizarán copias de seguridad de los datos de los discos NVMe.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "El modelo seleccionado está obsoleto. No es posible garantizar su disponibilidad."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
@@ -3,6 +3,7 @@
 
   "pci_projects_project_instances_add_flavor_title": "Sélectionnez un modèle",
   "pci_projects_project_instances_add_flavor_selected_title": "Modèle choisi : {{model}} à partir de {{price}}",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "Le modèle sélectionné est déprécié. Sa disponibilité ne peut pas être garantie.",
 
   "pci_projects_project_instances_add_region_title": "Sélectionnez une localisation",
   "pci_projects_project_instances_add_region_selected_title": "Localisation choisie : {{location}}",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
@@ -3,6 +3,7 @@
 
   "pci_projects_project_instances_add_flavor_title": "Sélectionnez un modèle",
   "pci_projects_project_instances_add_flavor_selected_title": "Modèle choisi : {{model}} à partir de {{price}}",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "Le modèle sélectionné est déprécié. Sa disponibilité ne peut pas être garantie.",
 
   "pci_projects_project_instances_add_region_title": "Sélectionnez une localisation",
   "pci_projects_project_instances_add_region_selected_title": "Localisation choisie : {{location}}",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Consigliato",
   "pci_projects_project_instances_add_privateNetwork_description": "Di default le istanze Public Cloud dispongono  di una rete pubblica, ma è possibile aggiungere anche una rete privata.",
   "pci_projects_project_instances_add_privateNetwork_add": "Crea una rete privata",
-  "pci_projects_project_instances_add_instance_is_iops": "Il backup automatico viene eseguito esclusivamente per i dati del disco locale della tua istanza. I dati dei dischi NVMe non saranno copiati."
+  "pci_projects_project_instances_add_instance_is_iops": "Il backup automatico viene eseguito esclusivamente per i dati del disco locale della tua istanza. I dati dei dischi NVMe non saranno copiati.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "Il modello selezionato è obsoleto. La sua disponibilità non può essere garantita."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Zalecane",
   "pci_projects_project_instances_add_privateNetwork_description": "Instancje Public Cloud połączone są domyślnie w ramach sieci publicznej, możesz dodać sieć prywatną.",
   "pci_projects_project_instances_add_privateNetwork_add": "Utwórz prywatną sieć",
-  "pci_projects_project_instances_add_instance_is_iops": "Usługa automatyczne kopie zapasowe ma zastosowanie wyłącznie w odniesieniu do danych znajdujących się na dysku lokalnym Twojej instancji. Nie będą tworzone kopie zapasowe danych znajdujących się na dyskach NVMe."
+  "pci_projects_project_instances_add_instance_is_iops": "Usługa automatyczne kopie zapasowe ma zastosowanie wyłącznie w odniesieniu do danych znajdujących się na dysku lokalnym Twojej instancji. Nie będą tworzone kopie zapasowe danych znajdujących się na dyskach NVMe.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "Wybrany model jest przestarzały. Nie można zagwarantować jego dostępności."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
@@ -47,5 +47,6 @@
   "pci_projects_project_instances_add_automated_backup_recommended": "Recomendado",
   "pci_projects_project_instances_add_privateNetwork_description": "Por predefinição, as instâncias Public Cloud possuem uma rede pública. Pode adicionar uma rede privada.",
   "pci_projects_project_instances_add_privateNetwork_add": "Criar uma rede privada",
-  "pci_projects_project_instances_add_instance_is_iops": "O backup automático aplica-se estritamente aos dados do disco local da sua instância. Os dados dos discos NVMe não serão guardados."
+  "pci_projects_project_instances_add_instance_is_iops": "O backup automático aplica-se estritamente aos dados do disco local da sua instância. Os dados dos discos NVMe não serão guardados.",
+  "pci_projects_project_instances_add_flavor_selected_legacy": "O modelo selecionado é obsoleto. A sua disponibilidade não pode ser garantida."
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-7382 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I added banner if select a legacy flavor.
I also fix bytesFilter which was not declared in the module and was generating console errors.
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
:flags:  Translations:
- [x] TRANS-42312
