### PR TITLE
fix: nutanix licence name

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/general-info/controller.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/controller.js
@@ -14,6 +14,7 @@ export default class NutanixGeneralInfoCtrl {
   $onInit() {
     this.loadServcesDetails();
     this.technicalDetails = this.getTechnicalDetails();
+    this.clusterTechnicalDetails = null;
     this.setPrivateBandwidthServiceId();
     this.clusterRedeploying = this.cluster.status === CLUSTER_STATUS.DEPLOYING;
   }
@@ -30,10 +31,18 @@ export default class NutanixGeneralInfoCtrl {
   }
 
   getTechnicalDetails() {
+    this.loadingTechnicalDetails = true;
     return this.NutanixService.getClusterHardwareInfo(
       this.serviceInfo.serviceId,
       this.server.serviceId,
-    );
+    )
+      .then((technicalDetails) => {
+        this.clusterTechnicalDetails = technicalDetails.nutanixCluster;
+        return technicalDetails.baremetalServers;
+      })
+      .finally(() => {
+        this.loadingTechnicalDetails = false;
+      });
   }
 
   setPrivateBandwidthServiceId() {

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
@@ -92,9 +92,15 @@
                 term="{{:: 'nutanix_dashboard_cluster_licence' | translate }}"
             >
                 <oui-tile-description>
+                    <oui-spinner
+                        data-ng-if="$ctrl.loadingTechnicalDetails"
+                        data-size="s"
+                    >
+                    </oui-spinner>
                     <span
+                        data-ng-if="!$ctrl.loadingTechnicalDetails && $ctrl.clusterTechnicalDetails"
                         class="text-capitalize"
-                        data-ng-bind=":: $ctrl.cluster.targetSpec.license"
+                        data-ng-bind=":: $ctrl.clusterTechnicalDetails.license.distribution"
                     >
                     </span>
                 </oui-tile-description>

--- a/packages/manager/modules/nutanix/src/service.js
+++ b/packages/manager/modules/nutanix/src/service.js
@@ -77,19 +77,17 @@ export default class NutanixService {
   getClusterHardwareInfo(serviceId, nodeServiceId) {
     return this.getClusterOptions(serviceId)
       .then((options) => {
-        const allOptions = [
-          ...options,
-          {
-            serviceId: nodeServiceId,
-          },
-        ];
+        const optionsServiceId = [nodeServiceId, serviceId];
+        options.forEach((option) => {
+          optionsServiceId.push(option.serviceId);
+        });
         return this.$q.all(
-          allOptions.map((option) => {
-            return this.getHardwareInfo(option.serviceId).then(
+          optionsServiceId.map((optionServiceId) => {
+            return this.getHardwareInfo(optionServiceId).then(
               (hardwareInfo) => {
                 return {
                   ...hardwareInfo,
-                  serviceId: option.serviceId,
+                  serviceId: optionServiceId,
                 };
               },
             );
@@ -107,6 +105,7 @@ export default class NutanixService {
    */
   static transformHardwareInfo(optionsHardwareInfo) {
     const baremetalServers = {};
+    let nutanixCluster = {};
     optionsHardwareInfo.forEach((hardwareInfo) => {
       if (hardwareInfo.baremetalServers) {
         const keys = Object.keys(hardwareInfo.baremetalServers);
@@ -127,8 +126,15 @@ export default class NutanixService {
           }
         });
       }
+      if (hardwareInfo.nutanixCluster) {
+        // only one nutanix cluster, no need merge the reults
+        nutanixCluster = hardwareInfo.nutanixCluster;
+      }
     });
-    return baremetalServers;
+    return {
+      baremetalServers,
+      nutanixCluster,
+    };
   }
 
   getClusterOptions(serviceId) {


### PR DESCRIPTION
licence name is not displayed on nutanix dashboard

ref: MANAGER-8903

Signed-off-by: Ravindra Adireddy <ravindra.adireddy@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8903
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
