### PR TITLE
fix(telecom): display correct data after abbreviated number deletion

### DIFF
--- a/packages/manager/modules/telecom-universe-components/src/telecom/telephony/abbreviatedNumbers/telecom-telephony-abbreviated-numbers.component.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/telephony/abbreviatedNumbers/telecom-telephony-abbreviated-numbers.component.js
@@ -50,7 +50,10 @@ export default {
               abbreviatedNumber,
             ),
           );
-          const index = self.abbreviatedNumbers.indexOf(abbreviatedNumber);
+          const index = self.abbreviatedNumbers.findIndex(
+            ({ abbreviatedNumber: number }) =>
+              number === abbreviatedNumber.abbreviatedNumber,
+          );
           self.abbreviatedNumbers.splice(index, 1);
         })
         .catch((err) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-71497
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Display correct data in the grid after 'Abbreviated Number' deletion

## Related

<!-- Link dependencies of this PR -->
