### PR TITLE
fix MANAGER-9132 (pci.storage.databases): avoid zindex conflict with languages dropdown

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/advanced-configuration/advanced-configuration.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/advanced-configuration/advanced-configuration.html
@@ -131,7 +131,7 @@
             </form>
         </div>
         <div class="col-lg-6">
-            <div class="sticky-top">
+            <div class="sticky-top advanced-configuration-json">
                 <!-- error messages -->
                 <cui-message-container
                     data-messages="$ctrl.messages"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/advanced-configuration/advanced-configuration.scss
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/advanced-configuration/advanced-configuration.scss
@@ -1,5 +1,5 @@
 ovh-manager-pci-project-database-advanced-configuration {
-  .ui-select-dropdown {
-    z-index: 1021 !important;
+  .advanced-configuration-json {
+    z-index: 1009 !important;
   }
 }


### PR DESCRIPTION
MANAGER-9132

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9132
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Avoid advanced configuration json summary hidding languages dropdown