### PR TITLE
fix(pcc.datastore): add link of price for host and storage order

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.controller.js
@@ -3,14 +3,18 @@ import head from 'lodash/head';
 import set from 'lodash/set';
 import size from 'lodash/size';
 import sortBy from 'lodash/sortBy';
+import { PRICE_LINK } from '../../dedicatedCloud-datacenter.constants';
 
 export default class {
   /* @ngInject */
-  constructor($q, $scope, OvhHttp, User) {
+  constructor($q, $scope, OvhHttp, User, coreConfig) {
     this.$q = $q;
     this.$scope = $scope;
     this.OvhHttp = OvhHttp;
     this.User = User;
+    this.coreConfig = coreConfig;
+    this.urlPrice =
+      PRICE_LINK[coreConfig.getUser().ovhSubsidiary] || PRICE_LINK.DEFAULT;
   }
 
   fetchOffers() {

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/dedicatedCloud-datacenter-datastore-order.html
@@ -21,6 +21,15 @@
     <p
         data-ng-bind=":: ('dedicatedCloud_datastore_order_info_' + $ctrl.pccType) | translate"
     ></p>
+    <a
+        target="_blank"
+        rel="noopener"
+        class="oui-link_icon"
+        data-ng-href="{{ $ctrl.urlPrice}}"
+        data-translate="dedicatedCloud_datastore_order_price"
+    >
+        <span class="oui-icon oui-icon-external-link" aria-hidden="true"></span>
+    </a>
     <p data-translate="dedicatedCloud_datastore_order_select"></p>
     <oui-datagrid data-rows-loader="$ctrl.fetchDatagridOffers()">
         <oui-datagrid-column
@@ -32,13 +41,6 @@
                 data-value="$row"
                 ><span data-ng-bind="$row.planCode"></span>
             </oui-radio>
-        </oui-datagrid-column>
-        <oui-datagrid-column
-            data-title=":: 'dedicatedCloud_datastore_order_price' | translate"
-        >
-            <span data-ng-bind="$row.prices[0].price.text"></span>
-            <br />
-            <small data-ng-bind="$row.prices[0].description"></small>
         </oui-datagrid-column>
     </oui-datagrid>
     <p data-translate="dedicatedCloud_datastore_order_quantity"></p>

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_de_DE.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "Sie können Ihre Private Cloud anpassen, indem Sie Datastores hinzufügen. Danach werden Sie zu einem neuen Tab weitergeleitet, um die Bestellung abzuschließen.",
   "dedicatedCloud_datastore_order_select": "Datastore-Typ auswählen:",
   "dedicatedCloud_datastore_order_type": "Typ",
-  "dedicatedCloud_datastore_order_price": "Preis",
+  "dedicatedCloud_datastore_order_price": "Zur Preisübersicht",
   "dedicatedCloud_datastore_order_quantity": "Anzahl:",
   "dedicatedCloud_datastore_order_confirm": "Bestellung bestätigen",
   "dedicatedCloud_datastore_order_loading_error": "Beim Laden der Datastore-Informationen ist ein Fehler aufgetreten.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_en_GB.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "You can customise your Private Cloud by adding datastores. You will then be redirected to a new tab to complete your order.",
   "dedicatedCloud_datastore_order_select": "Select a datastore type:",
   "dedicatedCloud_datastore_order_type": "Type",
-  "dedicatedCloud_datastore_order_price": "Price",
+  "dedicatedCloud_datastore_order_price": "View our prices",
   "dedicatedCloud_datastore_order_quantity": "Quantity:",
   "dedicatedCloud_datastore_order_confirm": "Confirm order",
   "dedicatedCloud_datastore_order_loading_error": "An error has occurred loading the datastore information.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_es_ES.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "Puede personalizar su cloud privado añadiendo datastores. A continuación, será redirigido a una nueva pestaña en la que podrá finalizar la contratación.",
   "dedicatedCloud_datastore_order_select": "Seleccionar un tipo de datastore:",
   "dedicatedCloud_datastore_order_type": "Tipo",
-  "dedicatedCloud_datastore_order_price": "Precio",
+  "dedicatedCloud_datastore_order_price": "Consultar nuestros precios",
   "dedicatedCloud_datastore_order_quantity": "Cantidad:",
   "dedicatedCloud_datastore_order_confirm": "Confirmar el pedido",
   "dedicatedCloud_datastore_order_loading_error": "Se ha producido un error al cargar la información de los datastores.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_fr_CA.json
@@ -4,7 +4,7 @@
   "dedicatedCloud_datastore_order_info_MBM": "Vous pouvez personnaliser votre Essentials en ajoutant des datastores. Vous serez ensuite redirigé dans un nouvel onglet pour finaliser votre commande.",
   "dedicatedCloud_datastore_order_select": "Sélectionner un type de datastore :",
   "dedicatedCloud_datastore_order_type": "Type",
-  "dedicatedCloud_datastore_order_price": "Prix",
+  "dedicatedCloud_datastore_order_price": "Consulter nos tarifs",
   "dedicatedCloud_datastore_order_quantity": "Quantité :",
   "dedicatedCloud_datastore_order_confirm": "Confirmer la commande",
   "dedicatedCloud_datastore_order_loading_error": "Une erreur est survenue lors du chargement des informations des datastores."

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_fr_FR.json
@@ -4,7 +4,7 @@
   "dedicatedCloud_datastore_order_info_MBM": "Vous pouvez personnaliser votre Essentials en ajoutant des datastores. Vous serez ensuite redirigé dans un nouvel onglet pour finaliser votre commande.",
   "dedicatedCloud_datastore_order_select": "Sélectionner un type de datastore :",
   "dedicatedCloud_datastore_order_type": "Type",
-  "dedicatedCloud_datastore_order_price": "Prix",
+  "dedicatedCloud_datastore_order_price": "Consulter nos tarifs",
   "dedicatedCloud_datastore_order_quantity": "Quantité :",
   "dedicatedCloud_datastore_order_confirm": "Confirmer la commande",
   "dedicatedCloud_datastore_order_loading_error": "Une erreur est survenue lors du chargement des informations des datastores."

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_it_IT.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "Per personalizzare il Private Cloud è possibile aggiungere datastore. Verrai reindirizzato a una nuova finestra da cui sarà possibile completare l’ordine.",
   "dedicatedCloud_datastore_order_select": "Seleziona un tipo di datastore:",
   "dedicatedCloud_datastore_order_type": "Tipo",
-  "dedicatedCloud_datastore_order_price": "Prezzo",
+  "dedicatedCloud_datastore_order_price": "Consultare le tariffe",
   "dedicatedCloud_datastore_order_quantity": "Quantità:",
   "dedicatedCloud_datastore_order_confirm": "Conferma l'ordine",
   "dedicatedCloud_datastore_order_loading_error": "Si è verificato un errore durante il caricamento delle informazioni dei datastore.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_pl_PL.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "Możesz spersonalizować swoją prywatną chmurę poprzez dodanie magazynów danych (datastore). Zostaniesz przekierowany do nowej zakładki, aby sfinalizować zamówienie.",
   "dedicatedCloud_datastore_order_select": "Wybierz rodzaj datastore:",
   "dedicatedCloud_datastore_order_type": "Typ",
-  "dedicatedCloud_datastore_order_price": "Cena",
+  "dedicatedCloud_datastore_order_price": "Sprawdź cennik",
   "dedicatedCloud_datastore_order_quantity": "Ilość:",
   "dedicatedCloud_datastore_order_confirm": "Potwierdź zamówienie",
   "dedicatedCloud_datastore_order_loading_error": "Wystąpił błąd podczas pobierania informacji na temat datastore.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/order/translations/Messages_pt_PT.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_datastore_order_info_EPCC": "Pode personalizar o seu Private Cloud adicionando datastores. De seguida, será redirecionado para um novo separador para finalizar a sua encomenda.",
   "dedicatedCloud_datastore_order_select": "Selecionar um tipo de datastore:",
   "dedicatedCloud_datastore_order_type": "Tipo",
-  "dedicatedCloud_datastore_order_price": "Preço",
+  "dedicatedCloud_datastore_order_price": "Consultar os nossos preços",
   "dedicatedCloud_datastore_order_quantity": "Quantidade:",
   "dedicatedCloud_datastore_order_confirm": "Confirmar a encomenda",
   "dedicatedCloud_datastore_order_loading_error": "Ocorreu um erro aquando do carregamento das informações dos datastores.",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dedicatedCloud-datacenter.constants.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dedicatedCloud-datacenter.constants.js
@@ -21,8 +21,24 @@ export const VDC_MIRGRATION_GUIDE_LINK = {
   DEFAULT: 'https://docs.ovh.com/gb/en/private-cloud/vdc-migration/',
 };
 
+export const PRICE_LINK = {
+  DEFAULT:
+    'https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/prices/',
+  FR: `https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/prices/`,
+  IE: `https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/prices/`,
+  ES: `https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/prices/`,
+  NL: `https://www.ovhcloud.com/nl/enterprise/products/hosted-private-cloud/prices/`,
+  IT: `https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud/prices/`,
+  PL: `https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/prices/`,
+  PT: `https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/prices/`,
+  GB: `https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/prices/`,
+  WE: `https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/prices/`,
+  US: `https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/prices/`,
+};
+
 export default {
   DEDICATED_CLOUD_DATACENTER,
   COMMERCIAL_RANGE_NAME_EOL,
   VDC_MIRGRATION_GUIDE_LINK,
+  PRICE_LINK,
 };

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dedicatedCloud-datacenter.constants.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dedicatedCloud-datacenter.constants.js
@@ -24,16 +24,26 @@ export const VDC_MIRGRATION_GUIDE_LINK = {
 export const PRICE_LINK = {
   DEFAULT:
     'https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/prices/',
-  FR: `https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/prices/`,
-  IE: `https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/prices/`,
-  ES: `https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/prices/`,
-  NL: `https://www.ovhcloud.com/nl/enterprise/products/hosted-private-cloud/prices/`,
-  IT: `https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud/prices/`,
-  PL: `https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/prices/`,
-  PT: `https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/prices/`,
-  GB: `https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/prices/`,
-  WE: `https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/prices/`,
-  US: `https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/prices/`,
+  FR:
+    'https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/prices/',
+  IE:
+    'https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/prices/',
+  ES:
+    'https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/prices/',
+  NL:
+    'https://www.ovhcloud.com/nl/enterprise/products/hosted-private-cloud/prices/',
+  IT:
+    'https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud/prices/',
+  PL:
+    'https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/prices/',
+  PT:
+    'https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/prices/',
+  GB:
+    'https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/prices/',
+  WE:
+    'https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/prices/',
+  US:
+    'https://us.ovhcloud.com/enterprise/products/hosted-private-cloud/prices/',
 };
 
 export default {

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/dedicatedCloud-datacenter-host-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/dedicatedCloud-datacenter-host-order.controller.js
@@ -3,14 +3,18 @@ import head from 'lodash/head';
 import set from 'lodash/set';
 import size from 'lodash/size';
 import sortBy from 'lodash/sortBy';
+import { PRICE_LINK } from '../../dedicatedCloud-datacenter.constants';
 
 export default class {
   /* @ngInject */
-  constructor($q, $translate, OvhHttp, User) {
+  constructor($q, $translate, OvhHttp, User, coreConfig) {
     this.$q = $q;
     this.$translate = $translate;
     this.OvhHttp = OvhHttp;
     this.User = User;
+    this.coreConfig = coreConfig;
+    this.urlPrice =
+      PRICE_LINK[coreConfig.getUser().ovhSubsidiary] || PRICE_LINK.DEFAULT;
   }
 
   $onInit() {

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/dedicatedCloud-datacenter-host-order.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/dedicatedCloud-datacenter-host-order.html
@@ -18,9 +18,19 @@
     >
         <span data-translate="core_user_trusted_retail_prices"></span>
     </oui-message>
+
     <p
         data-ng-bind=":: ('dedicatedCloud_host_order_info_' + $ctrl.pccType) | translate"
     ></p>
+    <a
+        target="_blank"
+        rel="noopener"
+        class="oui-link_icon"
+        data-ng-href="{{ $ctrl.urlPrice}}"
+        data-translate="dedicatedCloud_host_order_price"
+    >
+        <span class="oui-icon oui-icon-external-link" aria-hidden="true"></span>
+    </a>
     <p data-translate="dedicatedCloud_host_order_select"></p>
     <oui-datagrid data-rows-loader="$ctrl.fetchDatagridOffers()">
         <oui-datagrid-column
@@ -51,13 +61,6 @@
             data-title=":: 'dedicatedCloud_host_order_cores' | translate"
         >
             <span data-ng-bind="$row.profile.core"></span>
-        </oui-datagrid-column>
-        <oui-datagrid-column
-            data-title=":: 'dedicatedCloud_host_order_price' | translate"
-        >
-            <span data-ng-bind="$row.prices[0].price.text"></span>
-            <br />
-            <small data-ng-bind="$row.prices[0].description"></small>
         </oui-datagrid-column>
     </oui-datagrid>
     <p data-translate="dedicatedCloud_host_order_quantity"></p>

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_de_DE.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "Sie können Ihre Private Cloud anpassen, indem Sie Hosts hinzufügen. Danach werden Sie zu einem neuen Tab weitergeleitet, um die Bestellung abzuschließen.",
   "dedicatedCloud_host_order_select": "Host-Typ auswählen:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Preis",
+  "dedicatedCloud_host_order_price": "Zur Preisübersicht",
   "dedicatedCloud_host_order_speed": "CPU-Geschwindigkeit",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Core-Anzahl",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_en_GB.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "You can customise your Private Cloud by adding hosts. You will then be redirected to a new tab to complete your order.",
   "dedicatedCloud_host_order_select": "Select a host type:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Price",
+  "dedicatedCloud_host_order_price": "View our prices",
   "dedicatedCloud_host_order_speed": "CPU Speed",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Number of cores",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_es_ES.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "Puede personalizar su cloud privado añadiendo hosts. A continuación, será redirigido a una nueva pestaña en la que podrá finalizar la contratación.",
   "dedicatedCloud_host_order_select": "Seleccionar un tipo de host:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Precio",
+  "dedicatedCloud_host_order_price": "Consultar nuestros precios",
   "dedicatedCloud_host_order_speed": "Velocidad de CPU",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Número de núcleos",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_fr_CA.json
@@ -4,7 +4,7 @@
   "dedicatedCloud_host_order_info_MBM": "Vous pouvez personnaliser votre Essentials en ajoutant des hosts. Vous serez ensuite redirigé vers un nouvel onglet pour finaliser votre commande.",
   "dedicatedCloud_host_order_select": "Sélectionner un type d'host :",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Prix",
+  "dedicatedCloud_host_order_price": "Consulter nos tarifs",
   "dedicatedCloud_host_order_speed": "Vitesse CPU",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Nombre de cores",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_fr_FR.json
@@ -4,7 +4,7 @@
   "dedicatedCloud_host_order_info_MBM": "Vous pouvez personnaliser votre Essentials en ajoutant des hosts. Vous serez ensuite redirigé vers un nouvel onglet pour finaliser votre commande.",
   "dedicatedCloud_host_order_select": "Sélectionner un type d'host :",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Prix",
+  "dedicatedCloud_host_order_price": "Consulter nos tarifs",
   "dedicatedCloud_host_order_speed": "Vitesse CPU",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Nombre de cores",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_it_IT.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "Per personalizzare il Private Cloud è possibile aggiungere host. Verrai reindirizzato a una nuova finestra da cui sarà possibile completare l’ordine.",
   "dedicatedCloud_host_order_select": "Seleziona un tipo di host:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Prezzo",
+  "dedicatedCloud_host_order_price": "Consultare le tariffe",
   "dedicatedCloud_host_order_speed": "Velocità CPU",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Numero di core",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_pl_PL.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "Możesz spersonalizować swoją prywatną chmurę poprzez dodanie hostów. Zostaniesz przekierowany/-a do nowej zakładki, aby sfinalizować zamówienie.",
   "dedicatedCloud_host_order_select": "Wybierz rodzaj hosta:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Cena",
+  "dedicatedCloud_host_order_price": "Sprawdź cennik",
   "dedicatedCloud_host_order_speed": "Prędkość procesora",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Liczba rdzeni",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/host/order/translations/Messages_pt_PT.json
@@ -3,7 +3,7 @@
   "dedicatedCloud_host_order_info_EPCC": "Pode personalizar o seu Private Cloud adicionando hosts. De seguida, será redirecionado para um novo separador para finalizar a sua encomenda.",
   "dedicatedCloud_host_order_select": "Selecionar um tipo de host:",
   "dedicatedCloud_host_order_host": "Host",
-  "dedicatedCloud_host_order_price": "Preço",
+  "dedicatedCloud_host_order_price": "Consultar os nossos preços",
   "dedicatedCloud_host_order_speed": "Frequência CPU",
   "dedicatedCloud_host_order_memory": "RAM",
   "dedicatedCloud_host_order_cores": "Número de cores",


### PR DESCRIPTION
ref:MANAGER-10311

Signed-off-by: stif59100 <steeve.vanderstocken@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2246-2248`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-10311
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I delete the column price and add a link for price for host and datastore dedicated cloud

## Related

<!-- Link dependencies of this PR -->

:flags: Translation
- [x] TRANS-47379