### PR TITLE
fix(dedicated): server names getting back to old name

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/server.service.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/server.service.js
@@ -2213,4 +2213,17 @@ export default class ServerF {
       .get(`/dedicated/server/${serviceName}/bringYourOwnImage`)
       .then(({ data }) => data);
   }
+
+  getServices() {
+    return this.$http.get('/service', {
+      params: {
+        external: false,
+        type: '/dedicated/server',
+      },
+      serviceType: 'aapi',
+      headers: {
+        pragma: 'no-cache',
+      },
+    });
+  }
 }

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/display-name/display-name.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/display-name/display-name.controller.js
@@ -41,6 +41,7 @@ angular.module('App').controller(
             ),
             'server_dashboard_alert',
           );
+          this.Server.getServices();
           reload = true;
         })
         .catch(({ data }) => {


### PR DESCRIPTION
  ref: DTRSD-88132

  Adddition of If-modified-since header to handle random update of server name.

Signed-off-by: vikash singh <vikash.singh@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-88132
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Addition of 'if-modified-since' header to handle the random update of server name.

## Related

<!-- Link dependencies of this PR -->
