### PR TITLE
fix(pnr): hide some guide depending region on hosting onboarding page

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/onboarding/constants.js
+++ b/packages/manager/apps/web/client/app/hosting/onboarding/constants.js
@@ -88,6 +88,7 @@ export const GUIDES = [
       GB: 'https://docs.ovh.com/gb/en/hosting/activate-start10m/',
       FR: 'https://docs.ovh.com/fr/hosting/activer-start10m/',
     },
+    region: ['EU'],
   },
 ];
 

--- a/packages/manager/apps/web/client/app/hosting/onboarding/onboarding.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/onboarding/onboarding.controller.js
@@ -9,8 +9,11 @@ export default class HostingsOnboardingController {
 
   async $onInit() {
     const user = await this.coreConfig.getUser();
+    const region = await this.coreConfig.getRegion();
     this.ovhSubsidiary = user.ovhSubsidiary;
-    this.guides = GUIDES.map((guide) => ({
+    this.guides = GUIDES.filter((guide) => {
+      return guide.region ? guide.region.include(region) : true;
+    }).map((guide) => ({
       link: guide.links[this.ovhSubsidiary] || guide.links.DEFAULT,
       description: this.$translate.instant(guide.description),
       title: this.$translate.instant(guide.title),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9450
| License          | BSD 3-Clause

## Description

Hide some guide depending on region on hosting dashboard page.