### PR TITLE
fix(packages.components): reinit adyen after payment switch

### DIFF
--- a/packages/components/ng-ovh-payment-method/src/components/integration/component/adyen/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/component/adyen/controller.js
@@ -78,14 +78,16 @@ export default class OvhPaymentMethodIntegrationComponentAdyenCtrl {
   }
 
   createAdyenComponent(adyenConfiguration) {
-    this.checkout = new AdyenCheckout(adyenConfiguration);
-    this.checkout
-      .create('card', {
-        ...AdyenService.parseFormSessionId(
-          this.initialParams.paymentMethod.formSessionId,
-        ),
-      })
-      .mount('#adyen-component-container');
+    this.$timeout().then(() => {
+      this.checkout = new AdyenCheckout(adyenConfiguration);
+      this.checkout
+        .create('card', {
+          ...AdyenService.parseFormSessionId(
+            this.initialParams.paymentMethod.formSessionId,
+          ),
+        })
+        .mount('#adyen-component-container');
+    });
   }
 
   submit() {

--- a/packages/components/ng-ovh-payment-method/src/components/integration/component/adyen/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/component/adyen/controller.js
@@ -42,6 +42,7 @@ export default class OvhPaymentMethodIntegrationComponentAdyenCtrl {
 
   $onDestroy() {
     this.checkout = null;
+    this.isComponentLoaded = false;
   }
 
   /* Component related methods */


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-79128
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. fix issue (empty form) when customer switch from PayPal to Credit card payment method
2. force angular to consider the adding async Adyen content 