### PR TITLE
fix(pci.project): display only created users

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.controller.js
@@ -79,6 +79,7 @@ export default class PciStoragesContainersAddController {
       createOrLinkedMode: null,
     };
 
+    this.setUsersForContainerCreation();
     this.preselectStepItem();
   }
 
@@ -105,6 +106,10 @@ export default class PciStoragesContainersAddController {
 
   refreshMessages() {
     this.messages = this.messageHandler.getMessages();
+  }
+
+  setUsersForContainerCreation() {
+    this.users = this.allUserList.filter((user) => user.status === 'ok');
   }
 
   isRightOffer() {

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/add/add.html
@@ -191,7 +191,7 @@
     >
         <pci-project-storages-create-linked-user
             data-project-id="$ctrl.projectId"
-            data-users="$ctrl.allUserList"
+            data-users="$ctrl.users"
             data-user-model="$ctrl.userModel"
             data-field-secret-key-label=":: 'pci_projects_project_storages_containers_add_create_or_linked_user_success_field_secret_key' | translate"
         ></pci-project-storages-create-linked-user>

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/addUser/addUser.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/addUser/addUser.routing.js
@@ -29,7 +29,10 @@ export default /* @ngInject */ ($stateProvider) => {
         availableUsers: /* @ngInject */ (
           PciStoragesObjectStorageService,
           projectId,
-        ) => PciStoragesObjectStorageService.getS3Users(projectId),
+        ) =>
+          PciStoragesObjectStorageService.getS3Users(projectId).filter(
+            (user) => user.status === 'ok',
+          ),
         container: /* @ngInject */ (
           PciProjectStorageContainersService,
           projectId,

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/object/addUser/addUser.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/objects/object/object/addUser/addUser.routing.js
@@ -30,7 +30,10 @@ export default /* @ngInject */ ($stateProvider) => {
         availableUsers: /* @ngInject */ (
           PciStoragesObjectStorageService,
           projectId,
-        ) => PciStoragesObjectStorageService.getS3Users(projectId),
+        ) =>
+          PciStoragesObjectStorageService.getS3Users(projectId).filter(
+            (user) => user.status === 'ok',
+          ),
         goToUsersAndRoles: /* @ngInject */ ($state) => () =>
           $state.go('pci.projects.project.users'),
         goBack: /* @ngInject */ (goToStorageContainer) => goToStorageContainer,

--- a/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/object-storage/users/add/user-add/user-add.controller.js
@@ -25,8 +25,8 @@ export default class PciUsersAddController {
     this.isLoading = false;
     this.addExistingUser = 'addExistingUser';
     this.createNewUser = 'createNewUser';
-    this.allUserList = this.allUserList
-      .filter((user) => user)
+    this.users = this.allUserList
+      .filter((user) => user && user.status === 'ok')
       .map((user) => ({
         ...user,
         asCredentials: this.usersCredentials.find(
@@ -39,7 +39,7 @@ export default class PciUsersAddController {
               'pci_projects_project_users_add_as_no_credentials',
             ),
       }));
-    this.usersWithoutCredentials = this.allUserList
+    this.usersWithoutCredentials = this.users
       .filter(({ s3Credentials }) => !s3Credentials.length)
       .map((user) => ({
         ...user,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-9093`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9947
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display created users only while Creating a container, Associating a User to Container, Creating a User and Associating User to an object.

## Related

<!-- Link dependencies of this PR -->
