### PR TITLE
fix(dedicated): contact management menu missing

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
+++ b/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
@@ -114,7 +114,7 @@ angular
               });
             }
 
-            if (coreConfig.isRegion('EU') || coreConfig.isRegion('CA')) {
+            if (['EU', 'CA'].includes(coreConfig.getRegion())) {
               SidebarMenu.addMenuItem({
                 name: 'billingContacts',
                 title: $translate.instant('menu_contacts'),

--- a/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
+++ b/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
@@ -114,7 +114,7 @@ angular
               });
             }
 
-            if (coreConfig.isRegion('EU')) {
+            if (!coreConfig.isRegion('US')) {
               SidebarMenu.addMenuItem({
                 name: 'billingContacts',
                 title: $translate.instant('menu_contacts'),

--- a/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
+++ b/packages/manager/apps/dedicated/client/app/components/sidebar-menu/account/sidebar-menu-account.config.js
@@ -114,7 +114,7 @@ angular
               });
             }
 
-            if (!coreConfig.isRegion('US')) {
+            if (coreConfig.isRegion('EU') || coreConfig.isRegion('CA')) {
               SidebarMenu.addMenuItem({
                 name: 'billingContacts',
                 title: $translate.instant('menu_contacts'),


### PR DESCRIPTION
 Added contact management menu in left menu bar for CA region
 ref: MANAGER-8988

Signed-off-by: vikash singh <vsingh@LAPTOPC02H35JAQ6LR.local>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8988
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Enabled contact menu in the left side bar for CA region as well

## Related

<!-- Link dependencies of this PR -->
