### PR TITLE
fix(public-cloud.aitraining): change the breacrumb for english trad

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/training/translations/Messages_en_GB.json
@@ -4,7 +4,7 @@
   "pci_projects_project_training_parter_cli_name": "ovhai",
   "pci_projects_project_training_install_title": "Startup",
   "pci_projects_project_training_jobs_title": "Jobs",
-  "pci_projects_project_training_registries_title": "Private Docker<b> </b>Registry",
+  "pci_projects_project_training_registries_title": "Private Docker Registry",
   "pci_projects_project_training_jobs_list_submit": "Launch a new job",
   "pci_projects_project_training_data_list_add": "Attach a data container",
   "pci_projects_project_training_dashboard_title": "Home",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2252-2302
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-93019
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I deleted balise <b> on trad english anormaly

## Related

<!-- Link dependencies of this PR -->
