### PR TITLE
fix(pnr): set right feature name for cloud-connect

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/network.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/network.ts
@@ -37,7 +37,7 @@ export default {
         application: 'dedicated',
         hash: '#/cloud-connect',
       },
-      features: ['veeam-cloud-connect'],
+      features: ['cloud-connect'],
     },
     {
       id: 'iplb',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/run-2022-w35`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-96801
| License          | BSD 3-Clause

## Description

Replace feature `veeam-cloud-connect` for `cloud-connect' sidebar entry in container PNR.