### PR TITLE
fix(dedicated): map right incoming bandwidth

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/interfaces.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/interfaces/interfaces.html
@@ -198,7 +198,7 @@
         <div data-ng-if="$row.isPublic()">
             <span class="oui-icon oui-icon-arrow-down font-inherit"></span>
             <span
-                data-ng-bind="$ctrl.specifications.connection | serverBandwidth"
+                data-ng-bind="$ctrl.specifications.bandwidth.InternetToOvh | serverBandwidth"
             ></span>
         </div>
         <div data-ng-if="!$row.isPublic()">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-87713
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Fix to display correct incoming bandwidth information on network interfaces 

## Related

<!-- Link dependencies of this PR -->
