### PR TITLE
fix(dedicated-billing): remove redirect link to hub

### DIFF
--- a/packages/manager/modules/billing/src/payment/credits/movements/billing-credits-movements.html
+++ b/packages/manager/modules/billing/src/payment/credits/movements/billing-credits-movements.html
@@ -31,21 +31,6 @@
         </p>
 
         <p data-translate="billing_credit_sbg_services_intro"></p>
-
-        <p class="m-4">
-            <a
-                data-ng-href="{{:: $ctrl.incidentServicesStatus }}"
-                class="oui-link_icon"
-                target="_top"
-            >
-                <span data-translate="billing_credit_sbg_services"></span>
-                <span
-                    class="oui-icon oui-icon-arrow-right"
-                    aria-hidden="true"
-                ></span>
-            </a>
-        </p>
-
         <p data-translate="billing_credit_sbg_info"></p>
         <p data-translate="billing_credit_sbg_movements_intro"></p>
         <p data-translate="billing_credit_sbg_tips"></p>

--- a/packages/manager/modules/billing/src/payment/credits/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/payment/credits/translations/Messages_fr_FR.json
@@ -31,7 +31,6 @@
   "billing_credit_sbg_total_amount": "Montant global des mesures commerciales : {{amount}}",
   "billing_credit_sbg_total_balance": "Solde du bon d'achat au {{date}} : {{amount}}",
   "billing_credit_sbg_services_intro": "Vous bénéficiiez de mesures commerciales* relatives à votre (vos) service(s) impactés par l’incendie survenu sur notre site de Strasbourg (SBG).",
-  "billing_credit_sbg_services": "Voir mes services concernés",
   "billing_credit_sbg_info": "Le montant correspondant à ces mesures commerciales était mis à disposition sous la forme d’<strong>un bon d’achat** valable jusqu’au 31 août 2022 et utilisable sur tous les services OVHcloud. L’attribution de ce bon d’achat était automatique***.</strong>",
   "billing_credit_sbg_movements_intro": "Vous pouvez consulter l’historique des mouvements sur ce bon d’achat dans le tableau ci-dessous.",
   "billing_credit_sbg_tips": "A noter : Le bon d’achat était utilisé pour paiement des factures de renouvellement automatique de vos services existants et ce de manière automatique. Vous pouviez également l’utiliser pour payer vos nouvelles commandes et vos factures de renouvellement manuel.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/run-2022-w40-2` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-97755
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
Under dedicated billing section if you click on "Voir mes services concernés" you are redirect on :
https://www.ovh.com/manager/#/hub/incident/SBG/status
and finally on
https://www.ovh.com/manager/#/hub/
where nothing is display : app.dashboard.**
