### PR TITLE
fix(pci.projects.new.payment): allows creating project if default payment

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/components/voucher/component.js
+++ b/packages/manager/modules/pci/src/projects/new/components/voucher/component.js
@@ -14,5 +14,6 @@ export default {
     globalLoading: '<',
     trackProjectCreationError: '<',
     steps: '<',
+    defaultPaymentMethod: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/new/components/voucher/controller.js
+++ b/packages/manager/modules/pci/src/projects/new/components/voucher/controller.js
@@ -97,7 +97,10 @@ export default class PciProjectNewVoucherCtrl {
         return eligibilityOpts;
       })
       .then((eligibilityOpts) => {
-        if (!this.model.isVoucherRequirePaymentMethod) {
+        if (
+          !this.model.isVoucherRequirePaymentMethod &&
+          !this.defaultPaymentMethod
+        ) {
           this.model.paymentMethod = null;
         }
 

--- a/packages/manager/modules/pci/src/projects/new/payment/controller.js
+++ b/packages/manager/modules/pci/src/projects/new/payment/controller.js
@@ -295,7 +295,7 @@ export default class PciProjectNewPaymentCtrl {
     return (
       finalize ||
       isVoucherValidating ||
-      isVoucherRequirePaymentMethod ||
+      (isVoucherRequirePaymentMethod && !this.defaultPaymentMethod) ||
       (this.eligibility.isChallengePaymentMethodRequired() &&
         !challenge.isValid(this.defaultPaymentMethod.paymentType)) ||
       (!paymentMethod && this.eligibility.isAddPaymentMethodRequired()) ||


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRST-82610
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. allow customer to create a project if have a default payment mean even if had enter a wrong voucher 