### PR TITLE
fix(sidebar): wrong redirection with telecom

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/bareMetalCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/bareMetalCloud.ts
@@ -1,10 +1,6 @@
 export default {
   id: 'baremetal-cloud',
   translation: 'sidebar_bare_metal_cloud',
-  routing: {
-    application: 'dedicated',
-    hash: '#/configuration',
-  },
   children: [
     {
       id: 'bmc-dedicated-vps',

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/telecom.ts
@@ -1,10 +1,6 @@
 export default {
   id: 'telecom',
   translation: 'sidebar_telecom',
-  routing: {
-    application: 'telecom',
-    hash: '#/',
-  },
   children: [
     {
       id: 'internet',

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/webCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/webCloud.ts
@@ -1,10 +1,6 @@
 export default {
   id: 'web-cloud',
   translation: 'sidebar_web_cloud',
-  routing: {
-    application: 'web',
-    hash: '#/configuration',
-  },
   children: [
     {
       id: 'domain-dns',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description

If u go to any of telecom seervices, the sidebar redirects to telecom menu, instead of staying on the selected service. Now it's fixed. ( also removed useless options )