### PR TITLE
fix(hosting.clouddb): remove useless fields in db order

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/database/order/components/private-database/private-database.html
+++ b/packages/manager/apps/web/client/app/hosting/database/order/components/private-database/private-database.html
@@ -13,28 +13,6 @@
         on-success=":: $ctrl.handleSuccess(checkout)"
         on-error=":: $ctrl.handleError(error)"
     >
-        <!-- DB Type -->
-        <oui-step-form
-            data-header="{{:: 'hosting_database_order_private_step_header_type' | translate }}"
-            data-editable="$ctrl.isEditable && !$ctrl.checkoutLoading"
-        >
-            <oui-field
-                data-label="{{:: 'hosting_database_order_private_type' | translate }}"
-            >
-                <oui-radio
-                    name="orderType"
-                    data-description="{{:: 'hosting_database_order_private_type_text' | translate }}"
-                    data-model="$ctrl.order.type"
-                    data-value="$ctrl.CATALOG_PRODUCT.name"
-                    data-required
-                >
-                    <span
-                        data-translate="hosting_database_order_private_type_label"
-                    ></span>
-                </oui-radio>
-            </oui-field>
-        </oui-step-form>
-
         <!-- Customization -->
         <oui-step-form
             data-header="{{:: 'hosting_database_order_private_step_header_customize' | translate }}"

--- a/packages/manager/apps/web/client/app/hosting/database/order/components/private-database/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/database/order/components/private-database/translations/Messages_fr_FR.json
@@ -1,7 +1,6 @@
 {
   "hosting_database_order_private_title": "Commander un SQL Privé",
   "hosting_database_order_private_description": "Vous devez avoir un hébergement pour commander les options SQL Privé et Start SQL.",
-  "hosting_database_order_private_step_header_type": "Type de base de données",
   "hosting_database_order_private_step_header_customize": "Personnalisation",
   "hosting_database_order_private_step_header_duration": "Choisissez la durée",
   "hosting_database_order_private_step_header_activation": "Activation",
@@ -12,9 +11,6 @@
   "hosting_database_order_private_submit_pay": "Payer",
   "hosting_database_order_private_cancel": "Annuler",
   "hosting_database_order_private_select_placeholder": "Sélectionner…",
-  "hosting_database_order_private_type": "Quelle offre de base de données désirez vous ?",
-  "hosting_database_order_private_type_label": "SQL Privé",
-  "hosting_database_order_private_type_text": "Bases de données aux performances mémoires (RAM) garanties pour votre hébergement Web Hosting OVH",
   "hosting_database_order_private_hosting": "Hébergements",
   "hosting_database_order_private_ram": "RAM",
   "hosting_database_order_private_version": "Version",

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.component.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.component.js
@@ -5,7 +5,7 @@ export default {
   bindings: {
     cartId: '<',
     catalog: '<',
-    datacenters: '<',
+    datacenter: '<',
     defaultPaymentMean: '<',
     engines: '<',
     ramSizes: '<',

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
@@ -26,7 +26,6 @@ export default class PrivateDatabaseOrderCloudDbCtrl {
   initializeCustomizationOptions() {
     this.model.engine = undefined;
     this.model.ramSize = undefined;
-    this.model.datacenter = undefined;
 
     this.engineList = orderBy(
       this.engines.map((engine) => {
@@ -57,17 +56,10 @@ export default class PrivateDatabaseOrderCloudDbCtrl {
         })),
       'value',
     );
-
-    this.datacenterList = this.datacenters.map((datacenter) => ({
-      label: this.$translate.instant(
-        `private_database_order_clouddb_datacenter_${datacenter}`,
-      ),
-      value: datacenter,
-    }));
   }
 
   canGoToDurationStep() {
-    if (this.model.engine && this.model.ramSize && this.model.datacenter) {
+    if (this.model.engine && this.model.ramSize) {
       this.currentIndex += 1;
     }
   }
@@ -112,7 +104,7 @@ export default class PrivateDatabaseOrderCloudDbCtrl {
   prepareCheckout() {
     this.loadingCheckout = true;
     const checkoutData = {
-      datacenter: this.model.datacenter.value,
+      datacenter: this.datacenter,
       engine: this.model.engine.value,
       ramSize: this.model.ramSize.value,
       duration: this.model.duration.duration,

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
@@ -12,32 +12,6 @@
     data-on-finish="$ctrl.validateCheckout()"
 >
     <oui-step-form
-        data-header="{{:: 'private_database_order_clouddb_database_type' | translate }}"
-        data-on-focus="$ctrl.selectTypeOption()"
-        data-editable="false"
-        data-navigation="false"
-        data-disabled="$ctrl.hasValidatedCheckout"
-        data-valid="$ctrl.model.type"
-    >
-        <oui-field
-            data-label="{{:: 'private_database_order_clouddb_database_question' | translate }}"
-        >
-            <oui-radio
-                data-name="modelType"
-                data-model="$ctrl.model.type"
-                data-value="$ctrl.defaultModelType"
-            >
-                <span
-                    data-translate="{{:: 'private_database_order_clouddb_offer_title' | translate }}"
-                ></span>
-            </oui-radio>
-            <span
-                data-translate="{{:: 'private_database_order_clouddb_offer_subtitle' | translate }}"
-            ></span>
-        </oui-field>
-    </oui-step-form>
-
-    <oui-step-form
         data-header="{{:: 'private_database_order_clouddb_customization' | translate }}"
         data-editable="!$ctrl.loadingDurations && !$ctrl.loadingCheckout && !$ctrl.hasValidatedCheckout"
         data-navigation="false"
@@ -68,21 +42,6 @@
                 data-model="$ctrl.model.ramSize"
                 data-items="$ctrl.ramSizeList"
                 data-placeholder="{{:: 'private_database_order_clouddb_ram_option_placeholder' | translate }}"
-                data-on-change="$ctrl.canGoToDurationStep()"
-            >
-            </oui-select>
-        </oui-field>
-
-        <oui-field
-            data-label="{{:: 'private_database_order_clouddb_datacenter' | translate }}"
-            data-size="l"
-        >
-            <oui-select
-                data-name="datacenter"
-                data-match="label"
-                data-model="$ctrl.model.datacenter"
-                data-items="$ctrl.datacenterList"
-                data-placeholder="{{:: 'private_database_order_clouddb_datacenter_placeholder' | translate }}"
                 data-on-change="$ctrl.canGoToDurationStep()"
             >
             </oui-select>

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.routing.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.routing.js
@@ -14,8 +14,8 @@ export default /* @ngInject */ ($stateProvider) => {
         ),
       catalog: /* @ngInject */ (user, PrivateDatabaseOrderCloudDb) =>
         PrivateDatabaseOrderCloudDb.getCloudDBCatalog(user.ovhSubsidiary),
-      datacenters: /* @ngInject */ (catalog, PrivateDatabaseOrderCloudDb) =>
-        PrivateDatabaseOrderCloudDb.constructor.getOrderableDatacenters(
+      datacenter: /* @ngInject */ (catalog, PrivateDatabaseOrderCloudDb) =>
+        PrivateDatabaseOrderCloudDb.constructor.getOrderableDatacenter(
           catalog.plans,
         ),
       /* @ngInject */

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.service.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.service.js
@@ -101,11 +101,12 @@ export default class PrivateDatabaseOrderCloudDb {
     }));
   }
 
-  static getOrderableDatacenters(plans) {
+  static getOrderableDatacenter(plans) {
+    // there is only one available datacenter per geographical zone
     return PrivateDatabaseOrderCloudDb.filterOrderableItems(
       plans,
       DATACENTER_CONFIGURATION_KEY,
-    );
+    )[0];
   }
 
   static getOrderableEngines(plans) {

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/translations/Messages_fr_FR.json
@@ -2,11 +2,6 @@
   "private_database_order_clouddb_title": "Commander une base de données Cloud Databases",
   "private_database_order_clouddb_subtitle": "L’offre Cloud Databases nécessite un service ayant accès au réseau internet public.",
 
-  "private_database_order_clouddb_database_type": "Type de base de données",
-  "private_database_order_clouddb_database_question": "Quel offre de base de données voulez-vous ?",
-  "private_database_order_clouddb_offer_title": "Cloud Databases",
-  "private_database_order_clouddb_offer_subtitle" : "Idéales en complément de tous nos produits Cloud OVH comme nos VPS, serveurs dédiés, instances Public Cloud et Web Hosting Cloud Web",
-
   "private_database_order_clouddb_customization": "Personnalisation",
   "private_database_order_clouddb_server_version": "Version du serveur",
   "private_database_order_clouddb_server_version_placeholder": "Sélectionnez la version du serveur",
@@ -18,10 +13,6 @@
 
   "private_database_order_clouddb_ram_option": "RAM",
   "private_database_order_clouddb_ram_option_placeholder": "Sélectionnez la quantité de RAM",
-
-  "private_database_order_clouddb_datacenter": "Datacenter",
-  "private_database_order_clouddb_datacenter_placeholder": "Sélectionnez le datacenter",
-  "private_database_order_clouddb_datacenter_gra1": "Gravelines 1",
 
   "private_database_order_clouddb_duration": "Choisissez la durée",
   "private_database_order_clouddb_duration_month": "{{ number }} mois",


### PR DESCRIPTION
ref: WEB-12795

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | WEB-12795
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

We are currently updating clouddb and private sql orders. This PR goal is to clean useless fields in order pages : user doesnt need to choose database type and datacenter.
