### PR TITLE
fix(identity-check): allow 4 and 5 digits zipcode

### DIFF
--- a/packages/manager/modules/telecom-dashboard/src/identity-check/form/telecom-dashboard-identity-check-form.html
+++ b/packages/manager/modules/telecom-dashboard/src/identity-check/form/telecom-dashboard-identity-check-form.html
@@ -116,7 +116,7 @@
                         placeholder="{{ 'telecom_dashboard_identity_check_form_ownerZip' | translate }}"
                         type="text"
                         data-ng-model="$ctrl.model.ownerZip"
-                        data-ng-pattern="/^\d{4}$/"
+                        data-ng-pattern="/^\d{4,5}$/"
                         required
                     />
                 </oui-field>


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/run-2022-w36`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-97169,
| License          | BSD 3-Clause

## Description

Allow 4 & 5 digits on zipcode.

