### PR TITLE
fix(dedicated.os): display text when os is not install

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.html
@@ -124,12 +124,6 @@
                                     data-ng-if="$ctrl.server.os"
                                     data-ng-bind="$ctrl.server.os === 'byoi_32' ? ('server_configuration_distribution_byoi' | translate) : $ctrl.server.os"
                                 ></span>
-                                <span
-                                    class="oui-badge oui-badge_warning"
-                                    data-ng-if="!$ctrl.server.os"
-                                    data-translate="server_configuration_distribution_none"
-                                >
-                                </span>
                                 <p
                                     class="small"
                                     data-ng-if="$ctrl.ola.isConfigured()"


### PR DESCRIPTION
ref:MANAGER-8519

Signed-off-by: stif59100 <steeve.vanderstocken@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2244-2246`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-8519
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I removed the yellow tile not installed for the os.

## Related

<!-- Link dependencies of this PR -->
