### PR TITLE
feat: add support of apiv2

### DIFF
--- a/packages/manager/modules/core/src/index.js
+++ b/packages/manager/modules/core/src/index.js
@@ -230,6 +230,10 @@ export const registerCoreModule = (environment, { onLocaleChange } = {}) => {
             urlPrefix: '/engine/apiv6',
           },
           {
+            serviceType: 'apiv2',
+            urlPrefix: '/engine/api/v2',
+          },
+          {
             serviceType: 'aapi',
             urlPrefix: '/engine/2api',
           },

--- a/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
+++ b/packages/manager/modules/ng-layout-helpers/src/list/list-layout.utils.js
@@ -195,6 +195,7 @@ export const stateResolves = {
     $q,
     $transition$,
     apiPath,
+    apiVersion,
     defaultFilterColumn,
     iceberg,
     staticResources,
@@ -215,6 +216,7 @@ export const stateResolves = {
 
       let request = iceberg(apiPath)
         .query()
+        .setApiVersion(apiVersion)
         .expand('CachedObjectList-Pages')
         .limit(pageSize)
         .offset(page)
@@ -236,6 +238,16 @@ export const stateResolves = {
   schema: /* @ngInject */ ($http, apiPath) =>
     $http.get(`${apiPath}.json`).then(({ data }) => data),
   apiModel: /* @ngInject */ (dataModel, schema) => schema.models[dataModel],
+  apiVersion: /* @ngInject */ ($transition$) => {
+    try {
+      return $transition$
+        .injector()
+        .getAsync('serviceType')
+        .then((serviceType) => serviceType || 'apiv6');
+    } catch (err) {
+      return 'apiv6';
+    }
+  },
   paginationNumber: /* @ngInject */ (
     $transition$,
     resources,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | DTCORE-511
| License          | BSD 3-Clause

## Description

Add `apiv2` service type in `ssoAuthenticationProvider` in order to query the apiv2.
Enable to use `apiv2` with list layout from `ng-layout-helpers` package.

## Related

- ovh-ux/ng-ovh-api-wrappers#77
