### PR TITLE
build(dev-deps): upgrade `husky` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "git-raw-commits": "^2.0.2",
     "git-url-parse": "^11.1.2",
     "htmlhint": "^0.15.1",
-    "husky": "^7.0.0",
+    "husky": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "inquirer": "^7.0.6",
     "jest": "^27.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13115,10 +13115,10 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-husky@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.0.tgz#3dbd5d28e76234689ee29bb41e048f28e3e46616"
-  integrity sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
 
 hyphenate-style-name@^1.0.0, hyphenate-style-name@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~ (not applicable)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

### :arrow_up: Upgrade

c1f33fa - build(dev-deps): upgrade `husky` dependency

uses: `yarn upgrade-interactive --latest husky`

* husky@8.0.1

### :house: Internal

No quality check required.

## Related

see: https://github.com/typicode/husky/compare/v7.0.0...v8.0.0

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
