### PR TITLE
fix(dedicatedservers): fix listing search redirection to onboarding

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/servers.routing.js
@@ -53,6 +53,11 @@ export default /* @ngInject */ ($stateProvider) => {
           .catch(() => false),
       getServerDashboardLink: /* @ngInject */ ($state) => (server) =>
         $state.href('app.dedicated-server.server', { productId: server.name }),
+      noFiltersServers: /* @ngInject */ (iceberg) =>
+        iceberg('/dedicated/server')
+          .query()
+          .expand('CachedObjectList-Pages')
+          .execute(null, true).$promise,
       dedicatedServers: /* @ngInject */ ($transition$, iceberg) => {
         const { filter, pageSize, sort, sortOrder } = $transition$.params();
         let { page } = $transition$.params();
@@ -128,9 +133,9 @@ export default /* @ngInject */ ($stateProvider) => {
     redirectTo: (transition) =>
       transition
         .injector()
-        .getAsync('dedicatedServers')
-        .then((dedicatedServers) =>
-          dedicatedServers.data.length === 0
+        .getAsync('noFiltersServers')
+        .then((noFiltersServers) =>
+          noFiltersServers.data.length === 0
             ? 'app.dedicated-server.onboarding'
             : false,
         ),


### PR DESCRIPTION
ref:MANAGER-9270

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description
Fix bug that caused app to redirect to onboarding page when search results of filter was empty.

ref: MANAGER-9270