### PR TITLE
fix(pci.storage.databases): remove nodeList parameter

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.controller.js
@@ -173,7 +173,6 @@ export default class {
         (region) => region.region === this.model.subnet?.ipPools[0].region,
       )?.openstackId,
       subnetId: this.model.subnet?.id,
-      nodesList: null,
       nodesPattern: {
         flavor: this.model.flavor.name,
         number: this.model.plan.nodesCount,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
@@ -193,7 +193,6 @@ export default class {
       description: this.model.name,
       networkId: this.database?.networkId,
       subnetId: this.database?.subnetId,
-      nodesList: null,
       nodesPattern: {
         flavor: this.model.flavor.name,
         number: this.model.plan.nodesCount,


### PR DESCRIPTION
PUD-1412

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PUD-1412
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

When creating a db / forking a cluster, the request have both nodeList and nodePattern.
It should only have nodePattern to avoid a 400 on the backend.