### PR TITLE
feat(pci.storage.databases): change unit for network metrics from octects to megaoctects

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.constants.js
@@ -1,0 +1,13 @@
+export const UNITS_CONVERTER = {
+  bytes_to_megabytes: 1 / 1048576,
+};
+
+export const METRICS_CONVERTER = {
+  net_send: UNITS_CONVERTER.bytes_to_megabytes,
+  net_receive: UNITS_CONVERTER.bytes_to_megabytes,
+};
+
+export default {
+  UNITS_CONVERTER,
+  METRICS_CONVERTER,
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
@@ -112,7 +112,7 @@ export default class MetricsCtrl {
             (point) => {
               return {
                 timestamp: point.timestamp,
-                value: point.value / 1000000.0,
+                value: point.value / 1000000,
               };
             },
           );

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
@@ -79,7 +79,7 @@ export default class MetricsCtrl {
       );
 
       this.metricsData[metric].chart.setTooltipCallback('label', (item) =>
-        parseFloat(item.value, 10).toFixed(2),
+        parseFloat(item.value, 10).toPrecision(3),
       );
     });
   }
@@ -106,8 +106,19 @@ export default class MetricsCtrl {
         availableMetric,
         this.selectedTimeRange.value,
       ).then((data) => {
-        const metrics = sortBy(data.metrics, 'hostname');
-        this.metricsData[data.name].data = data;
+        const metricData = data;
+        if (['net_send', 'net_receive'].includes(availableMetric)) {
+          metricData.metrics[0].dataPoints = data.metrics[0].dataPoints.map(
+            (point) => {
+              return {
+                timestamp: point.timestamp,
+                value: point.value / 1000000.0,
+              };
+            },
+          );
+        }
+        const metrics = sortBy(metricData.metrics, 'hostname');
+        this.metricsData[metricData.name].data = metricData;
 
         metrics.forEach((metric) => {
           this.metricsData[data.name].chart.updateSerie(
@@ -125,7 +136,7 @@ export default class MetricsCtrl {
           );
         });
 
-        this.metricsData[data.name].utils.refresh();
+        this.metricsData[metricData.name].utils.refresh();
       });
     });
   }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_de_DE.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Belegter Festplattenspeicher (%)",
   "pci_databases_metrics_title_diskio_read": "Anzahl der IOPS (Lesen)",
   "pci_databases_metrics_title_diskio_writes": "Anzahl der IOPS (Schreiben)",
-  "pci_databases_metrics_title_net_receive": "Netzwerkempfang (Bytes/s)",
-  "pci_databases_metrics_title_net_send": "Netzwerkübertragung (Bytes/s)",
+  "pci_databases_metrics_title_net_receive": "Netzwerkempfang (MB/s)",
+  "pci_databases_metrics_title_net_send": "Netzwerkübertragung (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Verwendeter Speicher (%)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_en_GB.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Disk space used (%)",
   "pci_databases_metrics_title_diskio_read": "No. of IOPS (read)",
   "pci_databases_metrics_title_diskio_writes": "No. of IOPS (write)",
-  "pci_databases_metrics_title_net_receive": "Network Receive (bytes/sec)",
-  "pci_databases_metrics_title_net_send": "Network Transmission (bytes/sec)",
+  "pci_databases_metrics_title_net_receive": "Network Reception (MB/s)",
+  "pci_databases_metrics_title_net_send": "Network Transmission (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Memory used (%)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_es_ES.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Espacio en disco utilizado (%)",
   "pci_databases_metrics_title_diskio_read": "N.º de IOPS (lectura)",
   "pci_databases_metrics_title_diskio_writes": "N.º de IOPS (escritura)",
-  "pci_databases_metrics_title_net_receive": "Recepción de red (bytes/s)",
-  "pci_databases_metrics_title_net_send": "Transmisión de red (bytes/s)",
+  "pci_databases_metrics_title_net_receive": "Recepción de red (MB/s)",
+  "pci_databases_metrics_title_net_send": "Transmisión de red (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Memoria utilizada (%)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_CA.json
@@ -14,6 +14,6 @@
   "pci_databases_metrics_title_mem_usage_percent": "Mémoire utilisée (%)",
   "pci_databases_metrics_title_diskio_read": "Nb d'IOPS (lecture)",
   "pci_databases_metrics_title_diskio_writes": "Nb d'IOPS (écriture)",
-  "pci_databases_metrics_title_net_receive": "Réception réseau (octets/s)",
-  "pci_databases_metrics_title_net_send": "Transmission réseau (octets/s)"
+  "pci_databases_metrics_title_net_receive": "Réception réseau (Mo/s)",
+  "pci_databases_metrics_title_net_send": "Transmission réseau (Mo/s)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_fr_FR.json
@@ -14,6 +14,6 @@
   "pci_databases_metrics_title_mem_usage_percent": "Mémoire utilisée (%)",
   "pci_databases_metrics_title_diskio_read": "Nb d'IOPS (lecture)",
   "pci_databases_metrics_title_diskio_writes": "Nb d'IOPS (écriture)",
-  "pci_databases_metrics_title_net_receive": "Réception réseau (octets/s)",
-  "pci_databases_metrics_title_net_send": "Transmission réseau (octets/s)"
+  "pci_databases_metrics_title_net_receive": "Réception réseau (Mo/s)",
+  "pci_databases_metrics_title_net_send": "Transmission réseau (Mo/s)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_it_IT.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Spazio disco utilizzato (%)",
   "pci_databases_metrics_title_diskio_read": "N° di IOPS (lettura)",
   "pci_databases_metrics_title_diskio_writes": "N° di IOPS (scrittura)",
-  "pci_databases_metrics_title_net_receive": "Ricezione di rete (byte/s)",
-  "pci_databases_metrics_title_net_send": "Trasmissione di rete (byte/s)",
+  "pci_databases_metrics_title_net_receive": "Ricezione di rete (MB/s)",
+  "pci_databases_metrics_title_net_send": "Trasmissione di rete (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Memoria utilizzata (%)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_pl_PL.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Poziom wykorzystania przestrzeni dyskowej (%)",
   "pci_databases_metrics_title_diskio_read": "Liczba IOPS (odczyt)",
   "pci_databases_metrics_title_diskio_writes": "Liczba IOPS (zapis)",
-  "pci_databases_metrics_title_net_receive": "Odbiór danych w sieci (bajty/s)",
-  "pci_databases_metrics_title_net_send": "Transmisja danych w sieci (bajty/s)",
+  "pci_databases_metrics_title_net_receive": "Odbiór danych w sieci (MB/s)",
+  "pci_databases_metrics_title_net_send": "Transmisja danych w sieci (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Wykorzystana pamięć (%)"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/translations/Messages_pt_PT.json
@@ -13,7 +13,7 @@
   "pci_databases_metrics_title_disk_usage_percent": "Espaço de disco utilizado",
   "pci_databases_metrics_title_diskio_read": "Nº de IOPS (leitura)",
   "pci_databases_metrics_title_diskio_writes": "Nº de IOPS (escrita)",
-  "pci_databases_metrics_title_net_receive": "Receção de rede (bytes/s)",
-  "pci_databases_metrics_title_net_send": "Transmissão de rede (bytes/s)",
+  "pci_databases_metrics_title_net_receive": "Receção de rede (MB/s)",
+  "pci_databases_metrics_title_net_send": "Transmissão de rede (MB/s)",
   "pci_databases_metrics_title_mem_usage_percent": "Memória utilizada (%)"
 }


### PR DESCRIPTION
DATATR-29

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DATATR-29
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Convert network metrics from octects to megaoctects.

## Related

### :flags: Translations

- [x] TRANS-44559
