### PR TITLE
fix(kubernetes.create): fix the init of default privatenetworkrouting.

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/service.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/service.js
@@ -146,7 +146,7 @@ export default class Kubernetes {
       ...(gatewayConfig.enabled && {
         privateNetworkConfiguration: {
           defaultVrackGateway: gatewayConfig.ip,
-          privateNetworkRoutingAsDefault: !gatewayConfig.ip,
+          privateNetworkRoutingAsDefault: gatewayConfig.enabled,
         },
       }),
     });


### PR DESCRIPTION
ref: DTRSD-96279
Signed-off-by: Rafik Adiche <rafik.adiche.ext@corp.ovh.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-96279 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
