### PR TITLE
fix/manager 9305: init is-flex option according current flavor

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/edit/edit.controller.js
@@ -35,7 +35,7 @@ export default class PciInstanceEditController {
     this.messageContainers = ['name', 'image', 'flavor', 'billing'];
     this.messages = {};
     this.model = {
-      isInstanceFlex: false,
+      isInstanceFlex: new Flavor(this.editInstance.flavor).isFlex(),
     };
     this.imageEditMessage =
       this.imageEditMessage ||
@@ -107,7 +107,7 @@ export default class PciInstanceEditController {
       this.editInstance.flavorId = flavorGroup.getFlavorId(
         flavorType,
         this.instance.region,
-        this.defaultFlavor.isFlex(),
+        this.model.isInstanceFlex,
       );
     }
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2226-2228`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-9305
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. initialize the flex option according current flavor 