### PR TITLE
fix(public-cloud.privatenetwork): change the color for dhcp desactivate

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-networks/private-networks.html
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/private-networks.html
@@ -166,7 +166,7 @@
                                         data-translate="pci_projects_project_network_private_dhcp_active"
                                     ></span>
                                     <span
-                                        class="oui-badge oui-badge_error"
+                                        class="oui-badge oui-badge_sold-out"
                                         data-ng-if="!$row.loading && !subnetDetail.dhcpEnabled"
                                         data-translate="pci_projects_project_network_private_dhcp_disabled"
                                     ></span>


### PR DESCRIPTION
ref: MANAGER-10429

Signed-off-by: stif59100 <steeve.vanderstocken@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2252-2302
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | MANAGER-10429
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I change the color for dhcp on private network when he's desactivate

## Related

<!-- Link dependencies of this PR -->
