### PR TITLE
fix(telecom): display correct international numbers

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/international/international.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/international/international.controller.js
@@ -95,9 +95,9 @@ export default /* @ngInject */ function TelecomTelephonyAliasOrderInternationalC
   };
 
   this.changeZone = function changeZone() {
-    this.loading.init = true;
+    this.loading.numbers = true;
     getSpecificNumbers(self.form.country, self.form.zone).finally(() => {
-      self.loading.init = false;
+      self.loading.numbers = false;
     });
   };
 
@@ -224,6 +224,7 @@ export default /* @ngInject */ function TelecomTelephonyAliasOrderInternationalC
     self.billingAccount = $stateParams.billingAccount;
     self.loading = {
       init: true,
+      numbers: false,
     };
 
     self.preAmount = TELEPHONY_NUMBER_OFFER.preAmount.map((elt) => ({

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/international/international.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/international/international.html
@@ -133,7 +133,7 @@
                         <telecom-telephony-billing-account-order-alias-number-choice
                             name="offerChoice"
                             data-ng-model="AliasOrderInternationalCtrl.form"
-                            data-ng-if="AliasOrderInternationalCtrl.prices"
+                            data-ng-if="AliasOrderInternationalCtrl.prices && !AliasOrderInternationalCtrl.loading.numbers"
                             data-choices="AliasOrderInternationalCtrl.predefinedNumbers"
                             data-prices="AliasOrderInternationalCtrl.prices"
                             data-type="geographical"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2252-2302`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-101563
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display correct international numbers for selection based on selected geographic zone
