### PR TITLE
fix(shell): set app id at client init

### DIFF
--- a/packages/components/ovh-shell/__tests__/plugin/environment/environment.spec.ts
+++ b/packages/components/ovh-shell/__tests__/plugin/environment/environment.spec.ts
@@ -39,7 +39,7 @@ defineFeature(feature, (test) => {
     });
 
     when('I change the selected universe', () => {
-      envPlugin.setUniverseFromApplication('dedicated');
+      envPlugin.setApplication('dedicated');
     });
 
     then('I should have the universe updated', () => {

--- a/packages/components/ovh-shell/src/client/api.ts
+++ b/packages/components/ovh-shell/src/client/api.ts
@@ -21,10 +21,10 @@ export default function exposeApi(shellClient: ShellClient) {
           method: 'setUniverse',
           args: [universe],
         }),
-      setUniverseFromApplication: (applicationId: ApplicationId) =>
+      setApplication: (applicationId: ApplicationId) =>
         shellClient.invokePluginMethod({
           plugin: 'environment',
-          method: 'setUniverseFromApplication',
+          method: 'setApplication',
           args: [applicationId],
         }),
     },

--- a/packages/components/ovh-shell/src/client/index.ts
+++ b/packages/components/ovh-shell/src/client/index.ts
@@ -72,7 +72,7 @@ export default function init(applicationId: ApplicationId) {
   return initPromise.then((shellApi) => {
     shellApi.ux.resetAccountSidebar();
     return shellApi.environment
-      .setUniverseFromApplication(applicationId)
+      .setApplication(applicationId)
       .then(() => shellApi);
   });
 }

--- a/packages/components/ovh-shell/src/plugin/environment/index.ts
+++ b/packages/components/ovh-shell/src/plugin/environment/index.ts
@@ -16,7 +16,8 @@ export function environment(environment: Environment) {
       environment.setUniverse(universe);
       triggerListeners(environment.getUniverse());
     },
-    setUniverseFromApplication: (applicationId: ApplicationId) => {
+    setApplication: (applicationId: ApplicationId) => {
+      environment.setApplicationName(applicationId);
       environment.setUniverseFromApplicationId(applicationId);
       triggerListeners(environment.getUniverse());
     },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/produtc-nav-reshuffle
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9325
| License          | BSD 3-Clause

## Description

init application at shell client init