### PR TITLE
fix(dedicated.server): display correct incoming bandwidth information

### DIFF
--- a/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.html
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.html
@@ -37,7 +37,7 @@
                 <!-- Incoming Bandwidth -->
                 <span class="oui-icon oui-icon-arrow-down font-inherit"></span>
                 <span
-                    data-ng-bind="$ctrl.specifications.connection | serverBandwidth"
+                    data-ng-bind="$ctrl.specifications.bandwidth.InternetToOvh | serverBandwidth"
                 ></span>
                 <span
                     data-translate="dedicated_server_bandwidth_incoming"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-83020
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Fix to display correct incoming bandwidth information on Server dashboard

## Related

<!-- Link dependencies of this PR -->
