### PR TITLE
fix(pci.storage.databases): datatr-57 - deprecated availabilities

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/engines.constants.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/engines.constants.js
@@ -1,5 +1,7 @@
 export const ENGINES_STATUS = {
   BETA: 'BETA',
+  STABLE: 'STABLE',
+  DEPRECATED: 'DEPRECATED',
 };
 
 export const ENGINES_PRICE_SUFFIX = {

--- a/packages/manager/modules/pci/src/components/project/storages/databases/flavor.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/flavor.class.js
@@ -1,4 +1,5 @@
 import some from 'lodash/some';
+import { ENGINES_STATUS } from './engines.constants';
 
 export default class Flavor {
   constructor({ name, core, memory }, availability) {
@@ -67,6 +68,10 @@ export default class Flavor {
 
   get id() {
     return `${this.availability[0].engine}-${this.availability[0].plan.name}-${this.name}`;
+  }
+
+  get isDeprecated() {
+    return this.availability[0].status === ENGINES_STATUS.DEPRECATED;
   }
 
   compare(flavor) {

--- a/packages/manager/modules/pci/src/components/project/storages/databases/region.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/region.class.js
@@ -19,6 +19,8 @@ export default class Region {
       .sort((a, b) => b.compare(a));
     this.hasSufficientQuota = true;
     this.isDefault = some(availability, 'default');
+
+    this.availableFlavors = this.flavors.filter((f) => !f.isDeprecated);
   }
 
   hasEnoughQuota() {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -76,7 +76,7 @@
             </oui-field>
             <p data-translate="pci_database_add_select_flavor"></p>
             <database-flavors-list
-                data-flavors="$ctrl.model.region.flavors"
+                data-flavors="$ctrl.model.region.availableFlavors"
                 data-selected-flavor="$ctrl.model.flavor"
                 data-user="$ctrl.user"
                 on-change="$ctrl.onFlavorChanged(selectedFlavor)"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-node/upgrade-node.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-node/upgrade-node.routing.js
@@ -10,7 +10,7 @@ export default /* @ngInject */ ($stateProvider) => {
         currentFlavor: /* @ngInject */ (getCurrentFlavor) => getCurrentFlavor(),
         flavors: /* @ngInject */ (database, engine) =>
           engine.getRegion(database.version, database.plan, database.region)
-            .flavors,
+            .availableFlavors,
         onNodeUpgrade: /* @ngInject */ (goBackAndPoll) => goBackAndPoll,
       },
       atInternet: {

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.controller.js
@@ -169,7 +169,7 @@ export default class {
 
   onRegionSelect() {
     this.model.flavor = find(
-      this.model.region.flavors,
+      this.model.region.availableFlavors,
       (flavor) => flavor.name === this.model.flavor.name,
     );
     this.onFlavorSelect();

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/fork/fork.html
@@ -77,7 +77,7 @@
     </oui-field>
     <p data-translate="pci_database_fork_select_flavor"></p>
     <database-flavors-list
-        data-flavors="$ctrl.model.region.flavors"
+        data-flavors="$ctrl.model.region.availableFlavors"
         data-current-flavor="$ctrl.current.flavor"
         data-selected-flavor="$ctrl.model.flavor"
         data-user="$ctrl.user"


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #.DATATR-57
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

When creating a database service, do not show availabilities that have the status as "deprecated" .