### PR TITLE
fix(pnr): switch version widget display in mobile

### DIFF
--- a/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/Modal.tsx
+++ b/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/Modal.tsx
@@ -19,20 +19,22 @@ function NavReshuffleSwitchBackModal({
       <div className={style.modal}>
         <h1>{t('beta_modal_switch_title')}</h1>
         <p>{t('beta_modal_switch_infos')}</p>
-        <button
-          type="button"
-          className="oui-button oui-button_primary float-right"
-          onClick={() => onConfirm(true)}
-        >
-          {t('beta_modal_switch_accept')}
-        </button>
-        <button
-          type="button"
-          className="oui-button oui-button_secondary float-right mr-2"
-          onClick={() => onConfirm()}
-        >
-          {t('beta_modal_switch_later')}
-        </button>
+        <div className="d-flex flex-row-reverse justify-content-between">
+          <button
+            type="button"
+            className="oui-button oui-button_primary float-right"
+            onClick={() => onConfirm(true)}
+          >
+            {t('beta_modal_switch_accept')}
+          </button>
+          <button
+            type="button"
+            className="oui-button oui-button_secondary float-right mr-2"
+            onClick={() => onConfirm()}
+          >
+            {t('beta_modal_switch_later')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
+++ b/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
@@ -96,7 +96,7 @@ function NavReshuffleSwitchBack({ onChange }: Props): JSX.Element {
           </span>
         </button>
         <div className="oui-navbar-menu__wrapper">
-          <div className="oui-navbar-menu oui-navbar-menu_fixed oui-navbar-menu_end">
+          <div className="oui-navbar-menu oui-navbar-menu_end">
             <div className="oui-navbar-list_dropdown">
               <ul className="oui-navbar-list">
                 <li className="oui-navbar-list__item">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9295
| License          | BSD 3-Clause

## Description

Resolves display of switch version widget in mobile.
