### PR TITLE
fix(modules.vps): unblock vps memory upgrade

### DIFF
--- a/packages/manager/modules/vps/src/upscale/upscale.routing.js
+++ b/packages/manager/modules/vps/src/upscale/upscale.routing.js
@@ -39,7 +39,9 @@ export default /* @ngInject */ function($stateProvider) {
           .then(({ data }) => [
             ...data.map((option) => ({
               ...option,
-              ...catalog.products.find(({ name }) => name === option.planCode),
+              ...catalog.products.find(
+                ({ name }) => name === option.productName,
+              ),
             })),
             {
               ...current,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/us-vps-improvement`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-10374
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. display catalog products that are eligible for upgrade
2. compare using `productName` instead of `planCode` because `catalog.products` don't provide `planCode`
