### PR TITLE
fix(storages.databases.add): disable lab check for non beta engines

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -10,6 +10,7 @@ import {
   MAX_NAME_LENGTH,
   MIN_NAME_LENGTH,
 } from './add.constants';
+import { ENGINES_STATUS } from '../../../../../components/project/storages/databases/engines.constants';
 
 export default class {
   /* @ngInject */
@@ -194,14 +195,23 @@ export default class {
       'action',
       false,
     );
-    return this.DatabaseService.activateLab(this.projectId, this.lab)
-      .then(() =>
-        this.DatabaseService.createDatabase(
-          this.projectId,
-          this.model.engine.name,
-          this.orderData,
-        ),
-      )
+    // We only need to check the lab for BETA status
+    const createDatabasePromise =
+      this.model.engine.selectedVersion.status === ENGINES_STATUS.BETA
+        ? this.DatabaseService.activateLab(this.projectId, this.lab).then(() =>
+            this.DatabaseService.createDatabase(
+              this.projectId,
+              this.model.engine.name,
+              this.orderData,
+            ),
+          )
+        : this.DatabaseService.createDatabase(
+            this.projectId,
+            this.model.engine.name,
+            this.orderData,
+          );
+
+    return createDatabasePromise
       .then((databaseInfo) => {
         this.trackDatabases(
           `config_create_database_validated::${this.model.engine.name}`,


### PR DESCRIPTION
PUD-1370

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1370
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

The check on the lab contract signed should only be done when the engine state is in beta