### PR TITLE
fix(container): redirect to project creation

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -40,7 +40,7 @@ function Sidebar(): JSX.Element {
   } = useProductNavReshuffle();
   const [servicesCount, setServicesCount] = useState(null);
   const [menuItems, setMenuItems] = useState(null);
-  const [pciProjects, setPciProjects] = useState(null);
+  const [pciProjects, setPciProjects] = useState([]);
   const [selectedPciProject, setSelectedPciProject] = useState(null);
   const [pciProjectServiceCount, setPciProjectServiceCount] = useState(null);
   const [highlightedNode, setHighlightedNode] = useState(null);
@@ -162,7 +162,7 @@ function Sidebar(): JSX.Element {
   useEffect(() => {
     const { appId, appHash } = containerURL;
 
-    if (appId === 'manager' && !pciProjects) return;
+    if (appId === 'public-cloud' && !pciProjects) return;
     if (appId === 'hub' && appHash === '/catalog') {
       setHighlightedNode(null);
       return;


### PR DESCRIPTION
Signed-off-by: Zakaria Sahmane <zakaria.sahmane@corp.ovh.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause


## Description

If u click on public cloud and u have no pci projects, u have an empty page instead of creation page.
This PR fixes it
