### PR TITLE
fix(dedicated.server): modification bandwith button for us

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/server.feature-availability.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/server.feature-availability.js
@@ -21,15 +21,15 @@ export default class {
   }
 
   allowDedicatedServerBandwidthOption() {
-    return this.allow('EU', 'CA');
+    return this.allow('EU', 'CA', 'US');
   }
 
   allowDedicatedServerOrderBandwidthOption() {
-    return this.allow('EU', 'CA');
+    return this.allow('EU', 'CA', 'US');
   }
 
   allowDedicatedServerOrderVrackBandwidthOption() {
-    return this.allow('EU', 'CA');
+    return this.allow('EU', 'CA', 'US');
   }
 
   allowDedicatedServerOrderTrafficOption() {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2238-2240` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-9455
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Change feature to have the button modification bandwith for dedicated server for manager US

## Related

<!-- Link dependencies of this PR -->
