### PR TITLE
fix(dedicated.server): block nb disks selection on os with no partition

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -393,6 +393,7 @@ angular
         $scope.installation.noPartitioning = distribution?.noPartitioning;
         if (distribution?.noPartitioning) {
           $scope.installation.customInstall = false;
+          $scope.installation.nbDiskUse = 1;
         }
         // if saveSelectDistribution is not null, a partition has personnalisation
         // in progress and confirmation to delete is already display

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
@@ -1911,6 +1911,7 @@
                                 name="nbDiskUse"
                                 data-ng-options="nbdisk as nbdisk for nbdisk in getNbDisqueList(informations.nbDisk)"
                                 data-ng-model="installation.nbDiskUse"
+                                data-ng-disabled="installation.noPartitioning"
                             >
                             </select>
                         </div>


### PR DESCRIPTION
ref: MANAGER-9086

resolves #6566

Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9086
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~