### PR TITLE
fix(pci.block-storage): display correct unit

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/add/add.controller.js
@@ -133,14 +133,26 @@ export default class PciBlockStorageAddController {
     return iops.max || iops.level;
   }
 
+  static getDisplayUnit(unit) {
+    const perGB = '/GB';
+    if (unit.endsWith(perGB)) {
+      return unit.slice(0, unit.lastIndexOf(perGB));
+    }
+    return unit;
+  }
+
   computeBandwidthToAllocate() {
     const { bandwidth } = this.selectedVolumeAddon.blobs.technical;
     const allocatedBandwidth = this.storage.size * bandwidth.level;
     const maxBandwidthInMb = bandwidth.max * 1000;
 
     return allocatedBandwidth <= maxBandwidthInMb
-      ? `${allocatedBandwidth} ${bandwidth.unit}`
-      : `${maxBandwidthInMb} ${bandwidth.unit}`;
+      ? `${allocatedBandwidth} ${PciBlockStorageAddController.getDisplayUnit(
+          bandwidth.unit,
+        )}`
+      : `${maxBandwidthInMb} ${PciBlockStorageAddController.getDisplayUnit(
+          bandwidth.unit,
+        )}`;
   }
 
   computeIopsToAllocate() {
@@ -148,8 +160,10 @@ export default class PciBlockStorageAddController {
     const allocatedIops = this.storage.size * volume.iops.level;
 
     return allocatedIops <= volume.iops.max
-      ? `${allocatedIops} ${volume.iops.unit}`
-      : `${volume.iops.max} ${volume.iops.unit}`;
+      ? `${allocatedIops} ${PciBlockStorageAddController.getDisplayUnit(
+          volume.iops.unit,
+        )}`
+      : `${volume.iops.max} ${volume.iops.maxUnit}`;
   }
 
   isHighSpeedGen2Volume() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-96695
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display appropriate unit while creating Volume. API gives unit per GB. So `/GB` needs to be removed from the unit provided by API

## Related

<!-- Link dependencies of this PR -->
