### PR TITLE
fix(dedicated): enable weathermap link

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.constants.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.constants.js
@@ -10,9 +10,8 @@ export const URLS = {
 };
 
 export const WEATHERMAP_URL = {
-  EU: 'http://weathermap.ovh.net/',
-  CA: 'http://weathermap.ovh.net/',
   US: 'http://weathermap.ovh.net/#usa',
+  OTHERS: 'http://weathermap.ovh.net/',
 };
 
 const COMMIT_RECOMMIT_IMPRESSION_TRACKING_DATA = {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/dashboard/dashboard.controller.js
@@ -44,7 +44,7 @@ export default class DedicatedServerDashboard {
     this.RECOMMIT_IMPRESSION_TRACKING_DATA = RECOMMIT_IMPRESSION_TRACKING_DATA;
 
     this.servicesStateLinks = {
-      weathermap: WEATHERMAP_URL[this.user.country],
+      weathermap: WEATHERMAP_URL[this.user.country] || WEATHERMAP_URL.OTHERS,
       vms: this.constants.vmsUrl,
       status: this.constants.statusUrl,
     };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2248-2250` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... DTRSD-89252
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description
The links displayed in the section "Etats des services", the link "weathermap" has no link.

