### PR TITLE
fix (pci.ai.training): filter internal key on jobs volumes when resubmitting

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/notebooks/components/configuration-command/configuration-command.controller.js
@@ -23,7 +23,7 @@ export default class {
       let toRemove = false;
       let internalKey;
       Object.keys(volume).forEach((key) => {
-        if (volume[key].internal !== undefined) {
+        if (volume[key] && volume[key].internal !== undefined) {
           if (volume[key].internal === true) {
             toRemove = true;
           } else {

--- a/packages/manager/modules/pci/src/projects/project/training/job.service.js
+++ b/packages/manager/modules/pci/src/projects/project/training/job.service.js
@@ -30,20 +30,25 @@ export default class PciProjectTrainingJobService {
       // API does not accept volumes' internal property. We remove it before sending the request.
       toSubmit.volumes = jobSpec.volumes.flatMap((volume) => {
         let toRemove = false;
-        let internalKey;
+        const internalKeys = [];
+        let filteredVolume = volume;
         Object.keys(volume).forEach((key) => {
           if (volume[key] && volume[key].internal !== undefined) {
             if (volume[key].internal === true) {
               toRemove = true;
             } else {
-              internalKey = key;
+              internalKeys.push(key);
             }
           }
         });
         if (toRemove) {
           return [];
         }
-        return internalKey ? omit(volume, `${internalKey}.internal`) : volume;
+        // remove all 'internal' keys from object
+        internalKeys.forEach((key) => {
+          filteredVolume = omit(filteredVolume, `${key}.internal`);
+        });
+        return filteredVolume;
       });
     }
     return this.submit(projectId, toSubmit);


### PR DESCRIPTION
DATATR-56

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-56
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Currently, when we relaunch a job on AI Training, the manager tries to fill the `internal` parameter whereas it should not.

Good behavior should be:

* drop the volume whose `internal` parameter = `true`
* in any other case, we send the volume but we remove the `internal` parameter
