### PR TITLE
fix(hub): hub not visible after telephony banner in ca

### DIFF
--- a/packages/manager/modules/hub/src/components/telephony-procedure/telephony-procedure.controller.js
+++ b/packages/manager/modules/hub/src/components/telephony-procedure/telephony-procedure.controller.js
@@ -4,21 +4,27 @@ export default class TelephonyProcedureController {
     this.$http = $http;
     this.$q = $q;
     this.ovhFeatureFlipping = ovhFeatureFlipping;
-
-    this.identityCheckFormLink = coreURLBuilder.buildURL(
-      'telecom',
-      '#/identity-check',
-    );
+    this.coreURLBuilder = coreURLBuilder;
   }
 
   $onInit() {
     this.telephonyProcedureRequired = false;
-    const featureName = 'telephony';
+    const featureName = 'telecom,telephony';
 
     return this.ovhFeatureFlipping
       .checkFeatureAvailability(featureName)
-      .then((telephonyFeatureAvailability) => {
-        return telephonyFeatureAvailability.isFeatureAvailable(featureName)
+      .then((featureAvailability) => {
+        const isTelecomAvailable = featureAvailability.isFeatureAvailable(
+          'telecom',
+        );
+        if (isTelecomAvailable) {
+          this.identityCheckFormLink = this.coreURLBuilder.buildURL(
+            'telecom',
+            '#/identity-check',
+          );
+        }
+
+        return featureAvailability.isFeatureAvailable(featureName)
           ? this.$http
               .get('/telephony/procedure/required')
               .then(({ data: required }) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description
After adding telephony banner in hub, Hub in CA was broken because telecom doesn't exist in CA. This fixes it.
