### PR TITLE
fix(container): accout sidebar shortcut

### DIFF
--- a/packages/manager/apps/container/src/account-sidebar/Shortcuts/useShortcuts.js
+++ b/packages/manager/apps/container/src/account-sidebar/Shortcuts/useShortcuts.js
@@ -60,7 +60,7 @@ const useShortcuts = () => {
             },
           ]
         : []),
-      ...(['EU'].includes(region)
+      ...(['EU', 'CA'].includes(region)
         ? [
             {
               id: 'contacts',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/ovh-shell-integration
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9169
| License          | BSD 3-Clause

## Description

Add missing shortcut in account sidebar for CA region