### PR TITLE
fix: remove one-time binding on price in catalog-price component

### DIFF
--- a/packages/manager/modules/catalog-price/src/catalog-price.html
+++ b/packages/manager/modules/catalog-price/src/catalog-price.html
@@ -67,7 +67,7 @@
             data-ng-class="{ 'd-block': $ctrl.block }"
         >
             <span
-                data-ng-bind="::$ctrl.getPriceText($ctrl.price + $ctrl.tax)"
+                data-ng-bind="$ctrl.getPriceText($ctrl.price + $ctrl.tax)"
             ></span>
             <span data-ng-if="$ctrl.interval">
                 &#47;


### PR DESCRIPTION
DATATR-66

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-66
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Disable one-time binding on German prices so it can reflect price attribute changes.