### PR TITLE
feat(private-sql.activation): private SQL activation for db over 512MB

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/database/hosting-database.constants.js
+++ b/packages/manager/apps/web/client/app/hosting/database/hosting-database.constants.js
@@ -1,5 +1,7 @@
 export const PRIVATE_SQL_PLAN_CODE = 'private-sql-512';
+export const WEBHOSTING_PRODUCT_NAME = 'webHosting';
 
 export default {
   PRIVATE_SQL_PLAN_CODE,
+  WEBHOSTING_PRODUCT_NAME,
 };

--- a/packages/manager/apps/web/client/app/hosting/database/hosting-database.service.js
+++ b/packages/manager/apps/web/client/app/hosting/database/hosting-database.service.js
@@ -3,17 +3,40 @@ import forEach from 'lodash/forEach';
 import snakeCase from 'lodash/snakeCase';
 import some from 'lodash/some';
 
-import { PRIVATE_SQL_PLAN_CODE } from './hosting-database.constants';
+import {
+  PRIVATE_SQL_PLAN_CODE,
+  WEBHOSTING_PRODUCT_NAME,
+} from './hosting-database.constants';
 
 angular.module('services').service(
   'HostingDatabase',
   class HostingDatabase {
-    constructor($q, $rootScope, Hosting, OvhHttp, Poller) {
+    constructor(
+      $q,
+      $rootScope,
+      coreConfig,
+      Hosting,
+      OvhHttp,
+      Poller,
+      OvhApiOrderCatalogPublic,
+    ) {
       this.$q = $q;
       this.$rootScope = $rootScope;
+      this.coreConfig = coreConfig;
       this.Hosting = Hosting;
       this.OvhHttp = OvhHttp;
       this.Poller = Poller;
+      this.OvhApiOrderCatalogPublic = OvhApiOrderCatalogPublic;
+    }
+
+    /**
+     * Get agora webhosting catalog
+     */
+    getWebhostingCatalog() {
+      return this.OvhApiOrderCatalogPublic.v6().get({
+        productName: WEBHOSTING_PRODUCT_NAME,
+        ovhSubsidiary: this.coreConfig.getUser().ovhSubsidiary,
+      }).$promise;
     }
 
     /**

--- a/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.controller.js
@@ -3,7 +3,7 @@ import {
   workflowConstants,
 } from '@ovh-ux/manager-product-offers';
 
-import { PRODUCT_NAME } from './hosting-database-order-public.constants';
+import { WEBHOSTING_PRODUCT_NAME } from '../../hosting-database.constants';
 import HostingDatabaseOrderPublic from './hosting-database-order-public.service';
 
 export default class {
@@ -18,7 +18,7 @@ export default class {
       workflowOptions: {
         catalog: this.catalog,
         catalogItemTypeName: workflowConstants.CATALOG_ITEM_TYPE_NAMES.ADDON,
-        productName: PRODUCT_NAME,
+        productName: WEBHOSTING_PRODUCT_NAME,
         serviceNameToAddProduct: this.serviceName,
         getPlanCode: this.getPlanCode.bind(this),
       },

--- a/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.routing.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.routing.js
@@ -5,8 +5,8 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/order-public',
     component: component.name,
     resolve: {
-      catalog: /* @ngInject */ (HostingDatabaseOrderPublicService) =>
-        HostingDatabaseOrderPublicService.getCatalog(),
+      catalog: /* @ngInject */ (HostingDatabase) =>
+        HostingDatabase.getWebhostingCatalog(),
       characteristicsOfAvailableProducts: /* @ngInject */ (
         HostingDatabaseOrderPublicService,
         serviceName,

--- a/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.service.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order/public/hosting-database-order-public.service.js
@@ -74,13 +74,6 @@ export default class {
       );
   }
 
-  getCatalog() {
-    return this.OvhApiOrderCatalogPublic.v6().get({
-      productName: PRODUCT_NAME,
-      ovhSubsidiary: this.coreConfig.getUser().ovhSubsidiary,
-    }).$promise;
-  }
-
   getCharacteristicsOfAvailableProducts(serviceName) {
     return this.$q
       .all([

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/private-sql-activation.component.js
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/private-sql-activation.component.js
@@ -5,11 +5,14 @@ export default {
   controller,
   template,
   bindings: {
+    catalog: '<',
     goToHosting: '<',
     me: '<',
     hosting: '<',
     privateSqlOptions: '<',
     versions: '<',
-    services: '<',
+    datacenter: '<?',
+    onError: '<',
+    onSuccess: '<',
   },
 };

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/private-sql-activation.html
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/private-sql-activation.html
@@ -1,32 +1,29 @@
-<oui-back-button data-on-click="$ctrl.goToHosting()">
+<oui-back-button data-on-click=":: $ctrl.goToHosting()">
     <span data-translate="privatesql_activation_back"></span>
 </oui-back-button>
-<oui-stepper>
+
+<ovh-manager-product-offers
+    data-pricing-type="$ctrl.productOffers.pricingType"
+    data-workflow-options=":: $ctrl.productOffers.workflowOptions"
+    data-workflow-type=":: $ctrl.productOffers.workflowType"
+    data-on-success=":: $ctrl.onSuccess(checkout)"
+    data-on-error=":: $ctrl.onError(error)"
+    data-send-current-state=":: $ctrl.getOrderState(state)"
+>
     <oui-step-form
         data-header="{{:: 'privatesql_activation_step_1' | translate }}"
-        data-valid="$ctrl.hosting && $ctrl.option && $ctrl.version && !$ctrl.error.hosting"
-        data-prevent-next="true"
-        data-loading="$ctrl.loading.hosting"
-        data-editable="!$ctrl.loading.checkout"
-        data-on-submit="$ctrl.fetchCheckoutInformations()"
+        data-editable="$ctrl.options.isEditable"
     >
-        <oui-message data-type="error" data-ng-if="$ctrl.error.hosting">
-            <p data-translate="privatesql_activation_hosting_error"></p>
-            <p
-                data-ng-bind="$ctrl.error.hosting.data.message"
-                data-ng-if="$ctrl.error.hosting.data.message"
-            ></p>
-        </oui-message>
         <oui-field
-            data-size="xl"
             data-label="{{:: 'privatesql_activation_price_select' | translate }}"
+            data-size="xl"
         >
             <oui-select
-                name="optionSelect"
-                data-model="$ctrl.option"
-                data-items="$ctrl.options"
-                data-disabled="$ctrl.loading.hosting"
-                data-match="label"
+                data-name="optionSelect"
+                data-model="$ctrl.options.value"
+                data-items="$ctrl.options.values"
+                data-match="display"
+                data-required
             >
             </oui-select>
         </oui-field>
@@ -40,34 +37,9 @@
                 data-items="$ctrl.versions"
                 data-match="label"
                 data-searchable
+                data-required
             >
             </oui-select>
         </oui-field>
     </oui-step-form>
-    <oui-step-form
-        data-header="{{:: 'privatesql_activation_step_2' | translate }}"
-        data-valid="($ctrl.acceptContracts || !$ctrl.checkout.contracts.length) && !$ctrl.error.checkout"
-        data-prevent-next="true"
-        data-loading="$ctrl.loading.checkout"
-        data-submit-text="{{:: 'privatesql_activation_order' | translate }}"
-        data-on-submit="$ctrl.performCheckout()"
-    >
-        <ovh-contracts-summary
-            data-ng-if="$ctrl.checkout.contracts.length && !$ctrl.success"
-            data-name="acceptContracts"
-            data-items="$ctrl.checkout.contracts"
-            data-model="$ctrl.acceptContracts"
-        >
-        </ovh-contracts-summary>
-        <oui-message data-type="error" data-ng-if="$ctrl.error.checkout">
-            <p data-translate="privatesql_activation_checkout_error"></p>
-            <p
-                data-ng-bind="$ctrl.error.checkout.data.message"
-                data-ng-if="$ctrl.error.checkout.data.message"
-            ></p>
-        </oui-message>
-        <oui-message data-type="success" data-ng-if="$ctrl.success">
-            <p data-ng-bind-html="$ctrl.success"></p>
-        </oui-message>
-    </oui-step-form>
-</oui-stepper>
+</ovh-manager-product-offers>

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_de_DE.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "SQL Private",
   "privatesql_activation_success": "Die Aktivierung der Datenbank wurde erfolgreich abgeschlossen. Siehe meine <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">Rechnung.</a>.",
-  "privatesql_activation_success_bc": "Ihr <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">Bestellformular</a> wurde generiert. Bitte gehen Sie zur Zahlung dieses Betrags über, um Ihre Datenbank zu aktivieren."
+  "privatesql_activation_success_bc": "Ihr <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">Bestellformular</a> wurde generiert. Bitte gehen Sie zur Zahlung dieses Betrags über, um Ihre Datenbank zu aktivieren.",
+  "privatesql_activation_option_private-sql": "Private SQL {{diskSpace}} MB"
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_en_GB.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "Private SQL 512MB",
   "privatesql_activation_success": "Database enabled successfully. View <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">your bill</a>.",
-  "privatesql_activation_success_bc": "Your <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">purchase order</a> has been generated. Please pay for this order to enable your database."
+  "privatesql_activation_success_bc": "Your <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">purchase order</a> has been generated. Please pay for this order to enable your database.",
+  "privatesql_activation_option_private-sql": "Private SQL {{diskSpace}}MB"
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_es_ES.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "SQL Privado 512 MB",
   "privatesql_activation_success": "La base de datos se ha activado correctamente. Consultar <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">mi factura</a>.",
-  "privatesql_activation_success_bc": "La <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">orden de pedido</a> se ha generado correctamente. Por favor, abone la orden de pedido para poder activar la base de datos."
+  "privatesql_activation_success_bc": "La <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">orden de pedido</a> se ha generado correctamente. Por favor, abone la orden de pedido para poder activar la base de datos.",
+  "privatesql_activation_option_private-sql": "SQL Privado {{diskSpace}} MB"
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_fr_CA.json
@@ -27,7 +27,7 @@
   "privatesql_activation_version_v_redis_32": "Redis 3.2",
   "privatesql_activation_version_v_mongodb_40": "MongoDB 4.0",
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
-  "privatesql_activation_option_private-sql-512": "SQL Privé 512 Mo",
+  "privatesql_activation_option_private-sql": "SQL Privé {{diskSpace}} Mo",
   "privatesql_activation_success": "L'activation de la base de donnée a bien été effectuée. Voir <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">ma facture</a>.",
   "privatesql_activation_success_bc": "Votre <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">bon de commande</a> a été généré. Veuillez procéder au paiment de celui-ci afin d'activer votre base de donnée."
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_fr_FR.json
@@ -27,7 +27,7 @@
   "privatesql_activation_version_v_redis_32": "Redis 3.2",
   "privatesql_activation_version_v_mongodb_40": "MongoDB 4.0",
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
-  "privatesql_activation_option_private-sql-512": "SQL Privé 512 Mo",
+  "privatesql_activation_option_private-sql": "SQL Privé {{diskSpace}} Mo",
   "privatesql_activation_success": "L'activation de la base de donnée a bien été effectuée. Voir <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">ma facture</a>.",
   "privatesql_activation_success_bc": "Votre <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">bon de commande</a> a été généré. Veuillez procéder au paiment de celui-ci afin d'activer votre base de donnée."
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_it_IT.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "SQL Privato 512 MB",
   "privatesql_activation_success": "L’attivazione del database è stata eseguita correttamente. Consulta la <a href=\"{{ billUrl }}}\" target=\"_blank\" rel=\"noopener\">tua fattura</a>.",
-  "privatesql_activation_success_bc": "Il tuo <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">ordine</a> è stato generato. Effettua il pagamento per attivare il tuo database."
+  "privatesql_activation_success_bc": "Il tuo <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">ordine</a> è stato generato. Effettua il pagamento per attivare il tuo database.",
+  "privatesql_activation_option_private-sql": "SQL Privato {{diskSpace}} MB"
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_pl_PL.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "Prywatny SQL 512 MB",
   "privatesql_activation_success": "Baza danych została włączona. Wyświetl <a href=\"{{billUrl }}\" target=\"_blank\" rel=\"noopener\">fakturę</a>.",
-  "privatesql_activation_success_bc": "Twoje <a href=\"{{bcUrl}}\" target=\"_blank\" rel=\"noopener\">zamówienie</a> zostało wygenerowane. Aby włączyć bazę danych, najpierw dokonaj płatności."
+  "privatesql_activation_success_bc": "Twoje <a href=\"{{bcUrl}}\" target=\"_blank\" rel=\"noopener\">zamówienie</a> zostało wygenerowane. Aby włączyć bazę danych, najpierw dokonaj płatności.",
+  "privatesql_activation_option_private-sql": "Private SQL {{diskSpace}} MB"
 }

--- a/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/hosting/database/private-sql-activation/translations/Messages_pt_PT.json
@@ -29,5 +29,6 @@
   "privatesql_activation_version_v_redis_40": "Redis 4.0",
   "privatesql_activation_option_private-sql-512": "SQL Privado 512 MB",
   "privatesql_activation_success": "A ativação da base de dados foi concretizada com êxito. Ver <a href=\"{{ billUrl }}\" target=\"_blank\" rel=\"noopener\">a minha fatura</a>.",
-  "privatesql_activation_success_bc": "A sua <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">nota de encomenda</a> foi gerada. Efetue o pagamento para ativar a sua base de dados."
+  "privatesql_activation_success_bc": "A sua <a href=\"{{ bcUrl }}\" target=\"_blank\" rel=\"noopener\">nota de encomenda</a> foi gerada. Efetue o pagamento para ativar a sua base de dados.",
+  "privatesql_activation_option_private-sql": "SQL Privado {{diskSpace}} MB"
 }


### PR DESCRIPTION
WEB-13675

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

- [ ] AGORA CATALOG TO BE UPDATED BEFORE MERGE IN PROD

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | WEB-13675
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Customer can activate for free a private SQL 512M when he orders a perf hosting. We want to add new products : customer will be able to activate private SQL over 512M at a lower price when he has a perf hosting. This PR goal is to update manager private-sql-activation page to reflect this change.

## Related

<!-- Link dependencies of this PR -->
