### PR TITLE
feat (pci.ai.training): change joburl to url

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
+++ b/packages/manager/modules/pci/src/projects/project/training/jobs/info/info.html
@@ -150,7 +150,7 @@
                     </oui-tile-description>
                 </oui-tile-definition>
 
-                <div class="oui-tile__item" ng-if="$ctrl.job.status.jobUrl">
+                <div class="oui-tile__item" ng-if="$ctrl.job.status.url">
                     <dl class="oui-tile__definition">
                         <dt class="oui-tile__term">
                             <span
@@ -166,7 +166,7 @@
                         <oui-tile-description>
                             <a
                                 class="oui-link oui-link_icon"
-                                data-ng-href="{{ $ctrl.job.status.jobUrl }}"
+                                data-ng-href="{{ $ctrl.job.status.url }}"
                                 target="_blank"
                                 rel="noopener"
                             >


### PR DESCRIPTION
DATATR-28

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DATATR-28
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Currently the AI Training job info page use the field job.status.jobUrl which is deprecated and need to be switch to the field job.status.url.
