### PR TITLE
fix(refund): avoid refund amount error

### DIFF
--- a/packages/manager/modules/billing/src/payment/ovhAccount/refund/routing.js
+++ b/packages/manager/modules/billing/src/payment/ovhAccount/refund/routing.js
@@ -20,7 +20,8 @@ export default /* @ngInject */ ($stateProvider) => {
         $http.post(
           `/me/ovhAccount/${accountId}/movements/${movement.movementId}/requestRefund`,
           {
-            amount: movement.retrievableAmount.value * 100,
+            // We use Math.round to avoid floating point error
+            amount: Math.round(movement.retrievableAmount.value * 100),
           },
         ),
       goBack: /* @ngInject */ (goToOvhAccount) => goToOvhAccount,


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-88065,
| License          | BSD 3-Clause

## Description

Avoid floating point error in refund amount : the multiplication result, which is the requested refund amount, is greater than the available amount.

Example : 

```js
$ 145.05 * 100
14505.000000000002
```