### PR TITLE
fix(layout-helpers): add target top to links

### DIFF
--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
@@ -38,6 +38,7 @@ export const getLink = (column, tracker) => `
     data-ng-href="{{ $ctrl.getServiceNameLink($row) }}"
     data-ng-bind="$row.${column.property}"
     ${tracker ? `data-track-on="click" data-track-name="${tracker}"` : ''}
+    target="_top"
   ></a>
 `;
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/ovh-shell-batch2
| Bug fix?         | yes
| New feature?     |no
| Breaking change? |no
| Tickets          | MANAGER-9072
| License          | BSD 3-Clause

## Description

add target top attribute to links in ng-layout-helpers