### PR TITLE
fix(pci.storages.databases): datatr-171 - clear datasets when updating metrics

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/metrics/metrics.controller.js
@@ -108,8 +108,9 @@ export default class MetricsCtrl {
         this.selectedTimeRange.value,
       ).then((data) => {
         const metrics = sortBy(data.metrics, 'hostname');
-        this.metricsData[data.name].data = data;
 
+        this.metricsData[data.name].data = data;
+        this.metricsData[data.name].chart.data.datasets = [];
         metrics.forEach((metric) => {
           this.metricsData[data.name].chart.updateSerie(
             metric.hostname,


### PR DESCRIPTION
DATATR-171

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-171
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

When updating metrics charts, we should clear datasets first.
