### PR TITLE
fix(sidebar): update serviceType for object and archive storages

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
@@ -63,7 +63,7 @@ export default {
         {
           id: 'pci-object-storage',
           translation: 'sidebar_pci_object_storage',
-          serviceType: 'CLOUD_PROJECT_STORAGE',
+          serviceType: 'CLOUD_PROJECT_STORAGE_OBJECTS',
           routing: {
             application: 'public-cloud',
             hash: '#/pci/projects/{projectId}/storages/objects',
@@ -96,7 +96,7 @@ export default {
         {
           id: 'pci-cloud-archive',
           translation: 'sidebar_pci_cloud_archive',
-          serviceType: 'CLOUD_PROJECT_STORAGE',
+          serviceType: 'CLOUD_PROJECT_STORAGE_ARCHIVES',
           routing: {
             application: 'public-cloud',
             hash: '#/pci/projects/{projectId}/storages/cloud-archives',


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/product-nav-reshuffle`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description

Use 2 different Service type for object and archive storage to count number of services.