### PR TITLE
fix(container): display preloader on iframe load

### DIFF
--- a/packages/components/ovh-shell/src/plugin/routing/index.tsx
+++ b/packages/components/ovh-shell/src/plugin/routing/index.tsx
@@ -92,6 +92,7 @@ export function initRouting(
   });
 
   iframe.addEventListener('load', () => {
+    shell.getPlugin('ux').showPreloader();
     try {
       iframe.contentWindow.location.toString();
     } catch {


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9348,
| License          | BSD 3-Clause

## Description


Force to display preloader on iframe `onLoad`