### PR TITLE
feat(kube.node-pool): no desired in autoscale case

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/node-pool/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/node-pool/add/add.controller.js
@@ -41,17 +41,23 @@ export default class {
   create() {
     this.sendKubeTrack('details::nodepools::add::confirm');
 
+    const { flavor, name, antiAffinity } = this.nodePool;
+    const { monthlyBilling: monthlyBilled, autoscaling } = this.nodePool;
+    const { autoscale, nodes } = autoscaling;
+    const { lowest, desired, highest } = nodes;
+    const options = {
+      flavorName: flavor.name,
+      name,
+      antiAffinity,
+      monthlyBilled,
+      autoscale,
+      minNodes: lowest.value,
+      desiredNodes: autoscale ? lowest.value : desired.value,
+      maxNodes: highest.value,
+    };
+
     this.isAdding = true;
-    return this.Kubernetes.createNodePool(this.projectId, this.kubeId, {
-      flavorName: this.nodePool.flavor.name,
-      name: this.nodePool.name,
-      antiAffinity: this.nodePool.antiAffinity,
-      monthlyBilled: this.nodePool.monthlyBilling,
-      autoscale: this.nodePool.autoscaling.autoscale,
-      minNodes: this.nodePool.autoscaling.nodes.lowest.value,
-      desiredNodes: this.nodePool.autoscaling.nodes.desired.value,
-      maxNodes: this.nodePool.autoscaling.nodes.highest.value,
-    })
+    return this.Kubernetes.createNodePool(this.projectId, this.kubeId, options)
       .then(() =>
         this.goBack(
           this.$translate.instant('kube_add_node_pool_success', {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-9360
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. avoid to set a desired value in autoscale mode
2. in autoscale mode, desired must be equal to lowest value
