### PR TITLE
fix(container): add databases in pci storages for pnr

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
@@ -75,6 +75,17 @@ const pciNode: Node = {
           forceVisibility: true,
         },
         {
+          id: 'pci-databases',
+          translation: 'sidebar_pci_databases',
+          serviceType: 'CLOUD_PROJECT_DATABASE',
+          routing: {
+            application: 'public-cloud',
+            hash: '#/pci/projects/{projectId}/storages/databases',
+          },
+          features: ['databases'],
+          forceVisibility: true,
+        },
+        {
           id: 'pci-volume-snapshot',
           translation: 'sidebar_pci_volume_snapshot',
           serviceType: 'CLOUD_PROJECT_VOLUME_SNAPSHOT',


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9551,
| License          | BSD 3-Clause

## Description


Add missing databases entry in PNR PCI sidebar