### PR TITLE
fix(dbaas-logs): osd price reference

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
@@ -258,7 +258,7 @@ export default {
     NB_INSTANCE: 'logs-input-container-unit',
     NB_SHARD: 'logs-index-shards-unit',
     INDEXED_DOCUMENTS: 'logs-index-documents-in-gb',
-    KIBANA: 'logs-kibana-unit',
+    KIBANA: 'logs-osd-unit',
     STREAM: 'logs-indexed-in-gb',
   },
   COLDSTORAGE_INCREMENT: 1,


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #8039
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description
OpenSearch Dashboards price is not displayed anymore since it has been renamed from Kibana.

## Related

OB-4758 & OB-4606
