### PR TITLE
feat(kube.add): scroll to banner if error during creation

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.constants.js
@@ -1,7 +1,9 @@
 export const READY_STATUS = 'READY';
 export const DEFAULT_NODE_COUNT = 3;
+export const KUBE_CONTAINER_MESSAGES = 'kubeContainerMessages';
 
 export default {
   READY_STATUS,
   DEFAULT_NODE_COUNT,
+  KUBE_CONTAINER_MESSAGES,
 };

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
@@ -3,13 +3,14 @@ import get from 'lodash/get';
 import some from 'lodash/some';
 
 import Datacenter from '../../../../components/project/regions-list/datacenter.class';
-import { READY_STATUS } from './add.constants';
+import { KUBE_CONTAINER_MESSAGES, READY_STATUS } from './add.constants';
 
 export default class {
   /* @ngInject */
   constructor(
     $translate,
     $q,
+    $anchorScroll,
     CucCloudMessage,
     Kubernetes,
     OvhApiCloudProjectKube,
@@ -17,10 +18,13 @@ export default class {
   ) {
     this.$translate = $translate;
     this.$q = $q;
+    this.$anchorScroll = $anchorScroll;
     this.CucCloudMessage = CucCloudMessage;
     this.Kubernetes = Kubernetes;
     this.OvhApiCloudProjectKube = OvhApiCloudProjectKube;
     this.Poller = Poller;
+
+    this.KUBE_CONTAINER_MESSAGES = KUBE_CONTAINER_MESSAGES;
   }
 
   $onInit() {
@@ -111,6 +115,8 @@ export default class {
           };
         }
         this.CucCloudMessage.error(errorMessage);
+
+        this.$anchorScroll(KUBE_CONTAINER_MESSAGES);
       })
       .finally(() => {
         this.isAdding = false;

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.html
@@ -1,6 +1,8 @@
 <h1 data-translate="kubernetes_add"></h1>
 
-<cui-message-container data-messages="$ctrl.messages"></cui-message-container>
+<cui-message-container id="{{$ctrl.KUBE_CONTAINER_MESSAGES}}"
+                       data-messages="$ctrl.messages"
+></cui-message-container>
 
 <form name="kubeAddClusterForm">
     <oui-stepper data-current-index="$ctrl.currentStep">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | ` MANAGER-7867`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-9609
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. scroll to container messages if cluster creation fail