### PR TITLE
fix(hub): use default margins in container

### DIFF
--- a/packages/manager/apps/hub/src/index.html
+++ b/packages/manager/apps/hub/src/index.html
@@ -51,10 +51,7 @@
         </ovh-manager-notifications-sidebar>
         <div class="position-relative w-100 h-100 overflow-auto ng-cloak">
             <div
-                class="position-absolute hub-main w-100 h-100"
-                data-ng-class="{
-                    'hub-main-view_sidebar_expanded': $ctrl.isTopLevelApplication,
-                }"
+                class="position-absolute hub-main w-100 h-100 hub-main-view_sidebar_expanded"
             >
                 <ovh-manager-banner-text></ovh-manager-banner-text>
                 <div class="mb-5" data-ui-view="app">


### PR DESCRIPTION


| Question         | Answer
| ---------------- | ---
| Branch?          | feat/product-nav-reshuffle
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | ref: MANAGER-9297
| License          | BSD 3-Clause

## Description

fix hub alignment in container