### PR TITLE
fix(identify-check): allow `ownerZip` to be a 4 digit value

### DIFF
--- a/packages/manager/modules/telecom-dashboard/src/identity-check/form/telecom-dashboard-identity-check-form.html
+++ b/packages/manager/modules/telecom-dashboard/src/identity-check/form/telecom-dashboard-identity-check-form.html
@@ -116,7 +116,7 @@
                         placeholder="{{ 'telecom_dashboard_identity_check_form_ownerZip' | translate }}"
                         type="text"
                         data-ng-model="$ctrl.model.ownerZip"
-                        data-ng-pattern="/^\d{5}$/"
+                        data-ng-pattern="/^\d{4}$/"
                         required
                     />
                 </oui-field>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-94709
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

### :bug: Bug Fixes

5cca8e8 - fix(identify-check): allow `ownerZip` to be a 4 digit value

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
