### PR TITLE
feat(public-cloud): add option to add s3 user in object storage

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/component.js
@@ -1,0 +1,11 @@
+import template from './template.html';
+
+const component = {
+  bindings: {
+    user: '<',
+    credential: '<',
+  },
+  template,
+};
+
+export default component;

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/index.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
+
+import component from './component';
+
+const moduleName =
+  'ovhManagerPciStoragesContainersAddCreateLinkedUserCredentialBanner';
+
+angular
+  .module(moduleName, ['pascalprecht.translate', 'oui'])
+  .component('pciProjectStoragesUserCredentialBanner', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/template.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/template.html
@@ -1,0 +1,50 @@
+<oui-message type="success">
+    <p
+        data-translate="pci_projects_project_storages_containers_add_create_or_linked_user_linked_user_success_message"
+        data-translate-values="{ username: '<strong>'+$ctrl.user.description+'</strong>' }"
+    ></p>
+    <div class="row">
+        <div class="col-4">
+            <!--User username info-->
+            <oui-field
+                data-label="{{:: 'pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_username_label' | translate }}"
+            >
+                <oui-clipboard
+                    data-name="username"
+                    data-model="$ctrl.user.username"
+                ></oui-clipboard>
+            </oui-field>
+
+            <!--User description info-->
+            <oui-field
+                data-label="{{:: 'pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_description_label' | translate }}"
+            >
+                <oui-clipboard
+                    data-name="description"
+                    data-model="$ctrl.user.description"
+                ></oui-clipboard>
+            </oui-field>
+        </div>
+        <div class="col-8">
+            <!--User S3 credential access key-->
+            <oui-field
+                data-label="{{:: 'pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_access-key_label' | translate }}"
+            >
+                <oui-clipboard
+                    data-name="s3AccessKey"
+                    data-model="$ctrl.credential.access"
+                ></oui-clipboard>
+            </oui-field>
+
+            <!--User S3 credential secret key-->
+            <oui-field
+                data-label="{{:: 'pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_secret-key_label' | translate }}"
+            >
+                <oui-clipboard
+                    data-name="s3SecretKey"
+                    data-model="$ctrl.credential.secret"
+                ></oui-clipboard>
+            </oui-field>
+        </div>
+    </div>
+</oui-message>

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/component/credential-banner/translations/Messages_fr_FR.json
@@ -1,0 +1,9 @@
+{
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_message": "Les informations d'identification S3 pour l'utilisateur {{username}} ont été générées.",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_fail_message": "Les informations d'identification S3 n'ont pas été générées.",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_credential_fail_message": "La création de l'utilisateur {{username}} a échoué.",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_username_label": "Votre nom d'utilisateur S3 :",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_description_label": "Votre description :",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_access-key_label": "Votre clé d'accès :",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_secret-key_label": "Votre clé secrète :"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.routing.js
@@ -42,6 +42,11 @@ export default /* @ngInject */ ($stateProvider) => {
       userList: /* @ngInject */ (PciStoragesObjectStorageService, projectId) =>
         PciStoragesObjectStorageService.getS3Users(projectId),
 
+      allUserList: /* @ngInject */ (
+        PciStoragesObjectStorageService,
+        projectId,
+      ) => PciStoragesObjectStorageService.getAllS3Users(projectId),
+
       isUserTabActive: /* @ngInject */ ($transition$, $state) => () => {
         return $state
           .href($state.current.name, $transition$.params())

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.service.js
@@ -32,6 +32,24 @@ export default class PciStoragesObjectStorageService {
       .then(({ data }) => data);
   }
 
+  createUser(projectId, description) {
+    return this.$http
+      .post(`/cloud/project/${projectId}/user`, { description })
+      .then(({ data }) => data);
+  }
+
+  generateS3Credentials(projectId, userId) {
+    return this.$http
+      .post(`/cloud/project/${projectId}/user/${userId}/s3Credentials`)
+      .then(({ data }) => data);
+  }
+
+  getAllS3Users(projectId) {
+    return this.OvhApiCloudProjectUser.v6().query({
+      serviceName: projectId,
+    }).$promise;
+  }
+
   getS3Users(projectId) {
     this.OvhApiCloudProjectUser.v6().resetQueryCache();
     return this.OvhApiCloudProjectUser.v6()

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/add.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/add.module.js
@@ -1,0 +1,9 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import userAdd from './user-add';
+import routing from './add.routing';
+
+const moduleName = 'ovhManagerObjectStorageUsersAdd';
+angular.module(moduleName, [userAdd, 'ui.router']).config(routing);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/add.routing.js
@@ -1,0 +1,28 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state(
+    'pci.projects.project.storages.object-storage.users.add',
+    {
+      url: '/new',
+      views: {
+        modal: {
+          component: 'pciProjectObjectStorageUsersAdd',
+        },
+      },
+      layout: 'modal',
+      resolve: {
+        breadcrumb: () => null, // Hide breadcrumb
+        cancel: /* @ngInject */ (goToUsers) => goToUsers,
+        goBack: /* @ngInject */ (goToUsersBanner) => goToUsersBanner,
+        usersCredentials: /* @ngInject */ (
+          projectId,
+          allUserList,
+          PciStoragesUsersService,
+        ) =>
+          PciStoragesUsersService.getUsersCredentials(
+            projectId,
+            allUserList.map((user) => user.id),
+          ),
+      },
+    },
+  );
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/index.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerObjectStorageUsersAddLazyLoading';
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state(
+      'pci.projects.project.storages.object-storage.users.add.**',
+      {
+        url: '/new',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+          return import('./add.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      },
+    );
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/index.js
@@ -1,0 +1,19 @@
+import angular from 'angular';
+import '@ovh-ux/ng-translate-async-loader';
+import 'angular-translate';
+import 'ovh-api-services';
+
+import component from './user-add.component';
+
+const moduleName = 'ovhManagerPciUsersAddComponent';
+
+angular
+  .module(moduleName, [
+    'oui',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .component('pciProjectObjectStorageUsersAdd', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/translations/Messages_fr_FR.json
@@ -1,0 +1,17 @@
+{
+  "pci_projects_project_users_add_title": "Ajouter un utilisateur S3",
+  "pci_projects_project_users_add_short_description": "Afin d'accéder au stockage objet, veuillez ajouter un utilisateur à votre conteneur. Vous pouvez sélectionner un utilisateur existant ou en créer un nouveau.Chaque utilisateur (OpenStack) sera associé à une ou plusieurs paires de clés S3 (les credentials S3) composées chacune d'un 'Access Key' et d'un 'Secret Key'.",
+  "pci_projects_project_users_add_submit_label": "Créer",
+  "pci_projects_project_users_add_cancel_label": "Annuler",
+  "pci_projects_project_users_add_description_label": "Description de l'utilisateur",
+  "pci_projects_project_users_add_existing_user": "Sélectionner un utilisateur existant",
+  "pci_projects_project_users_add_create_user": "Créer un nouvel utilisateur",
+  "pci_projects_project_users_add_success_message": "Les informations d'identification S3 pour l'utilisateur {{user}} ont été générées",
+  "pci_projects_project_users_add_error_message": "Les informations d'identification S3 pour l'utilisateur {{user}} n'ont pas pu être générées.",
+  "pci_projects_project_users_add_username": "Votre nom d'utilisateur OpenStack :",
+  "pci_projects_project_users_add_description": "Votre description :",
+  "pci_projects_project_users_add_accesskey": "Votre clé d'accès S3 :",
+  "pci_projects_project_users_add_secretkey": "Votre clé secrète S3 :",
+  "pci_projects_project_users_add_as_no_credentials": "Pas de credentials",
+  "pci_projects_project_users_add_as_credentials": "Credentials générés"
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.component.js
@@ -1,0 +1,15 @@
+import controller from './user-add.controller';
+import template from './user-add.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    projectId: '<',
+    goBack: '<',
+    userList: '<',
+    allUserList: '<',
+    cancel: '<',
+    usersCredentials: '<',
+  },
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
@@ -1,0 +1,109 @@
+export default class PciUsersAddController {
+  /* @ngInject */
+  constructor(
+    $translate,
+    CucCloudMessage,
+    PciStoragesObjectStorageService,
+    $state,
+  ) {
+    this.$translate = $translate;
+    this.CucCloudMessage = CucCloudMessage;
+    this.PciStoragesObjectStorageService = PciStoragesObjectStorageService;
+    this.$state = $state;
+  }
+
+  $onInit() {
+    this.isLoading = false;
+    this.disable = true;
+    this.addExistingUser = 'addExistingUser';
+    this.createNewUser = 'createNewUser';
+    this.allUserList = this.allUserList.map((userList) => ({
+      ...userList,
+      asCredentials: this.usersCredentials.find(
+        (credential) => credential.userId === userList.id,
+      ).asCredentials
+        ? this.$translate.instant(
+            'pci_projects_project_users_add_as_credentials',
+          )
+        : this.$translate.instant(
+            'pci_projects_project_users_add_as_no_credentials',
+          ),
+    }));
+    [this.userModel] = this.allUserList;
+  }
+
+  onChange(action) {
+    this.model = action;
+    this.disable = false;
+  }
+
+  submit(user, action) {
+    this.isLoading = true;
+    if (action === 'addExistingUser') {
+      return this.getUserS3Credential(user.id)
+        .then((credentials) => {
+          if (credentials.length === 0)
+            return this.generateUserS3Credential(user);
+
+          return this.goBack(true, user, { ...credentials.pop() });
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
+    }
+    // action === 'createNewUser'
+    return this.createUser(user.description)
+      .then((data) => this.generateUserS3Credential(data))
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+
+  getUserS3Credential(userId) {
+    return this.PciStoragesObjectStorageService.getS3Credentials(
+      this.projectId,
+      userId,
+    )
+      .then((data) => data)
+      .catch(() => {
+        return this.CucCloudMessage.error(
+          this.$translate.instant(
+            'pci_projects_project_users_add_error_message',
+          ),
+        );
+      });
+  }
+
+  createUser(description) {
+    return this.PciStoragesObjectStorageService.createUser(
+      this.projectId,
+      description,
+    )
+      .then((user) => user)
+      .catch(() => {
+        return this.CucCloudMessage.error(
+          this.$translate.instant(
+            'pci_projects_project_users_add_error_message',
+          ),
+        );
+      });
+  }
+
+  generateUserS3Credential(user) {
+    return this.PciStoragesObjectStorageService.generateS3Credentials(
+      this.projectId,
+      user.id,
+    )
+      .then((data) => this.goBack(true, user, data))
+      .catch(() => {
+        return this.CucCloudMessage.error(
+          this.$translate.instant(
+            'pci_projects_project_users_add_error_message',
+            {
+              user: user.description,
+            },
+          ),
+        );
+      });
+  }
+}

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.html
@@ -1,0 +1,71 @@
+<form novalidate name="user-add-form">
+    <oui-modal
+        data-heading="{{ 'pci_projects_project_users_add_title' | translate }}"
+        data-primary-label="{{:: 'pci_projects_project_users_add_submit_label' | translate }}"
+        data-primary-action="$ctrl.submit($ctrl.userModel,$ctrl.model)"
+        data-secondary-action="$ctrl.cancel()"
+        data-secondary-label="{{:: 'pci_projects_project_users_add_cancel_label' | translate }}"
+        data-on-dismiss="$ctrl.goBack()"
+        data-primary-disabled="$ctrl.disable"
+        data-secondary-disabled="$ctrl.disable"
+        data-loading="$ctrl.isLoading"
+    >
+        <p
+            data-translate="pci_projects_project_users_add_short_description"
+        ></p>
+        <oui-radio
+            model="$ctrl.model"
+            name="addExistingUser"
+            on-change="$ctrl.onChange($ctrl.addExistingUser)"
+            value="$ctrl.addExistingUser"
+        >
+            <span
+                data-translate="pci_projects_project_users_add_existing_user"
+            ></span>
+        </oui-radio>
+        <oui-field
+            data-size="xl"
+            data-ng-if="$ctrl.model === $ctrl.addExistingUser"
+        >
+            <oui-select
+                data-name="userList"
+                data-model="$ctrl.userModel"
+                data-items="$ctrl.allUserList"
+                data-match="username"
+            >
+                <span data-ng-bind="$item.username"></span>
+                <small>
+                    <span
+                        class="float-right"
+                        data-ng-bind="$item.asCredentials"
+                    ></span>
+                </small>
+            </oui-select>
+        </oui-field>
+        <oui-radio
+            model="$ctrl.model"
+            name="createNewUser"
+            on-change="$ctrl.onChange($ctrl.createNewUser)"
+            value="$ctrl.createNewUser"
+        >
+            <span
+                data-translate="pci_projects_project_users_add_create_user"
+            ></span>
+        </oui-radio>
+        <oui-field
+            data-label="{{:: 'pci_projects_project_users_add_description_label' | translate }}"
+            data-size="xl"
+            data-ng-if="$ctrl.model === $ctrl.createNewUser"
+        >
+            <input
+                class="oui-input"
+                type="text"
+                id="description"
+                name="description"
+                ng-model="$ctrl.userModel.description"
+                maxlength="255"
+                required
+            />
+        </oui-field>
+    </oui-modal>
+</form>

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/index.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/index.js
@@ -8,10 +8,12 @@ import 'ovh-api-services';
 import 'angular-ui-bootstrap';
 
 import component from './users.component';
+import credentialBanner from '../component/credential-banner';
 import routing from './users.routing';
 import deleteUser from './delete';
 import importPolicy from './import';
 import downloadRclone from './download-rclone';
+import addUser from './add';
 
 const moduleName = 'ovhManagerPciStoragesObjectStorageUserList';
 
@@ -27,8 +29,9 @@ angular
     deleteUser,
     importPolicy,
     downloadRclone,
+    addUser,
   ])
-  .component('pciProjectStorageObjectStorageUsers', component)
+  .component('pciProjectStorageObjectStorageUsers', component, credentialBanner)
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);
 

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.component.js
@@ -13,5 +13,9 @@ export default {
     goToUsers: '<',
     trackingPrefix: '<',
     downloadOpenStackRclone: '<',
+    goToAddUser: '<',
+    goToUsersBanner: '<',
+    userDetails: '<',
+    userCredential: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.html
@@ -14,6 +14,12 @@
 <p
     data-translate="pci_projects_project_storages_containers_users_user_description"
 ></p>
+<!--User credential overview inform -->
+<pci-project-storages-user-credential-banner
+    data-ng-if="$ctrl.userDetails"
+    data-user="$ctrl.userDetails"
+    data-credential="$ctrl.userCredential"
+></pci-project-storages-user-credential-banner>
 
 <oui-datagrid data-rows="$ctrl.userList">
     <oui-datagrid-column
@@ -72,7 +78,7 @@
     <oui-datagrid-topbar>
         <button
             class="oui-button oui-button_secondary"
-            data-ng-click="$ctrl.goToUsersAndRoles()"
+            data-ng-click="$ctrl.goToAddUser()"
         >
             <span class="oui-icon oui-icon-add pr-1" aria-hidden="true"></span>
             <span

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.routing.js
@@ -4,7 +4,15 @@ export default /* @ngInject */ ($stateProvider) => {
     views: {
       containersView: 'pciProjectStorageObjectStorageUsers',
     },
+    params: {
+      userDetails: null,
+      userCredential: null,
+    },
     resolve: {
+      userDetails: /* @ngInject */ ($transition$) =>
+        $transition$.params().userDetails,
+      userCredential: /* @ngInject */ ($transition$) =>
+        $transition$.params().userCredential,
       goToUsersAndRoles: /* @ngInject */ (
         $state,
         atInternet,
@@ -35,6 +43,24 @@ export default /* @ngInject */ ($stateProvider) => {
             userId: user.id,
           },
         ),
+      goToUsersBanner: /* @ngInject */ ($state, projectId) => (
+        reload = false,
+        userDetails,
+        userCredential,
+      ) =>
+        $state.go(
+          'pci.projects.project.storages.object-storage.users',
+          {
+            projectId,
+            userDetails,
+            userCredential,
+          },
+          {
+            reload,
+          },
+        ),
+      goToAddUser: /* @ngInject */ ($state) => () =>
+        $state.go('pci.projects.project.storages.object-storage.users.add'),
       goToUsers: /* @ngInject */ (CucCloudMessage, $state, projectId) => (
         message = false,
         type = 'success',

--- a/packages/manager/modules/pci/src/projects/project/storages/storage-users.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/storage-users.service.js
@@ -1,8 +1,9 @@
 export default class {
   /* @ngInject */
-  constructor($http, Poller) {
+  constructor($http, Poller, $q) {
     this.$http = $http;
     this.Poller = Poller;
+    this.$q = $q;
   }
 
   getBuckets(serviceName, regionName) {
@@ -56,6 +57,22 @@ export default class {
     return this.$http
       .delete(`/cloud/project/${serviceName}/user/${userId}`)
       .then(({ data }) => data);
+  }
+
+  getUsersCredentials(serviceName, usersIds) {
+    const promises = usersIds.map((userId) =>
+      this.asCredentials(serviceName, userId),
+    );
+    return this.$q.all(promises).then((data) => data);
+  }
+
+  asCredentials(serviceName, userId) {
+    return this.$http
+      .get(`/cloud/project/${serviceName}/user/${userId}/s3Credentials`)
+      .then(({ data }) => ({
+        userId,
+        asCredentials: data.length !== 0,
+      }));
   }
 
   getS3Credentials(serviceName, userId) {


### PR DESCRIPTION
 | Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-9099
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Create a new model to add s3 user by either creating a new user or by generating credentials for existing user in object storage.
