### PR TITLE
fix MLS-2743 (pci.notebooks): filter notebook volumes before fetching command

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.controller.js
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import { DOCUMENTATION_LINK } from './configuration-command.constants';
 
 export default class {
@@ -17,8 +18,32 @@ export default class {
     this.getConfigurationCommand();
   }
 
+  getFilteredVolumes() {
+    return this.notebookSpecs.volumes.flatMap((volume) => {
+      let toRemove = false;
+      let internalKey;
+      Object.keys(volume).forEach((key) => {
+        if (volume[key].internal !== undefined) {
+          if (volume[key].internal === true) {
+            toRemove = true;
+          } else {
+            internalKey = key;
+          }
+        }
+      });
+      if (toRemove) {
+        return [];
+      }
+      return internalKey ? omit(volume, `${internalKey}.internal`) : volume;
+    });
+  }
+
   getConfigurationCommand() {
     this.loading = true;
+    if (this.notebookSpecs.volumes) {
+      // API does not accept volumes' internal property. We remove it before sending the request.
+      this.notebookSpecs.volumes = this.getFilteredVolumes();
+    }
     return this.NotebookService.getNotebookConfigurationCommand(
       this.projectId,
       this.notebookSpecs,


### PR DESCRIPTION
MLS-2743

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MLS-2743
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

The command showed on a notebook's dashboard does not work anymore, due to an incorrect parameter send to the api.
Before POSTing the spec object on the command route:
- Drop volumes inside spec whose `internal` parameter is `true`
- Don't POST that `internal` parameter inside the spec payload