### PR TITLE
fix(pci.project): create user with Object Storage role

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/object-storage.service.js
@@ -32,9 +32,9 @@ export default class PciStoragesObjectStorageService {
       .then(({ data }) => data);
   }
 
-  createUser(projectId, description) {
+  createUser(projectId, description, role) {
     return this.$http
-      .post(`/cloud/project/${projectId}/user`, { description })
+      .post(`/cloud/project/${projectId}/user`, { description, role })
       .then(({ data }) => data);
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
@@ -2,6 +2,7 @@ import {
   NAMESPACES,
   TRACKING_S3_POLICY_ADD,
   USER_STATUS,
+  OBJECT_STORAGE_USER_ROLE,
 } from '../../users.constants';
 
 export default class PciUsersAddController {
@@ -118,6 +119,7 @@ export default class PciUsersAddController {
     return this.PciStoragesObjectStorageService.createUser(
       this.projectId,
       description,
+      OBJECT_STORAGE_USER_ROLE,
     )
       .then((user) => {
         return this.PciStoragesObjectStorageService.pollUserStatus(

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.constants.js
@@ -13,10 +13,13 @@ export const USER_STATUS = {
   OK: 'ok',
 };
 
+export const OBJECT_STORAGE_USER_ROLE = 'objectstore_operator';
+
 export default {
   DOWNLOAD_FILENAME,
   DOWNLOAD_TYPE,
   TRACKING_S3_POLICY,
   TRACKING_S3_POLICY_ADD,
   TRACKING_S3_POLICY_DELETE,
+  OBJECT_STORAGE_USER_ROLE,
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9923
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Create User with Object Storage operator role in S3 Users section
