### PR TITLE
fix(web.exchange): name of exchange 2010 account not displayed

### DIFF
--- a/packages/manager/modules/exchange/src/account/update/account-update.controller.js
+++ b/packages/manager/modules/exchange/src/account/update/account-update.controller.js
@@ -20,6 +20,7 @@ export default class ExchangeUpdateAccountCtrl {
     $timeout,
     exchangeServiceInfrastructure,
     exchangeAccountTypes,
+    exchangeVersion,
     wucExchange,
     wucExchangePassword,
     messaging,
@@ -30,6 +31,7 @@ export default class ExchangeUpdateAccountCtrl {
     this.$timeout = $timeout;
     this.exchangeServiceInfrastructure = exchangeServiceInfrastructure;
     this.exchangeAccountTypes = exchangeAccountTypes;
+    this.exchangeVersion = exchangeVersion;
     this.wucExchange = wucExchange;
     this.wucExchangePassword = wucExchangePassword;
     this.messaging = messaging;
@@ -410,7 +412,11 @@ export default class ExchangeUpdateAccountCtrl {
       this.originalValues.streetAddress !== modifiedBuffer.streetAddress ||
       this.originalValues.postalCode !== modifiedBuffer.postalCode ||
       this.originalValues.city !== modifiedBuffer.city ||
-      this.originalValues.countryCode !== modifiedBuffer.countryCode ||
+      (modifiedBuffer.countryCode != null &&
+        this.originalValues.countryCode !==
+          (typeof modifiedBuffer.countryCode === 'string'
+            ? modifiedBuffer.countryCode
+            : modifiedBuffer.countryCode.code)) ||
       this.originalValues.region !== modifiedBuffer.region ||
       this.originalValues.phone !== modifiedBuffer.phone ||
       this.originalValues.mobile !== modifiedBuffer.mobile ||
@@ -512,11 +518,11 @@ export default class ExchangeUpdateAccountCtrl {
       );
       this.updateAccountForm.selectedAccountPassword.$setValidity(
         'isSameAsSAMAccountName',
-        isEmpty(this.selectedAccount.samAccountName) ||
+        isEmpty(this.selectedAccount.samaccountName) ||
           (isString(this.selectedAccount.password) &&
-            isString(this.selectedAccount.samAccountName) &&
+            isString(this.selectedAccount.samaccountName) &&
             this.selectedAccount.selectedAccountPassword.toUpperCase() !==
-              this.selectedAccount.samAccountName.toUpperCase()),
+              this.selectedAccount.samaccountName.toUpperCase()),
       );
     } else {
       this.updateAccountForm.selectedAccountPassword.$setValidity(

--- a/packages/manager/modules/exchange/src/account/update/account-update.html
+++ b/packages/manager/modules/exchange/src/account/update/account-update.html
@@ -173,23 +173,6 @@
                         </div>
                     </div>
 
-                    <!--Exchange 2010-->
-                    <oui-field
-                        data-label="{{:: 'exchange_account_update_samAccountName_label' | translate }}"
-                        data-ng-if="$ctrl.exchangeVersion.isVersion(2010)"
-                    >
-                        <input
-                            class="oui-input"
-                            type="text"
-                            id="samAccountName"
-                            name="samAccountName"
-                            maxlength="256"
-                            data-ng-model="$ctrl.selectedAccount.samAccountName"
-                            data-ng-change="$ctrl.checkPasswordValidity()"
-                            data-ng-model-options="{ updateOn: 'blur' }"
-                        />
-                    </oui-field>
-
                     <!--Name and first name-->
                     <div class="row">
                         <!--First name-->
@@ -509,6 +492,26 @@
                                 <div class="oui-field-control text-nowrap">
                                     <span
                                         data-ng-bind="$ctrl.emailAccount.exchangeGuid"
+                                    ></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!--Exchange 2010-->
+                    <div
+                        class="row"
+                        data-ng-if="$ctrl.exchangeVersion.isVersion(2010)"
+                    >
+                        <div class="col-md-6 oui-field mb-4">
+                            <label
+                                class="oui-field__label oui-label"
+                                data-translate="exchange_account_update_samAccountName_label"
+                            ></label>
+                            <div class="oui-field__content">
+                                <div class="oui-field-control text-nowrap">
+                                    <span
+                                        data-ng-bind="$ctrl.emailAccount.samaccountName"
                                     ></span>
                                 </div>
                             </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `bugfix/MANAGER-8230` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9154 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
In fact the name of exchange 2010 information is read-only. So I changed the way the information is returned.
I also corrected a bug on the disabled button of the form validation.
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
