### PR TITLE
fix: cascade alias and dashboard removal

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/home/logs-aliases-home.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/home/logs-aliases-home.controller.js
@@ -89,7 +89,7 @@ export default class LogsAliasesHomeCtrl {
           alias: alias.name,
         }),
       })
-      .then(() => this.delete(alias));
+      .then(() => this.remove(alias));
   }
 
   /**
@@ -98,12 +98,12 @@ export default class LogsAliasesHomeCtrl {
    * @param {any} alias to delete
    * @memberof LogsAliasesHomeCtrl
    */
-  delete(alias) {
+  remove(alias) {
     this.delete = this.CucControllerHelper.request.getHashLoader({
       loaderFunction: () =>
         this.LogsAliasesService.deleteAlias(this.serviceName, alias)
           .then(() => this.initLoaders())
-          .catch(() => this.CucControllerHelper.scrollPageToTop()),
+          .finally(() => this.CucControllerHelper.scrollPageToTop()),
     });
     this.delete.load();
   }

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/logs-aliases.service.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/logs-aliases.service.js
@@ -180,6 +180,7 @@ export default class LogsAliasesService {
       alias,
     )
       .$promise.then((operation) => {
+        this.getAliases(serviceName);
         return this.LogsHelperService.handleOperation(
           serviceName,
           operation.data || operation,

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/dashboards/logs-dashboards.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/dashboards/logs-dashboards.controller.js
@@ -89,7 +89,7 @@ export default class LogsDashboardsCtrl {
           dashboardName: dashboard.title,
         }),
       })
-      .then(() => this.delete(dashboard));
+      .then(() => this.remove(dashboard));
   }
 
   /**
@@ -98,7 +98,7 @@ export default class LogsDashboardsCtrl {
    * @param {any} dashboard to delete
    * @memberof LogsDashboardsCtrl
    */
-  delete(dashboard) {
+  remove(dashboard) {
     this.delete = this.CucControllerHelper.request.getHashLoader({
       loaderFunction: () =>
         this.LogsDashboardsService.deleteDashboard(this.serviceName, dashboard)

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/home/info/logs-inputs-home-info.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/home/info/logs-inputs-home-info.html
@@ -13,6 +13,17 @@
     </oui-field>
 
     <oui-field
+        data-label="{{ ::'inputs_info_exposedport' | translate}}"
+        data-size="s"
+    >
+        <oui-clipboard
+            id="input_exposedport"
+            data-model="ctrl.currentInput.info.exposedPort"
+            name="input_exposedport"
+        ></oui-clipboard>
+    </oui-field>
+
+    <oui-field
         data-label="{{ ::'inputs_info_ipaddress' | translate}}"
         data-size="m"
     >

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Administrator",
   "logs_tile_subscription_contact_billing": "Abrechnung",
   "logs_tile_subscription_contact_technical": "Technisch",
-  "logs_order": "Bestellen"
+  "logs_order": "Bestellen",
+  "inputs_info_exposedport": "Exponierter TCP-Port"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Administrator",
   "logs_tile_subscription_contact_billing": "Billing",
   "logs_tile_subscription_contact_technical": "Technical",
-  "logs_order": "Order"
+  "logs_order": "Order",
+  "inputs_info_exposedport": "TCP port exposed"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Administrador",
   "logs_tile_subscription_contact_billing": "Facturación",
   "logs_tile_subscription_contact_technical": "Técnico",
-  "logs_order": "Contratar"
+  "logs_order": "Contratar",
+  "inputs_info_exposedport": "Puerto TCP expuesto"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
@@ -464,6 +464,7 @@
   "inputs_info_title": "Informations utiles",
   "inputs_info_description": "Cliquez sur les options proposées pour les copier dans votre presse-papiers.",
   "inputs_info_hostname": "Nom de l'hôte",
+  "inputs_info_exposedport": "Port TCP exposé",
   "inputs_info_ipaddress": "(Adresse) IP publique",
   "inputs_info_certificate": "Type de certificat",
   "inputs_logs_title": "Sortie console de {{inputTitle}}",

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
@@ -464,6 +464,7 @@
   "inputs_info_title": "Informations utiles",
   "inputs_info_description": "Cliquez sur les options proposées pour les copier dans votre presse-papiers.",
   "inputs_info_hostname": "Nom de l'hôte",
+  "inputs_info_exposedport": "Port TCP exposé",
   "inputs_info_ipaddress": "(Adresse) IP publique",
   "inputs_info_certificate": "Type de certificat",
   "inputs_logs_title": "Sortie console de {{inputTitle}}",

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Amministratore",
   "logs_tile_subscription_contact_billing": "Fatturazione",
   "logs_tile_subscription_contact_technical": "Tecnico",
-  "logs_order": "Ordina"
+  "logs_order": "Ordina",
+  "inputs_info_exposedport": "Porta TCP esposta"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Administrator",
   "logs_tile_subscription_contact_billing": "Płatności",
   "logs_tile_subscription_contact_technical": "Kontakt techniczny",
-  "logs_order": "Zamów"
+  "logs_order": "Zamów",
+  "inputs_info_exposedport": "Port TCP otwarty"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
@@ -721,5 +721,6 @@
   "logs_tile_subscription_contact_admin": "Administrador",
   "logs_tile_subscription_contact_billing": "Faturação",
   "logs_tile_subscription_contact_technical": "Técnico",
-  "logs_order": "Encomendar"
+  "logs_order": "Encomendar",
+  "inputs_info_exposedport": "Porta TCP exposta"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix OB-4675,  OB-4680
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

This PR fix the possibility to remove multiple dashboard and alias in a row and display the exposed port of a data gathering tool in the more details modal.

## Translations

- [x] TRANS-46941