### PR TITLE
feat(pnr): add telecom v4 in sidebar

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
@@ -78,5 +78,10 @@ export default {
         hash: '#/task',
       },
     },
+    {
+      id: 'telecom-v4',
+      translation: 'sidebar_telecom_v4',
+      url: 'https://www.ovh.com/managerv3/telephony2-main.pl',
+    },
   ],
 };

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
@@ -77,11 +77,13 @@ export default {
         application: 'telecom',
         hash: '#/task',
       },
+      count: false,
     },
     {
       id: 'telecom-v4',
       translation: 'sidebar_telecom_v4',
       url: 'https://www.ovh.com/managerv3/telephony2-main.pl',
+      count: false,
     },
   ],
 };

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
@@ -9,6 +9,7 @@
   "sidebar_dedicated_housing": "Housing",
   "sidebar_telecom": "Télécom",
   "sidebar_telecom_operations": "Opérations",
+  "sidebar_telecom_v4": "Manager v4",
   "sidebar_vps": "Serveurs Privés Virtuels",
   "sidebar_storage_backup": "Stockage et sauvegarde",
   "sidebar_dedicated_cloud": "Managed Bare Metal",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-9260
| License          | BSD 3-Clause

## Description

Add access to manager v4 in the "Telecom" category like so:
> **Telecom**
Accès Internet >
Téléphonie >
Opérations
Manager v4