### PR TITLE
fix(preloader): use loading message in container

### DIFF
--- a/packages/manager/modules/preloader/src/index.js
+++ b/packages/manager/modules/preloader/src/index.js
@@ -28,14 +28,18 @@ const hasSwitchParameter = (search) =>
 const isManagerBaseUrl = (url) =>
   MANAGER_BASE_URLS.some((baseUrl) => url.startsWith(baseUrl));
 
+const isInContainer = () => window.top !== window.self;
+
+const shouldDisplayLoadingMessage = () =>
+  hasSwitchParameter(window.location.search) ||
+  isManagerBaseUrl(document.referrer) ||
+  isInContainer();
+
 export const attach = (language = 'en') => {
   const template = document.createElement('template');
 
   let messageSource = WELCOME_MESSAGES;
-  if (
-    hasSwitchParameter(window.location.search) ||
-    isManagerBaseUrl(document.referrer)
-  ) {
+  if (shouldDisplayLoadingMessage()) {
     messageSource = LOADING_MESSAGES;
   }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9235,
| License          | BSD 3-Clause

## Description

Force to display loading message instead of welcome message in container.
