### PR TITLE
fix(dashboard): hide ips field when prism central type is alone

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/constants.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/constants.js
@@ -5,7 +5,14 @@ export const REDEPLOY_CONFIG_OPTIONS = {
   CUSTOM: 'redeployCustomConfig',
 };
 
-export const PRISM_CENTRAL_TYPES = ['alone', 'scale'];
+export const PRISM_CENTRAL_TYPE_ALONE = 'alone';
+
+export const PRISM_CENTRAL_TYPE_SCALE = 'scale';
+
+export const PRISM_CENTRAL_TYPES = [
+  PRISM_CENTRAL_TYPE_ALONE,
+  PRISM_CENTRAL_TYPE_SCALE,
+];
 
 export const IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
@@ -26,6 +33,8 @@ export const CLUSTER_CONFIG_TERMS = {
 export default {
   TRACKING_PREFIX,
   REDEPLOY_CONFIG_OPTIONS,
+  PRISM_CENTRAL_TYPE_ALONE,
+  PRISM_CENTRAL_TYPE_SCALE,
   PRISM_CENTRAL_TYPES,
   IPV4_REGEX,
   IPV4_BLOCK_REGEX,

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/controller.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/controller.js
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import {
   REDEPLOY_CONFIG_OPTIONS,
+  PRISM_CENTRAL_TYPE_ALONE,
   PRISM_CENTRAL_TYPES,
   IPV4_REGEX,
   IPV4_BLOCK_REGEX,
@@ -14,6 +15,7 @@ export default class NutanixGeneralInfoRedeployCtrl {
     this.$translate = $translate;
     this.atInternet = atInternet;
     this.REDEPLOY_CONFIG_OPTIONS = REDEPLOY_CONFIG_OPTIONS;
+    this.PRISM_CENTRAL_TYPE_ALONE = PRISM_CENTRAL_TYPE_ALONE;
     this.prismCentralTypes = PRISM_CENTRAL_TYPES;
     this.IPV4_REGEX = IPV4_REGEX;
     this.IPV4_BLOCK_REGEX = IPV4_BLOCK_REGEX;
@@ -46,6 +48,24 @@ export default class NutanixGeneralInfoRedeployCtrl {
       type: 'action',
       name: `${TRACKING_PREFIX}::${label}`,
     });
+  }
+
+  addEmptyIp(prismCentralType) {
+    if (
+      this.config.prismCentral?.ips?.length === 0 &&
+      prismCentralType !== PRISM_CENTRAL_TYPE_ALONE
+    ) {
+      this.config.prismCentral.ips = [''];
+    }
+  }
+
+  onPrismCentralTypeChange(modelValue) {
+    this.config.prismCentral.ips =
+      modelValue === PRISM_CENTRAL_TYPE_ALONE
+        ? []
+        : cloneDeep(this.cluster.targetSpec.prismCentral.ips);
+    this.addEmptyIp(modelValue);
+    return modelValue;
   }
 
   addPrismCentralIp() {
@@ -81,9 +101,7 @@ export default class NutanixGeneralInfoRedeployCtrl {
         this.redundancyFactorValue = `${this.cluster.allowedRedundancyFactor[0]}`;
         this.config.redundancyFactor = +this.redundancyFactorValue;
       }
-      if (this.config.prismCentral?.ips?.length === 0) {
-        this.config.prismCentral.ips = [''];
-      }
+      this.addEmptyIp(this.config.prismCentral.type);
     }
   }
 

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/redeploy/template.html
@@ -225,6 +225,7 @@
                         data-placeholder="{{::$ctrl.CLUSTER_CONFIG_TERMS.PRISM_CENTRAL_TYPE }}"
                         data-model="$ctrl.config.prismCentral.type"
                         data-items="$ctrl.prismCentralTypes"
+                        data-on-change="$ctrl.onPrismCentralTypeChange(modelValue)"
                     ></oui-select>
                 </oui-field>
                 <oui-field
@@ -239,7 +240,9 @@
                         data-ng-pattern="$ctrl.IPV4_REGEX"
                     />
                 </oui-field>
-                <div>
+                <div
+                    data-ng-if="$ctrl.config.prismCentral.type !== $ctrl.PRISM_CENTRAL_TYPE_ALONE"
+                >
                     <div class="row ml-1 mb-2">
                         <label
                             class="oui-field__label"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-77058
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

 Hide 'IPs' field when the selected Prism Central Type is 'Alone' while nutanc cluster redeploy

## Related

<!-- Link dependencies of this PR -->
