### PR TITLE
fix(ng-ovh-sidebar-menu): remove top margin

### DIFF
--- a/packages/components/ng-ovh-sidebar-menu/src/_variables.less
+++ b/packages/components/ng-ovh-sidebar-menu/src/_variables.less
@@ -9,7 +9,7 @@
 @sidebar-font-color: #113f6d;
 @sidebar-height: 100%;
 @sidebar-max-width: rem-calc(300);
-@sidebar-offset-top: rem-calc(44);
+@sidebar-offset-top: 0;
 @sidebar-padding: 0 rem-calc(10);
 @sidebar-z-index: @base-z-index-sidebar;
 @sidebar-z-index_fixed: @base-z-index-panel;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/product-nav-reshuffle
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9302
| License          | BSD 3-Clause

## Description

remove sidebar menu margin top