### PR TITLE
fix(storages.containers.add): make linked user step conditional

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
@@ -5,6 +5,8 @@ import Container from '../container.class';
 
 import {
   OBJECT_CONTAINER_NAME_PATTERN,
+  OBJECT_CONTAINER_OFFER_HIGH_PERFORMANCE,
+  OBJECT_CONTAINER_OFFER_STORAGE_STANDARD,
   OBJECT_CONTAINER_OFFERS,
   OBJECT_CONTAINER_OFFERS_LABELS,
   OBJECT_CONTAINER_TYPE_OFFERS,
@@ -101,6 +103,13 @@ export default class PciStoragesContainersAddController {
 
   refreshMessages() {
     this.messages = this.messageHandler.getMessages();
+  }
+
+  isRightOffer() {
+    return [
+      OBJECT_CONTAINER_OFFER_STORAGE_STANDARD,
+      OBJECT_CONTAINER_OFFER_HIGH_PERFORMANCE,
+    ].includes(this.container.offer);
   }
 
   isReadyForValidation() {

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
@@ -177,6 +177,7 @@
 
     <!--Create/Linked user-->
     <oui-step-form
+        data-ng-if="$ctrl.isRightOffer()"
         data-header="{{:: 'pci_projects_project_storages_containers_add_create_or_linked_user_title' | translate }}"
         data-navigation="$ctrl.isReadyForValidation()"
         data-name="storage_container_user"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9624
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. display linked step only if user select `standard s3` or `standard s3 high perf`