### PR TITLE
fix(object-storage-users.add): display only users without credentials

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
@@ -25,6 +25,7 @@ export default class PciUsersAddController {
     this.disable = true;
     this.addExistingUser = 'addExistingUser';
     this.createNewUser = 'createNewUser';
+
     this.allUserList = this.allUserList.map((userList) => ({
       ...userList,
       asCredentials: this.usersCredentials.find(
@@ -37,6 +38,12 @@ export default class PciUsersAddController {
             'pci_projects_project_users_add_as_no_credentials',
           ),
     }));
+    this.usersWithoutCredentials = this.allUserList.filter(
+      ({ s3Credentials }) => !s3Credentials.length,
+    );
+    this.isUserCouldGenerateCredentails =
+      this.usersWithoutCredentials?.length > 0;
+
     [this.userModel] = this.allUserList;
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.html
@@ -14,10 +14,11 @@
             data-translate="pci_projects_project_users_add_short_description"
         ></p>
         <oui-radio
-            model="$ctrl.model"
-            name="addExistingUser"
-            on-change="$ctrl.onChange($ctrl.addExistingUser)"
-            value="$ctrl.addExistingUser"
+            data-ng-if="$ctrl.isUserCouldGenerateCredentails"
+            data-model="$ctrl.model"
+            data-name="addExistingUser"
+            data-on-change="$ctrl.onChange($ctrl.addExistingUser)"
+            data-value="$ctrl.addExistingUser"
         >
             <span
                 data-translate="pci_projects_project_users_add_existing_user"
@@ -29,7 +30,7 @@
             <oui-select
                 data-name="userList"
                 data-model="$ctrl.userModel"
-                data-items="$ctrl.allUserList"
+                data-items="$ctrl.usersWithoutCredentials"
                 data-match="username"
             >
                 <span data-ng-bind="$item.username"></span>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9695
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. don't allow to select a users list if all user already have credentials
2. disable checkbox radio