### PR TITLE
fix(storage.databases): datatr-145 - change price unit for offers

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_de_DE.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD-Storage",
   "pci_database_plans_list_current_offer": "Derzeitiges Angebot",
   "pci_database_plans_list_spec_private_network": "Private Netzwerke",
-  "pci_database_plans_list_spec_price_unit": " / Stunde / Node"
+  "pci_database_plans_list_spec_price_unit": " / Stunde"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_en_GB.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} SSD storage",
   "pci_database_plans_list_current_offer": "Current solution",
   "pci_database_plans_list_spec_private_network": "Private networks",
-  "pci_database_plans_list_spec_price_unit": " /hour/node"
+  "pci_database_plans_list_spec_price_unit": " /hour"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_es_ES.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} de almacenamiento SSD",
   "pci_database_plans_list_current_offer": "Solución actual",
   "pci_database_plans_list_spec_private_network": "Redes privadas",
-  "pci_database_plans_list_spec_price_unit": " /hora por nodo"
+  "pci_database_plans_list_spec_price_unit": " /hora"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_CA.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} de stockage SSD",
   "pci_database_plans_list_current_offer": "Offre actuelle",
   "pci_database_plans_list_spec_private_network": "Réseaux privés",
-  "pci_database_plans_list_spec_price_unit": " / heure / nœud"
+  "pci_database_plans_list_spec_price_unit": " / heure"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} de stockage SSD",
   "pci_database_plans_list_current_offer": "Offre actuelle",
   "pci_database_plans_list_spec_private_network": "Réseaux privés",
-  "pci_database_plans_list_spec_price_unit": " / heure / nœud"
+  "pci_database_plans_list_spec_price_unit": " / heure"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_it_IT.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} di storage SSD",
   "pci_database_plans_list_current_offer": "Soluzione corrente",
   "pci_database_plans_list_spec_private_network": "Reti private",
-  "pci_database_plans_list_spec_price_unit": " /ora/nodo"
+  "pci_database_plans_list_spec_price_unit": " /ora"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pl_PL.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} przestrzeni dyskowej SSD",
   "pci_database_plans_list_current_offer": "Aktualna oferta",
   "pci_database_plans_list_spec_private_network": "Sieci prywatne",
-  "pci_database_plans_list_spec_price_unit": " / godzina / węzeł"
+  "pci_database_plans_list_spec_price_unit": " /godzina"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_pt_PT.json
@@ -12,5 +12,5 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} de armazenamento SSD",
   "pci_database_plans_list_current_offer": "Oferta atual",
   "pci_database_plans_list_spec_private_network": "Redes privadas",
-  "pci_database_plans_list_spec_price_unit": " /hora por nó"
+  "pci_database_plans_list_spec_price_unit": " /hora"
 }


### PR DESCRIPTION
DATATR-145

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-145
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Change price unit for offers

### :flags: Translations
- [x] TRANS-47953
