### PR TITLE
feat(ovh-shell): add standalone query param

### DIFF
--- a/packages/components/ovh-shell/__tests__/client/client-init.spec.ts
+++ b/packages/components/ovh-shell/__tests__/client/client-init.spec.ts
@@ -1,0 +1,93 @@
+import { loadFeature, defineFeature } from 'jest-cucumber';
+import { Application } from '@ovh-ux/manager-config/types/application';
+import { buildURLIfStandalone } from '../../src/client';
+
+const feature = loadFeature('../../features/client/client-init.feature', {
+  loadRelativePath: true,
+});
+
+defineFeature(feature, (test) => {
+  afterEach(() => {
+    delete window.location;
+  });
+
+  test('Open app without container when standalone', ({
+    given,
+    and,
+    when,
+    then,
+  }) => {
+    const appConfig = {
+      publicURL: 'https://www.publicstandalone.com/',
+      container: {
+        enabled: false,
+      },
+    } as Application;
+    let finalURL = '';
+
+    given('I have a standalone application', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://www.ovhcontainer.com/manager/#/foo?mon=1&standalone=1',
+          search: '?mon=1&standalone=1',
+          origin: 'https://www.ovhcontainer.com',
+          host: 'ovhcontainer',
+          hostname: 'ovhcontainer',
+          hash: '#',
+        },
+      });
+    });
+
+    and('Container is enabled', () => {
+      appConfig.container.enabled = true;
+    });
+
+    when('I detect the parameter standalone in the URL', () => {
+      finalURL = buildURLIfStandalone(appConfig);
+    });
+
+    then('I do not redirect and returns current url without change', () => {
+      expect(finalURL).toBe(window.location.href);
+    });
+  });
+
+  test('Open app in container when not standalone', ({
+    given,
+    and,
+    when,
+    then,
+  }) => {
+    const appConfig = {
+      publicURL: 'https://www.publicstandalone.com/',
+      container: {
+        enabled: false,
+      },
+    } as Application;
+    let finalURL = '';
+
+    given('I have an app', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://www.ovhcontainer.com/manager/#/foo?mon=1',
+          search: '?mon=1',
+          origin: 'https://www.ovhcontainer.com',
+          host: 'ovhcontainer',
+          hostname: 'ovhcontainer',
+          hash: '#',
+        },
+      });
+    });
+
+    and('Container is enabled', () => {
+      appConfig.container.enabled = true;
+    });
+
+    when('I do not see the parameter standone in the url', () => {
+      finalURL = buildURLIfStandalone(appConfig);
+    });
+
+    then('I redirect to public URL', () => {
+      expect(finalURL).toBe('https://www.publicstandalone.com/#/');
+    });
+  });
+});

--- a/packages/components/ovh-shell/features/client/client-init.feature
+++ b/packages/components/ovh-shell/features/client/client-init.feature
@@ -1,0 +1,13 @@
+Feature: Shell initialization
+
+Scenario: Open app without container when standalone
+  Given I have a standalone application
+  And Container is enabled
+  When I detect the parameter standalone in the URL
+  Then I do not redirect and returns current url without change
+
+Scenario: Open app in container when not standalone
+  Given I have an app
+  And Container is enabled
+  When I do not see the parameter standone in the url
+  Then I redirect to public URL

--- a/packages/components/ovh-shell/src/client/index.ts
+++ b/packages/components/ovh-shell/src/client/index.ts
@@ -38,18 +38,25 @@ export function initStandaloneClientApi(
     throw new Error(`Unknown application '${appId}'`);
   }
 
-  // check for container redirection
+  const queryParams = Object.fromEntries(
+    new URLSearchParams(window.location.search).entries(),
+  );
+
+  // check for container redirection ...
   if (appConfig.container?.enabled === true) {
-    const targetURL = new URL(appConfig.publicURL);
-    const currentHash = window.location.hash;
-    if (currentHash) {
-      targetURL.hash = `${(targetURL.hash || '#').replace(
-        /\/$/,
-        '',
-      )}/${currentHash.replace(/^#?\/?/, '')}`;
-    }
-    if (window.location.hostname !== 'localhost') {
-      window.location.href = targetURL.href;
+    // ... but skip redirection if we are forcing standalone
+    if (!queryParams.hasOwnProperty('standalone')) {
+      const targetURL = new URL(appConfig.publicURL);
+      const currentHash = window.location.hash;
+      if (currentHash) {
+        targetURL.hash = `${(targetURL.hash || '#').replace(
+          /\/$/,
+          '',
+        )}/${currentHash.replace(/^#?\/?/, '')}`;
+      }
+      if (window.location.hostname !== 'localhost') {
+        window.location.href = targetURL.href;
+      }
     }
   }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/shell-monitoring
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-9647
| License          | BSD 3-Clause

## Description

for monitoring : add "standalone" parameter to query params in order to force an application to be displayed as standalone instead of being redirected to the container in production