### PR TITLE
fix(pci.storage.databases): datatr-89 - remove help text

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/service-integration/add/add.html
@@ -115,10 +115,9 @@
             <oui-field
                 data-label="{{parameter.name}}"
                 data-help-text="{{:: 'pci_databases_service_integration_add_string_parameter_description' | translate }}"
+                data-ng-if="parameter.type === 'string'"
             >
-                <input type="hidden" name="hiddenfield" />
                 <input
-                    data-ng-if="parameter.type === 'string'"
                     class="oui-input"
                     type="text"
                     name="{{parameter.name}}"
@@ -127,8 +126,12 @@
                     data-ng-maxlength="$ctrl.stringParameterOptions.maxLength"
                     required
                 />
+            </oui-field>
+            <oui-field
+                data-label="{{parameter.name}}"
+                data-ng-if="parameter.type === 'integer'"
+            >
                 <oui-numeric
-                    data-ng-if="parameter.type === 'integer'"
                     data-min="1"
                     data-model="$ctrl.parameters[parameter.name]"
                     data-required


### PR DESCRIPTION
DATATR-89

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/datatr-30-new-integrations`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-89
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Remove help-text for numeric inputs in the integration add page.