### PR TITLE
fix(public cloud): 404 URLs for AI products documentation

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/ai/ai.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/ai.constants.js
@@ -1,8 +1,8 @@
-export const GUIDE_URL = 'https://docs.ovh.com/gb/en/ai-training';
+export const GUIDE_URL = 'https://docs.ovh.com/gb/en/publiccloud/ai/';
 export const COMMUNITY_URL = 'https://community.ovh.com/en/c/Data-AI';
 export const DISCORD_URL = 'https://discord.com/invite/vXVurFfwe9';
 export const DOC_DOCKER_BUILD_URL =
-  'https://docs.ovh.com/gb/en/ai-training/build-use-custom-image/';
+  'https://docs.ovh.com/gb/en/publiccloud/ai/training/build-use-custom-image/';
 
 export default {
   GUIDE_URL,

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-command/app-command.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-command/app-command.constants.js
@@ -1,11 +1,11 @@
 export const DOCUMENTATION_LINK = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
-  ASIA: 'https://docs.ovh.com/asia/en/ai-training/overview-cli/',
-  AU: 'https://docs.ovh.com/au/en/ai-training/overview-cli/',
-  CA: 'https://docs.ovh.com/ca/en/ai-training/overview-cli/',
-  GB: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
-  IE: 'https://docs.ovh.com/ie/en/ai-training/overview-cli/',
-  SG: 'https://docs.ovh.com/sg/en/ai-training/overview-cli/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
+  ASIA: 'https://docs.ovh.com/asia/en/publiccloud/ai/cli/overview-cli/',
+  AU: 'https://docs.ovh.com/au/en/publiccloud/ai/cli/overview-cli/',
+  CA: 'https://docs.ovh.com/ca/en/publiccloud/ai/cli/overview-cli/',
+  GB: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
+  IE: 'https://docs.ovh.com/ie/en/publiccloud/ai/cli/overview-cli/',
+  SG: 'https://docs.ovh.com/sg/en/publiccloud/ai/cli/overview-cli/',
 };
 
 export default {

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/app.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/app.constants.js
@@ -41,12 +41,12 @@ export const APP_FRAMEWORK_INFO = {
 };
 
 export const APP_AUTOMATION_INFO = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
 };
 
 export const APP_STORAGE_INFO = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/data/',
-  CA: 'https://docs.ovh.com/ca/en/ai-training/data/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/data/',
+  CA: 'https://docs.ovh.com/ca/en/publiccloud/ai/data/',
 };
 
 export const APP_MULTIPLY_SIGN = ' × ';

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/onboarding/onboarding.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/onboarding/onboarding.constants.js
@@ -1,24 +1,24 @@
 export const GUIDES = [
   {
     id: 'documentation',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/apps/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/',
   },
   {
     id: 'definition',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/apps/definition/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/ai-comparative-tables/',
   },
   {
     id: 'start',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/apps/getting-started-cli/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/apps/getting-started/',
   },
   {
     id: 'share',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/apps/sharing-apps/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/ai-apps-tokens/',
   },
   {
     id: 'object_storage_access',
     link:
-      'https://docs.ovh.com/gb/en/publiccloud/ai/apps/access-object-storage-data/',
+      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/',
   },
 ];
 

--- a/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.constants.js
@@ -1,11 +1,11 @@
 export const DOCUMENTATION_LINK = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
-  ASIA: 'https://docs.ovh.com/asia/en/ai-training/overview-cli/',
-  AU: 'https://docs.ovh.com/au/en/ai-training/overview-cli/',
-  CA: 'https://docs.ovh.com/ca/en/ai-training/overview-cli/',
-  GB: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
-  IE: 'https://docs.ovh.com/ie/en/ai-training/overview-cli/',
-  SG: 'https://docs.ovh.com/sg/en/ai-training/overview-cli/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
+  ASIA: 'https://docs.ovh.com/asia/en/publiccloud/ai/cli/overview-cli/',
+  AU: 'https://docs.ovh.com/au/en/publiccloud/ai/cli/overview-cli/',
+  CA: 'https://docs.ovh.com/ca/en/publiccloud/ai/cli/overview-cli/',
+  GB: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
+  IE: 'https://docs.ovh.com/ie/en/publiccloud/ai/cli/overview-cli/',
+  SG: 'https://docs.ovh.com/sg/en/publiccloud/ai/cli/overview-cli/',
 };
 
 export default {

--- a/packages/manager/modules/pci/src/projects/project/notebooks/notebook.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/notebook.constants.js
@@ -37,12 +37,12 @@ export const NOTEBOOK_FRAMEWORK_INFO = {
 };
 
 export const NOTEBOOK_AUTOMATION_INFO = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/overview-cli/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/overview-cli/',
 };
 
 export const NOTEBOOK_STORAGE_INFO = {
-  DEFAULT: 'https://docs.ovh.com/gb/en/ai-training/data/',
-  CA: 'https://docs.ovh.com/ca/en/ai-training/data/',
+  DEFAULT: 'https://docs.ovh.com/gb/en/publiccloud/ai/data/',
+  CA: 'https://docs.ovh.com/ca/en/publiccloud/ai/data/',
 };
 
 export const NOTEBOOK_MULTIPLY_SIGN = ' × ';

--- a/packages/manager/modules/pci/src/projects/project/notebooks/onboarding/onboarding.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/onboarding/onboarding.constants.js
@@ -1,26 +1,26 @@
 export const GUIDES = [
   {
     id: 'documentation',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/',
   },
   {
     id: 'definition',
-    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/ai-comparative-tables/',
   },
   {
     id: 'start',
     link:
-      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/getting-started-cli/',
+      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/',
   },
   {
     id: 'share',
     link:
-      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/sharing-notebooks/',
+      'https://docs.ovh.com/gb/en/publiccloud/ai/cli/sharing-notebooks/',
   },
   {
     id: 'object_storage_access',
     link:
-      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/access-object-storage-data/',
+      'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/',
   },
 ];
 

--- a/packages/manager/modules/pci/src/projects/project/training/onboarding/onboarding.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/training/onboarding/onboarding.constants.js
@@ -1,13 +1,13 @@
 export const GUIDES = [
   {
     id: 'eai-job-submit',
-    link: 'https://docs.ovh.com/gb/en/ai-training/submit-job/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/training/submit-job/',
     tracking:
       'public-cloud::pci::projects::project::training::onboarding::go-to-docs-tasks',
   },
   {
     id: 'install-cli',
-    link: 'https://docs.ovh.com/gb/en/ai-training/install-client/',
+    link: 'https://docs.ovh.com/gb/en/publiccloud/ai/cli/install-client/',
     tracking:
       'public-cloud::pci::projects::project::training::onboarding::go-to-docs-install',
   },

--- a/packages/manager/modules/pci/src/projects/project/training/training.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/training/training.constants.js
@@ -1,7 +1,7 @@
-export const GUIDE_URL = 'https://docs.ovh.com/gb/en/ai-training';
+export const GUIDE_URL = 'https://docs.ovh.com/gb/en/publiccloud/ai/';
 export const DISCORD_URL = 'https://discord.com/invite/vXVurFfwe9';
 export const DOC_DOCKER_BUILD_URL =
-  'https://docs.ovh.com/gb/en/ai-training/build-use-custom-image/';
+  'https://docs.ovh.com/gb/en/publiccloud/ai/training/build-use-custom-image/';
 export const JOB_SSH_KEYS = {
   MAX: 10,
   CUSTOM_SELECT: '-',


### PR DESCRIPTION
Signed-off-by: Bastien Verdebout <bastien.verdebout@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | no ticket
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Hello, Recently the AI documentations main URL has been changed, causing 404 on many documentation pages
This fix replace 404 URL to new ones

The content of the guides, remain unchanged, allowing us to avoid translations requets

For info, new URL for documentation : https://docs.ovh.com/gb/en/publiccloud/ai/

## Related

nothing related
