### PR TITLE
build: start application handle empty directories

### DIFF
--- a/scripts/start-application.js
+++ b/scripts/start-application.js
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import concurrently from 'concurrently';
 import execa from 'execa';
 import inquirer from 'inquirer';
@@ -16,7 +16,11 @@ const applicationsWorkspace = 'packages/manager/apps';
 const getApplications = () =>
   readdirSync(applicationsWorkspace, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
-    .map(({ name: application }) => {
+    .map(({ name }) => ({ application: name }))
+    .filter(({ application }) =>
+      existsSync(`${applicationsWorkspace}/${application}/package.json`),
+    )
+    .map(({ application }) => {
       const data = readFileSync(
         `${applicationsWorkspace}/${application}/package.json`,
         'utf8',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | 
| License          | BSD 3-Clause

## Description

avoid the start application script to exit with a SIGINT if an empty application folder exists on the monorepo