### PR TITLE
fix(dedicated-cloud): retrieve servicename in kms deletion

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/security/kms/delete/dedicatedCloud-security-kms-delete.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/security/kms/delete/dedicatedCloud-security-kms-delete.controller.js
@@ -7,10 +7,10 @@ export default class {
     this.$timeout = $timeout;
     this.$translate = $translate;
     this.DedicatedCloud = DedicatedCloud;
-    this.serviceName = this.productId;
   }
 
   $onInit() {
+    this.serviceName = this.productId;
     this.deletionTaskId = null;
     this.kmsDeletionTask = {
       name: null,


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-79041
| License          | BSD 3-Clause


## Description

use `productId` resolvable in `$onInit` instead of `constructor` (PCC serviceName was missing in DELETE API call)
