### PR TITLE
fix(container): fix redirections to hub

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -244,7 +244,7 @@ function Sidebar(): JSX.Element {
 
       if (project) {
         setSelectedPciProject(project);
-      } else if (currentNavigationNode.id === 'pci') {
+      } else if (currentNavigationNode.id === 'pci' && !selectedPciProject) {
         reketInstance
           .get('/me/preferences/manager/PUBLIC_CLOUD_DEFAULT_PROJECT')
           .then((result) => JSON.parse(result.value).projectId)

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -227,39 +227,41 @@ function Sidebar(): JSX.Element {
    * Synchronize selected public cloud project with pci's project id in URL
    */
   useEffect(() => {
-    const { appHash } = containerURL;
-    if (appHash.startsWith('/pci/projects/new')) {
-      setSelectedPciProject(null);
-    } else {
-      if (!pciProjects?.length) return;
+    const { appId, appHash } = containerURL;
+    if (appId === 'public-cloud') {
+      if (appHash.startsWith('/pci/projects/new')) {
+        setSelectedPciProject(null);
+      } else {
+        if (!pciProjects?.length) return;
 
-      const pciProjectMatch = (appHash || '').match(
-        /^\/pci\/projects\/([^/?]+)/,
-      );
-      let project;
-      if (pciProjectMatch && pciProjectMatch.length >= 2) {
-        const [, pciProjectId] = pciProjectMatch;
-        project = pciProjects.find((p) => p.project_id === pciProjectId);
-      }
+        const pciProjectMatch = (appHash || '').match(
+          /^\/pci\/projects\/([^/?]+)/,
+        );
+        let project;
+        if (pciProjectMatch && pciProjectMatch.length >= 2) {
+          const [, pciProjectId] = pciProjectMatch;
+          project = pciProjects.find((p) => p.project_id === pciProjectId);
+        }
 
-      if (project) {
-        setSelectedPciProject(project);
-      } else if (currentNavigationNode.id === 'pci' && !selectedPciProject) {
-        reketInstance
-          .get('/me/preferences/manager/PUBLIC_CLOUD_DEFAULT_PROJECT')
-          .then((result) => JSON.parse(result.value).projectId)
-          .then((projectId) => {
-            navigationPlugin.navigateTo(
-              'public-cloud',
-              `#/pci/projects/${projectId}`,
-            );
-          })
-          .catch(() => {
-            navigationPlugin.navigateTo(
-              'public-cloud',
-              `#/pci/projects/${pciProjects[0].project_id}`,
-            );
-          });
+        if (project) {
+          setSelectedPciProject(project);
+        } else if (currentNavigationNode.id === 'pci' && !selectedPciProject) {
+          reketInstance
+            .get('/me/preferences/manager/PUBLIC_CLOUD_DEFAULT_PROJECT')
+            .then((result) => JSON.parse(result.value).projectId)
+            .then((projectId) => {
+              navigationPlugin.navigateTo(
+                'public-cloud',
+                `#/pci/projects/${projectId}`,
+              );
+            })
+            .catch(() => {
+              navigationPlugin.navigateTo(
+                'public-cloud',
+                `#/pci/projects/${pciProjects[0].project_id}`,
+              );
+            });
+        }
       }
     }
   }, [pciProjects, currentNavigationNode, containerURL]);

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/root.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/root.ts
@@ -8,10 +8,6 @@ import telecom from './services/telecom';
 export default {
   id: 'home',
   translation: 'sidebar_home',
-  routing: {
-    application: 'hub',
-    hash: '#/',
-  },
   count: false,
   children: [
     bareMetalCloud,

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
@@ -1,10 +1,6 @@
 export default {
   id: 'pci',
   translation: 'sidebar_pci',
-  routing: {
-    application: 'public-cloud',
-    hash: '#/pci/projects/{projectId}',
-  },
   children: [
     {
       id: 'pci-compute',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description

When u go to any project, sometimes you are redirected to the hub. This fixes the redirection by removing the hub routing since we don't need it, but it actually doesn't resolve the underlying problem which is quite hard to find in localhost.

The hub route shouldn't match anyway. But it does because its hash is '#/'.

