### PR TITLE
fix(server-sidebar): allow to use search params from API

### DIFF
--- a/packages/manager/modules/server-sidebar/src/controller.js
+++ b/packages/manager/modules/server-sidebar/src/controller.js
@@ -461,6 +461,13 @@ export default class OvhManagerServerSidebarController {
                   menuItem.addSearchKey(service.serviceName);
                 }
 
+                // add search keys from API
+                if (has(service, 'searchParams')) {
+                  each(service.searchParams, (searchParam) => {
+                    menuItem.addSearchKey(searchParam);
+                  });
+                }
+
                 // add searchKeys from type definition in item searchKeys
                 if (
                   has(typeServices.type, 'searchKeys') &&


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-93208,
| License          | BSD 3-Clause

## Description


Allow to use searchParams from API.

## Related

- [x] 2API service#100