### PR TITLE
fix(container): sidebar autoclose in responsive mode

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance.tsx
@@ -3,12 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { useReket } from '@ovh-ux/ovh-reket';
 import { useURL } from '@/container/common/urls-constants';
 import ApplicationContext from '@/context';
-import { ONBOARDING_STATUS_ENUM } from '@/core/onboarding';
 import useProductNavReshuffle from '@/core/product-nav-reshuffle';
 
 import SidebarLink from './SidebarLink';
 import style from './style.module.scss';
-import { ComponentProps, findPathToNode } from './utils';
+import { ComponentProps } from './utils';
 
 interface Props {
   containerURL: { appId: string; appHash: string };
@@ -33,7 +32,7 @@ const AssistanceSidebar: React.FC<ComponentProps<Props>> = ({
   const hasAdvancedSupport = ['EU', 'CA'].includes(environment.getRegion());
   const [hasChatbot, setHashChatbot] = useState(false);
 
-  const { openOnboarding, onboardingOpenedState } = useProductNavReshuffle();
+  const { closeNavigationSidebar, openOnboarding } = useProductNavReshuffle();
 
   useEffect(() => {
     const initChatbot = async () => {
@@ -115,7 +114,10 @@ const AssistanceSidebar: React.FC<ComponentProps<Props>> = ({
                 },
                 count: false,
               }}
-              onClick={() => trackNode('assistance_tickets')}
+              onClick={() => {
+                trackNode('assistance_tickets');
+                closeNavigationSidebar();
+              }}
             />
           </li>
           <li>
@@ -144,7 +146,10 @@ const AssistanceSidebar: React.FC<ComponentProps<Props>> = ({
                   },
                   count: false,
                 }}
-                onClick={() => trackNode('assistance_support_level')}
+                onClick={() => {
+                  trackNode('assistance_support_level');
+                  closeNavigationSidebar();
+                }}
               />
             </li>
           )}
@@ -158,6 +163,7 @@ const AssistanceSidebar: React.FC<ComponentProps<Props>> = ({
                 onClick={() => {
                   shell.getPlugin('ux').openChatbot();
                   trackNode('assistance_live_chat');
+                  closeNavigationSidebar();
                 }}
               />
             </li>

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -35,6 +35,7 @@ function Sidebar(): JSX.Element {
     routingPlugin.parseContainerURL(),
   );
   const {
+    closeNavigationSidebar,
     currentNavigationNode,
     setCurrentNavigationNode,
     navigationTree,
@@ -72,6 +73,8 @@ function Sidebar(): JSX.Element {
   const menuClickHandler = (node) => {
     if (node.children) {
       setCurrentNavigationNode(node);
+    } else {
+      closeNavigationSidebar();
     }
 
     let trackingIdComplement = 'navbar_v2_entry_';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/product-nav-reshuffle
| Bug fix?         | yes
| New feature?     |no
| Breaking change? |no
| Tickets          | MANAGER-9321
| License          | BSD 3-Clause

## Description

close the sidebar when navigating on a terminal node
(only in responsive mode since the sidebar is locked in desktop mode)