### PR TITLE
fix(pci.project): display disabled subnet info

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-networks/private-networks.html
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/private-networks.html
@@ -168,7 +168,7 @@
                                     <span
                                         class="oui-badge oui-badge_error"
                                         data-ng-if="!$row.loading && !subnetDetail.dhcpEnabled"
-                                        data-translate="pci_projects_project_network_private_dhcp_suspended"
+                                        data-translate="pci_projects_project_network_private_dhcp_disabled"
                                     ></span>
                                 </td>
                                 <td class="oui-table__cell">

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_de_DE.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "ausgesetzt",
   "pci_projects_project_network_private_ip_allocation": "Zugewiesene IP-Adresse",
   "pci_projects_project_network_private_assign_gateway": "Eine Gateway-Instanz zuweisen",
-  "pci_projects_project_network_private_no_data": "Es sind keine Daten verfügbar."
+  "pci_projects_project_network_private_no_data": "Es sind keine Daten verfügbar.",
+  "pci_projects_project_network_private_dhcp_disabled": "deaktiviert"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_en_GB.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "suspended",
   "pci_projects_project_network_private_ip_allocation": "IP allocated",
   "pci_projects_project_network_private_assign_gateway": "Assign a Gateway instance",
-  "pci_projects_project_network_private_no_data": "No data available."
+  "pci_projects_project_network_private_no_data": "No data available.",
+  "pci_projects_project_network_private_dhcp_disabled": "disabled"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_es_ES.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "suspendido",
   "pci_projects_project_network_private_ip_allocation": "Direcciones IP asignadas",
   "pci_projects_project_network_private_assign_gateway": "Asignar una instancia Gateway",
-  "pci_projects_project_network_private_no_data": "No hay ningún dato disponible."
+  "pci_projects_project_network_private_no_data": "No hay ningún dato disponible.",
+  "pci_projects_project_network_private_dhcp_disabled": "desactivado"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_fr_CA.json
@@ -7,7 +7,7 @@
   "pci_projects_project_network_private_region": "Région",
   "pci_projects_project_network_private_gateway": "Passerelle",
   "pci_projects_project_network_private_dhcp_active": "actif",
-  "pci_projects_project_network_private_dhcp_suspended": "suspendu",
+  "pci_projects_project_network_private_dhcp_disabled": "désactivé",
   "pci_projects_project_network_private_ip_allocation": "Adresse IP allouées",
   "pci_projects_project_network_private_assign_gateway": "Assigner une instance Gateway",
   "pci_projects_project_network_private_delete": "Supprimer",

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_fr_FR.json
@@ -7,7 +7,7 @@
   "pci_projects_project_network_private_region": "Région",
   "pci_projects_project_network_private_gateway": "Passerelle",
   "pci_projects_project_network_private_dhcp_active": "actif",
-  "pci_projects_project_network_private_dhcp_suspended": "suspendu",
+  "pci_projects_project_network_private_dhcp_disabled": "désactivé",
   "pci_projects_project_network_private_ip_allocation": "Adresse IP allouées",
   "pci_projects_project_network_private_assign_gateway": "Assigner une instance Gateway",
   "pci_projects_project_network_private_delete": "Supprimer",

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_it_IT.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "sospeso",
   "pci_projects_project_network_private_ip_allocation": "Indirizzo IP assegnato",
   "pci_projects_project_network_private_assign_gateway": "Assegnare un'istanza Gateway",
-  "pci_projects_project_network_private_no_data": "Nessun dato disponibile"
+  "pci_projects_project_network_private_no_data": "Nessun dato disponibile",
+  "pci_projects_project_network_private_dhcp_disabled": "Disattivato"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_pl_PL.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "Zawieszony",
   "pci_projects_project_network_private_ip_allocation": "Przypisane adresy IP",
   "pci_projects_project_network_private_assign_gateway": "Przypisz instancję Gateway",
-  "pci_projects_project_network_private_no_data": "Brak dostępnych danych."
+  "pci_projects_project_network_private_no_data": "Brak dostępnych danych.",
+  "pci_projects_project_network_private_dhcp_disabled": "wyłączony"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/translations/Messages_pt_PT.json
@@ -13,5 +13,6 @@
   "pci_projects_project_network_private_dhcp_suspended": "suspenso",
   "pci_projects_project_network_private_ip_allocation": "Endereços IP atribuídos",
   "pci_projects_project_network_private_assign_gateway": "Atribuir uma instância Gateway",
-  "pci_projects_project_network_private_no_data": "Nenhum dado disponível."
+  "pci_projects_project_network_private_no_data": "Nenhum dado disponível.",
+  "pci_projects_project_network_private_dhcp_disabled": "desativado"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/l3-services`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10206
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [N/A]

## Description

Change display label from `Suspended` to `disabled` for Subnet DHCP config info on Private Network listing page

## Translations

- [x] TRANS-46906