### PR TITLE
fix(pci.storage.databases): show all metrics

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
@@ -111,7 +111,7 @@ export default class MetricsCtrl {
 
         metrics.forEach((metric) => {
           this.metricsData[data.name].chart.updateSerie(
-            metric.hostname.substring(0, metric.hostname.indexOf('-')),
+            metric.hostname,
             map(metric.dataPoints, (point) => ({
               x: moment.unix(point.timestamp),
               y: point.value,


### PR DESCRIPTION
DATATR-36

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-36
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Use metrics name coming from api to be able to display metrics for all nodes