### PR TITLE
fix(pci): update back link target to avoid reload

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/config/index.html
+++ b/packages/manager/modules/pci/src/projects/new/config/index.html
@@ -68,7 +68,6 @@
             data-track-on="click"
             data-track-name="PublicCloud::pci::projects::new_project_cancel"
             data-track-type="navigation"
-            target="_top"
         >
             <span
                 data-translate="pci_project_new_config_btn_return_to_projects"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/run-2022-w36`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-94876
| License          | BSD 3-Clause

## Description

Update target on PCI project creation Back link to avoid to reload the application.