### PR TITLE
fix(server.display-name): display loader during state navigation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/display-name/display-name.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/display-name/display-name.controller.js
@@ -27,6 +27,7 @@ angular.module('App').controller(
       }
 
       this.loading.update = true;
+      let reload = false;
 
       return this.Server.updateDisplayName({
         serviceId: this.dedicatedServer.serviceId,
@@ -40,13 +41,7 @@ angular.module('App').controller(
             ),
             'server_dashboard_alert',
           );
-          this.$state.go(
-            '^',
-            {},
-            {
-              reload: true,
-            },
-          );
+          reload = true;
         })
         .catch(({ data }) => {
           this.Alerter.error(
@@ -61,8 +56,16 @@ angular.module('App').controller(
             ].join('. '),
             'server_dashboard_alert',
           );
-          this.$state.go('^');
         })
+        .finally(() =>
+          this.$state.go(
+            '^',
+            {},
+            {
+              reload,
+            },
+          ),
+        )
         .finally(() => {
           this.loading.update = false;
         });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8749
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Display loader during state navigation after server name update

## Related

<!-- Link dependencies of this PR -->
