### PR TITLE
fix(dedicated.server): remove card expansion for hardware infos

### DIFF
--- a/packages/manager/modules/bm-server-components/src/technical-details/technical-details.html
+++ b/packages/manager/modules/bm-server-components/src/technical-details/technical-details.html
@@ -85,12 +85,4 @@
             'dedicated_server_dashboard_technical_details_data_disk_upgrade') | translate"
         ></span>
     </oui-tile-button>
-    <oui-tile-definition
-        term="{{:: 'dedicated_server_dashboard_technical_details_extension_card_many' | translate }}"
-        data-ng-if="$ctrl.formattedExtensionCard"
-    >
-        <oui-tile-description>
-            <span data-ng-bind=":: $ctrl.formattedExtensionCard"></span>
-        </oui-tile-description>
-    </oui-tile-definition>
 </oui-tile>


### PR DESCRIPTION
ref:MANAGER-10249

Signed-off-by: stif59100 <steeve.vanderstocken@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? |no
| Tickets          | MANAGER-10249
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~ Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I remove the informations of expansion cards for hardware informations dedicated server

## Related

<!-- Link dependencies of this PR -->
