### PR TITLE
feat(private-database.upgrade): deprecate order/hosting routes

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_de_DE.json
@@ -502,5 +502,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "Beim Laden der Informationen ist ein Fehler aufgetreten."
 }

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_en_GB.json
@@ -500,5 +500,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "An error has occurred loading information."
 }

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_es_ES.json
@@ -502,5 +502,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "Se ha producido un error al cargar la información."
 }

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_CA.json
@@ -357,6 +357,7 @@
   "privateDatabase_RAM_add_do_order_attention": "Attention !",
   "privateDatabase_RAM_add_do_order_warning": "L'opération entraîne un redémarrage du serveur.",
   "privateDatabase_RAM_loading_order": "Chargement des offres en cours...",
+  "privateDatabase_order_RAM_step1_loading_error": "Une erreur s'est produite lors du chargement des informations.",
   "privateDatabase_order_RAM_finish_success": "Votre <a href=\"{{t0}}\" target=\"_blank\">bon de commande</a> a été généré avec succès. La quantité de RAM sera modifiée lorsque vous l'aurez validé.",
   "privateDatabase_order_RAM_finish_error": "Une erreur est survenue lors de la création du bon de commande.",
   "privateDatabase_order_RAM_resume": "Résumé de votre commande",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_FR.json
@@ -357,6 +357,7 @@
   "privateDatabase_RAM_add_do_order_attention": "Attention !",
   "privateDatabase_RAM_add_do_order_warning": "L'opération entraîne un redémarrage du serveur.",
   "privateDatabase_RAM_loading_order": "Chargement des offres en cours...",
+  "privateDatabase_order_RAM_step1_loading_error": "Une erreur s'est produite lors du chargement des informations.",
   "privateDatabase_order_RAM_finish_success": "Votre <a href=\"{{t0}}\" target=\"_blank\">bon de commande</a> a été généré avec succès. La quantité de RAM sera modifiée lorsque vous l'aurez validé.",
   "privateDatabase_order_RAM_finish_error": "Une erreur est survenue lors de la création du bon de commande.",
   "privateDatabase_order_RAM_resume": "Résumé de votre commande",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_it_IT.json
@@ -502,5 +502,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "Si è verificato un errore durante il caricamento delle informazioni."
 }

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pl_PL.json
@@ -502,5 +502,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "Wystąpił błąd podczas pobierania informacji."
 }

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pt_PT.json
@@ -502,5 +502,6 @@
   "privateDatabase_order_datacenter_gra": "Gravelines",
   "privateDatabase_order_datacenter_gra3": "Gravelines 3",
   "privateDatabase_order_datacenter_bhs": "Beauharnois",
-  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1"
+  "privateDatabase_order_datacenter_bhs1": "Beauharnois 1",
+  "privateDatabase_order_RAM_step1_loading_error": "Erro ao carregar a informação."
 }

--- a/packages/manager/apps/web/client/app/private-database/database/ram/update/private-database-database-ram-update.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/database/ram/update/private-database-database-ram-update.controller.js
@@ -58,18 +58,33 @@ angular.module('App').controller(
              ============================== */
       this.loading.availableRam = true;
 
-      this.privateDatabaseService.listAvailableRam().then((availableRam) => {
-        this.loading.availableRam = false;
-        this.data.availableRam = availableRam;
-        if (this.database.infrastructure === 'legacy') {
-          remove(this.data.availableRam, (ram) => ram === '2048');
-        }
+      this.privateDatabaseService
+        .getUpgradePlans(this.productId)
+        .then((result) => {
+          this.data.availableRam = result.map(
+            (e) => e.planCode.match(/[0-9]+/)?.[0],
+          );
+          if (this.database.infrastructure === 'legacy') {
+            remove(this.data.availableRam, (ram) => ram === '2048');
+          }
 
-        remove(
-          this.data.availableRam,
-          (ram) => +ram === +this.database.ram.value,
-        );
-      });
+          remove(
+            this.data.availableRam,
+            (ram) => +ram === +this.database.ram.value,
+          );
+        })
+        .catch((err) => {
+          this.alerter.alertFromSWS(
+            this.$translate.instant(
+              'privateDatabase_order_RAM_step1_loading_error',
+            ),
+            err,
+            this.$scope.alerts.main,
+          );
+        })
+        .finally(() => {
+          this.loading.availableRam = false;
+        });
 
       /*= =============================
              =            STEP 2            =


### PR DESCRIPTION
Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | WEB-12807
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

APIv6 routes order/hosting are deprecated. This PR aim is to switch order/hosting/privateSQL route to /order/upgrade/cloudDB for cloudDB and privateSQL upgrade pages.
However, during testing of PR https://github.com/ovh/manager/pull/7899 we found out that some of the order/hosting/privateSQL routes cant be removed (legacy billing privateSQL cannot be upgraded via the new routes).
This PR removes as many calls to deprecated routes as possible

## Translations

- [ ] TRANS-46967
