### PR TITLE
fix(ovh-shell): enable account sidebar toggle by default

### DIFF
--- a/packages/components/ovh-shell/src/client/index.ts
+++ b/packages/components/ovh-shell/src/client/index.ts
@@ -70,6 +70,7 @@ export default function init(applicationId: ApplicationId) {
   }
 
   return initPromise.then((shellApi) => {
+    shellApi.ux.enableAccountSidebarToggle();
     return shellApi.environment.setUniverse(applicationId).then(() => shellApi);
   });
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/ovh-shell-integration`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9054
| License          | BSD 3-Clause

## Description

Enable account sidebar toggle by default.