### PR TITLE
fix(pci.ai): datatr-186 - ai deploy - add default port to model

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/ai/apps/add/add.controller.js
@@ -130,6 +130,7 @@ export default class AppAddController {
       scalingStrategy,
       preset,
       probe,
+      port,
     } = appModel;
 
     return {
@@ -146,6 +147,7 @@ export default class AppAddController {
       unsecureHttp: APP_PRIVACY_SETTINGS.PUBLIC === privacy,
       probe: AppAddController.buildProbe(probe),
       scalingStrategy: AppAddController.buildScalingBody(scalingStrategy),
+      defaultHttpPort: port,
     };
   }
 


### PR DESCRIPTION
datatr-186

Signed-off-by: Jonathan Perchoc <jonathan.perchoc@ovhcloud.com>

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #datatr-186
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Forward default http port  from model to api for apps.