### PR TITLE
fix(cookie-policy): use sources instead of build

### DIFF
--- a/packages/manager/modules/cookie-policy/package.json
+++ b/packages/manager/modules/cookie-policy/package.json
@@ -19,22 +19,7 @@
     "directory": "packages/manager/modules/cookie-policy"
   },
   "license": "BSD-3-Clause",
-  "main": "./dist/esm/index.js",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "rollup -c --environment BUILD:production",
-    "dev": "rollup -c --environment BUILD:development",
-    "dev:watch": "yarn run dev --watch",
-    "prepare": "yarn run build",
-    "start": "lerna exec --stream --scope='@ovh-ux/manager-cookie-policy' --include-dependencies -- yarn run build",
-    "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-cookie-policy' --include-dependencies -- yarn run dev",
-    "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-cookie-policy' --include-dependencies -- yarn run dev:watch"
-  },
-  "devDependencies": {
-    "@ovh-ux/component-rollup-config": "^11.0.0 || ^12.0.0"
-  },
+  "main": "./src/index.js",
   "peerDependencies": {
     "@ovh-ux/manager-config": "^5.0.1",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",

--- a/packages/manager/modules/cookie-policy/rollup.config.js
+++ b/packages/manager/modules/cookie-policy/rollup.config.js
@@ -1,7 +1,0 @@
-import rollupConfig from '@ovh-ux/component-rollup-config';
-
-const config = rollupConfig({
-  input: 'src/index.js',
-});
-
-export default [config.es()];


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/stack-clean-apps`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-9745,
| License          | BSD 3-Clause

## Description

Stop building `@ovh-ux/manager-cookie-policy` as this feature is now built-in in container and this package is only used in `@ovh-ux/sign-up-app`.