### PR TITLE
ci(workflow): add stale action for issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,18 @@
+name: 'Stale issues'
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at 00:00
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-issue-stale: 30
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
+          remove-issue-stale-when-updated: true


### PR DESCRIPTION
ref: MANAGER-8514
Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-8514
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

This is a first version of an action to at least, tag old issues as stale. There are many other options (like ones to closes issues, add condition before staling an issue), but as a first step, I didn't choose to set too much behavior

All feedbacks are welcome :)