### PR TITLE
fix(pci.container): create user with Object Storage role

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/constant.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/constant.js
@@ -20,6 +20,7 @@ export const NAMESPACES = {
 export const TRACKING_PREFIX = 'storage_container_add_user::';
 export const TRACKING_CREATE_USER = 'create-user';
 export const TRACKING_ASSOCIATE_USER = 'associate-user';
+export const OBJECT_STORAGE_USER_ROLE = 'objectstore_operator';
 
 export default {
   CONTAINER_USER_ASSOCIATION_MODES,
@@ -29,4 +30,5 @@ export default {
   TRACKING_PREFIX,
   TRACKING_CREATE_USER,
   TRACKING_ASSOCIATE_USER,
+  OBJECT_STORAGE_USER_ROLE,
 };

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/components/associate-user-to-container/controller.js
@@ -6,6 +6,7 @@ import {
   TRACKING_CREATE_USER,
   TRACKING_PREFIX,
   USER_STATUS,
+  OBJECT_STORAGE_USER_ROLE,
 } from './constant';
 
 export default class CreateLinkedUserController {
@@ -99,6 +100,7 @@ export default class CreateLinkedUserController {
   createUser(description) {
     return this.PciStoragesUsersService.createUser(this.projectId, {
       description,
+      role: OBJECT_STORAGE_USER_ROLE,
     })
       .then((user) => {
         return this.PciStoragesUsersService.pollUserStatus(


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9923
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

 Create User with Object Storage operator role in Container creation.
