### PR TITLE
fix(mfa-enrollment): avoid to be stuck on mfa-enrollment page

### DIFF
--- a/packages/manager/modules/mfa-enrollment/src/mfa-enrollment.controller.js
+++ b/packages/manager/modules/mfa-enrollment/src/mfa-enrollment.controller.js
@@ -23,6 +23,10 @@ export default class mfaEnrollmentCtrl {
   }
 
   goBack() {
-    this.$state.go(this.from ? this.from : this.rootState);
+    if (this.from) {
+      window.history.back();
+    } else {
+      this.$state.go(this.rootState);
+    }
   }
 }


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9561,
| License          | BSD 3-Clause

## Description

- Redirect mfa enrollment page when the first ui-router transition is completed to avoid to be stuck.
- Use `history` to go back instead of using `$state` (we have a lot of states with parameters and we don't handle it; history back handle it for us). 