### PR TITLE
Feat/manager 10102: find and use renew capacity 

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.controller.js
@@ -102,12 +102,11 @@ export default class AgoraIpOrderCtrl {
   }
 
   createOfferDto(ipOffer) {
-    const maximumQuantity = get(
-      ipOffer.details.pricings.default.find(
-        (price) => head(price.capacities) === 'renew',
-      ),
-      'maximumQuantity',
+    const { default: defaultPricing } = ipOffer.details.pricings;
+    const renewCapacity = defaultPricing.find((price) =>
+      price.capacities.find((capacity) => capacity === 'renew'),
     );
+    const { maximumQuantity } = renewCapacity;
 
     const countryCodes = ipOffer.details.product.configurations.find(
       (config) => config.name === 'country',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `MANAGER-10085`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-10102
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
find and use `renew` capacity instead of getting the head entry from `pricing.default`