### PR TITLE
Fix/dtrsd 81766

### DIFF
--- a/packages/components/ovh-shell/__tests__/plugin/routing/orchestrator.spec.ts
+++ b/packages/components/ovh-shell/__tests__/plugin/routing/orchestrator.spec.ts
@@ -86,6 +86,41 @@ defineFeature(feature, (test) => {
     });
   });
 
+  test('Changing the container URL to a standalone application root path', ({
+    given,
+    and,
+    when,
+    then,
+  }) => {
+    given('A routing configuration', () => {
+      config = new RoutingConfiguration();
+      config.addConfiguration({ id: 'home', path: '/hub/' });
+      config.addRedirection(
+        'dedicated',
+        'https://www.ovh.com/manager/dedicated/',
+      );
+    });
+
+    and('An orchestrator', () => {
+      orchestrator = new Orchestrator(config, iframe, container);
+    });
+
+    when(
+      'I change the container URL to a standalone application root path',
+      () => {
+        container.setURL('https://www.ovh.com/manager/#/dedicated');
+        iframe.setURL('https://www.ovh.com/hub/#/');
+        orchestrator.updateIframeURL();
+      },
+    );
+
+    then('I should be redirected', () => {
+      expect(container.getURL().href).toBe(
+        'https://www.ovh.com/manager/dedicated/#/',
+      );
+    });
+  });
+
   test('Changing the container URL to a standalone application', ({
     given,
     and,
@@ -114,6 +149,38 @@ defineFeature(feature, (test) => {
     then('I should be redirected', () => {
       expect(container.getURL().href).toBe(
         'https://www.ovh.com/manager/dedicated/#/hello?foo=bar',
+      );
+    });
+  });
+
+  test('Changing the container URL to a subpart of a standalone application', ({
+    given,
+    and,
+    when,
+    then,
+  }) => {
+    given('A routing configuration with hash in URL', () => {
+      config = new RoutingConfiguration();
+      config.addConfiguration({ id: 'home', path: '/hub/' });
+      config.addRedirection(
+        'billing',
+        'https://www.ovh.com/manager/dedicated/#/billing',
+      );
+    });
+
+    and('An orchestrator', () => {
+      orchestrator = new Orchestrator(config, iframe, container);
+    });
+
+    when('I change the container URL to a standalone application', () => {
+      container.setURL('https://www.ovh.com/manager/#/billing/hello?foo=bar');
+      iframe.setURL('https://www.ovh.com/hub/#/');
+      orchestrator.updateIframeURL();
+    });
+
+    then('I should be redirected preserving the hash from the URL', () => {
+      expect(container.getURL().href).toBe(
+        'https://www.ovh.com/manager/dedicated/#/billing/hello?foo=bar',
       );
     });
   });

--- a/packages/components/ovh-shell/features/plugin/routing/orchestrator.feature
+++ b/packages/components/ovh-shell/features/plugin/routing/orchestrator.feature
@@ -12,11 +12,23 @@ Scenario: Changing the container URL update the iframe URL
   When I change the container URL
   Then The iframe URL should be updated
 
+Scenario: Changing the container URL to a standalone application root path
+  Given A routing configuration
+  And An orchestrator
+  When I change the container URL to a standalone application root path
+  Then I should be redirected
+
 Scenario: Changing the container URL to a standalone application
   Given A routing configuration
   And An orchestrator
   When I change the container URL to a standalone application
   Then I should be redirected
+
+Scenario: Changing the container URL to a subpart of a standalone application
+  Given A routing configuration with hash in URL
+  And An orchestrator
+  When I change the container URL to a standalone application
+  Then I should be redirected preserving the hash from the URL
 
 Scenario: Changing the container URL to an unknown application
   Given A routing configuration

--- a/packages/components/ovh-shell/src/plugin/routing/orchestrator.ts
+++ b/packages/components/ovh-shell/src/plugin/routing/orchestrator.ts
@@ -1,3 +1,4 @@
+import { buildURL } from '@ovh-ux/ufrontend';
 import RoutingConfiguration from './configuration';
 
 interface ILocation {
@@ -83,9 +84,11 @@ class Orchestrator {
     } else {
       const redirection = this.config.findRedirection(appId);
       if (redirection) {
-        const target = new URL(redirection.href);
-        target.hash = appHash;
-        this.container.setURL(target.href);
+        let hash = appHash;
+        if (!appHash.startsWith('#')) {
+          hash = `#${appHash}`;
+        }
+        this.container.setURL(buildURL(redirection.href, hash, {}));
       } else {
         this.redirectToContainerHome();
       }

--- a/packages/manager/modules/ufrontend/url-builder.ts
+++ b/packages/manager/modules/ufrontend/url-builder.ts
@@ -50,9 +50,11 @@ export const buildURL = (
   params: Record<string, ParamValueType>,
 ): string => {
   let { url: buildedPath, params: queryObject } = buildURLPattern(path, params);
-
   if (baseURL.includes('#') && buildedPath.includes('#')) {
     buildedPath = buildedPath.replace('#', '');
+  }
+  if (baseURL.endsWith('/') && buildedPath.startsWith('/')) {
+    buildedPath = buildedPath.substring(1);
   }
 
   let queryString = queryObject ? buildQueryString(queryObject) : '';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-81766
| License          | BSD 3-Clause


## Description

fix `buildURL`to avoid to have double slash in builded URL.
fix shell orchestrator to use buildURL to build redirection URL (and preserve hash from application URL)

## Related

- [] applications#17
