### PR TITLE
fix(ai-volume-permissions): add RWD missing permission

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-attach/notebook-attach.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/components/notebook-attach/notebook-attach.controller.js
@@ -11,6 +11,7 @@ export default class NotebookAttachController {
     this.permissions = [
       NOTEBOOK_ATTACH_STORAGE.PERMISSION_READ_ONLY,
       NOTEBOOK_ATTACH_STORAGE.PERMISSION_READ_WRITE,
+      NOTEBOOK_ATTACH_STORAGE.PERMISSION_READ_WRITE_DELETE,
     ];
   }
 

--- a/packages/manager/modules/pci/src/projects/project/notebooks/add/notebook.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/add/notebook.constants.js
@@ -19,6 +19,7 @@ export const NOTEBOOK_ATTACH_STORAGE = {
   GIT_URL_REGEX: 'http(s)?://([\\w\\.\\:/\\-~]+)(\\.git)(/)?',
   PERMISSION_READ_ONLY: 'RO',
   PERMISSION_READ_WRITE: 'RW',
+  PERMISSION_READ_WRITE_DELETE: 'RWD',
   MAX_VOLUMES: 10,
 };
 

--- a/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/submit/submit.controller.js
@@ -69,7 +69,7 @@ export default class PciTrainingJobsSubmitController {
     );
 
     this.httpHeader = [];
-    this.volumesPermissions = ['RO', 'RW'];
+    this.volumesPermissions = ['RO', 'RW', 'RWD'];
     this.discordUrl = DISCORD_URL;
     this.docDockerBuildUrl = DOC_DOCKER_BUILD_URL;
     // Form payload


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MLS-2882
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

## Description

On AI Training and AI Notebook, the RWD select option is missing when trying to attach a volume. This PR fix this issue. 
