### PR TITLE
fix(apps.sign-up): use en language for us region

### DIFF
--- a/packages/manager/apps/sign-up/src/form/form.controller.js
+++ b/packages/manager/apps/sign-up/src/form/form.controller.js
@@ -3,11 +3,13 @@ import isFunction from 'lodash/isFunction';
 import some from 'lodash/some';
 
 const OVH_SUBSIDIARY_ITEM_NAME = 'ovhSubsidiaryCreationForm';
+const US_DEFAULT_LANGUAGE = 'en';
 
 export default class SignUpFormAppCtrl {
   /* @ngInject */
-  constructor($location, atInternet) {
+  constructor($location, coreConfig, atInternet) {
     this.$location = $location;
+    this.coreConfig = coreConfig;
     this.atInternet = atInternet;
     this.isActivityStepVisible = false;
     this.saveError = null;
@@ -64,6 +66,15 @@ export default class SignUpFormAppCtrl {
   $onInit() {
     this.saveError = null;
     this.loading.init = true;
+
+    /**
+     * temporary fixed to avoid inherit another language for US customers
+     * TODO: It's better to have a feature to allow customers change the language as we have across Manager
+     */
+    const { lang } = this.$location.search();
+    if (this.coreConfig.isRegion('US') && lang !== US_DEFAULT_LANGUAGE) {
+      this.$location.search('lang', US_DEFAULT_LANGUAGE);
+    }
 
     const { ovhSubsidiary } = this.$location.search();
     if (ovhSubsidiary && ovhSubsidiary.match(/^[\w]{2}$/)) {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-104272
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. avoid using another language instead of English on signup page for US customers