### PR TITLE
fix(pnr): enable onboarding widget to open after chatbot interaction

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/onboarding/introduction.jsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/onboarding/introduction.jsx
@@ -38,6 +38,7 @@ export const OnboardingIntroduction = () => {
   });
 
   const openOnboarding = () => {
+    setIsPopoverVisible(true);
     productNavReshuffle.openOnboarding();
   };
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9316
| License          | BSD 3-Clause

## Description

Fix onboarding introduction popup display after chatbot opening.