### PR TITLE
fix(enterprise-clouddb): remove entry in beta sidebar

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/bareMetalCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/bareMetalCloud.ts
@@ -132,7 +132,7 @@ export default {
     {
       id: 'bmc-databases',
       translation: 'sidebar_databases',
-      features: ['logs-data-platform', 'enterprise-cloud-database'],
+      features: ['logs-data-platform'],
       children: [
         {
           id: 'pci-logs-data-platform',
@@ -143,16 +143,6 @@ export default {
             hash: '#/dbaas/logs',
           },
           features: ['logs-data-platform'],
-        },
-        {
-          id: 'enterprise-cloud-db',
-          translation: 'sidebar_enterprise_cloud_db',
-          serviceType: 'CLOUDDB_ENTERPRISE_CLUSTER',
-          routing: {
-            application: 'dedicated',
-            hash: '#/enterprise-cloud-database',
-          },
-          features: ['enterprise-cloud-database'],
         },
       ],
     },


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix 
| License          | BSD 3-Clause

## Description


As we remove enterprise cloud database product section in previous PR (https://github.com/ovh/manager/pull/7341)
We have to remove it from the container sidebar.