### PR TITLE
fix(modules.storage): use help-text directive instead of tooltip

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.html
@@ -88,7 +88,7 @@
                 <oui-field
                     data-ng-if="!$ctrl.archive"
                     data-label="{{:: 'pci_projects_project_storages_containers_container_info_publicUrl' | translate }}"
-                    data-label-popover="{{:: 'pci_projects_project_storages_containers_container_info_publicUrl_help' | translate }}"
+                    data-help-text="{{:: 'pci_projects_project_storages_containers_container_info_publicUrl_help' | translate}}"
                 >
                     <oui-clipboard
                         data-name="containerPublicUrl"
@@ -100,7 +100,7 @@
                 <oui-field
                     data-ng-if="!$ctrl.archive"
                     data-label="{{:: $ctrl.container.s3StorageType ? $ctrl.objectS3staticUrlInfo : ('pci_projects_project_storages_containers_container_object_info_staticUrl' | translate) }}"
-                    data-label-popover="{{:: 'pci_projects_project_storages_containers_container_object_info_' + ($ctrl.container.s3StorageType ? 's3_staticUrl_help' : 'staticUrl_help') | translate }}"
+                    data-help-text="{{:: 'pci_projects_project_storages_containers_container_object_info_' + ($ctrl.container.s3StorageType ? 's3_staticUrl_help' : 'staticUrl_help') | translate }}"
                 >
                     <oui-clipboard
                         data-name="containerStaticUrl"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2302-2304`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-97503
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
1. to avoid mobile display issue, instead of using the label-tooltip we use help-text directive