### PR TITLE
fix(pci.users): display username while openstack token generation

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/users/openstack-token/openstack-token.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/users/openstack-token/openstack-token.controller.js
@@ -12,6 +12,7 @@ export default class PciUsersOpenstackTokenController {
     this.user = {
       id: this.userId,
       password: null,
+      username: this.user.username,
     };
     this.token = null;
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-98598
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display username while openstack token generation

## Related

<!-- Link dependencies of this PR -->
