### PR TITLE
fix(pci): missing region for highperfstorage on add new user

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/addUser/addUser.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/addUser/addUser.routing.js
@@ -41,6 +41,7 @@ export default /* @ngInject */ ($stateProvider) => {
             projectId,
             containerId,
             container.isHighPerfStorage,
+            container.region,
           );
         },
         goToUsersAndRoles: /* @ngInject */ ($state) => () =>


### PR DESCRIPTION
 Addition of region as query param on click of add new user  for highperfstorages.
 ref: DTRSD-83162

Signed-off-by: vikash singh <vikash.singh@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-83162
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Addition of region as query param for highperf storage on click on add new user feature.

## Related

<!-- Link dependencies of this PR -->
