### PR TITLE
fix(ng-layout-helpers): remove target _top from link

### DIFF
--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
@@ -38,7 +38,6 @@ export const getLink = (column, tracker) => `
     data-ng-href="{{ $ctrl.getServiceNameLink($row) }}"
     data-ng-bind="$row.${column.property}"
     ${tracker ? `data-track-on="click" data-track-name="${tracker}"` : ''}
-    target="_top"
   ></a>
 `;
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/product-nav-reshuffle
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

remove target _top from link