### PR TITLE
fix(telecom.telephony.contact): see an empty waynumberextra in select

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/contact.constants.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/contact.constants.js
@@ -32,9 +32,9 @@ export const WAY_NUMBER_EXTRA = [
 ];
 
 export const DIRECTORY_WAY_NUMBER_EXTRA_ENUM = {
-  BE: ['', 'A', 'B', 'C', ...WAY_NUMBER_EXTRA],
+  BE: ['&nbsp;', 'A', 'B', 'C', ...WAY_NUMBER_EXTRA],
   OTHER: [
-    '',
+    '&nbsp;',
     'bis',
     'ter',
     'quater',

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/contact.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/contact/contact.controller.js
@@ -381,6 +381,12 @@ export default class TelecomTelephonyServiceContactCtrl {
     if (this.directoryForm.legalForm !== 'individual') {
       this.directoryForm.PJSocialNomination = this.directoryForm.socialNomination;
     }
+
+    this.directoryForm.wayNumberExtra = this.directoryForm.wayNumberExtra.replace(
+      /&nbsp;/g,
+      '',
+    );
+
     const modified = assign(this.directory, this.directoryForm);
     this.isUpdating = true;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `fix/MANAGER-9067` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9159 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I fixed the fact of see an empty waynumberextra in select.
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
