### PR TITLE
fix(domain.order-hosting): remove useless option in canada

### DIFF
--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/dnsConfiguration/domain-webhosting-order-steps-dnsConfiguration.controller.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/dnsConfiguration/domain-webhosting-order-steps-dnsConfiguration.controller.js
@@ -1,4 +1,21 @@
 export default class {
+  /* @ngInject */
+  constructor(ovhFeatureFlipping) {
+    this.ovhFeatureFlipping = ovhFeatureFlipping;
+  }
+
+  $onInit() {
+    const emailDnsConfigurationFeature = 'hosting:email-dns-configuration';
+
+    this.ovhFeatureFlipping
+      .checkFeatureAvailability(emailDnsConfigurationFeature)
+      .then((featureAvailability) => {
+        this.emailDnsConfigurationAvailable = featureAvailability.isFeatureAvailable(
+          emailDnsConfigurationFeature,
+        );
+      });
+  }
+
   enableHelpers() {
     this.isHostingHelpOpen = undefined;
     this.isEmailHelpOpen = undefined;

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/dnsConfiguration/domain-webhosting-order-steps-dnsConfiguration.html
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/dnsConfiguration/domain-webhosting-order-steps-dnsConfiguration.html
@@ -29,7 +29,7 @@
             data-translate="domain_webhosting_order_dns_configuration_enable_hosting_help"
         ></span>
     </div>
-    <div>
+    <div data-ng-if="$ctrl.emailDnsConfigurationAvailable">
         <oui-checkbox
             class="d-inline-block"
             data-model="$ctrl.dnsConfiguration.enableEmails"


### PR DESCRIPTION

- [ ] to be prod after feature-availability pull-request 322

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #WEB-13060
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

In Canada, option to configure DNS zone for email is useless when ordering a hosting (no DNS for email plan in CA)
It was spotted during investigation of DTRSD-89911

