### PR TITLE
fix(payment-method): force redirect to open in top frame

### DIFF
--- a/packages/components/ng-ovh-payment-method/src/components/integration/redirect/controller.js
+++ b/packages/components/ng-ovh-payment-method/src/components/integration/redirect/controller.js
@@ -21,7 +21,7 @@ export default class OvhPaymentMethodIntegrationRedirectCtrl {
             AVAILABLE_PAYMENT_METHOD_INTEGRATION_ENUM.REDIRECT &&
           response.url
         ) {
-          this.$window.location = response.url;
+          window.top.location = response.url;
         }
         return response;
       })


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-89271
| License          | BSD 3-Clause

## Description

Force to redirect payment method to open in top frame.