### PR TITLE
fix(pnr): avoid to display marketplace and sunrise entries

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/root.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/root.ts
@@ -27,7 +27,7 @@ export default {
         application: 'sunrise',
       },
       count: false,
-      feature: 'sunrise',
+      features: ['sunrise'],
       separator: true,
     },
     {
@@ -105,7 +105,7 @@ export default {
       url: 'https://marketplace.ovhcloud.com/',
       isExternal: true,
       count: false,
-      feature: 'marketplace',
+      features: ['marketplace'],
     },
   ],
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9422
| License          | BSD 3-Clause

## Description

Avoid Marketplace and Sunrise entries in sidebar.