### PR TITLE
fix DTRSD-80072(pci.storage.databases): redis user information modal

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.controller.js
@@ -11,13 +11,14 @@ export default class usrInfomrationCtrl {
   $onInit() {
     this.trackDashboard('users::show_informations', 'page');
     this.isLoading = false;
+    this.userLists = [];
     USER_INFORMATIONS_LISTS.forEach((element) => {
       this.mapArrayForChip(element);
     });
   }
 
   mapArrayForChip(key) {
-    this.user[key] = map(this.user[key], (a) => {
+    this.userLists[key] = map(this.user[key], (a) => {
       return { title: a };
     });
   }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.html
@@ -26,7 +26,7 @@
                 <h4
                     data-translate="pci_databases_users_informations_keys_label"
                 ></h4>
-                <oui-chips items="$ctrl.user.keys"></oui-chips>
+                <oui-chips items="$ctrl.userLists.keys"></oui-chips>
             </div>
         </div>
         <div class="col">
@@ -34,7 +34,7 @@
                 <h4
                     data-translate="pci_databases_users_informations_categories_label"
                 ></h4>
-                <oui-chips items="$ctrl.user.categories"></oui-chips>
+                <oui-chips items="$ctrl.userLists.categories"></oui-chips>
             </div>
         </div>
     </div>
@@ -45,7 +45,7 @@
                 <h4
                     data-translate="pci_databases_users_informations_commands_label"
                 ></h4>
-                <oui-chips items="$ctrl.user.commands"></oui-chips>
+                <oui-chips items="$ctrl.userLists.commands"></oui-chips>
             </div>
         </div>
         <div class="col">
@@ -53,7 +53,7 @@
                 <h4
                     data-translate="pci_databases_users_informations_channels_label"
                 ></h4>
-                <oui-chips items="$ctrl.user.channels"></oui-chips>
+                <oui-chips items="$ctrl.userLists.channels"></oui-chips>
             </div>
         </div>
     </div>


### PR DESCRIPTION
DTRSD-80072

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-80072
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix user information modal for Redis users by using an internal variable instead of assigning the result of `mapArrayForChip` directly to the user.