### PR TITLE
Fix/dtrsd-102443: load vrack translations

### DIFF
--- a/packages/manager/modules/vrack/src/index.js
+++ b/packages/manager/modules/vrack/src/index.js
@@ -52,5 +52,12 @@ angular
         },
       });
     },
-  );
+  )
+  .run(
+    /* @ngInject */ ($translate, $transitions) => {
+      $transitions.onBefore({ to: 'vrack.**' }, () => $translate.refresh());
+    },
+  )
+  .run(/* @ngTranslationsInject:json ./translations */);
+
 export default moduleName;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2050-2052`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-102443
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. load translation before loading the state