### PR TITLE
fix(pci.kube.reset): force routing to true if gateway enabled

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/reset/reset.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/service/reset/reset.controller.js
@@ -61,7 +61,7 @@ export default class kubernetesResetCtrl {
       ...(this.model.network.gateway.enabled && {
         privateNetworkConfiguration: {
           defaultVrackGateway: this.model.network.gateway.ip,
-          privateNetworkRoutingAsDefault: !this.model.network.gateway.ip,
+          privateNetworkRoutingAsDefault: true,
         },
       }),
     };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2250-2252`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-103302
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description
1.  in case where the gateway is enabled we have to force default as true
