### PR TITLE
fix(netapp): displaying size of the volume

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/template.html
@@ -47,6 +47,10 @@
             property="protocol"
         ></oui-datagrid-column>
         <oui-datagrid-column
+            title=":: 'netapp_volumes_allocated_quota' | translate"
+            property="size"
+        ></oui-datagrid-column>
+        <oui-datagrid-column
             title=":: 'netapp_volumes_mount_path' | translate"
             property="mountPath"
         >


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9006
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

On creating the netapp volume, size was not visible earlier as size field was not present.

## Related

<!-- Link dependencies of this PR -->
