### PR TITLE
fix(hosting.clouddb): remove privateSQL from command menu

### DIFF
--- a/packages/manager/modules/server-sidebar/src/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/server-sidebar/src/translations/Messages_fr_FR.json
@@ -73,7 +73,7 @@
   "server_sidebar_order_item_sharepoint_title": "Sharepoint",
   "server_sidebar_order_item_zone_title": "Zone DNS",
   "server_sidebar_order_item_enterprise_cloud_database_title": "Enterprise Cloud Database",
-  "server_sidebar_order_item_cloudDatabase_title": "Cloud DB",
+  "server_sidebar_order_item_cloudDatabase_title": "CloudDB",
   "server_sidebar_order_item_ovh_cloud_connect_title": "OVHcloud Connect",
   "server_sidebar_order_item_web_paas_title": "Web PaaS",
   "server_sidebar_item_nutanix_title": "Nutanix",

--- a/packages/manager/modules/server-sidebar/src/web.constants.js
+++ b/packages/manager/modules/server-sidebar/src/web.constants.js
@@ -107,24 +107,6 @@ export const HOSTING_CONFIG = {
   feature: 'hosting',
 };
 
-export const PRIVATE_DATABASE_CONFIG = {
-  id: 'privateDatabases',
-  loadOnState: 'app.private-database.dashboard',
-  types: [
-    {
-      path: '/hosting/privateDatabase',
-      category: 'PRIVATE_DATABASE',
-      state: 'app.private-database.dashboard',
-      stateParams: ['productId'],
-      icon: 'ovh-font ovh-font-database',
-      app: [WEB],
-    },
-  ],
-  icon: 'ovh-font ovh-font-database',
-  app: [WEB],
-  feature: 'private-database',
-};
-
 export const EMAIL_PRO_CONFIG = {
   id: 'emailPros',
   loadOnState: 'email-pro.dashboard',
@@ -271,7 +253,6 @@ export const PSH_CONFIG = {
 export const WEB_SIDEBAR_CONFIG = [
   DOMAIN_CONFIG,
   HOSTING_CONFIG,
-  PRIVATE_DATABASE_CONFIG,
   EMAIL_PRO_CONFIG,
   EMAIL_CONFIG,
   MICROSOFT_CONFIG,
@@ -383,14 +364,6 @@ export const WEB_ORDER_SIDEBAR_CONFIG = [
     feature: 'cloud-database',
     app: [WEB],
     tracker: 'web::orders::cloud-db::order',
-  },
-  {
-    id: 'orderPrivateDatabase',
-    title: 'privateDatabase',
-    icon: 'ovh-font ovh-font-database',
-    state: 'app.private-database.order',
-    feature: 'private-database',
-    app: [WEB],
   },
   {
     id: 'orderWebPaas',


### PR DESCRIPTION
ref: WEB-13237

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | WEB-13237
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Private SQL button is removed from sidebar command menu

## Related

<!-- Link dependencies of this PR -->
