### PR TITLE
fix(sidebar): allow pci reload on error

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -41,6 +41,7 @@ function Sidebar(): JSX.Element {
   const [servicesCount, setServicesCount] = useState(null);
   const [menuItems, setMenuItems] = useState(null);
   const [pciProjects, setPciProjects] = useState([]);
+  const [pciError, setPciError] = useState(false);
   const [selectedPciProject, setSelectedPciProject] = useState(null);
   const [pciProjectServiceCount, setPciProjectServiceCount] = useState(null);
   const [highlightedNode, setHighlightedNode] = useState(null);
@@ -128,10 +129,7 @@ function Sidebar(): JSX.Element {
       .then((result) => setServicesCount(result));
   }, []);
 
-  /**
-   * Initialize list of pci projects
-   */
-  useEffect(() => {
+  const fetchPciProjects = () => {
     reketInstance
       .get('/cloud/project', {
         headers: {
@@ -140,10 +138,20 @@ function Sidebar(): JSX.Element {
         },
       })
       .then((result) => {
+        setPciError(false);
         if (result && result.length) {
           setPciProjects(result);
         }
+      })
+      .catch((error) => {
+        setPciError(true);
       });
+  };
+  /**
+   * Initialize list of pci projects
+   */
+  useEffect(() => {
+    fetchPciProjects();
   }, []);
 
   /** Watch URL changes to update selected menu dynamically */
@@ -364,6 +372,15 @@ function Sidebar(): JSX.Element {
                   }}
                   createLabel={t('sidebar_pci_new')}
                 />
+                {pciError && (
+                  <button
+                    className={style.sidebar_pci_refresh}
+                    onClick={() => fetchPciProjects()}
+                  >
+                    <span>{t('sidebar_pci_load_error')}</span>
+                    <span className="oui-icon oui-icon-refresh"></span>
+                  </button>
+                )}
                 {selectedPciProject && (
                   <span
                     className={`d-flex px-1 ${style.sidebar_clipboard}`}

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/style.module.scss
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/style.module.scss
@@ -2,6 +2,8 @@
 @import '@ovh-ux/ui-kit/dist/scss/tokens/_fonts';
 @import '@ovh-ux/ui-kit/dist/scss/tokens/_globals';
 
+$selected: #00185e;
+
 .sidebar {
   @import '@ovh-ux/manager-hub/src/variables.scss';
   width: 20rem;
@@ -12,6 +14,23 @@
   min-width: 20rem;
   color: white;
 
+  &_pci_refresh {
+    line-height: 1rem;
+    display: flex;
+    margin-top: 0.4rem;
+    background: none;
+    border: none;
+    font-size: 0.9rem;
+    color: inherit;
+    border-radius: 10px;
+    cursor: pointer;
+    padding: 0.5rem;
+    transition: all 0.3s ease-in-out;
+
+    &:hover {
+      background: $selected;
+    }
+  }
   &_menu {
     overflow-y: auto;
     flex: 1;
@@ -126,7 +145,7 @@
   }
 
   &_selected {
-    background-color: #00185e;
+    background-color: $selected;
   }
 
   select {

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
@@ -59,6 +59,7 @@
   "sidebar_pci_credits_vouchers": "Credit and Vouchers",
   "sidebar_pci_contacts_rights": "Contact and Rights",
   "sidebar_pci_project_settings": "Project Settings",
+  "sidebar_pci_load_error": "Une erreur est survenue lors de la récupération de la liste de projets",
   "sidebar_storage": "Services de stockage",
   "sidebar_nasha": "NAS-HA",
   "sidebar_nas": "NAS",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| License          | BSD 3-Clause


## Description

Add button to allow reload on error on pci menu 

