### PR TITLE
fix(telephony): check can transfer deposit on target selection

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/deposit-movement.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/deposit-movement.html
@@ -180,6 +180,13 @@
                                 data-translate="telephony_group_billing_deposit_movement_destination_subtitle"
                             ></h2>
                         </header>
+                        <div
+                            class="alert alert-danger"
+                            role="alert"
+                            data-ng-if="BillingAccountDepositMovementCtrl.target && BillingAccountDepositMovementCtrl.targetError"
+                            data-translate="telephony_group_billing_deposit_movement_error_destination"
+                        ></div>
+
                         <div class="form-group">
                             <label
                                 for="target"
@@ -192,6 +199,7 @@
                                 name="target"
                                 id="target"
                                 required
+                                data-ng-change="BillingAccountDepositMovementCtrl.onChangeTarget()"
                                 data-ng-model="BillingAccountDepositMovementCtrl.target"
                                 data-ng-options="item.value as item.label disable when item.disable for item in BillingAccountDepositMovementCtrl.targets"
                                 data-ng-disabled="!BillingAccountDepositMovementCtrl.source || BillingAccountDepositMovementCtrl.loading.submit"
@@ -205,7 +213,7 @@
                             ></label>
                             <p
                                 class="form-control-static"
-                                data-ng-if="BillingAccountDepositMovementCtrl.target.securityDeposit"
+                                data-ng-if="BillingAccountDepositMovementCtrl.target.securityDeposit && BillingAccountDepositMovementCtrl.canTransferSecurityDepositOnTarget"
                             >
                                 <span
                                     data-ng-bind="BillingAccountDepositMovementCtrl.target.securityDeposit.text"
@@ -223,7 +231,7 @@
                             ></label>
                             <p
                                 class="form-control-static"
-                                data-ng-if="BillingAccountDepositMovementCtrl.amount && BillingAccountDepositMovementCtrl.target.securityDeposit"
+                                data-ng-if="BillingAccountDepositMovementCtrl.amount && BillingAccountDepositMovementCtrl.target.securityDeposit && BillingAccountDepositMovementCtrl.canTransferSecurityDepositOnTarget"
                             >
                                 <span
                                     data-ng-bind="(BillingAccountDepositMovementCtrl.amount + BillingAccountDepositMovementCtrl.target.securityDeposit.value) | currency : BillingAccountDepositMovementCtrl.currency : 2"
@@ -239,7 +247,7 @@
                         <button
                             type="submit"
                             class="btn btn-primary"
-                            data-ng-disabled="!depositMovementForm.$valid || !(BillingAccountDepositMovementCtrl.amount > 0) || BillingAccountDepositMovementCtrl.loading.submit"
+                            data-ng-disabled="!depositMovementForm.$valid || !(BillingAccountDepositMovementCtrl.amount > 0) || BillingAccountDepositMovementCtrl.canTransferSecurityDepositOnTarget || BillingAccountDepositMovementCtrl.loading.submit"
                             data-translate="telephony_group_billing_deposit_movement_submit"
                         ></button>
                     </div>

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/billing/depositMovement/translations/Messages_fr_FR.json
@@ -17,5 +17,6 @@
   "telephony_group_billing_deposit_movement_error_amount_number": "Veuillez saisir un montant valide.",
   "telephony_group_billing_deposit_movement_error_amount_min": "La valeur minimum de ce champ est {{ min }}.",
   "telephony_group_billing_deposit_movement_error_amount_max": "La valeur maximum de ce champ est {{ max }}.",
+  "telephony_group_billing_deposit_movement_error_destination": "Votre dépôt de garantie ne peut pas être transféré sur ce groupe",
   "telephony_group_billing_deposit_movement_capability_error": "Oups ! Nous n'avons pas pu vérifier les groupes de facturation transférables."
 }


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/run-2022-w36`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-80172,
| License          | BSD 3-Clause

## Description

Check target billingAccount can transfer Security Deposit on Target selection instead of "prefetching" it for all billing account.