### PR TITLE
fix(pci.instances): display private networks

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -257,7 +257,9 @@ export default class PciInstancesAddController {
             ).then((data) => {
               return {
                 ...privateNetwork,
-                subnet: [...data],
+                subnet: data.filter(
+                  (subnet) => subnet.ipPools[0].region === this.instance.region,
+                ),
               };
             });
           }
@@ -267,7 +269,7 @@ export default class PciInstancesAddController {
       .then((data) => {
         this.availablePrivateNetworks = [
           this.defaultPrivateNetwork,
-          ...data.filter(({ subnet }) => subnet && subnet.length === 1),
+          ...data.filter(({ subnet }) => subnet?.length > 0),
         ];
         return this.availablePrivateNetworks;
       });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10313
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display Private networks to associate while creating Instance
