### PR TITLE
fix(modem.templates): revert to display modem templates

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/index.js
@@ -18,6 +18,7 @@ import ports from './router/ports';
 import router from './router';
 import lan from './router/lan';
 import service from './service';
+import XdslModemTemplates from './templates';
 
 import component from './pack-xdsl-modem.component';
 import { PACK_XDSL_MODEM } from './pack-xdsl-modem.constant';
@@ -49,6 +50,7 @@ angular
     wifi,
     wifiConfig,
     XdslModemDhcpBdhcp,
+    XdslModemTemplates,
   ])
   .component('packXdslModem', component)
   .config(routing)

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/config/templates-config.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/config/templates-config.controller.js
@@ -147,15 +147,17 @@ export default class XdslModemTemplateConfigCtrl {
 
   convertCapabilities(capabilities, paramsToIgnore, isParametersToIgnore) {
     const parametersToIgnore = {
-      mtuSize: capabilities.mtuSize ? !capabilities.mtuSize : '',
-      dmzIP: capabilities.dmzIP ? !capabilities.dmzIP : '',
-      LANandDHCP: capabilities.LANandDHCP ? !capabilities.LANandDHCP : '',
+      mtuSize: capabilities?.mtuSize ? !capabilities.mtuSize : '',
+      dmzIP: capabilities?.dmzIP ? !capabilities.dmzIP : '',
+      LANandDHCP: capabilities?.LANandDHCP ? !capabilities.LANandDHCP : '',
     };
-    this.isDisabled = {
-      mtuSize: !capabilities.mtuSize,
-      dmzIP: !capabilities.dmzIP,
-      LANandDHCP: !capabilities.LANandDHCP,
-    };
+    if (capabilities) {
+      this.isDisabled = {
+        mtuSize: !capabilities.mtuSize,
+        dmzIP: !capabilities.dmzIP,
+        LANandDHCP: !capabilities.LANandDHCP,
+      };
+    }
     if (isParametersToIgnore) {
       if (paramsToIgnore) {
         this.parametersToIgnore = paramsToIgnore;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/config/templates-config.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/config/templates-config.html
@@ -82,6 +82,11 @@
                 >
                     <span
                         data-ng-bind="$ctrl.template.detail.capabilities"
+                        data-ng-if="$ctrl.template.detail.capabilities"
+                    ></span>
+                    <span
+                        data-ng-bind="$ctrl.template.error"
+                        data-ng-if="!$ctrl.template.detail.capabilities"
                     ></span> </oui-message
                 ><!-- End of Empty config Display -->
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/index.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import ngOvhTelecomUniverseComponents from '@ovh-ux/ng-ovh-telecom-universe-components';
+import '@uirouter/angularjs';
+import '@ovh-ux/ng-translate-async-loader';
+import 'angular-translate';
+import 'ovh-api-services';
+
+import component from './pack-xdsl-modem-templates.component';
+import config from './config';
+
+const moduleName = 'ovhManagerTelecomPackXdslModemTemplates';
+
+angular
+  .module(moduleName, [
+    ngOvhTelecomUniverseComponents,
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+    'ovh-api-services',
+    'ui.router',
+    config,
+  ])
+  .component('xdslModemTemplates', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/pack-xdsl-modem-templates.component.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/templates/pack-xdsl-modem-templates.component.js
@@ -1,7 +1,7 @@
 import XdslModemTemplateCtrl from './pack-xdsl-modem-templates.controller';
 import template from './pack-xdsl-modem-templates.html';
 
-angular.module('managerApp').component('xdslModemTemplates', {
+export default {
   template,
   controller: XdslModemTemplateCtrl,
-});
+};


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-440
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Revert code to display modem templates to configure modem

