### PR TITLE
refactor(*): use /services in place of /order/upgrade

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.component.js
@@ -13,5 +13,6 @@ export default {
     user: '<',
     handleError: '<',
     handleSuccess: '<',
+    serviceId: '<',
   },
 };

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.routing.js
@@ -20,6 +20,15 @@ export default /* @ngInject */ ($stateProvider) => {
         breadcrumb: () => null,
         hasDefaultPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
           ovhPaymentMethod.hasDefaultPaymentMethod(),
+        serviceId: /* @ngInject */ ($http, serviceInfos) =>
+          $http
+            .get(`/services/${serviceInfos.serviceId}/options`)
+            .then(
+              ({ data: options }) =>
+                options.find((option) =>
+                  option.resource.product.name.startsWith('vrack-bandwidth'),
+                )?.serviceId,
+            ),
         trackingPrefix: () =>
           'dedicated::server::interfaces::bandwidth-private-order::',
       },

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/template.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/template.html
@@ -9,4 +9,5 @@
     specifications="$ctrl.specifications"
     tracking-prefix="$ctrl.trackingPrefix"
     user="$ctrl.user"
+    service-id="$ctrl.serviceId"
 ></server-order-private-bandwidth>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.component.js
@@ -10,6 +10,7 @@ export default {
     goBack: '<',
     hasDefaultPaymentMethod: '<',
     serverName: '<',
+    serviceId: '<',
     specifications: '<',
     trackingPrefix: '<',
     user: '<',

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
@@ -20,7 +20,7 @@ export default class {
         isLoading: () => this.isLoading,
         load: () => {
           this.isLoading = true;
-          return this.Server.getBareMetalPublicBandwidthOptions(this.serverName)
+          return this.Server.getBareMetalPublicBandwidthOptions(this.serviceId)
             .then((plans) => {
               this.plans = this.Server.getValidBandwidthPlans(plans);
               this.plans.sort(
@@ -47,8 +47,9 @@ export default class {
         load: () => {
           this.isLoading = true;
           return this.Server.getBareMetalPublicBandwidthOrder(
-            this.serverName,
+            this.serviceId,
             this.model.plan,
+            this.getServiceUpgradeParams(),
           )
             .then((res) => {
               res.bandwidth = find(this.plans, {
@@ -91,9 +92,9 @@ export default class {
       this.isLoading = true;
       this.atTrack(`${this.trackingPrefix}confirm`);
       this.Server.bareMetalPublicBandwidthPlaceOrder(
-        this.serverName,
+        this.serviceId,
         this.model.plan,
-        this.region === 'US' || this.model.autoPay,
+        this.getServiceUpgradeParams(),
       )
         .then((result) => {
           this.model.orderUrl = result.order.url;
@@ -111,5 +112,18 @@ export default class {
 
   seeOrder() {
     this.$window.open(this.model.orderUrl, '_blank');
+  }
+
+  getServiceUpgradeParams() {
+    const { duration, pricingMode } = this.plans
+      .find(({ planCode }) => planCode === this.model.plan)
+      ?.prices?.find(({ capacities }) => capacities.includes('renew'));
+    return {
+      autoPayWithPreferredPaymentMethod:
+        this.region === 'US' || this.model.autoPay,
+      duration,
+      pricingMode,
+      quantity: 1,
+    };
   }
 }

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.routing.js
@@ -20,6 +20,15 @@ export default /* @ngInject */ ($stateProvider) => {
         breadcrumb: () => null,
         hasDefaultPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
           ovhPaymentMethod.hasDefaultPaymentMethod(),
+        serviceId: /* @ngInject */ ($http, serviceInfos) =>
+          $http
+            .get(`/services/${serviceInfos.serviceId}/options`)
+            .then(
+              ({ data: options }) =>
+                options.find((option) =>
+                  option.resource.product.name.startsWith('bandwidth-'),
+                )?.serviceId,
+            ),
         trackingPrefix: () =>
           'dedicated::server::interfaces::bandwidth-public-order::',
       },

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
@@ -7,6 +7,7 @@ export default {
     goBack: '<',
     hasDefaultPaymentMethod: '<',
     serverName: '<',
+    serviceId: '<',
     specifications: '<',
     trackingPrefix: '<',
     user: '<',

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/service.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/service.js
@@ -4,34 +4,21 @@ export default class BmServerComponentsOrderPrivateBandwidthService {
     this.$http = $http;
   }
 
-  getBareMetalPrivateBandwidthOptions(serviceName) {
+  getBareMetalPrivateBandwidthOptions(serviceId) {
     return this.$http
-      .get(`/order/upgrade/baremetalPrivateBandwidth/${serviceName}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getBareMetalPrivateBandwidthOrder(serviceName, planCode) {
+  getBareMetalPrivateBandwidthOrder(serviceId, planCode, params) {
     return this.$http
-      .get(
-        `/order/upgrade/baremetalPrivateBandwidth/${serviceName}/${planCode}`,
-        {
-          params: {
-            quantity: 1,
-          },
-        },
-      )
+      .post(`/services/${serviceId}/upgrade/${planCode}/simulate`, params)
       .then(({ data }) => data);
   }
 
-  bareMetalPrivateBandwidthPlaceOrder(serviceName, planCode, autoPay) {
+  bareMetalPrivateBandwidthPlaceOrder(serviceId, planCode, params) {
     return this.$http
-      .post(
-        `/order/upgrade/baremetalPrivateBandwidth/${serviceName}/${planCode}`,
-        {
-          quantity: 1,
-          autoPayWithPreferredPaymentMethod: autoPay,
-        },
-      )
+      .post(`/services/${serviceId}/upgrade/${planCode}/execute`, params)
       .then(({ data }) => data);
   }
 }

--- a/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/routing.js
+++ b/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/routing.js
@@ -77,20 +77,20 @@ export default /* @ngInject */ ($stateProvider) => {
       upgradeInfo: /* @ngInject */ (
         $q,
         configurationTile,
-        serviceName,
+        serviceInfos,
         upgradeSuccess,
         upgradeType,
         vpsUpgrade,
+        defaultPaymentMethod,
       ) => {
         if (upgradeSuccess) {
           return true;
         }
-
         return vpsUpgrade
           .getUpgrade(
-            serviceName,
-            get(configurationTile.upgrades, `${upgradeType}.plan.planCode`),
-            { quantity: 1 },
+            serviceInfos.serviceId,
+            get(configurationTile.upgrades, `${upgradeType}.plan`),
+            defaultPaymentMethod != null,
           )
           .catch((error) => {
             if (error.status === 400) {

--- a/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/service.js
+++ b/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/service.js
@@ -11,23 +11,42 @@ export default class VpsUpgradeService {
     this.upgradeTaskPolling = null;
   }
 
-  getAvailableUpgrades(serviceName) {
+  static getPlanUpgradeParams(plan, autoPayWithPreferredPaymentMethod) {
+    return {
+      autoPayWithPreferredPaymentMethod,
+      duration: plan.prices[2]?.duration,
+      pricingMode: plan.prices[2]?.pricingMode,
+      quantity: 1,
+    };
+  }
+
+  getAvailableUpgrades(serviceId) {
     return this.$http
-      .get(`/order/upgrade/vps/${serviceName}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getUpgrade(serviceName, planCode, params) {
+  getUpgrade(serviceId, plan, autoPayWithPreferredPaymentMethod) {
     return this.$http
-      .get(`/order/upgrade/vps/${serviceName}/${planCode}`, {
-        params,
-      })
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/simulate `,
+        VpsUpgradeService.getPlanUpgradeParams(
+          plan,
+          autoPayWithPreferredPaymentMethod,
+        ),
+      )
       .then(({ data }) => data);
   }
 
-  startUpgrade(serviceName, planCode, httpData) {
+  startUpgrade(serviceId, plan, autoPayWithPreferredPaymentMethod) {
     return this.$http
-      .post(`/order/upgrade/vps/${serviceName}/${planCode}`, httpData)
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/execute `,
+        VpsUpgradeService.getPlanUpgradeParams(
+          plan,
+          autoPayWithPreferredPaymentMethod,
+        ),
+      )
       .then(({ data }) => data);
   }
 

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -69,10 +69,12 @@ export default /* @ngInject */ ($stateProvider) => {
 
       availableUpgrades: /* @ngInject */ (
         isVpsNewRange,
-        serviceName,
+        serviceInfos,
         vpsUpgradeTile,
       ) =>
-        isVpsNewRange ? vpsUpgradeTile.getAvailableUpgrades(serviceName) : [],
+        isVpsNewRange
+          ? vpsUpgradeTile.getAvailableUpgrades(serviceInfos.serviceId)
+          : [],
 
       isCommitmentAvailable: /* @ngInject */ (ovhFeatureFlipping) =>
         ovhFeatureFlipping

--- a/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
+++ b/packages/manager/modules/vps/src/upgrade/vps-upgrade.controller.js
@@ -257,7 +257,7 @@ export default class VpsUpgradeCtrl {
       })
       .then(({ availableUpgrades, availableOffers }) => {
         // map available upgrades by adding details with the informations
-        // provided by /order/upgrade/vps API response
+        // provided by /services/vpsServiceId/upgrade API response
         const availableUpgrade = map(availableUpgrades, (upgradeParam) => {
           const upgrade = upgradeParam;
           upgrade.isCurrentOffer = false;

--- a/packages/manager/modules/vps/src/upscale/upscale.controller.js
+++ b/packages/manager/modules/vps/src/upscale/upscale.controller.js
@@ -392,14 +392,10 @@ export default class UpscaleController {
     this.scrollToTop();
   }
 
-  fetchUpscaleInformation(_planCode) {
+  fetchUpscaleInformation() {
     this.loading.getUpscaleInformation = true;
-    let planCode = _planCode;
-    if (!planCode) {
-      planCode = this.range.planCode;
-    }
 
-    return this.getUpscaleInformation(planCode)
+    return this.getUpscaleInformation(this.range)
       .then(({ order }) => {
         this.order = order;
         this.order.prices.withoutTax.unit = Price.UNITS.CENTS;
@@ -478,9 +474,8 @@ export default class UpscaleController {
     });
 
     this.loading.performUpscale = true;
-    const planCode = this.planCode || this.range.planCode;
 
-    return this.performUpscale(planCode)
+    return this.performUpscale(this.range)
       .then((upscaleOrder) => {
         const baseKey = this.isEliteUpgrade
           ? 'vps_upscale_elite_upgrade_success'

--- a/packages/manager/modules/vps/src/upscale/upscale.html
+++ b/packages/manager/modules/vps/src/upscale/upscale.html
@@ -233,7 +233,7 @@
         </oui-step-form>
         <oui-step-form
             header="{{:: 'vps_upscale_user_conditions_agreements' | translate }}"
-            on-focus="$ctrl.fetchUpscaleInformation($ctrl.planCode)"
+            on-focus="$ctrl.fetchUpscaleInformation()"
             loading="$ctrl.loading.getUpscaleInformation"
             editable="!$ctrl.loading.performUpscale"
             prevent-next="true"

--- a/packages/manager/modules/web-paas/src/components/addon/component.js
+++ b/packages/manager/modules/web-paas/src/components/addon/component.js
@@ -13,6 +13,7 @@ export default {
     selectedPlan: '<',
     user: '<',
     trackTextPrefix: '<',
+    addOnServiceId: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/web-paas/src/components/addon/controller.js
+++ b/packages/manager/modules/web-paas/src/components/addon/controller.js
@@ -71,7 +71,12 @@ export default class {
           : this.addon.quantity);
     }
 
-    this.WebPaas.getAddonSummary(this.project, this.addon, this.quantity)
+    this.WebPaas.getAddonSummary(
+      this.project,
+      this.addon,
+      this.quantity,
+      this.addOnServiceId,
+    )
       .then(({ contracts, prices, cart }) => {
         this.cart = cart;
         this.contracts = contracts;
@@ -105,6 +110,7 @@ export default class {
       this.project.serviceId,
       this.addon,
       this.quantity,
+      this.addOnServiceId,
     )
       .then(({ order }) => this.onAddonOrderSuccess(order))
       .catch((error) =>

--- a/packages/manager/modules/web-paas/src/components/addon/utils.js
+++ b/packages/manager/modules/web-paas/src/components/addon/utils.js
@@ -28,6 +28,19 @@ export const commonResolves = {
       },
     );
   },
+  addOnServiceId: (WebPaas, serviceInfo, addonType) => {
+    if (addonType === ADDON_TYPE.STORAGE) {
+      return WebPaas.getAddOnServiceId(
+        serviceInfo.serviceId,
+        ADDON_TYPE.ENVIRONMENT,
+      ).then((stagingServiceId) =>
+        WebPaas.getAddOnServiceId(stagingServiceId, ADDON_TYPE.STORAGE).then(
+          (serviceId) => serviceId,
+        ),
+      );
+    }
+    return WebPaas.getAddOnServiceId(serviceInfo.serviceId, addonType);
+  },
   getOrderUrl: /* @ngInject */ () => (orderId) =>
     buildURL('dedicated', '#/billing/orders', {
       status: 'all',

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.component.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.component.js
@@ -12,6 +12,7 @@ export default {
     plans: '<',
     projectId: '<',
     selectedProject: '<',
+    serviceInfo: '<',
     user: '<',
   },
   controller,

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.controller.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.controller.js
@@ -160,8 +160,9 @@ export default class {
     set(this.selectedProject, 'quantity', 1);
     this.getTotalPrice();
     return this.WebPaas.getUpgradeCheckoutInfo(
-      this.selectedProject.serviceId,
+      this.serviceInfo.serviceId,
       this.selectedPlan,
+      this.selectedProject.quantity,
     )
       .then(({ contracts, prices, cart }) => {
         this.cart = cart;
@@ -178,7 +179,7 @@ export default class {
     this.trackChangeOffer('confirm');
     this.orderInProgress = true;
     return this.WebPaas.checkoutUpgrade(
-      this.selectedProject.serviceId,
+      this.serviceInfo.serviceId,
       this.selectedPlan,
       this.selectedProject.quantity,
     )

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.routing.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.routing.js
@@ -15,8 +15,13 @@ export default /* @ngInject */ ($stateProvider) => {
       cpu: /* @ngInject */ ($transition$) => $transition$.params().cpu,
       selectedProject: /* @ngInject */ (WebPaas, projectId) =>
         WebPaas.getProjectDetails(projectId),
-      availablePlans: /* @ngInject */ (selectedProject, WebPaas, cpu) =>
-        WebPaas.getUpgradeOffers(selectedProject.serviceId).then((data) => {
+      availablePlans: /* @ngInject */ (
+        selectedProject,
+        serviceInfo,
+        WebPaas,
+        cpu,
+      ) =>
+        WebPaas.getUpgradeOffers(serviceInfo.serviceId).then((data) => {
           if (cpu) {
             return compact(
               map(data, (plan) =>

--- a/packages/manager/modules/web-paas/src/web-paas.service.js
+++ b/packages/manager/modules/web-paas/src/web-paas.service.js
@@ -75,6 +75,16 @@ export default class WebPaasService {
       });
   }
 
+  getAddOnServiceId(serviceId, addOnType) {
+    return this.$http
+      .get(`/services/${serviceId}/options`)
+      .then(
+        ({ data }) =>
+          data.find((addOn) => addOn.resource?.product?.name === addOnType)
+            ?.serviceId,
+      );
+  }
+
   getProjectDetails(projectId) {
     return this.$http
       .get(`/webPaaS/subscription/${projectId}`)
@@ -331,9 +341,9 @@ export default class WebPaasService {
       .finally(() => this.deleteCart());
   }
 
-  getAddonSummary(project, addon, quantity) {
+  getAddonSummary(project, addon, quantity, addOnServiceId) {
     if (addon.serviceName && addon.environmentServiceName === undefined) {
-      return this.getUpgradeCheckoutInfo(addon.serviceName, addon, quantity);
+      return this.getUpgradeCheckoutInfo(addOnServiceId, addon, quantity);
     }
 
     return this.createCart()
@@ -378,11 +388,11 @@ export default class WebPaasService {
     return this.OvhApiOrderCart.getCheckout({ cartId: cart.cartId }).$promise;
   }
 
-  checkoutAddon(cart, serviceName, selectedPlan, quantity) {
+  checkoutAddon(cart, serviceName, selectedPlan, quantity, addOnServiceId) {
     if (cart) {
       return this.goToExpressOrderOption(serviceName, selectedPlan, quantity);
     }
-    return this.checkoutUpgrade(serviceName, selectedPlan, quantity);
+    return this.checkoutUpgrade(addOnServiceId, selectedPlan, quantity);
   }
 
   getAdditionalOption(serviceName, project) {
@@ -411,32 +421,41 @@ export default class WebPaasService {
     }).$promise;
   }
 
-  getUpgradeOffers(projectId) {
+  getUpgradeOffers(serviceId) {
     return this.$http
-      .get(`/order/upgrade/webPaaS/${projectId}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getUpgradeCheckoutInfo(serviceName, plan, quantity) {
+  static getServiceUpgradeParams(plan, quantity) {
+    const pricings = plan.pricings ? plan.pricings : plan.prices;
+    const pricing = pricings.find(({ capacities }) =>
+      capacities.includes('renew'),
+    );
+    return {
+      autoPayWithPreferredPaymentMethod: true,
+      duration:
+        pricing.duration ||
+        `P${pricing.interval}${pricing.intervalUnit[0]?.toUpperCase()}`,
+      pricingMode: pricing.pricingMode || pricing.mode,
+      quantity,
+    };
+  }
+
+  getUpgradeCheckoutInfo(serviceId, plan, quantity) {
     return this.$http
-      .get(`/order/upgrade/webPaaS/${serviceName}/${plan.planCode}`, {
-        params: {
-          quantity: quantity || plan.quantity,
-        },
-      })
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/simulate`,
+        WebPaasService.getServiceUpgradeParams(plan, quantity),
+      )
       .then(({ data }) => data.order);
   }
 
-  checkoutUpgrade(serviceName, plan, quantity) {
+  checkoutUpgrade(serviceId, plan, quantity) {
     return this.$http
       .post(
-        `/order/upgrade/webPaaS/${
-          plan.serviceName ? plan.serviceName : serviceName
-        }/${plan.planCode}`,
-        {
-          autoPayWithPreferredPaymentMethod: true,
-          quantity: quantity || plan.quantity,
-        },
+        `/services/${serviceId}/upgrade/${plan.planCode}/execute`,
+        WebPaasService.getServiceUpgradeParams(plan, quantity),
       )
       .then(({ data }) => data);
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2236-2238`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10011
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Replace `/order/upgrade` API calls with `/services` in the following actions

- Server Bandwidth Upgrade (Public and Private)
- VPS Upgrade (Storage, RAM, cores, Upscale)
- Web-PaaS (User License, Storage, Range and Test Environment)


## Related

<!-- Link dependencies of this PR -->
