### PR TITLE
build(deps): bump ng-ovh-api-wrappers to 5.1.0

### DIFF
--- a/packages/manager/apps/anthos/package.json
+++ b/packages/manager/apps/anthos/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-config": "^6.5.2",
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-telecom-styles": "^4.6.1",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-mondial-relay": "^8.5.1",

--- a/packages/manager/apps/cda/package.json
+++ b/packages/manager/apps/cda/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",

--- a/packages/manager/apps/dbaas-logs/package.json
+++ b/packages/manager/apps/dbaas-logs/package.json
@@ -28,7 +28,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -56,7 +56,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-browser-alert": "^2.0.6",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contacts": "^5.1.3",

--- a/packages/manager/apps/email-domain/package.json
+++ b/packages/manager/apps/email-domain/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-email-domain": "^1.2.2",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",

--- a/packages/manager/apps/email-pro/package.json
+++ b/packages/manager/apps/email-pro/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-emailpro": "^3.3.3",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",

--- a/packages/manager/apps/exchange/package.json
+++ b/packages/manager/apps/exchange/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-exchange": "^2.0.0 || ^3.0.0",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",

--- a/packages/manager/apps/freefax/package.json
+++ b/packages/manager/apps/freefax/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-telecom-styles": "^4.6.1",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.6",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/manager-trusted-nic": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/metrics/package.json
+++ b/packages/manager/apps/metrics/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/manager-server-sidebar": "^3.29.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/netapp/package.json
+++ b/packages/manager/apps/netapp/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",

--- a/packages/manager/apps/nutanix/package.json
+++ b/packages/manager/apps/nutanix/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-nutanix": "^1.5.3",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",

--- a/packages/manager/apps/office/package.json
+++ b/packages/manager/apps/office/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-office": "^2.8.2",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-overthebox": "^6.9.2",
     "@ovh-ux/manager-telecom-styles": "^4.6.1",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.6",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-http": "^5.0.6",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-trusted-nic": "^0.0.0 || ^1.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contacts": "^5.1.3",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contacts": "^5.1.3",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",

--- a/packages/manager/apps/sharepoint/package.json
+++ b/packages/manager/apps/sharepoint/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-sharepoint": "^2.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-payment-method": "^9.4.1",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",

--- a/packages/manager/apps/sms/package.json
+++ b/packages/manager/apps/sms/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/manager-telecom-styles": "^4.6.1",
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.6",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -21,7 +21,7 @@
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-support": "^1.16.1",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.8",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -40,7 +40,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-browser-alert": "^2.0.6",
     "@ovh-ux/ng-ovh-checkbox-table": "^2.0.6",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/manager-filters": "^0.1.0 || ^1.1.1",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-veeam-cloud-connect": "^1.0.0 || ^2.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-veeam-enterprise": "^0.3.0 || ^1.0.0",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-http": "^5.0.6",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.6",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/manager-product-offers": "^5.3.1",
     "@ovh-ux/manager-vps": "^2.29.4",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.6",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-core": "^12.12.9",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.2",
     "@ovh-ux/manager-vrack": "^1.5.3",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/web-paas/package.json
+++ b/packages/manager/apps/web-paas/package.json
@@ -26,7 +26,7 @@
     "@ovh-ux/manager-web-paas": "^1.6.1",
     "@ovh-ux/manager-webpack-dev-server": "^2.10.0 || ^3.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.5",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.7",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -41,7 +41,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.5",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^3.2.3",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.16",
-    "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^5.1.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.7.1",
     "@ovh-ux/ng-ovh-contracts": "^4.2.3",
     "@ovh-ux/ng-ovh-export-csv": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,10 +6551,10 @@
     rollup-plugin-sass "^1.2.2"
     slash "^2.0.0"
 
-"@ovh-ux/ng-ovh-api-wrappers@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-api-wrappers/-/ng-ovh-api-wrappers-5.0.0.tgz#b6d2668cb37592594369315ed3c563b6ab53837b"
-  integrity sha512-VXWI8X3GNPBI3Jxormh0E/WRgVi4Q3yA1UX6sRPNcID+eZCzLVSt58nXSttcgmJoQnVVDBMOYnuxT8WDAEe+pA==
+"@ovh-ux/ng-ovh-api-wrappers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-api-wrappers/-/ng-ovh-api-wrappers-5.1.0.tgz#b8bfef258a4e0860eabf219cb1880ca0a15da687"
+  integrity sha512-xljPUGrnTPUNnuTAblmOonCMnrrh2KcoUytvO4eIKFva2Dzd2AavUcSo0qbKgmCdFX86v96DDldHO89S/eQKmA==
   dependencies:
     lodash "^4.17.21"
 
@@ -10833,11 +10833,6 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -10853,7 +10848,7 @@ commander@7:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-commander@^2.18.0, commander@^2.20.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -14604,10 +14599,15 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatpickr@4.6.9, flatpickr@^4.6.3, flatpickr@~4.5.2:
+flatpickr@^4.6.3:
   version "4.6.9"
   resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.9.tgz#9a13383e8a6814bda5d232eae3fcdccb97dc1499"
   integrity sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw==
+
+flatpickr@~4.5.2:
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.5.7.tgz#6efc0d93c65547aa77294205c67830ebabe3565c"
+  integrity sha512-JqPfihUc9A/j9QAsh6otoARmMyUauPE17vRBEG+ThJwbl8zAq4ssGpxlPK3wWM/i8EFxkHg9UuVo0ds7XluKxw==
 
 flatted@^2.0.0:
   version "2.0.1"
@@ -23938,13 +23938,6 @@ rxjs@^7.0.0:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.2.0:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
-  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-2304-2306-w4`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [ ] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Bump `ng-ovh-api-wrappers` from `5.0.0` to `5.1.0`
