### PR TITLE
fix(pci.project): syntax error on country choices for IP Failover

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/additional-ips/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/additional-ips/translations/Messages_fr_FR.json
@@ -16,7 +16,7 @@
   "pci_additional_ips_country_BE": "Belgique",
   "pci_additional_ips_country_CZ": "République Tchèque",
   "pci_additional_ips_country_FI": "Finlande",
-  "pci_additional_ips_country_IE": "Irelande",
+  "pci_additional_ips_country_IE": "Irlande",
   "pci_additional_ips_country_LT": "Lituanie",
   "pci_additional_ips_country_NL": "Pays-Bas",
   "pci_additional_ips_country_PT": "Portugal",

--- a/packages/manager/modules/pci/src/projects/project/failover-ips/order/order/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/failover-ips/order/order/translations/Messages_fr_FR.json
@@ -19,7 +19,7 @@
   "pci_projects_project_failoverip_order_country_BE": "Belgique",
   "pci_projects_project_failoverip_order_country_CZ": "République Tchèque",
   "pci_projects_project_failoverip_order_country_FI": "Finlande",
-  "pci_projects_project_failoverip_order_country_IE": "Irelande",
+  "pci_projects_project_failoverip_order_country_IE": "Irlande",
   "pci_projects_project_failoverip_order_country_LT": "Lituanie",
   "pci_projects_project_failoverip_order_country_NL": "Pays-Bas",
   "pci_projects_project_failoverip_order_country_PT": "Portugal",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/l3-services`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-9997
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Translation file update to fix syntax error for country choices in IP failover

## Related

<!-- Link dependencies of this PR -->
