### PR TITLE
feat(dedicated.server.install): remove deprecated API flag

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -2518,7 +2518,6 @@ angular
             diskGroupId: !isDefaultDiskGroup($scope.installation.diskGroup)
               ? $scope.installation.diskGroup.diskGroupId
               : null,
-            resetHwRaid: !isDefaultDiskGroup($scope.installation.diskGroup),
           },
         ).then(
           (task) => {


### PR DESCRIPTION
ref: DTRSD-85191

Signed-off-by: JeremyDec <jeremy.de-cesare@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DTRSD-85191
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Flag `resetHwRaid` is now deprecated on API side, and will be completely removed on next months 
