### PR TITLE
feat(*): replace /order/upgrade API calls with /services

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenters/upgrade-range/component.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenters/upgrade-range/component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     backButtonText: '<',
     goBack: '<',
+    managementFeeServiceId: '<',
     productId: '<',
     range: '<',
     upgradeCode: '<',

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenters/upgrade-range/controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenters/upgrade-range/controller.js
@@ -10,11 +10,26 @@ export default class {
       init: true,
     };
 
-    return this.DedicatedCloud.getManagementFee(
-      this.productId,
+    return this.DedicatedCloud.getManagementFeePlan(
+      this.managementFeeServiceId,
       this.upgradeCode,
       1,
     )
+      .then((data) => {
+        const renewPrice = data.prices?.find((price) =>
+          price.capacities.includes('renew'),
+        );
+        this.plan = {
+          planCode: this.upgradeCode,
+          duration: renewPrice?.duration,
+          pricingMode: renewPrice?.pricingMode,
+        };
+        return this.DedicatedCloud.getOrderDetails(
+          this.managementFeeServiceId,
+          this.plan,
+          1,
+        );
+      })
       .then((data) => {
         this.upgradePlan = data;
       })
@@ -38,8 +53,8 @@ export default class {
     this.loading.init = true;
 
     return this.DedicatedCloud.orderManagementFee(
-      this.productId,
-      this.upgradeCode,
+      this.managementFeeServiceId,
+      this.plan,
       1,
     )
       .then(() => {

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dedicatedCloud.service.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dedicatedCloud.service.js
@@ -1498,29 +1498,32 @@ class DedicatedCloudService {
   }
 
   /* ------- Management Fees -------*/
-  getManagementFee(serviceName, planCode, quantity) {
-    return this.OvhHttp.get(
-      `/order/upgrade/privateCloudManagementFee/${serviceName}%2Fmanagementfee/${planCode}`,
-      {
-        rootPath: 'apiv6',
-        params: {
-          quantity,
-        },
-      },
-    );
+  getManagementFeePlan(serviceId, planCode) {
+    return this.$http
+      .get(`/services/${serviceId}/upgrade/${planCode}`)
+      .then(({ data }) => data);
   }
 
-  orderManagementFee(serviceName, planCode, quantity) {
-    return this.OvhHttp.post(
-      `/order/upgrade/privateCloudManagementFee/${serviceName}%2Fmanagementfee/${planCode}`,
-      {
-        rootPath: 'apiv6',
-        data: {
-          quantity,
-          autoPayWithPreferredPaymentMethod: true,
-        },
-      },
-    );
+  getOrderDetails(serviceId, plan, quantity) {
+    return this.$http
+      .post(`/services/${serviceId}/upgrade/${plan.planCode}/simulate`, {
+        quantity,
+        duration: plan.duration,
+        pricingMode: plan.pricingMode,
+        autoPayWithPreferredPaymentMethod: true,
+      })
+      .then(({ data }) => data);
+  }
+
+  orderManagementFee(serviceId, plan, quantity) {
+    return this.$http
+      .post(`/services/${serviceId}/upgrade/${plan.planCode}/execute`, {
+        quantity,
+        duration: plan.duration,
+        pricingMode: plan.pricingMode,
+        autoPayWithPreferredPaymentMethod: true,
+      })
+      .then(({ data }) => data);
   }
 
   /* ------- Operations -------*/

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.component.js
@@ -13,5 +13,6 @@ export default {
     user: '<',
     handleError: '<',
     handleSuccess: '<',
+    serviceId: '<',
   },
 };

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/private-order.routing.js
@@ -20,6 +20,15 @@ export default /* @ngInject */ ($stateProvider) => {
         breadcrumb: () => null,
         hasDefaultPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
           ovhPaymentMethod.hasDefaultPaymentMethod(),
+        serviceId: /* @ngInject */ ($http, serviceInfos) =>
+          $http
+            .get(`/services/${serviceInfos.serviceId}/options`)
+            .then(
+              ({ data: options }) =>
+                options.find((option) =>
+                  option.resource.product.name.startsWith('vrack-bandwidth'),
+                )?.serviceId,
+            ),
         trackingPrefix: () =>
           'dedicated::server::interfaces::bandwidth-private-order::',
       },

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/template.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/private-order/template.html
@@ -9,4 +9,5 @@
     specifications="$ctrl.specifications"
     tracking-prefix="$ctrl.trackingPrefix"
     user="$ctrl.user"
+    service-id="$ctrl.serviceId"
 ></server-order-private-bandwidth>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.component.js
@@ -10,6 +10,7 @@ export default {
     goBack: '<',
     hasDefaultPaymentMethod: '<',
     serverName: '<',
+    serviceId: '<',
     specifications: '<',
     trackingPrefix: '<',
     user: '<',

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
@@ -115,14 +115,14 @@ export default class {
   }
 
   getServiceUpgradeParams() {
-    const { duration, pricingMode } = this.plans
-      .find(({ planCode }) => planCode === this.model.plan)
-      ?.prices?.find(({ capacities }) => capacities.includes('renew'));
+    const renewPrice = this.plans
+      .find((plan) => plan.planCode === this.model.plan)
+      ?.prices?.find((price) => price.capacities.includes('renew'));
     return {
       autoPayWithPreferredPaymentMethod:
         this.region === 'US' || this.model.autoPay,
-      duration,
-      pricingMode,
+      duration: renewPrice?.duration,
+      pricingMode: renewPrice?.pricingMode,
       quantity: 1,
     };
   }

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
@@ -20,7 +20,7 @@ export default class {
         isLoading: () => this.isLoading,
         load: () => {
           this.isLoading = true;
-          return this.Server.getBareMetalPublicBandwidthOptions(this.serverName)
+          return this.Server.getBareMetalPublicBandwidthOptions(this.serviceId)
             .then((plans) => {
               this.plans = this.Server.getValidBandwidthPlans(plans);
               this.plans.sort(
@@ -47,8 +47,9 @@ export default class {
         load: () => {
           this.isLoading = true;
           return this.Server.getBareMetalPublicBandwidthOrder(
-            this.serverName,
+            this.serviceId,
             this.model.plan,
+            this.getServiceUpgradeParams(),
           )
             .then((res) => {
               res.bandwidth = find(this.plans, {
@@ -91,9 +92,9 @@ export default class {
       this.isLoading = true;
       this.atTrack(`${this.trackingPrefix}confirm`);
       this.Server.bareMetalPublicBandwidthPlaceOrder(
-        this.serverName,
+        this.serviceId,
         this.model.plan,
-        this.region === 'US' || this.model.autoPay,
+        this.getServiceUpgradeParams(),
       )
         .then((result) => {
           this.model.orderUrl = result.order.url;
@@ -111,5 +112,18 @@ export default class {
 
   seeOrder() {
     this.$window.open(this.model.orderUrl, '_blank');
+  }
+
+  getServiceUpgradeParams() {
+    const { duration, pricingMode } = this.plans
+      .find(({ planCode }) => planCode === this.model.plan)
+      ?.prices?.find(({ capacities }) => capacities.includes('renew'));
+    return {
+      autoPayWithPreferredPaymentMethod:
+        this.region === 'US' || this.model.autoPay,
+      duration,
+      pricingMode,
+      quantity: 1,
+    };
   }
 }

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.routing.js
@@ -20,6 +20,15 @@ export default /* @ngInject */ ($stateProvider) => {
         breadcrumb: () => null,
         hasDefaultPaymentMethod: /* @ngInject */ (ovhPaymentMethod) =>
           ovhPaymentMethod.hasDefaultPaymentMethod(),
+        serviceId: /* @ngInject */ ($http, serviceInfos) =>
+          $http
+            .get(`/services/${serviceInfos.serviceId}/options`)
+            .then(
+              ({ data: options }) =>
+                options.find((option) =>
+                  option.resource.product.name.startsWith('bandwidth-'),
+                )?.serviceId,
+            ),
         trackingPrefix: () =>
           'dedicated::server::interfaces::bandwidth-public-order::',
       },

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenters/add/upgrade-range/routes.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenters/add/upgrade-range/routes.js
@@ -15,6 +15,20 @@ export default /* @ngInject */ ($stateProvider) => {
         upgradeCode: /* @ngInject */ ($transition$) => {
           return $transition$.params().upgradeCode;
         },
+        managementFeeServiceId: /* @ngInject */ (
+          $http,
+          dedicatedCloud,
+          productId,
+        ) =>
+          $http
+            .get(`/services/${dedicatedCloud.serviceInfos.serviceId}/options`)
+            .then(({ data }) => {
+              const managementServicename = `${productId}/managementfee`;
+              const managementFeePlan = data.find(
+                (option) => option.resource.name === managementServicename,
+              );
+              return managementFeePlan?.serviceId;
+            }),
         backButtonText: /* @ngInject */ ($translate) =>
           $translate.instant('dedicated_cloud_upgrade_range'),
         breadcrumb: /* @ngInject */ ($translate) =>

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/datacenters/add/upgrade-range/routes.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/datacenters/add/upgrade-range/routes.js
@@ -15,6 +15,20 @@ export default /* @ngInject */ ($stateProvider) => {
         upgradeCode: /* @ngInject */ ($transition$) => {
           return $transition$.params().upgradeCode;
         },
+        managementFeeServiceId: /* @ngInject */ (
+          $http,
+          dedicatedCloud,
+          productId,
+        ) =>
+          $http
+            .get(`/services/${dedicatedCloud.serviceInfos.serviceId}/options`)
+            .then(({ data }) => {
+              const managementServicename = `${productId}/managementfee`;
+              const managementFeeOption = data.find(
+                (option) => option.resource.name === managementServicename,
+              );
+              return managementFeeOption?.serviceId;
+            }),
         backButtonText: /* @ngInject */ ($translate) =>
           $translate.instant('managed_baremetal_upgrade_range'),
         breadcrumb: /* @ngInject */ ($translate) =>

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
@@ -7,6 +7,7 @@ export default {
     goBack: '<',
     hasDefaultPaymentMethod: '<',
     serverName: '<',
+    serviceId: '<',
     specifications: '<',
     trackingPrefix: '<',
     user: '<',

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.controller.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.controller.js
@@ -187,14 +187,14 @@ export default class BmServerComponentsOrderPrivateBandwidthCtrl {
   }
 
   getServiceUpgradeParams() {
-    const { duration, pricingMode } = this.plans
-      .find(({ planCode }) => planCode === this.model.plan)
-      ?.prices?.find(({ capacities }) => capacities.includes('renew'));
+    const renewPrice = this.plans
+      .find((plan) => plan.planCode === this.model.plan)
+      ?.prices?.find((price) => price.capacities.includes('renew'));
     return {
       autoPayWithPreferredPaymentMethod:
         this.region === 'US' || this.model.autoPay,
-      duration,
-      pricingMode,
+      duration: renewPrice?.duration,
+      pricingMode: renewPrice?.pricingMode,
       quantity: 1,
     };
   }

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/service.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/service.js
@@ -4,34 +4,21 @@ export default class BmServerComponentsOrderPrivateBandwidthService {
     this.$http = $http;
   }
 
-  getBareMetalPrivateBandwidthOptions(serviceName) {
+  getBareMetalPrivateBandwidthOptions(serviceId) {
     return this.$http
-      .get(`/order/upgrade/baremetalPrivateBandwidth/${serviceName}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getBareMetalPrivateBandwidthOrder(serviceName, planCode) {
+  getBareMetalPrivateBandwidthOrder(serviceId, planCode, params) {
     return this.$http
-      .get(
-        `/order/upgrade/baremetalPrivateBandwidth/${serviceName}/${planCode}`,
-        {
-          params: {
-            quantity: 1,
-          },
-        },
-      )
+      .post(`/services/${serviceId}/upgrade/${planCode}/simulate`, params)
       .then(({ data }) => data);
   }
 
-  bareMetalPrivateBandwidthPlaceOrder(serviceName, planCode, autoPay) {
+  bareMetalPrivateBandwidthPlaceOrder(serviceId, planCode, params) {
     return this.$http
-      .post(
-        `/order/upgrade/baremetalPrivateBandwidth/${serviceName}/${planCode}`,
-        {
-          quantity: 1,
-          autoPayWithPreferredPaymentMethod: autoPay,
-        },
-      )
+      .post(`/services/${serviceId}/upgrade/${planCode}/execute`, params)
       .then(({ data }) => data);
   }
 }

--- a/packages/manager/modules/vps/src/dashboard/index.js
+++ b/packages/manager/modules/vps/src/dashboard/index.js
@@ -7,8 +7,6 @@ import ngOvhFeatureFlipping from '@ovh-ux/ng-ovh-feature-flipping';
 import component from './vps-dashboard.component';
 import routing from './vps-dashboard.routing';
 
-import vpsUpgradeTileService from './tile/configuration/upgrade/service';
-
 import vpsTileStatusItem from './vpsTileStatus/vps-tile-status.component';
 
 import ovhManagerVpsDashboardCommitment from './commitment';
@@ -65,7 +63,6 @@ angular
     ovhManagerVpsDashboardTerminateOption,
     'ui.router',
   ])
-  .service('vpsUpgradeTile', vpsUpgradeTileService)
   .component(component.name, component)
   .component(vpsTileStatusItem.name, vpsTileStatusItem)
   .config(routing)

--- a/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/index.js
+++ b/packages/manager/modules/vps/src/dashboard/tile/configuration/upgrade/index.js
@@ -5,7 +5,6 @@ import ngUiRouterLayout from '@ovh-ux/ng-ui-router-layout';
 
 import component from './component';
 import routing from './routing';
-import service from './service';
 
 const moduleName = 'ovhManagerVpsDashboardTileConfigurationUpgrade';
 
@@ -17,7 +16,6 @@ angular
   ])
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */)
-  .service('vpsUpgrade', service)
   .component(component.name, component);
 
 export default moduleName;

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
@@ -31,6 +31,7 @@ export default class {
     VpsService,
     VpsHelperService,
     vpsUpgradeTile,
+    VpsUpgradeService,
   ) {
     this.$filter = $filter;
     this.$q = $q;
@@ -45,6 +46,7 @@ export default class {
     this.VpsService = VpsService;
     this.VpsHelperService = VpsHelperService;
     this.vpsUpgradeTile = vpsUpgradeTile;
+    this.VpsUpgradeService = VpsUpgradeService;
     this.DASHBOARD_FEATURES = DASHBOARD_FEATURES;
     this.SERVICE_TYPE = SERVICE_TYPE;
 
@@ -93,7 +95,7 @@ export default class {
 
   $onDestroy() {
     if (this.vpsUpgradeTask) {
-      this.vpsUpgradeTile.stopUpgradeTaskPolling();
+      this.VpsUpgradeService.stopUpgradeTaskPolling();
       this.vpsUpgradeTask = null;
     }
   }
@@ -118,7 +120,7 @@ export default class {
 
   initUpgradePolling() {
     if (this.vpsUpgradeTask && !this.vpsMigrationTask) {
-      this.vpsUpgradeTile.startUpgradeTaskPolling(
+      this.VpsUpgradeService.startUpgradeTaskPolling(
         this.serviceName,
         this.vpsUpgradeTask,
         {

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.routing.js
@@ -73,10 +73,12 @@ export default /* @ngInject */ ($stateProvider) => {
 
       availableUpgrades: /* @ngInject */ (
         isVpsNewRange,
-        serviceName,
-        vpsUpgradeTile,
+        serviceInfos,
+        VpsUpgradeService,
       ) =>
-        isVpsNewRange ? vpsUpgradeTile.getAvailableUpgrades(serviceName) : [],
+        isVpsNewRange
+          ? VpsUpgradeService.getAvailableUpgrades(serviceInfos.serviceId)
+          : [],
 
       isCommitmentAvailable: /* @ngInject */ (ovhFeatureFlipping) =>
         ovhFeatureFlipping
@@ -97,8 +99,8 @@ export default /* @ngInject */ ($stateProvider) => {
         $http.get(`/vps/${serviceName}/serviceInfos`).then(({ data }) => data),
       shouldReengage: /* @ngInject */ (vps) => vps.shouldReengage,
       user: /* @ngInject */ (coreConfig) => coreConfig.getUser(),
-      vpsUpgradeTask: /* @ngInject */ (serviceName, vpsUpgradeTile) =>
-        vpsUpgradeTile.getUpgradeTask(serviceName),
+      vpsUpgradeTask: /* @ngInject */ (serviceName, VpsUpgradeService) =>
+        VpsUpgradeService.getUpgradeTask(serviceName),
 
       vpsMigrationTask: /* @ngInject */ (serviceName, VpsTaskService) =>
         VpsTaskService.getPendingTasks(serviceName, 'migrate').then((tasks) =>

--- a/packages/manager/modules/vps/src/import/vps-upgrade.service.js
+++ b/packages/manager/modules/vps/src/import/vps-upgrade.service.js
@@ -11,23 +11,45 @@ export default class VpsUpgradeService {
     this.upgradeTaskPolling = null;
   }
 
-  getAvailableUpgrades(serviceName) {
+  static getPlanUpgradeParams(plan, autoPayWithPreferredPaymentMethod) {
+    const { duration, pricingMode } =
+      plan.prices.find(({ capacities = [] }) => capacities.includes('renew')) ||
+      {};
+    return {
+      autoPayWithPreferredPaymentMethod,
+      duration,
+      pricingMode,
+      quantity: 1,
+    };
+  }
+
+  getAvailableUpgrades(serviceId) {
     return this.$http
-      .get(`/order/upgrade/vps/${serviceName}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getUpgrade(serviceName, planCode, params) {
+  getUpgrade(serviceId, plan, autoPayWithPreferredPaymentMethod) {
     return this.$http
-      .get(`/order/upgrade/vps/${serviceName}/${planCode}`, {
-        params,
-      })
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/simulate `,
+        VpsUpgradeService.getPlanUpgradeParams(
+          plan,
+          autoPayWithPreferredPaymentMethod,
+        ),
+      )
       .then(({ data }) => data);
   }
 
-  startUpgrade(serviceName, planCode, httpData) {
+  startUpgrade(serviceId, plan, autoPayWithPreferredPaymentMethod) {
     return this.$http
-      .post(`/order/upgrade/vps/${serviceName}/${planCode}`, httpData)
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/execute `,
+        VpsUpgradeService.getPlanUpgradeParams(
+          plan,
+          autoPayWithPreferredPaymentMethod,
+        ),
+      )
       .then(({ data }) => data);
   }
 

--- a/packages/manager/modules/vps/src/upscale/upscale.controller.js
+++ b/packages/manager/modules/vps/src/upscale/upscale.controller.js
@@ -392,14 +392,10 @@ export default class UpscaleController {
     this.scrollToTop();
   }
 
-  fetchUpscaleInformation(_planCode) {
+  fetchUpscaleInformation() {
     this.loading.getUpscaleInformation = true;
-    let planCode = _planCode;
-    if (!planCode) {
-      planCode = this.range.planCode;
-    }
 
-    return this.getUpscaleInformation(planCode)
+    return this.getUpscaleInformation(this.range)
       .then(({ order }) => {
         this.order = order;
         this.order.prices.withoutTax.unit = Price.UNITS.CENTS;
@@ -478,9 +474,8 @@ export default class UpscaleController {
     });
 
     this.loading.performUpscale = true;
-    const planCode = this.planCode || this.range.planCode;
 
-    return this.performUpscale(planCode)
+    return this.performUpscale(this.range)
       .then((upscaleOrder) => {
         const baseKey = this.isEliteUpgrade
           ? 'vps_upscale_elite_upgrade_success'

--- a/packages/manager/modules/vps/src/upscale/upscale.html
+++ b/packages/manager/modules/vps/src/upscale/upscale.html
@@ -233,7 +233,7 @@
         </oui-step-form>
         <oui-step-form
             header="{{:: 'vps_upscale_user_conditions_agreements' | translate }}"
-            on-focus="$ctrl.fetchUpscaleInformation($ctrl.planCode)"
+            on-focus="$ctrl.fetchUpscaleInformation()"
             loading="$ctrl.loading.getUpscaleInformation"
             editable="!$ctrl.loading.performUpscale"
             prevent-next="true"

--- a/packages/manager/modules/vps/src/upscale/upscale.routing.js
+++ b/packages/manager/modules/vps/src/upscale/upscale.routing.js
@@ -7,57 +7,62 @@ export default /* @ngInject */ function($stateProvider) {
     resolve: {
       agreements: /* @ngInject */ (coreConfig, CORE_URLS) =>
         CORE_URLS.agreements[coreConfig.getRegion()],
-      getUpscaleInformation: /* @ngInject */ (serviceName, vpsUpgrade) => (
-        planCode,
-      ) =>
-        vpsUpgrade.getUpgrade(serviceName, planCode, {
-          quantity: 1,
-        }),
+      serviceInfos: /* @ngInject */ ($http, serviceName) =>
+        $http.get(`/vps/${serviceName}/serviceInfos`).then(({ data }) => data),
+      getUpscaleInformation: /* @ngInject */ (
+        serviceInfos,
+        VpsUpgradeService,
+        defaultPaymentMethod,
+      ) => (plan) =>
+        VpsUpgradeService.getUpgrade(
+          serviceInfos.serviceId,
+          plan,
+          defaultPaymentMethod != null,
+        ),
       getRebootLink: /* @ngInject */ ($state) => () =>
         $state.href('vps.detail.dashboard.reboot'),
       performUpscale: /* @ngInject */ (
         defaultPaymentMethod,
-        serviceName,
-        vpsUpgrade,
-      ) => (planCode) =>
-        vpsUpgrade.startUpgrade(serviceName, planCode, {
-          autoPayWithPreferredPaymentMethod: defaultPaymentMethod != null,
-          quantity: 1,
-        }),
+        serviceInfos,
+        VpsUpgradeService,
+      ) => (plan) =>
+        VpsUpgradeService.startUpgrade(
+          serviceInfos.serviceId,
+          plan,
+          defaultPaymentMethod != null,
+        ),
       upscaleOptions: /* @ngInject */ (
-        $http,
         catalog,
         connectedUser,
-        serviceName,
+        serviceInfos,
         stateVps,
+        VpsUpgradeService,
       ) => {
         const current = catalog.plans.find(
           ({ planCode }) => planCode === stateVps.model.name,
         );
-        return $http
-          .get(`/order/upgrade/vps/${serviceName}`)
-          .then(({ data }) => [
-            ...data.map((option) => ({
-              ...option,
-              ...catalog.products.find(
-                ({ name }) => name === option.productName,
-              ),
+        return VpsUpgradeService.getAvailableUpgrades(
+          serviceInfos.serviceId,
+        ).then((data) => [
+          ...data.map((option) => ({
+            ...option,
+            ...catalog.products.find(({ name }) => name === option.planCode),
+          })),
+          {
+            ...current,
+            ...catalog.products.find(
+              ({ name }) => name === stateVps.model.name,
+            ),
+            prices: current.pricings.map((price) => ({
+              ...price,
+              price: {
+                currencyCode: connectedUser.currency.code,
+              },
+              pricingMode: price.mode,
+              priceInUcents: price.price,
             })),
-            {
-              ...current,
-              ...catalog.products.find(
-                ({ name }) => name === stateVps.model.name,
-              ),
-              prices: current.pricings.map((price) => ({
-                ...price,
-                price: {
-                  currencyCode: connectedUser.currency.code,
-                },
-                pricingMode: price.mode,
-                priceInUcents: price.price,
-              })),
-            },
-          ]);
+          },
+        ]);
       },
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('vps_upscale_title'),

--- a/packages/manager/modules/vps/src/vps/vps.module.js
+++ b/packages/manager/modules/vps/src/vps/vps.module.js
@@ -19,6 +19,7 @@ import { region } from '@ovh-ux/manager-components';
 import VpsTaskService from './vps-task.service';
 import VpsNotificationIpv6Service from '../import/notification.service';
 import VpsService from '../import/vps.service';
+import VpsUpgradeService from '../import/vps-upgrade.service';
 import VpsHelperService from '../import/helper.service';
 
 import detailComponent from '../detail/vps-detail.component';
@@ -77,6 +78,7 @@ angular
   .service('VpsNotificationIpv6', VpsNotificationIpv6Service)
   .service('VpsService', VpsService)
   .service('VpsHelperService', VpsHelperService)
+  .service('VpsUpgradeService', VpsUpgradeService)
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);
 

--- a/packages/manager/modules/web-paas/src/components/addon/component.js
+++ b/packages/manager/modules/web-paas/src/components/addon/component.js
@@ -13,6 +13,7 @@ export default {
     selectedPlan: '<',
     user: '<',
     trackTextPrefix: '<',
+    addOnServiceId: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/web-paas/src/components/addon/component.js
+++ b/packages/manager/modules/web-paas/src/components/addon/component.js
@@ -13,7 +13,7 @@ export default {
     selectedPlan: '<',
     user: '<',
     trackTextPrefix: '<',
-    addOnServiceId: '<',
+    addonServiceId: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/web-paas/src/components/addon/controller.js
+++ b/packages/manager/modules/web-paas/src/components/addon/controller.js
@@ -71,7 +71,12 @@ export default class {
           : this.addon.quantity);
     }
 
-    this.WebPaas.getAddonSummary(this.project, this.addon, this.quantity)
+    this.WebPaas.getAddonSummary(
+      this.project,
+      this.addon,
+      this.quantity,
+      this.addOnServiceId,
+    )
       .then(({ contracts, prices, cart }) => {
         this.cart = cart;
         this.contracts = contracts;
@@ -105,6 +110,7 @@ export default class {
       this.project.serviceId,
       this.addon,
       this.quantity,
+      this.addOnServiceId,
     )
       .then(({ order }) => this.onAddonOrderSuccess(order))
       .catch((error) =>

--- a/packages/manager/modules/web-paas/src/components/addon/controller.js
+++ b/packages/manager/modules/web-paas/src/components/addon/controller.js
@@ -75,7 +75,7 @@ export default class {
       this.project,
       this.addon,
       this.quantity,
-      this.addOnServiceId,
+      this.addonServiceId,
     )
       .then(({ contracts, prices, cart }) => {
         this.cart = cart;
@@ -110,7 +110,7 @@ export default class {
       this.project.serviceId,
       this.addon,
       this.quantity,
-      this.addOnServiceId,
+      this.addonServiceId,
     )
       .then(({ order }) => this.onAddonOrderSuccess(order))
       .catch((error) =>

--- a/packages/manager/modules/web-paas/src/components/addon/utils.js
+++ b/packages/manager/modules/web-paas/src/components/addon/utils.js
@@ -27,6 +27,19 @@ export const commonResolves = {
       },
     );
   },
+  addonServiceId: /* @ngInject */ (WebPaas, serviceInfo, addonType) => {
+    if (addonType === ADDON_TYPE.STORAGE) {
+      return WebPaas.getAddonServiceId(
+        serviceInfo.serviceId,
+        ADDON_TYPE.ENVIRONMENT,
+      ).then((stagingServiceId) =>
+        WebPaas.getAddonServiceId(stagingServiceId, ADDON_TYPE.STORAGE).then(
+          (serviceId) => serviceId,
+        ),
+      );
+    }
+    return WebPaas.getAddonServiceId(serviceInfo.serviceId, addonType);
+  },
   getOrderUrl: /* @ngInject */ (coreURLBuilder) => (orderId) =>
     coreURLBuilder.buildURL('dedicated', '#/billing/orders/:orderId', {
       orderId,

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.component.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.component.js
@@ -12,6 +12,7 @@ export default {
     plans: '<',
     projectId: '<',
     selectedProject: '<',
+    serviceInfo: '<',
     user: '<',
   },
   controller,

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.controller.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.controller.js
@@ -160,8 +160,9 @@ export default class {
     set(this.selectedProject, 'quantity', 1);
     this.getTotalPrice();
     return this.WebPaas.getUpgradeCheckoutInfo(
-      this.selectedProject.serviceId,
+      this.serviceInfo.serviceId,
       this.selectedPlan,
+      this.selectedProject.quantity,
     )
       .then(({ contracts, prices, cart }) => {
         this.cart = cart;
@@ -178,7 +179,7 @@ export default class {
     this.trackChangeOffer('confirm');
     this.orderInProgress = true;
     return this.WebPaas.checkoutUpgrade(
-      this.selectedProject.serviceId,
+      this.serviceInfo.serviceId,
       this.selectedPlan,
       this.selectedProject.quantity,
     )

--- a/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.routing.js
+++ b/packages/manager/modules/web-paas/src/details/service/change-offer/change-offer.routing.js
@@ -15,8 +15,13 @@ export default /* @ngInject */ ($stateProvider) => {
       cpu: /* @ngInject */ ($transition$) => $transition$.params().cpu,
       selectedProject: /* @ngInject */ (WebPaas, projectId) =>
         WebPaas.getProjectDetails(projectId),
-      availablePlans: /* @ngInject */ (selectedProject, WebPaas, cpu) =>
-        WebPaas.getUpgradeOffers(selectedProject.serviceId).then((data) => {
+      availablePlans: /* @ngInject */ (
+        selectedProject,
+        serviceInfo,
+        WebPaas,
+        cpu,
+      ) =>
+        WebPaas.getUpgradeOffers(serviceInfo.serviceId).then((data) => {
           if (cpu) {
             return compact(
               map(data, (plan) =>

--- a/packages/manager/modules/web-paas/src/web-paas.service.js
+++ b/packages/manager/modules/web-paas/src/web-paas.service.js
@@ -75,12 +75,12 @@ export default class WebPaasService {
       });
   }
 
-  getAddOnServiceId(serviceId, addOnType) {
+  getAddonServiceId(serviceId, addonType) {
     return this.$http
       .get(`/services/${serviceId}/options`)
       .then(
         ({ data }) =>
-          data.find((addOn) => addOn.resource?.product?.name === addOnType)
+          data.find((addon) => addon.resource?.product?.name === addonType)
             ?.serviceId,
       );
   }
@@ -341,9 +341,9 @@ export default class WebPaasService {
       .finally(() => this.deleteCart());
   }
 
-  getAddonSummary(project, addon, quantity, addOnServiceId) {
+  getAddonSummary(project, addon, quantity, addonServiceId) {
     if (addon.serviceName && addon.environmentServiceName === undefined) {
-      return this.getUpgradeCheckoutInfo(addOnServiceId, addon, quantity);
+      return this.getUpgradeCheckoutInfo(addonServiceId, addon, quantity);
     }
 
     return this.createCart()
@@ -388,11 +388,11 @@ export default class WebPaasService {
     return this.OvhApiOrderCart.getCheckout({ cartId: cart.cartId }).$promise;
   }
 
-  checkoutAddon(cart, serviceName, selectedPlan, quantity, addOnServiceId) {
+  checkoutAddon(cart, serviceName, selectedPlan, quantity, addonServiceId) {
     if (cart) {
       return this.goToExpressOrderOption(serviceName, selectedPlan, quantity);
     }
-    return this.checkoutUpgrade(addOnServiceId, selectedPlan, quantity);
+    return this.checkoutUpgrade(addonServiceId, selectedPlan, quantity);
   }
 
   getAdditionalOption(serviceName, project) {

--- a/packages/manager/modules/web-paas/src/web-paas.service.js
+++ b/packages/manager/modules/web-paas/src/web-paas.service.js
@@ -75,6 +75,16 @@ export default class WebPaasService {
       });
   }
 
+  getAddOnServiceId(serviceId, addOnType) {
+    return this.$http
+      .get(`/services/${serviceId}/options`)
+      .then(
+        ({ data }) =>
+          data.find((addOn) => addOn.resource?.product?.name === addOnType)
+            ?.serviceId,
+      );
+  }
+
   getProjectDetails(projectId) {
     return this.$http
       .get(`/webPaaS/subscription/${projectId}`)
@@ -331,9 +341,9 @@ export default class WebPaasService {
       .finally(() => this.deleteCart());
   }
 
-  getAddonSummary(project, addon, quantity) {
+  getAddonSummary(project, addon, quantity, addOnServiceId) {
     if (addon.serviceName && addon.environmentServiceName === undefined) {
-      return this.getUpgradeCheckoutInfo(addon.serviceName, addon, quantity);
+      return this.getUpgradeCheckoutInfo(addOnServiceId, addon, quantity);
     }
 
     return this.createCart()
@@ -378,11 +388,11 @@ export default class WebPaasService {
     return this.OvhApiOrderCart.getCheckout({ cartId: cart.cartId }).$promise;
   }
 
-  checkoutAddon(cart, serviceName, selectedPlan, quantity) {
+  checkoutAddon(cart, serviceName, selectedPlan, quantity, addOnServiceId) {
     if (cart) {
       return this.goToExpressOrderOption(serviceName, selectedPlan, quantity);
     }
-    return this.checkoutUpgrade(serviceName, selectedPlan, quantity);
+    return this.checkoutUpgrade(addOnServiceId, selectedPlan, quantity);
   }
 
   getAdditionalOption(serviceName, project) {
@@ -411,32 +421,41 @@ export default class WebPaasService {
     }).$promise;
   }
 
-  getUpgradeOffers(projectId) {
+  getUpgradeOffers(serviceId) {
     return this.$http
-      .get(`/order/upgrade/webPaaS/${projectId}`)
+      .get(`/services/${serviceId}/upgrade`)
       .then(({ data }) => data);
   }
 
-  getUpgradeCheckoutInfo(serviceName, plan, quantity) {
+  static getServiceUpgradeParams(plan, quantity) {
+    const pricings = plan.pricings ? plan.pricings : plan.prices;
+    const pricing = pricings.find(({ capacities }) =>
+      capacities.includes('renew'),
+    );
+    return {
+      autoPayWithPreferredPaymentMethod: true,
+      duration:
+        pricing.duration ||
+        `P${pricing.interval}${pricing.intervalUnit[0]?.toUpperCase()}`,
+      pricingMode: pricing.pricingMode || pricing.mode,
+      quantity,
+    };
+  }
+
+  getUpgradeCheckoutInfo(serviceId, plan, quantity) {
     return this.$http
-      .get(`/order/upgrade/webPaaS/${serviceName}/${plan.planCode}`, {
-        params: {
-          quantity: quantity || plan.quantity,
-        },
-      })
+      .post(
+        `/services/${serviceId}/upgrade/${plan.planCode}/simulate`,
+        WebPaasService.getServiceUpgradeParams(plan, quantity),
+      )
       .then(({ data }) => data.order);
   }
 
-  checkoutUpgrade(serviceName, plan, quantity) {
+  checkoutUpgrade(serviceId, plan, quantity) {
     return this.$http
       .post(
-        `/order/upgrade/webPaaS/${
-          plan.serviceName ? plan.serviceName : serviceName
-        }/${plan.planCode}`,
-        {
-          autoPayWithPreferredPaymentMethod: true,
-          quantity: quantity || plan.quantity,
-        },
+        `/services/${serviceId}/upgrade/${plan.planCode}/execute`,
+        WebPaasService.getServiceUpgradeParams(plan, quantity),
       )
       .then(({ data }) => data);
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2236-2238`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10011
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Replaces `/order/upgrade` calls with `/services` for upgrade.

Impacts:

- Server Bandwidth upgrade (Public and Private)
- VPS Upgrades (Storage, vCores, RAM and VPS Upgrade)
- Web PaaS (User License, Storage, Range and Test Environment)
- PCC (Service-pack and Management Fee upgrade)
