### PR TITLE
fix: remove extra column helpers on `<ovh-manager-server-sidebar>`

### DIFF
--- a/packages/manager/apps/telecom/src/index.html
+++ b/packages/manager/apps/telecom/src/index.html
@@ -62,7 +62,6 @@
                             <ovh-manager-server-sidebar
                                 data-ng-if="$ctrl.sidebarUniverse"
                                 universe="$ctrl.sidebarUniverse"
-                                class="col-md-3 col-lg-2"
                             >
                             </ovh-manager-server-sidebar>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-82722
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

### :bug: Bug Fixes

afb7240 - fix: remove extra column helpers on `<ovh-manager-server-sidebar>`

## Related

#6154
