### PR TITLE
fix(pci.storages.databases): datatr-149 add translation for pending status into maintenance view

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_de_DE.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "Bei der Durchführung der Wartungsarbeiten ist ein Fehler aufgetreten.",
   "pci_databases_maintenances_update_time_success": "Der Zeitpunkt der Wartung wurde geändert und gilt nun für die kommenden Wartungsarbeiten.",
   "pci_databases_maintenances_update_time_error": "Bei der Änderung des Zeitpunkts der Wartung ist ein Fehler aufgetreten.",
-  "pci_databases_maintenances_update_time": "Zeitpunkt für Wartungen (UTC)"
+  "pci_databases_maintenances_update_time": "Zeitpunkt für Wartungen (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "Ausstehend"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_en_GB.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "An error has occurred applying maintenance",
   "pci_databases_maintenances_update_time_success": "The maintenance time has been updated successfully, and will be applied to future maintenance.",
   "pci_databases_maintenances_update_time_error": "An error has occurred updating the maintenance time",
-  "pci_databases_maintenances_update_time": "Maintenance time (UTC)"
+  "pci_databases_maintenances_update_time": "Maintenance time (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "Queued"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_es_ES.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "Se ha producido un error al ejecutar el mantenimiento.",
   "pci_databases_maintenances_update_time_success": "La hora de mantenimiento se ha modificado correctamente y se aplicará a las próximas operaciones de mantenimiento.",
   "pci_databases_maintenances_update_time_error": "Se ha producido un error al modificar la hora de mantenimiento.",
-  "pci_databases_maintenances_update_time": "Hora de mantenimiento (UTC)"
+  "pci_databases_maintenances_update_time": "Hora de mantenimiento (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "Pendiente"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_fr_CA.json
@@ -10,6 +10,7 @@
   "pci_databases_maintenances_maintenance_status_APPLYING": "En cours",
   "pci_databases_maintenances_maintenance_status_SCHEDULED": "Planifiée",
   "pci_databases_maintenances_maintenance_status_ERROR": "En erreur",
+  "pci_databases_maintenances_maintenance_status_PENDING": "En attente",
   "pci_databases_maintenances_maintenance_apply_now": "Appliquer maintenant",
   "pci_databases_maintenances_back": "Informations générales",
   "pci_databases_maintenances_maintenance_apply_success": "La maintenance a été appliquée avec succès",

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_fr_FR.json
@@ -10,6 +10,7 @@
   "pci_databases_maintenances_maintenance_status_APPLYING": "En cours",
   "pci_databases_maintenances_maintenance_status_SCHEDULED": "Planifiée",
   "pci_databases_maintenances_maintenance_status_ERROR": "En erreur",
+  "pci_databases_maintenances_maintenance_status_PENDING": "En attente",
   "pci_databases_maintenances_maintenance_apply_now": "Appliquer maintenant",
   "pci_databases_maintenances_back": "Informations générales",
   "pci_databases_maintenances_maintenance_apply_success": "La maintenance a été appliquée avec succès",

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_it_IT.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "Si è verificato un errore durante l'avvio della manutenzione",
   "pci_databases_maintenances_update_time_success": "L'orario della manutenzione è stato modificato correttamente e sarà applicato alle prossime operazioni.",
   "pci_databases_maintenances_update_time_error": "Si è verificato un errore durante la modifica dell'orario della manutenzione",
-  "pci_databases_maintenances_update_time": "Orario della manutenzione (UTC)"
+  "pci_databases_maintenances_update_time": "Orario della manutenzione (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "In attesa"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_pl_PL.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "Wystąpił błąd podczas realizacji prac konserwacyjnych",
   "pci_databases_maintenances_update_time_success": "Godzina prac konserwacyjnych została zmodyfikowana i zostanie zastosowana podczas kolejnych prac.",
   "pci_databases_maintenances_update_time_error": "Wystąpił błąd podczas zmiany godziny prac konserwacyjnych",
-  "pci_databases_maintenances_update_time": "Godzina prac konserwacyjnych (UTC)"
+  "pci_databases_maintenances_update_time": "Godzina prac konserwacyjnych (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "Oczekujące"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/maintenances/translations/Messages_pt_PT.json
@@ -16,5 +16,6 @@
   "pci_databases_maintenances_maintenance_apply_error": "Ocorreu um erro aquando da aplicação da manutenção",
   "pci_databases_maintenances_update_time_success": "A hora de manutenção foi modificada com sucesso e será aplicada às próximas manutenções.",
   "pci_databases_maintenances_update_time_error": "Ocorreu um erro aquando da modificação da hora de manutenção",
-  "pci_databases_maintenances_update_time": "Hora de manutenção (UTC)"
+  "pci_databases_maintenances_update_time": "Hora de manutenção (UTC)",
+  "pci_databases_maintenances_maintenance_status_PENDING": "Em espera"
 }


### PR DESCRIPTION
DATATR-148

Signed-off-by: Alexandre Claveau <alexandre.claveau@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-149
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- Add new translation

### :flags: Translations
- [x] TRANS-48179
