### PR TITLE
fix (pci.storage.databases): manager-8953 fix plan compare function

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/connectors.constants.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/connectors.constants.js
@@ -39,7 +39,7 @@ export const EXTRA_CONFIG_PROPERTY = '*';
 export const GROUP_NAMES_WITH_MESSAGES = {
   TRANSFORMS: 'Transforms',
   EXTRA: 'Extra',
-}
+};
 
 export default {
   CONNECTOR_STATUS,

--- a/packages/manager/modules/pci/src/components/project/storages/databases/plan.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/plan.class.js
@@ -86,12 +86,19 @@ export default class Plan {
     return maxBy(this.availability, 'maxDiskSize').maxDiskSize;
   }
 
+  get specsScore() {
+    return this.maxCores + this.maxMemory + this.maxNodes + this.maxStorage;
+  }
+
   compare(plan) {
     // greater than 0 if current plan is the lower one
     // less than 0 if current plan is the higher one
     // 0 if equal
     if (!plan) return -1;
-    return plan.minNodes - this.minNodes;
+    const planScore = plan.specsScore;
+    const thisScore = this.specsScore;
+    if (planScore === thisScore) return 0;
+    return planScore > thisScore ? 1 : -1;
   }
 
   getDefaultRegion(selectedRegion) {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.html
@@ -120,20 +120,20 @@
             ></span>
             <span
                 data-ng-bind="' / ' + ( 'pci_database_node_type_memory' | translate:{
-                    memorySize: ($ctrl.getCurrentFlavor($row).memory | cucBytes:2:false:'GB')
+                    memorySize: ($ctrl.getCurrentFlavor($row).memory | bytes:2:false:'GB')
                 })"
             ></span>
             <span
                 ng-if="$ctrl.getCurrentFlavor($row).hasStorage && !$ctrl.getCurrentFlavor($row).isStorageRange"
                 data-ng-bind="' / ' + ( 'pci_database_node_type_storage' | translate:{
-                    storageSize: ($ctrl.getCurrentFlavor($row).minDiskSize | cucBytes:2:false:'GB')
+                    storageSize: ($ctrl.getCurrentFlavor($row).minDiskSize | bytes:2:false:'GB')
                 })"
             ></span>
             <span
                 ng-if="$ctrl.getCurrentFlavor($row).hasStorage && $ctrl.getCurrentFlavor($row).isStorageRange"
                 data-ng-bind="' / ' + ( 'pci_database_node_type_storage_range' | translate:{
-                    storageMinSize: ($ctrl.getCurrentFlavor($row).minDiskSize | cucBytes:2:false:'GB'),
-                    storageMaxSize: ($ctrl.getCurrentFlavor($row).maxDiskSize | cucBytes:2:false:'GB')
+                    storageMinSize: ($ctrl.getCurrentFlavor($row).minDiskSize | bytes:2:false:'GB'),
+                    storageMaxSize: ($ctrl.getCurrentFlavor($row).maxDiskSize | bytes:2:false:'GB')
                 })"
             ></span>
         </oui-datagrid-column>


### PR DESCRIPTION
MANAGER-8953

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/aiven-ga2`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8953
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- Fix lint error (missing ";" in constants file)
- Use `bytes` filter instead of `cucBytes`, which was causing error
- Change `compare` function for plans to take all specs into account instead of only the number of nodes