### PR TITLE
fix(dedicated.ip): resolve scope issue in firewall

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/rule/add/ip-ip-firewall-rule-add.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/rule/add/ip-ip-firewall-rule-add.controller.js
@@ -133,7 +133,7 @@ export default /* @ngInject */ (
     $scope.loading = true;
 
     // set empty string to null values to avoid API error
-    $scope.rule.source = isEmpty(get($scope.rule, 'source', '').trim())
+    $scope.rule.source = isEmpty(get($scope.rule, 'source', '')?.trim())
       ? null
       : $scope.rule.source;
     $scope.rule.sourcePort = isEmpty(get($scope.rule, 'sourcePort', '').trim())

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
@@ -430,7 +430,7 @@ export default class IpListController {
       self
         .goToGameFirewall(ip)
         .then(() =>
-          $scope.$broadcast('ips.gameFirewall.display', { ipBlock, ip }),
+          $rootScope.$broadcast('ips.gameFirewall.display', { ipBlock, ip }),
         );
     };
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/worldline-w51`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10625
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

When user tries to navigate from ip page to game firewall there was a error due to incorrect scoping.  

## Related

<!-- Link dependencies of this PR -->
