### PR TITLE
feat(web.exchange.account-add): avoid going to emails if create request fail

### DIFF
--- a/packages/manager/modules/exchange/src/account/account.service.js
+++ b/packages/manager/modules/exchange/src/account/account.service.js
@@ -81,17 +81,12 @@ export default class ExchangeAccount {
    * @param {object} newAccount
    */
   sendingNewAccount(organizationName, serviceName, newAccount) {
-    return this.OvhHttp.post(
-      `/email/exchange/${organizationName}/service/${serviceName}/account`,
-      {
-        rootPath: 'apiv6',
-        data: newAccount,
-      },
-    ).then((data) => {
-      this.wucExchange.refreshViews('Accounts', 'Tasks');
-
-      return data;
-    });
+    return this.$http
+      .post(
+        `/email/exchange/${organizationName}/service/${serviceName}/account`,
+        newAccount,
+      )
+      .then(({ data }) => data);
   }
 
   /**

--- a/packages/manager/modules/exchange/src/account/add/account-add.controller.js
+++ b/packages/manager/modules/exchange/src/account/add/account-add.controller.js
@@ -4,7 +4,9 @@ import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
 import isString from 'lodash/isString';
 import map from 'lodash/map';
+
 import { ACCOUNT_WORLD_PHONE_REGEX } from '../account.constants';
+import { EXCHANGE_CONTAINER_MESSAGING } from '../../dashboard/exchange.constants';
 
 export default class ExchangeAccountAddController {
   /* @ngInject */
@@ -12,6 +14,8 @@ export default class ExchangeAccountAddController {
     $scope,
     $timeout,
     $translate,
+    $location,
+    $anchorScroll,
     exchangeAccountTypes,
     wucExchange,
     exchangeAccount,
@@ -23,6 +27,8 @@ export default class ExchangeAccountAddController {
     this.$scope = $scope;
     this.$timeout = $timeout;
     this.$translate = $translate;
+    this.$location = $location;
+    this.$anchorScroll = $anchorScroll;
 
     this.exchangeAccountTypes = exchangeAccountTypes;
     this.wucExchange = wucExchange;
@@ -160,7 +166,7 @@ export default class ExchangeAccountAddController {
   }
 
   hide() {
-    this.goToAccounts();
+    return this.goToAccounts();
   }
 
   switchBetweenPasswordAndTextInput() {
@@ -226,11 +232,13 @@ export default class ExchangeAccountAddController {
         formattedAccount,
       )
       .then((data) => {
-        this.messaging.writeSuccess(
-          this.$translate.instant('exchange_account_add_submit_success', {
-            t0: `${formattedAccount.login}@${formattedAccount.domain}`,
-          }),
-          data,
+        this.goToAccounts().then(() =>
+          this.messaging.writeSuccess(
+            this.$translate.instant('exchange_account_add_submit_success', {
+              t0: `${formattedAccount.login}@${formattedAccount.domain}`,
+            }),
+            data,
+          ),
         );
       })
       .catch((error) => {
@@ -242,7 +250,10 @@ export default class ExchangeAccountAddController {
         );
       })
       .finally(() => {
-        this.hide();
+        this.isSendingNewAccount = false;
+
+        this.$location.hash(EXCHANGE_CONTAINER_MESSAGING);
+        this.$anchorScroll();
       });
   }
 

--- a/packages/manager/modules/exchange/src/dashboard/exchange.constants.js
+++ b/packages/manager/modules/exchange/src/dashboard/exchange.constants.js
@@ -150,8 +150,11 @@ export const DOMAIN_ORDER_URL = {
   WS: 'https://us.ovh.com/es/order/webcloud',
 };
 
+export const EXCHANGE_CONTAINER_MESSAGING = 'exchangeMessagingContainerId';
+
 export default {
   EXCHANGE_MX_CONFIG,
   EXCHANGE_CONFIG_URL,
   EXCHANGE_CONFIG,
+  EXCHANGE_CONTAINER_MESSAGING,
 };

--- a/packages/manager/modules/exchange/src/dashboard/exchange.controller.js
+++ b/packages/manager/modules/exchange/src/dashboard/exchange.controller.js
@@ -3,6 +3,8 @@ import isEmpty from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 
+import { EXCHANGE_CONTAINER_MESSAGING } from './exchange.constants';
+
 export default class ExchangeCtrl {
   /* @ngInject */
   constructor(
@@ -58,6 +60,8 @@ export default class ExchangeCtrl {
     };
     this.exchange = exchange;
     this.$routerParams = wucExchange.getParams();
+
+    this.EXCHANGE_CONTAINER_MESSAGING = EXCHANGE_CONTAINER_MESSAGING;
 
     set(navigation, '$exchangeRootScope', $scope);
     set(messaging, '$exchangeRootScope', $scope);

--- a/packages/manager/modules/exchange/src/dashboard/exchange.html
+++ b/packages/manager/modules/exchange/src/dashboard/exchange.html
@@ -103,6 +103,7 @@
             </oui-header-tabs>
 
             <div
+                id="{{:: ctrl.EXCHANGE_CONTAINER_MESSAGING}}"
                 class="alert alert-dismissible"
                 role="alert"
                 data-ng-class="ctrl.services.messaging.alertType"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-8230`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8672
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. don't return to emails page if the create request was failed to avoid customers to re filled fields