### PR TITLE
fix(vps.additional-disk): gray order button if no options available

### DIFF
--- a/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.controller.js
+++ b/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.controller.js
@@ -72,6 +72,6 @@ export default class {
   }
 
   canOrder() {
-    return isEmpty(this.additionalDisks);
+    return this.hasAdditionalDiskOption && isEmpty(this.additionalDisks);
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-7322`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8858
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. grayed order button if no available additional disk options