### PR TITLE
feat(*): error page tracking improvements

### DIFF
--- a/packages/manager/apps/anthos/src/app.module.js
+++ b/packages/manager/apps/anthos/src/app.module.js
@@ -46,22 +46,31 @@ export default (containerEl, environment) => {
       },
     )
     .run(
-      /* @ngInject */ ($state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $state.go(
               'error',
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     );

--- a/packages/manager/apps/anthos/src/error/error.routing.js
+++ b/packages/manager/apps/anthos/src/error/error.routing.js
@@ -2,16 +2,21 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('error', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     component: 'managerErrorPage',
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('app'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ () => 'anthos',
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
       breadcrumb: () => null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -349,10 +349,6 @@ export default (containerEl, environment) => {
             $rootScope.$emit('ovh::sidebar::hide');
             $state.go('app.error', { error });
           }
-        });
-
-        $state.defaultErrorHandler((error) => {
-          console.log(error);
           if (error.type === RejectType.ERROR && !error.handled) {
             $rootScope.$emit('ovh::sidebar::hide');
             $state.go(
@@ -360,14 +356,23 @@ export default (containerEl, environment) => {
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+
+        $state.defaultErrorHandler((error) => {
+          console.log(error);
         });
 
         set($rootScope, 'worldPart', coreConfig.getRegion());

--- a/packages/manager/apps/dedicated/client/app/error/error.routing.js
+++ b/packages/manager/apps/dedicated/client/app/error/error.routing.js
@@ -3,6 +3,7 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/error',
     params: {
       detail: null,
+      to: null,
     },
     views: {
       'app@': {
@@ -13,9 +14,20 @@ export default /* @ngInject */ ($stateProvider) => {
       cancelLink: /* @ngInject */ ($state) =>
         $state.href('app.configuration', { reload: true }),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ ($state, $transition$) => {
+        const { state, params } = $transition$.params().to;
+        // href will include # so split with '/' and take second element
+        const [, product] = $state
+          .href(state, params, { lossy: true })
+          .split('/');
+        return product;
+      },
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/dedicated/client/app/expired/expired.routing.js
+++ b/packages/manager/apps/dedicated/client/app/expired/expired.routing.js
@@ -5,6 +5,7 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/expired',
     params: {
       error: null,
+      product: null,
     },
     views: {
       'container@': {
@@ -16,8 +17,12 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href('app.configuration', { reload: true }),
       error: /* @ngInject */ ($transition$) =>
         get($transition$.params(), 'error'),
+      product: /* @ngInject */ ($transition$) => $transition$.params()?.product,
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
       breadcrumb: () => null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/details/managed-baremetal.module.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/details/managed-baremetal.module.js
@@ -34,7 +34,10 @@ angular
         const error = transition.error();
         if (get(error, 'detail.code') === 460) {
           error.handled = true;
-          $state.go('app.expired', { error });
+          $state.go('app.expired', {
+            error,
+            product: 'expired-managedBaremetal',
+          });
         }
       });
     },

--- a/packages/manager/apps/hub/src/app.module.js
+++ b/packages/manager/apps/hub/src/app.module.js
@@ -155,22 +155,31 @@ export default async (containerEl, shellClient) => {
       },
     )
     .run(
-      /* @ngInject */ ($state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $state.go(
               'error',
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     )

--- a/packages/manager/apps/hub/src/components/error-page/error-page.routing.js
+++ b/packages/manager/apps/hub/src/components/error-page/error-page.routing.js
@@ -2,6 +2,7 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('error', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     views: {
@@ -10,9 +11,13 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('app'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ () => 'hub',
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       breadcrumb: () => null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/netapp/src/app.module.js
+++ b/packages/manager/apps/netapp/src/app.module.js
@@ -49,22 +49,31 @@ export default (containerEl, environment) => {
       },
     )
     .run(
-      /* @ngInject */ ($state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $state.go(
               'error',
               {
                 detail: {
                   message: error.detail?.data?.message,
+                  status: error.detail.status,
                   code: error.detail.headers
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     );

--- a/packages/manager/apps/netapp/src/error/error.routing.js
+++ b/packages/manager/apps/netapp/src/error/error.routing.js
@@ -2,16 +2,21 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('error', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     component: 'managerErrorPage',
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('app'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ () => 'netapp',
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
       breadcrumb: () => null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/nutanix/src/app.module.js
+++ b/packages/manager/apps/nutanix/src/app.module.js
@@ -65,22 +65,32 @@ export default (containerEl, environment) => {
       },
     )
     .run(
-      /* @ngInject */ ($state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $state.go(
               'error',
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     );

--- a/packages/manager/apps/nutanix/src/error/error.routing.js
+++ b/packages/manager/apps/nutanix/src/error/error.routing.js
@@ -2,16 +2,21 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('error', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     component: 'managerErrorPage',
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('app'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ () => 'nutanix',
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
       breadcrumb: () => null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/public-cloud/src/app.module.js
+++ b/packages/manager/apps/public-cloud/src/app.module.js
@@ -117,8 +117,9 @@ export default (containerEl, environment) => {
       },
     )
     .run(
-      /* @ngInject */ ($rootScope, $state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($rootScope, $state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $rootScope.$emit('ovh::sidebar::hide');
             $state.go(
@@ -126,14 +127,22 @@ export default (containerEl, environment) => {
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     )

--- a/packages/manager/apps/telecom/src/app/app.module.js
+++ b/packages/manager/apps/telecom/src/app/app.module.js
@@ -339,8 +339,9 @@ export default (containerEl, environment) => {
     )
     .controller('TelecomAppCtrl', TelecomAppCtrl)
     .run(
-      /* @ngInject */ ($rootScope, $state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($rootScope, $state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $rootScope.$emit('ovh::sidebar::hide');
             $state.go(
@@ -348,14 +349,22 @@ export default (containerEl, environment) => {
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail?.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     )

--- a/packages/manager/apps/telecom/src/app/error-page/error-page.routing.js
+++ b/packages/manager/apps/telecom/src/app/error-page/error-page.routing.js
@@ -2,6 +2,7 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('telecomError', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     views: {
@@ -10,9 +11,20 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('telecom'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ ($state, $transition$) => {
+        const { state, params } = $transition$.params().to;
+        // href will include # so split with '/' and take second element
+        const [, product] = $state
+          .href(state, params, { lossy: true })
+          .split('/');
+        return product;
+      },
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
       translationsRefresh: /* @ngInject */ ($translate) => $translate.refresh(),
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -559,8 +559,9 @@ export default (containerEl, environment) => {
     })
     .constant('UNIVERSE', 'WEB')
     .run(
-      /* @ngInject */ ($rootScope, $state) => {
-        $state.defaultErrorHandler((error) => {
+      /* @ngInject */ ($rootScope, $state, $transitions) => {
+        $transitions.onError({}, (transition) => {
+          const error = transition.error();
           if (error.type === RejectType.ERROR) {
             $rootScope.$emit('ovh::sidebar::hide');
             $state.go(
@@ -568,14 +569,22 @@ export default (containerEl, environment) => {
               {
                 detail: {
                   message: get(error.detail, 'data.message'),
+                  status: error.detail?.status,
                   code: has(error.detail, 'headers')
                     ? error.detail.headers('x-ovh-queryId')
                     : null,
+                },
+                to: {
+                  state: transition.to(),
+                  params: transition.params(),
                 },
               },
               { location: false },
             );
           }
+        });
+        $state.defaultErrorHandler((error) => {
+          return error;
         });
       },
     )

--- a/packages/manager/apps/web/client/app/error-page/error-page.routing.js
+++ b/packages/manager/apps/web/client/app/error-page/error-page.routing.js
@@ -2,6 +2,7 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('error', {
     params: {
       detail: null,
+      to: null,
     },
     url: '/error',
     views: {
@@ -10,8 +11,19 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       cancelLink: /* @ngInject */ ($state) => $state.href('app'),
       error: /* @ngInject */ ($transition$) => $transition$.params(),
+      product: /* @ngInject */ ($state, $transition$) => {
+        const { state, params } = $transition$.params().to;
+        // href will include # so split with '/' and take second element
+        const [, product] = $state
+          .href(state, params, { lossy: true })
+          .split('/');
+        return product;
+      },
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };

--- a/packages/manager/modules/error-page/src/error.component.js
+++ b/packages/manager/modules/error-page/src/error.component.js
@@ -8,6 +8,7 @@ export default {
     error: '<',
     image: '<',
     message: '<',
+    product: '<',
     submitAction: '<',
     submitLink: '<',
     submitLabel: '<',

--- a/packages/manager/modules/error-page/src/error.constants.js
+++ b/packages/manager/modules/error-page/src/error.constants.js
@@ -2,6 +2,13 @@ import OOPS from './assets/oops.png';
 
 export const DEFAULT_ASSET = OOPS;
 
+export const TRACKING_LABELS = {
+  SERVICE_NOT_FOUND: 'service_not_found',
+  UNAUTHORIZED: 'unauthorized',
+  PAGE_LOAD: 'error_during_page_loading',
+};
+
 export default {
   DEFAULT_ASSET,
+  TRACKING_LABELS,
 };

--- a/packages/manager/modules/error-page/src/error.controller.js
+++ b/packages/manager/modules/error-page/src/error.controller.js
@@ -1,7 +1,28 @@
-import { DEFAULT_ASSET } from './error.constants';
+import { DEFAULT_ASSET, TRACKING_LABELS } from './error.constants';
 
 export default class {
-  constructor() {
+  /* @ngInject */
+  constructor(atInternet) {
+    this.atInternet = atInternet;
     this.DEFAULT_ASSET = DEFAULT_ASSET;
+  }
+
+  $onInit() {
+    this.atInternet.trackPage({
+      name: `errors::${this.getTrackingTypology()}::${this.product}`,
+      type: 'navigation',
+    });
+  }
+
+  getTrackingTypology() {
+    if (
+      this.error?.detail?.status &&
+      parseInt(this.error.detail.status / 100, 10) === 4
+    ) {
+      return [401, 403].includes(this.error.detail.status)
+        ? TRACKING_LABELS.UNAUTHORIZED
+        : TRACKING_LABELS.SERVICE_NOT_FOUND;
+    }
+    return TRACKING_LABELS.PAGE_LOAD;
   }
 }

--- a/packages/manager/modules/pci/src/error/error.routing.js
+++ b/packages/manager/modules/pci/src/error/error.routing.js
@@ -11,6 +11,7 @@ export default /* @ngInject */ ($stateProvider) => {
       submitAction: null,
       message: null,
       image: null,
+      to: null,
     },
     resolve: {
       breadcrumb: () => null,
@@ -30,6 +31,13 @@ export default /* @ngInject */ ($stateProvider) => {
 
         return error;
       },
+      product: /* @ngInject */ ($state, $transition$) => {
+        const { state, params } = $transition$.params().to;
+        const url = $state.href(state, params, { lossy: true }).split('/');
+        // url of all states follow #/pci/projects/projectId/(instance/storages/load-balancer)
+        // if type of product is present, pick it otherwise generalise the label 'pci-project'
+        return `${url[1]}-${url[4] ? url[4] : 'project'}`;
+      },
       submitAction: /* @ngInject */ ($window) => () =>
         $window.location.reload(),
 
@@ -44,6 +52,9 @@ export default /* @ngInject */ ($stateProvider) => {
 
       submitLink: /* @ngInject */ ($transition$) =>
         $transition$.params().submitLink || null,
+    },
+    atInternet: {
+      ignore: true,
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8559
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

For the tracking improvements on error page, following changes has been implemented,

1. Earlier implementation of state navigation to error state has been moved from $state.defaultErrorHandler  to $transitions.onError
2. From the state name which caused the error, product is identified from the url after # like (#/server, #domain, #nutanix etc)
3. Error typology is determined as follows,
      Error code 401, 403 is classified as UNAUTHORIZED
      Error codes 4xx as SERVICE_NOT_FOUND
      Other errors as ERROR_DURING_PAGE_LOADING

## Related

<!-- Link dependencies of this PR -->
