### PR TITLE
fix(container): allow to switch back without survey

### DIFF
--- a/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/Modal.tsx
+++ b/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/Modal.tsx
@@ -6,7 +6,7 @@ import style from './style.module.scss';
 
 type Props = {
   onCancel(): void;
-  onConfirm(): void;
+  onConfirm(showModal?: boolean): void;
 };
 
 function NavReshuffleSwitchBackModal({
@@ -15,23 +15,23 @@ function NavReshuffleSwitchBackModal({
 }: Props): JSX.Element {
   const { t } = useTranslation('beta-modal');
   return (
-    <div className={style.backdrop}>
+    <div className={style.backdrop} onClick={onCancel}>
       <div className={style.modal}>
         <h1>{t('beta_modal_switch_title')}</h1>
         <p>{t('beta_modal_switch_infos')}</p>
         <button
           type="button"
           className="oui-button oui-button_primary float-right"
-          onClick={onConfirm}
+          onClick={() => onConfirm(true)}
         >
           {t('beta_modal_switch_accept')}
         </button>
         <button
           type="button"
           className="oui-button oui-button_secondary float-right mr-2"
-          onClick={onCancel}
+          onClick={() => onConfirm()}
         >
-          {t('beta_modal_switch_cancel')}
+          {t('beta_modal_switch_later')}
         </button>
       </div>
     </div>

--- a/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
+++ b/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
@@ -29,12 +29,14 @@ function NavReshuffleSwitchBack({ onChange }: Props): JSX.Element {
 
   useClickAway(ref, () => setShow(false));
 
-  const switchBack = () => {
-    window.open(
-      'https://survey.ovh.com/index.php/813778',
-      '_blank',
-      'noopener',
-    );
+  const switchBack = (openSurvey = false) => {
+    if (openSurvey) {
+      window.open(
+        'https://survey.ovh.com/index.php/813778',
+        '_blank',
+        'noopener',
+      );
+    }
     updateBetaChoice(false);
   };
 
@@ -47,7 +49,7 @@ function NavReshuffleSwitchBack({ onChange }: Props): JSX.Element {
       {confirm && (
         <NavReshuffleSwitchBackModal
           onCancel={() => setConfirm(false)}
-          onConfirm={() => switchBack()}
+          onConfirm={(openSurvey = false) => switchBack(openSurvey)}
         />
       )}
       <div className="oui-navbar-dropdown" ref={ref}>

--- a/packages/manager/apps/container/src/public/translations/beta-modal/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/beta-modal/Messages_fr_FR.json
@@ -10,6 +10,6 @@
   "beta_modal_switch_title": "Vous voulez retourner à la version précédente du manager",
   "beta_modal_switch_infos": "Pour être toujours au plus près de vos attentes, votre avis est important pour nous. Aidez-nous à nous améliorer!",
   "beta_modal_switch_accept": "Je donne mon avis",
-  "beta_modal_switch_cancel": "Annuler",
-  "beta_switch": "Basculer de version"
+  "beta_switch": "Basculer de version",
+  "beta_modal_switch_later": "Plus tard"
 }


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9308,
| License          | BSD 3-Clause

## Description


Update switch back to allow to close modal on backdrop click. 
Allow to switch back without opening the feedback survey.