### PR TITLE
fix(vps): display upgrade error when vps in rescue mode

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/index.html
+++ b/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/index.html
@@ -2,8 +2,19 @@
     <!-- Display the catched error -->
     <div data-ng-if="$ctrl.resolve.upgradeInfo.error">
         <span
+            data-ng-if="$ctrl.resolve.stateVps.state !== 'rescued'"
             data-translate="vps_dashboard_tile_configuration_upgrade_catched_error"
         ></span>
+        <div data-ng-if="$ctrl.resolve.stateVps.state === 'rescued'">
+            <span
+                data-translate="vps_dashboard_tile_configuration_upgrade_fail_vps_in_rescue_info"
+            ></span>
+            <a href="{{:: $ctrl.resolve.getRebootLink()}}">
+                <span
+                    data-translate="vps_dashboard_tile_configuration_upgrade_fail_vps_in_rescue_action"
+                ></span>
+            </a>
+        </div>
     </div>
 
     <!-- No catched error - display the upgrade informations -->


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2228-2230`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-8909
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display upgrade error when vps in rescue mode

## Related

<!-- Link dependencies of this PR -->
