### PR TITLE
fix(ng-layout-helpers): display description column by default

### DIFF
--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
@@ -134,11 +134,29 @@ export const getDefaultConfiguration = (
   const columns = mapApiProperties(dataModel.properties).filter(
     ({ label }) => label !== defaultFilterColumn,
   );
+
+  // pull the service's description column to the front then ...
+  columns.sort((a, b) => {
+    if (a.property === 'description') return -1;
+    if (b.properby === 'description') return 1;
+    return 0;
+  });
+
+  // ... pull the service's displayName column to the front then ...
+  columns.sort((a, b) => {
+    if (a.property === 'displayName') return -1;
+    if (b.properby === 'displayName') return 1;
+    return 0;
+  });
+
+  // ... prepend the serviceName, so the initial columns order
+  // will be [serviceName, displayName, description, ...]
   columns.unshift({
     label: defaultFilterColumn,
     property: defaultFilterColumn,
     serviceLink: true,
   });
+
   return {
     data: columns.map((column, index) => ({
       ...column,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/product-nav-reshuffle
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9292
| License          | BSD 3-Clause

## Description

in order to make listing pages easier to navigate in product nav reshuffle beta version, display the service description next to the serviceName by default in product listing pages