### PR TITLE
fix(pnr): use feature flipping to display cloudDB order link

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.component.js
+++ b/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.component.js
@@ -6,5 +6,6 @@ export default {
   controller,
   bindings: {
     ctaURLs: '<',
+    cloudDbAvailability: '<',
   },
 };

--- a/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.html
+++ b/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.html
@@ -9,6 +9,7 @@
             class="oui-button oui-button_primary oui-button_l text-light"
             data-translate="private_databases_onboarding_order"
             href="{{:: $ctrl.cta }}"
+            data-ng-if="$ctrl.cloudDbAvailability"
         >
         </a>
         <a

--- a/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.routing.js
+++ b/packages/manager/apps/web/client/app/private-database/onboarding/onboarding.routing.js
@@ -13,6 +13,15 @@ export default /* @ngInject */ ($stateProvider) => {
         ),
     resolve: {
       hideBreadcrumb: () => true,
+      cloudDbAvailability: /* @ngInject */ (ovhFeatureFlipping) => {
+        const cloudDbFeature = 'cloud-database';
+
+        return ovhFeatureFlipping
+          .checkFeatureAvailability(cloudDbFeature)
+          .then((featureAvailability) => {
+            return featureAvailability.isFeatureAvailable(cloudDbFeature);
+          });
+      },
       resources: /* @ngInject */ ($http) =>
         $http.get('/hosting/privateDatabase').then(({ data }) => data),
       ctaURLs: /* @ngInject */ ($state) => [


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9430
| License          | BSD 3-Clause

## Description

Use feature flipping in order to display cloudDB order link on private database onboarding page.