### PR TITLE
fix(storages.components.clipboard): add missed tooltip feature

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/controller.js
@@ -2,7 +2,9 @@ import ClipboardJS from 'clipboard';
 
 export default class PasswordClipboardComponentController {
   /* @ngInject */
-  constructor($translate) {
+  constructor($element, $timeout, $translate) {
+    this.$element = $element;
+    this.$timeout = $timeout;
     this.$translate = $translate;
 
     this.SECRET_KEY_CLIPBOARD_BTN_ID = 'secretKeyClipboardCopyBtnId';
@@ -10,8 +12,30 @@ export default class PasswordClipboardComponentController {
   }
 
   $onInit() {
-    this.secretKeyClipboard = new ClipboardJS(
-      `#${this.SECRET_KEY_CLIPBOARD_BTN_ID}`,
+    return this.$timeout().then(() => {
+      const tooltipText = this.getClipboardTooltipContent();
+      this.model = {
+        clipboard: new ClipboardJS(`#${this.SECRET_KEY_CLIPBOARD_BTN_ID}`),
+        target: this.$element[0].querySelector('.oui-clipboard__control'),
+        isTextCopied: false,
+        tooltipText,
+      };
+
+      this.model.clipboard
+        .on('success', (evt) => this.onClipboardCopySuccess(evt))
+        .on('error', (evt) => this.onClipboardCopyFail(evt));
+    });
+  }
+
+  $onDestroy() {
+    return this.model.clipboard.destroy();
+  }
+
+  getClipboardTooltipContent() {
+    return this.$translate.instant(
+      this?.model?.isTextCopied
+        ? 'pci_projects_project_storages_components_password_clipboard_tooltip_action_copied'
+        : 'pci_projects_project_storages_components_password_clipboard_tooltip_action_copy',
     );
   }
 
@@ -20,6 +44,27 @@ export default class PasswordClipboardComponentController {
       isText
         ? 'pci_projects_project_storages_components_password_clipboard_label_hide_password'
         : 'pci_projects_project_storages_components_password_clipboard_label_show_password',
+    );
+  }
+
+  resetToDefault() {
+    this.model.isTextCopied = false;
+    this.model.tooltipText = this.getClipboardTooltipContent();
+  }
+
+  onClipboardClick() {
+    return this.resetToDefault();
+  }
+
+  onClipboardCopySuccess() {
+    this.model.isTextCopied = true;
+    this.model.tooltipText = this.getClipboardTooltipContent();
+    this.model.target.focus();
+  }
+
+  onClipboardCopyFail() {
+    this.model.tooltipText = this.$translate.instant(
+      'pci_projects_project_storages_components_password_clipboard_tooltip_action_copy_not_supported',
     );
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/template.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/template.html
@@ -9,6 +9,8 @@
             data-ng-attr-name="{{:: $ctrl.SECRET_KEY_INPUT_ID}}"
             data-ng-attr-type="{{ passwordClipboard.isText ? 'text' : 'password' }}"
             data-ng-value="$ctrl.fieldSecretKeyValue"
+            data-ng-click="$ctrl.onClipboardClick()"
+            data-oui-tooltip="{{ $ctrl.model.tooltipText }}"
             readonly
         />
         <button
@@ -26,7 +28,7 @@
             type="button"
             class="oui-button ml-1"
             aria-label="{{:: 'pci_projects_project_storages_components_password_clipboard_label_copy_to_clipboard' | translate }}"
-            data-ng-if="$ctrl.secretKeyClipboard"
+            data-ng-if="$ctrl.model.clipboard"
             data-ng-attr-id="{{:: $ctrl.SECRET_KEY_CLIPBOARD_BTN_ID}}"
             data-clipboard-text="{{:: $ctrl.fieldSecretKeyValue}}"
         >

--- a/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/components/password-clipboard/translations/Messages_fr_FR.json
@@ -1,5 +1,8 @@
 {
   "pci_projects_project_storages_components_password_clipboard_label_show_password": "Montrer le mot de passe",
   "pci_projects_project_storages_components_password_clipboard_label_hide_password": "Cacher le mot de passe",
-  "pci_projects_project_storages_components_password_clipboard_label_copy_to_clipboard": "Copier dans le presse-papier"
+  "pci_projects_project_storages_components_password_clipboard_label_copy_to_clipboard": "Copier dans le presse-papier",
+  "pci_projects_project_storages_components_password_clipboard_tooltip_action_copy": "Copier dans le presse-papier",
+  "pci_projects_project_storages_components_password_clipboard_tooltip_action_copied": "Copié",
+  "pci_projects_project_storages_components_password_clipboard_tooltip_action_copy_not_supported": "La copie dans le presse-papiers est non prise en charge. Veuillez copier le texte manuellement."
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/componenets/credential-banner/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/componenets/credential-banner/translations/Messages_fr_FR.json
@@ -3,6 +3,6 @@
   "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_fail_message": "Les informations d'identification S3 n'ont pas été générées.",
   "pci_projects_project_storages_containers_add_create_or_linked_user_create_credential_fail_message": "La création de l'utilisateur {{username}} a échoué.",
   "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_username_label": "Votre nom d'utilisateur S3",
-  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_access-key_label": "Votre clé d'accès",
-  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_secret-key_label": "Votre clé secrète"
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_access-key_label": "Votre clé d'accès :",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_secret-key_label": "Votre clé secrète :"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/translations/Messages_fr_FR.json
@@ -15,7 +15,7 @@
   "pci_projects_project_storages_containers_add_region_title": "Sélectionnez une localisation",
   "pci_projects_project_storages_containers_add_type_title": "Sélectionnez un type de conteneur",
   "pci_projects_project_storages_containers_add_create_or_linked_user_title": "Associer un utilisateur",
-  "pci_projects_project_storages_containers_add_create_or_linked_user_success_field_secret_key": "Votre clé secrète",
+  "pci_projects_project_storages_containers_add_create_or_linked_user_success_field_secret_key": "Votre clé secrète :",
   "pci_projects_project_storages_containers_add_create_or_linked_user_description": "Vous avez la possibilité de donner l'accès à votre conteneur à un utilisateur prédéfini ou de créer un nouvel utilisateur.",
   "pci_projects_project_storages_containers_add_type_static_label": "Hébergement statique",
   "pci_projects_project_storages_containers_add_type_static_description": "Accès rapide et performant pour vos sites. Liez vos domaines et déposez vos fichiers.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9655
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. display tooltip `copied` message once clipboard is copied
2. reset tooltip message once clipboard is clicked
3. add missed semicolon for some content key 