### PR TITLE
fix(pci.project): display floating ip as default page

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/additional-ips/additional-ips.html
+++ b/packages/manager/modules/pci/src/projects/project/additional-ips/additional-ips.html
@@ -6,19 +6,19 @@
     >
         <oui-header-tabs>
             <oui-header-tabs-item
-                data-href="{{:: $ctrl.failoverIpsLink }}"
-                data-active="$ctrl.currentActiveLink() === $ctrl.failoverIpsLink"
-            >
-                <span
-                    data-translate="pci_additional_ips_failover_ip_title"
-                ></span>
-            </oui-header-tabs-item>
-            <oui-header-tabs-item
                 data-href="{{:: $ctrl.floatingIpsLink }}"
                 data-active="$ctrl.currentActiveLink() === $ctrl.floatingIpsLink"
             >
                 <span
                     data-translate="pci_additional_ips_floating_ip_title"
+                ></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item
+                data-href="{{:: $ctrl.failoverIpsLink }}"
+                data-active="$ctrl.currentActiveLink() === $ctrl.failoverIpsLink"
+            >
+                <span
+                    data-translate="pci_additional_ips_failover_ip_title"
                 ></span>
             </oui-header-tabs-item>
         </oui-header-tabs>

--- a/packages/manager/modules/pci/src/projects/project/additional-ips/additional-ips.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/additional-ips/additional-ips.routing.js
@@ -2,7 +2,7 @@ import map from 'lodash/map';
 import { TABS, TRACKING_PREFIX } from './additional-ips.constants';
 import { PCI_FEATURES } from '../../projects.constant';
 
-const getStateToNavigate = (activeTab = TABS.FAILOVER_IP) =>
+const getStateToNavigate = (activeTab = TABS.FLOATING_IP) =>
   activeTab === TABS.FLOATING_IP
     ? 'pci.projects.project.additional-ips.floating-ips'
     : 'pci.projects.project.additional-ips.failover-ips';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/l3-services`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10021
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Updation of additional ip page with Floating IP as default page instead of Failover IP.

## Related

<!-- Link dependencies of this PR -->
