### PR TITLE
fix(pci.storage.databases): datatr-75 - remove deprecated field for pool page

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/pool.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/pool.class.js
@@ -12,6 +12,7 @@ export default class Pool {
     userId,
     userName,
     port,
+    sslMode,
   }) {
     Object.assign(this, {
       databaseId,
@@ -26,6 +27,7 @@ export default class Pool {
       userId,
       userName,
       port,
+      sslMode,
     });
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/pools/information/information.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/pools/information/information.html
@@ -31,7 +31,7 @@
                 ></dt>
                 <dd
                     class="col-sm-9 my-auto text-capitalize"
-                    data-ng-bind="$ctrl.database.sslMode"
+                    data-ng-bind="$ctrl.pool.sslMode"
                 ></dd>
             </div>
             <div class="my-2 py-2 border-top">


### PR DESCRIPTION
DATATR-75

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-75
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

The page pool information uses the deprecated field "sslMode" of the service.

Use the field "sslMode" of the pool object instead.