### PR TITLE
feat(pci): removed region query #8895

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/containers.service.js
@@ -134,8 +134,6 @@ export default class PciStoragesContainersService {
       queryParams.archive = false;
     }
 
-    queryParams.region = OPENIO_DEFAULT_REGION;
-
     return this.OvhApiCloudProjectStorage.Aapi()
       .query(queryParams)
       .$promise.then((containers) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/MANAGER-8895
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-8895
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Manager PCI - Object storage and regionalization: Currenlty we are passing region(SBG) as hardcoded value, now we have a requirement to pass other region(GRA) to get the services and in future many more region will come. To pass the region dynamically we need to update 2API and pass region dynamically to get all the high perf services.

## Related
