### PR TITLE
feat(pci.project): refresh s3 credentials in Object-storage

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.component.js
@@ -18,5 +18,6 @@ export default {
     userDetails: '<',
     userCredential: '<',
     trackingInfo: '<',
+    refreshS3Credentials: '<',
   },
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.html
@@ -87,5 +87,12 @@
                 data-translate="pci_projects_project_storages_containers_users_add_user"
             ></span>
         </button>
+        <button
+            class="oui-button oui-button_s oui-button_secondary float-right"
+            data-ng-if="$ctrl.refreshS3Credentials"
+            data-ng-click="$ctrl.refreshS3Credentials()"
+        >
+            <span class="oui-icon oui-icon-refresh" aria-hidden="true"></span>
+        </button>
     </oui-datagrid-topbar>
 </oui-datagrid>

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/users.routing.js
@@ -14,6 +14,7 @@ export default /* @ngInject */ ($stateProvider) => {
         $transition$.params().userCredential,
       trackingInfo: /* @ngInject */ ($transition$) =>
         $transition$.params().trackingInfo,
+      refreshS3Credentials: /* @ngInj ect */ ($state) => () => $state.reload(),
       goToUsersAndRoles: /* @ngInject */ (
         $state,
         atInternet,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-9874
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Addition of refresh containers capability in Object-storage containers page

