### PR TITLE
fix(pnr): display microsoft exchange entry in ca sidebar

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/webCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/webCloud.ts
@@ -104,7 +104,7 @@ export default {
     {
       id: 'microsoft',
       translation: 'sidebar_microsoft',
-      features: ['office', 'exchange:web-dashboard', 'sharepoint'],
+      features: ['office', 'exchange', 'sharepoint'],
       children: [
         {
           id: 'office',
@@ -124,7 +124,7 @@ export default {
             application: 'web',
             hash: '#/exchange',
           },
-          features: ['exchange:web-dashboard'],
+          features: ['exchange'],
         },
         {
           id: 'sharepoint',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9379, MANAGER-9380
| License          | BSD 3-Clause

## Description

Change `exchange:web-dashboard` feature name by `exchange` in web sidebar config to enable exchange in CA.