### PR TITLE
fix(pnr): flatpickr loaded language

### DIFF
--- a/packages/manager/apps/dedicated/client/app/app.module.js
+++ b/packages/manager/apps/dedicated/client/app/app.module.js
@@ -474,7 +474,7 @@ export default async (containerEl, shellClient) => {
     )
     .config(
       /* @ngInject */ (ouiCalendarConfigurationProvider) => {
-        const lang = locale;
+        const [lang] = locale.split('_');
         return import(`flatpickr/dist/l10n/${lang}.js`)
           .then((module) => {
             ouiCalendarConfigurationProvider.setLocale(module.default[lang]);

--- a/packages/manager/apps/public-cloud/src/app.module.js
+++ b/packages/manager/apps/public-cloud/src/app.module.js
@@ -151,7 +151,7 @@ export default async (containerEl, shellClient) => {
     )
     .config(
       /* @ngInject */ (ouiCalendarConfigurationProvider) => {
-        const lang = locale;
+        const [lang] = locale.split('_');
         return import(`flatpickr/dist/l10n/${lang}.js`)
           .then((module) => {
             ouiCalendarConfigurationProvider.setLocale(module.default[lang]);

--- a/packages/manager/apps/telecom/src/app/app.module.js
+++ b/packages/manager/apps/telecom/src/app/app.module.js
@@ -299,7 +299,7 @@ export default async (containerEl, shellClient) => {
     )
     .config(
       /* @ngInject */ (ouiCalendarConfigurationProvider) => {
-        const lang = locale;
+        const [lang] = locale.split('_');
         return import(`flatpickr/dist/l10n/${lang}.js`)
           .then((module) => {
             ouiCalendarConfigurationProvider.setLocale(module.default[lang]);

--- a/packages/manager/apps/web/client/app/app.module.js
+++ b/packages/manager/apps/web/client/app/app.module.js
@@ -553,7 +553,7 @@ export default async (containerEl, shellClient) => {
 
     .config(
       /* @ngInject */ (ouiCalendarConfigurationProvider) => {
-        const lang = locale;
+        const [lang] = locale.split('_');
         return import(`flatpickr/dist/l10n/${lang}.js`)
           .then((module) => {
             ouiCalendarConfigurationProvider.setLocale(module.default[lang]);


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9338
| License          | BSD 3-Clause

## Description

Split the locale in order to load right locale for flatpickr component in monoliths.