### PR TITLE
Feat/manager 8851: don't allow to upgrade disk if no options

### DIFF
--- a/packages/manager/modules/vps/src/additional-disk/upgrade/upgrade.routing.js
+++ b/packages/manager/modules/vps/src/additional-disk/upgrade/upgrade.routing.js
@@ -8,9 +8,6 @@ export default /* @ngInject */ ($stateProvider) => {
     },
     layout: 'modal',
     resolve: {
-      upgradableDisks: /* @ngInject */ (catalog, vpsLinkedDisk, VpsService) =>
-        VpsService.getUpgradableAdditionalDisk(catalog, vpsLinkedDisk),
-
       goBack: /* @ngInject */ ($state) => () => $state.go('^'),
     },
   });

--- a/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.component.js
+++ b/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.component.js
@@ -9,6 +9,7 @@ export default {
     serviceName: '<',
     vps: '<',
     isVpsNewRange: '<',
+    upgradableDisks: '<',
     tabSummary: '<',
     goToOrderAdditionalDisk: '<',
     goToUpgradeDisk: '<',

--- a/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.html
+++ b/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.html
@@ -53,7 +53,7 @@
             <oui-action-menu data-compact data-placement="end">
 
                 <!--Upgrade disk: increase capacity-->
-                <oui-action-menu-item data-disabled="!$ctrl.isVpsNewRange"
+                <oui-action-menu-item data-disabled="!$ctrl.isVpsNewRange || !this.upgradableDisks.length"
                                       data-on-click="$ctrl.goToUpgradeDisk($row)">
                     <span data-translate="vps_additional_disk_actions_increase_disk"></span>
                 </oui-action-menu-item>

--- a/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.routing.js
+++ b/packages/manager/modules/vps/src/additional-disk/vps-additional-disk.routing.js
@@ -12,6 +12,9 @@ export default /* @ngInject */ ($stateProvider) => {
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('vps_additional_disk'),
 
+      upgradableDisks: /* @ngInject */ (catalog, vpsLinkedDisk, VpsService) =>
+        VpsService.getUpgradableAdditionalDisk(catalog, vpsLinkedDisk),
+
       goToOrderAdditionalDisk: /* @ngInject */ ($state) => () =>
         $state.go('vps.detail.additional-disk.order'),
 

--- a/packages/manager/modules/vps/src/dashboard/additional-disk/upgrade/upgrade.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/additional-disk/upgrade/upgrade.routing.js
@@ -8,9 +8,6 @@ export default /* @ngInject */ ($stateProvider) => {
     },
     layout: 'modal',
     resolve: {
-      upgradableDisks: /* @ngInject */ (catalog, vpsLinkedDisk, VpsService) =>
-        VpsService.getUpgradableAdditionalDisk(catalog, vpsLinkedDisk),
-
       goBack: /* @ngInject */ ($state) => () => $state.go('^'),
     },
   });

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -571,7 +571,7 @@
                             </oui-action-menu-item>
                             <oui-action-menu-item
                                 data-ng-if="$ctrl.actions.terminateAdditionalDiskOption.isAvailable()"
-                                data-disabled="!$ctrl.isVpsNewRange"
+                                data-disabled="!$ctrl.isVpsNewRange || !$ctrl.upgradableDisks.length"
                                 aria-label="{{:: 'vps_configuration_additional_disk_upgrade_option' | translate}}"
                                 data-on-click="$ctrl.goToUpgradeAdditionalDisk('additionalDisk')">
                                 <span

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -159,6 +159,9 @@ export default /* @ngInject */ ($stateProvider) => {
       breadcrumb: () => null,
       trackingPrefix: () => 'vps::detail::dashboard',
 
+      upgradableDisks: /* @ngInject */ (catalog, vpsLinkedDisk, VpsService) =>
+        VpsService.getUpgradableAdditionalDisk(catalog, vpsLinkedDisk),
+
       stein: /* @ngInject */ ($http, stateVps) =>
         $http
           .get('/vps/migrationStein')


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-7322`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8851
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. Upgrade disk available only if upgrade options are returned