### PR TITLE
feat(dedicated-ip): add cta and icons in ip dashboard

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/ip.constant.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip.constant.js
@@ -1,0 +1,5 @@
+export const BRING_YOUR_OWN_IP = 'Bring your own IP';
+
+export default {
+  BRING_YOUR_OWN_IP,
+};

--- a/packages/manager/apps/dedicated/client/app/ip/ip.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip.controller.js
@@ -1,3 +1,5 @@
+import { BRING_YOUR_OWN_IP } from './ip.constant';
+
 export default /* @ngInject */ function IpMainCtrl(
   $scope,
   $timeout,
@@ -8,14 +10,18 @@ export default /* @ngInject */ function IpMainCtrl(
   currentUser,
   dashboardLink,
   goToOrganisation,
+  goToByoipConfiguration,
+  goToAgoraOrder,
 ) {
   $scope.currentUser = currentUser;
   this.currentActiveLink = currentActiveLink;
   this.dashboardLink = dashboardLink;
 
   $scope.goToOrganisation = () => goToOrganisation();
-
+  $scope.goToByoipConfiguration = goToByoipConfiguration;
+  $scope.goToAgoraOrder = goToAgoraOrder;
   $scope.worldPart = coreConfig.getRegion();
+  $scope.BRING_YOUR_OWN_IP = BRING_YOUR_OWN_IP;
 
   // ---
 

--- a/packages/manager/apps/dedicated/client/app/ip/ip.html
+++ b/packages/manager/apps/dedicated/client/app/ip/ip.html
@@ -1,5 +1,32 @@
 <div data-ui-view="byoip">
-    <oui-header heading="{{:: 'module_ip_dashboard_title' | translate }}">
+    <header class="oui-header">
+        <div class="oui-header__container">
+            <h1 class="oui-header__title">
+                <span data-translate="module_ip_dashboard_title"></span>
+                <oui-button
+                    class="oui-button_secondary"
+                    data-on-click="goToAgoraOrder()"
+                >
+                    <i
+                        class="oui-icon oui-icon-add pr-1"
+                        aria-hidden="true"
+                    ></i>
+                    <span
+                        data-translate="module_ip_dashboard_order_IP_action_label"
+                    ></span>
+                </oui-button>
+                <oui-button
+                    class="oui-button_secondary"
+                    data-on-click="goToByoipConfiguration()"
+                >
+                    <i
+                        class="oui-icon oui-icon-add pr-1"
+                        aria-hidden="true"
+                    ></i>
+                    <span data-ng-bind=":: BRING_YOUR_OWN_IP"></span>
+                </oui-button>
+            </h1>
+        </div>
         <oui-header-tabs>
             <oui-header-tabs-item
                 href="{{ $ctrl.dashboardLink }}"
@@ -8,7 +35,7 @@
                 <span data-translate="ip_ip"></span>
             </oui-header-tabs-item>
         </oui-header-tabs>
-    </oui-header>
+    </header>
 
     <div>
         <div data-ovh-alert></div>

--- a/packages/manager/apps/dedicated/client/app/ip/ip.routing.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip.routing.js
@@ -35,6 +35,14 @@ export default /* @ngInject */ ($stateProvider) => {
         ovhFeatureFlipping
           .checkFeatureAvailability(allowByoipFeatureName)
           .then((feature) => feature.isFeatureAvailable(allowByoipFeatureName)),
+      goToByoipConfiguration: /* @ngInject */ ($state, trackClick) => () => {
+        trackClick('bring-your-own-ip');
+        return $state.go('app.ip.byoip');
+      },
+      goToAgoraOrder: /* @ngInject */ ($state, trackPage) => () => {
+        trackPage('order');
+        return $state.go('app.ip.dashboard.agora-order');
+      },
       breadcrumb: /* @ngInject */ ($translate) => $translate.instant('ip_ip'),
     },
     atInternet: {

--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.controller.js
@@ -126,6 +126,7 @@ export default /* @ngInject */
     ipFeatureAvailability.allowIPFailoverOrder() && orderIpAvailable;
   $scope.canOrderAgoraIPFO = () =>
     ipFeatureAvailability.allowIPFailoverAgoraOrder() && orderIpAvailable;
+  $scope.canExportCsv = () => $scope.state.loaded !== $scope.state.total;
   $scope.goToAgoraOrder = goToAgoraOrder;
   $scope.goToByoipConfiguration = goToByoipConfiguration;
 

--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.html
@@ -185,6 +185,39 @@
             </div>
         </div>
         <h4 data-translate="ip_addresses_grid_header"></h4>
+        <div class="float-right">
+            <oui-dropdown>
+                <button
+                    type="button"
+                    class="oui-button oui-button_secondary oui-button_s"
+                    oui-dropdown-trigger
+                >
+                    <span
+                        class="oui-icon oui-icon-settings"
+                        aria-hidden="true"
+                    ></span>
+                </button>
+                <oui-dropdown-content>
+                    <oui-dropdown-item
+                        on-click="importIPFO()"
+                        data-ng-if="canImportIPFO()"
+                    >
+                        <span data-translate="ip_migration"></span>
+                    </oui-dropdown-item>
+                    <oui-dropdown-item on-click="displayOrganisation()">
+                        <span data-translate="ip_organisation_button"></span>
+                    </oui-dropdown-item>
+                </oui-dropdown-content>
+            </oui-dropdown>
+            <oui-button
+                type="button"
+                class="oui-button_secondary"
+                disabled="canExportCsv()"
+                on-click="exportCsv(ipsList)"
+            >
+                <span class="oui-icon oui-icon-export_concept"></span>
+            </oui-button>
+        </div>
         <div class="form-group w-25" data-ng-if="services.length">
             <label
                 class="control-label"

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
@@ -1,5 +1,6 @@
 {
   "module_ip_dashboard_title": "Gérer les IPs",
+  "module_ip_dashboard_order_IP_action_label": "Commander une IP",
   "ip_dashboard_error": "Une erreur est survenue lors du chargement de vos informations.",
   "ip_services_error": "Une erreur est survenue lors du chargement de ces services : {{t0}}. Veuillez réessayer plus tard.",
   "ip_block_error": "Une erreur est survenue lors du chargement des informations de {{t0}}.",
@@ -485,7 +486,7 @@
   "ip_order_finish_error": "Une erreur est survenue lors de la commande d'IPs additionnelles.",
   "ip_order_free_activation_fee": "Pour les serveurs dont l'abonnement des IPs additionnelles est offert, ces frais d'activation ne seront pas refacturés à l'issu du renouvellement du serveur.",
   "ip_organisation_title": "Gérer mes organisations",
-  "ip_organisation_button": "Gérer mes organisations",
+  "ip_organisation_button": "Gérer mes organisation",
   "ip_organisation_table_organisation": "Organisation",
   "ip_organisation_table_type": "Type",
   "ip_organisation_table_lastname": "Nom",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/ip-strat`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-9932
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

In dashboard of IP section add :
Next to the title add 2 CTA:
   - Commander une IP 
   - Bring you own IP 
Setting icon:
   - Importer mes adresses IP de SYS vers OVHcloud 
   - Gérer mes organisations 
Download Icon
