### PR TITLE
fix(dedicated.support): add standard s3 on support tickets

### DIFF
--- a/packages/manager/modules/support/src/tickets/new-ticket/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/support/src/tickets/new-ticket/translations/Messages_fr_FR.json
@@ -118,6 +118,10 @@
   "ovhManagerSupport_new_serviceType_managed_kafka_connect": "Public Cloud databases for Kafka Connect",
   "ovhManagerSupport_new_serviceType_managed_cassandra": "Public Cloud databases for Cassandra",
   "ovhManagerSupport_new_serviceType_license_office_prepaid": "Licence Microsoft 365",
+  "ovhManagerSupport_new_serviceType_publiccloud_storage": "Object Storage S3 Standard",
+  "ovhManagerSupport_new_serviceType_publiccloud_storage_highperf": "Object Storage S3 High Perf",
+  "ovhManagerSupport_new_serviceType_publiccloud_storage_swift": "Object Storage Swift Standard",
+  "ovhManagerSupport_new_serviceType_publiccloud_storage_swift_archive": "Object Storage Swift Archive",
   "ovhManagerSupport_new_service": "Service concerné",
   "ovhManagerSupport_new_service_unknown": "Mon service n'est pas listé et/ou je ne dispose pas encore de ce service",
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2240-2242` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-10132
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Add object storage S3 on the support standard ticket

## Related

<!-- Link dependencies of this PR -->
