### PR TITLE
fix(hosting.offer): implement detach addon of start10M

### DIFF
--- a/packages/manager/modules/product-offers/src/services/product-offers-action.service.js
+++ b/packages/manager/modules/product-offers/src/services/product-offers-action.service.js
@@ -35,6 +35,18 @@ export default class ProductOffersActionService {
   }
 
   /**
+   * Get the detach plancode information for its options (addons)
+   * @param  {string} planCode  Plancode identifier
+   * @param  {string} serviceId Id of the service
+   * @return {Promise<Object>}  Promise of the addon detach details
+   */
+  getDetachPlancodeInformationOptions(serviceId, planCode) {
+    return this.$http
+      .get(`/services/${serviceId}/detach/${planCode}/options`)
+      .then(({ data }) => data);
+  }
+
+  /**
    * Retrieve all available options for a given service
    * @param  {string} serviceId Id of the service
    * @return {Promise<Array>}   Promise of the plancodes list


### PR DESCRIPTION
Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #WEB-12035
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Start10m is a free hosting offered to customer when ordering a domain. We want this customer to be able to upgrade it to a paid offer (perso2014). It was done through https://github.com/ovh/manager/pull/6385
However we add an issue: if the start10m has an addon (free email), we couldn't detach it. This PR aim is to solve this issue.
