### PR TITLE
fix(pcc.anthos): remove cta order for end of sales of anthos

### DIFF
--- a/packages/manager/modules/anthos/src/anthos.html
+++ b/packages/manager/modules/anthos/src/anthos.html
@@ -13,15 +13,6 @@
         data-messages="$ctrl.messages"
     ></cui-message-container>
     <oui-datagrid id="hpcAnthosTenantsDatagrid" data-rows="$ctrl.tenants">
-        <oui-datagrid-topbar>
-            <oui-button
-                variant="secondary"
-                type="button"
-                data-on-click="$ctrl.gotoOrder()"
-            >
-                <span data-translate="anthos_tenants_order"></span>
-            </oui-button>
-        </oui-datagrid-topbar>
         <oui-datagrid-column
             title=":: 'anthos_tenants_grid_headers_serviceName' | translate"
             data-property="id"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
 Branch?          | `release/sprint-2244-2246` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-10309
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I remove the cta order for anthos on pcc.

## Related

<!-- Link dependencies of this PR -->
