### PR TITLE
fix(pci.data-processing): datatr-101 - add missing banner 

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/submit-job.html
+++ b/packages/manager/modules/pci/src/projects/project/data-processing/submit-job/submit-job.html
@@ -4,7 +4,7 @@
         class="mb-2"
         data-heading="{{ ::'data_processing_submit_job_title' | translate }}"
     ></oui-header>
-    <oui-message data-ng-if="$ctrl.conatiners.length === 0" data-type="warning">
+    <oui-message data-ng-if="$ctrl.containers.length === 0" data-type="warning">
         <span data-translate="data_processing_submit_no_container"></span>
         <a href="" data-ng-click="$ctrl.goToObjectStorage()">
             <span


### PR DESCRIPTION
DATATR-101

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/datatr-2-dataprocessing-new-job`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-101
| License          | BSD 3-Clause


- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix condition to correctly show banner when no object storage is found.