### PR TITLE
feat(pci.ai.apps): datatr-81 - ai deploy - custom readiness probe

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.constants.js
@@ -17,6 +17,14 @@ export const APP_ATTACH_STORAGE = {
   MAX_VOLUMES: 10,
 };
 
+export const APP_PROBE = {
+  MIN_PATH_LENGTH: 1,
+  MAX_PATH_LENGTH: 1000,
+  PATH_REGEX: '^[a-zA-Z0-9._-/]+$',
+  MIN_PORT: 1024,
+  MAX_PORT: 65535,
+};
+
 export default {
   APP_LABELS,
   APP_PRIVACY_SETTINGS,

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.controller.js
@@ -34,6 +34,11 @@ export default class AppAddController {
       preset: null,
       port: 8080,
       useCase: null,
+      probe: {
+        enabled: false,
+        path: null,
+        port: 8080,
+      },
       resource: {
         nbResources: 1,
         usage: 'cpu',
@@ -87,6 +92,16 @@ export default class AppAddController {
     });
   }
 
+  static buildProbe(probe) {
+    const { enabled, path, port } = probe;
+    return enabled
+      ? {
+          path,
+          port,
+        }
+      : null;
+  }
+
   static convertAppModel(appModel) {
     const {
       name,
@@ -98,6 +113,7 @@ export default class AppAddController {
       privacy,
       replicas,
       preset,
+      probe,
     } = appModel;
 
     return {
@@ -117,6 +133,7 @@ export default class AppAddController {
           replicas,
         },
       },
+      probe: AppAddController.buildProbe(probe),
     };
   }
 

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.html
@@ -137,7 +137,7 @@
         data-loading="$ctrl.isAdding"
     >
         <app-review
-            data-ng-if="stepReview.display && !$ctrl.stepper.appAttach.display"
+            data-ng-if="stepReview.display && !$ctrl.stepper.appSettings.display"
             data-project-id="$ctrl.projectId"
             data-app-model="$ctrl.appModel"
             data-convert-model-to-specs="$ctrl.constructor.convertAppModel"

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/app-configuration.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/app-configuration.controller.js
@@ -1,4 +1,8 @@
-import { APP_LABELS, APP_PRIVACY_SETTINGS } from '../../add.constants';
+import {
+  APP_LABELS,
+  APP_PRIVACY_SETTINGS,
+  APP_PROBE,
+} from '../../add.constants';
 import { nameGenerator } from '../../../../../data-processing/data-processing.utils';
 
 export default class AppConfigurationController {
@@ -9,6 +13,7 @@ export default class AppConfigurationController {
   constructor() {
     this.APP_LABELS = APP_LABELS;
     this.APP_PRIVACY_SETTINGS = APP_PRIVACY_SETTINGS;
+    this.APP_PROBE = APP_PROBE;
   }
 
   $onInit() {

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/app-configuration.html
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/app-configuration.html
@@ -166,3 +166,56 @@
         </oui-select-picker>
     </div>
 </div>
+<!--Readiness probe-->
+<div>
+    <p class="oui-heading_5 mb-2">
+        <strong data-translate="pci_app_add_readiness_probe"></strong>
+    </p>
+    <p data-translate="pci_app_add_readiness_probe_description"></p>
+
+    <oui-field
+        label="{{:: 'pci_app_add_readiness_probe_switch_label' | translate}}"
+    >
+        <oui-switch data-model="$ctrl.appModel.probe.enabled" name="oui-switch">
+        </oui-switch>
+        <strong
+            class="d-inline-block mx-2"
+            data-ng-bind="($ctrl.appModel.probe.enabled ? 'pci_app_add_readiness_probe_switch_enabled':'pci_app_add_readiness_probe_switch_disabled') | translate"
+        >
+        </strong>
+    </oui-field>
+    <oui-field
+        data-help-text="{{:: 'pci_app_add_readiness_probe_path_help_text' | translate }}"
+        data-label="{{:: 'pci_app_add_readiness_probe_path_label' | translate}}"
+        data-ng-if="$ctrl.appModel.probe.enabled"
+    >
+        <input
+            class="oui-input"
+            type="text"
+            id="probe-path"
+            name="probe-path"
+            placeholder="/health"
+            data-ng-minlength="$ctrl.APP_PROBE.MIN_PATH_LENGTH"
+            data-ng-maxlength="$ctrl.APP_PROBE.MAX_PATH_LENGTH"
+            data-ng-pattern="$ctrl.APP_PROBE.PATH_REGEX"
+            data-ng-model="$ctrl.appModel.probe.path"
+            required
+        />
+    </oui-field>
+    <oui-field
+        data-help-text="{{:: 'pci_app_add_readiness_probe_port_help_text' | translate }}"
+        data-label="{{:: 'pci_app_add_readiness_probe_port_label' | translate}}"
+        data-ng-if="$ctrl.appModel.probe.enabled"
+    >
+        <input
+            class="oui-input"
+            type="number"
+            id="probe-port"
+            name="probe-port"
+            data-ng-model="$ctrl.appModel.probe.port"
+            data-ng-min="$ctrl.APP_PROBE.MIN_PORT"
+            data-ng-max="$ctrl.APP_PROBE.MAX_PORT"
+            required
+        />
+    </oui-field>
+</div>

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-configuration/translations/Messages_fr_FR.json
@@ -15,5 +15,14 @@
   "pci_app_add_privacy_settings_item_public_warning": "Soyez prudent·e avec les données sensibles.",
   "pci_app_add_privacy_title": "Règle d'accès à votre AI App",
   "pci_app_add_settings_port": "Port HTTP",
-  "pci_app_add_settings_port_help": "Port HTTP sur lequel votre AI App est liée."
+  "pci_app_add_settings_port_help": "Port HTTP sur lequel votre AI App est liée.",
+  "pci_app_add_readiness_probe": "Sonde de disponibilité",
+  "pci_app_add_readiness_probe_description": "Afin de pouvoir déterminer lorsque votre application est prête à recevoir une requête HTTP, vous pouvez paramétrer une sonde de disponibilité (Kubernetes Readiness probe) entièrement personnalisée via l'addition d'un point de terminaison API et d'un port.",
+  "pci_app_add_readiness_probe_switch_label": "Utiliser une sonde de disponibilité",
+  "pci_app_add_readiness_probe_switch_enabled": "Sonde de disponibilité activée",
+  "pci_app_add_readiness_probe_switch_disabled": "Sonde de disponibilité désactivée",
+  "pci_app_add_readiness_probe_path_label": "Path de la sonde",
+  "pci_app_add_readiness_probe_path_help_text": "Point de terminaison API de la sonde de disponibilité. Doit renvoyer un statut 2XX ou 3XX",
+  "pci_app_add_readiness_probe_port_label": "Port de la sonde",
+  "pci_app_add_readiness_probe_port_help_text": "Vous permet de configurer un port spécifique pour ce chemin d'accès API"
 }

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-image/app-image.html
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-image/app-image.html
@@ -59,6 +59,7 @@
     oui-tooltip-placement="top"
     type="button"
     data-ng-click="$ctrl.onClickAdvancedImage()"
+    data-ng-if="$ctrl.presets.length > 0"
 >
     <span data-translate="pci_app_submit_select_image_advanced"></span>
 </button>
@@ -67,7 +68,7 @@
     data-size="xl"
     data-help-text="{{:: 'pci_app_submit_select_image_tips' | translate  }}"
     data-label="{{:: 'pci_app_submit_select_image_name' | translate }}"
-    data-ng-if="$ctrl.showAdvancedImage"
+    data-ng-if="$ctrl.showAdvancedImage || $ctrl.presets.length === 0"
 >
     <input
         class="oui-input"

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-review/app-review.html
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-review/app-review.html
@@ -76,6 +76,17 @@
                     data-ng-bind="$ctrl.getResourceInfo()"
                 ></oui-tile-description>
             </oui-tile-definition>
+            <!-- Custom probe -->
+            <oui-tile-definition
+                data-ng-if="$ctrl.appModel.probe.enabled"
+                data-term="{{:: 'pci_app_add_review_probe' | translate }}"
+            >
+                <oui-tile-description>
+                    <code
+                        data-ng-bind="$ctrl.appModel.probe.path + ':' + $ctrl.appModel.probe.port"
+                    ></code>
+                </oui-tile-description>
+            </oui-tile-definition>
         </oui-tile>
     </div>
     <!--App review automation-->

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-review/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/components/app-review/translations/Messages_fr_FR.json
@@ -7,5 +7,6 @@
   "pci_app_add_review_price_resource_free": "Ressource·s offerte·s par OVHcloud pendant l'alpha",
   "pci_app_add_review_price_total": "Prix total",
   "pci_app_add_review_price_info": "{{ price }} HT /heure",
-  "pci_app_add_review_resources": "Modèle et nombre d'instance(s) choisis"
+  "pci_app_add_review_resources": "Modèle et nombre d'instance(s) choisis",
+  "pci_app_add_review_probe": "Sonde de disponibilité"
 }

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/dashboard/general-information/general-information.html
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/dashboard/general-information/general-information.html
@@ -64,6 +64,18 @@
                     </oui-tile-description>
                 </oui-tile-definition>
 
+                <!-- Custom probe -->
+                <oui-tile-definition
+                    data-ng-if="$ctrl.app.spec.probe"
+                    data-term="{{:: 'pci_apps_general_information_info_app_probe' | translate }}"
+                >
+                    <oui-tile-description>
+                        <code
+                            data-ng-bind="$ctrl.app.spec.probe.path + ':' + $ctrl.app.spec.probe.port"
+                        ></code>
+                    </oui-tile-description>
+                </oui-tile-definition>
+
                 <!--Confidentiality-->
                 <oui-tile-definition
                     data-term="{{:: 'pci_apps_general_information_info_app_env_confidentiality' | translate }}"

--- a/packages/manager/modules/pci/src/projects/project/ai/apps/dashboard/general-information/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/dashboard/general-information/translations/Messages_fr_FR.json
@@ -10,6 +10,7 @@
   "pci_apps_general_information_info_app_tags_tag_add": "Ajouter un label",
   "pci_apps_general_information_info_app_tags_tag_remove_success": "Le label a bien été supprimé.",
   "pci_apps_general_information_info_app_tags_tag_remove_fail": "Une erreur est survenue lors de la suppression du label : {{ message }}.",
+  "pci_apps_general_information_info_app_probe": "Sonde de disponibilité",
   "pci_apps_general_information_info_app_env": "Environnement",
   "pci_apps_general_information_info_app_env_confidentiality": "Confidentialité",
   "pci_apps_general_information_info_app_env_confidentiality_true": "Publique",


### PR DESCRIPTION
DATATR-81

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/ai-apps-beta`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DATATR-81
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Add readiness probe to ai deploy