### PR TITLE
fix(telecom): load targets for transfer of security deposit

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/deposit-movement.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/deposit-movement.html
@@ -194,7 +194,7 @@
                                 required
                                 data-ng-model="BillingAccountDepositMovementCtrl.target"
                                 data-ng-options="item.value as item.label disable when item.disable for item in BillingAccountDepositMovementCtrl.targets"
-                                data-ng-disabled="!BillingAccountDepositMovementCtrl.source || BillingAccountDepositMovementCtrl.loading.submit"
+                                data-ng-disabled="!BillingAccountDepositMovementCtrl.source || BillingAccountDepositMovementCtrl.loading.submit || BillingAccountDepositMovementCtrl.loading.target"
                             >
                             </select>
                         </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-80172
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Existing behaviour: While transferring Security deposit, when user selects the source, API calls are made on the list of targets to determine if Security Deposit can be transferred to the specified target. If the targets list is huge, the API calls are rejected by the server with HTTP status code 429.
To avoid making more calls at the same time, the implementation has been modified to fetch data in chunks of 10.

## Related

<!-- Link dependencies of this PR -->
