### PR TITLE
fix(iplb): edit frontend http headers as array

### DIFF
--- a/packages/manager/modules/iplb/src/frontends/iplb-frontends-edit.controller.js
+++ b/packages/manager/modules/iplb/src/frontends/iplb-frontends-edit.controller.js
@@ -270,6 +270,9 @@ export default class IpLoadBalancerFrontendsEditCtrl {
     if (this.type === 'udp') {
       delete request.allowedSource;
     }
+    if (request.httpHeader) {
+      request.httpHeader = request.httpHeader.split(',');
+    }
 
     delete request.protocol;
     return request;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-94369
| License          | BSD 3-Clause

## Description

When editing a front-end, set the http headers as an Array and not a simple string in the API PUT call payload.
