### PR TITLE
fix(pci.storages.databases):datatr-187 - replace soft cancel per immediate termination

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
@@ -833,11 +833,17 @@ export default class DatabaseService {
       .then(({ data }) => data);
   }
 
-  postTerminateQuery(serviceName, databaseId, databaseEngine, queryPid) {
+  postTerminateQuery(
+    serviceName,
+    databaseId,
+    databaseEngine,
+    queryPid,
+    terminateRequest,
+  ) {
     return this.$http
       .post(
         `/cloud/project/${serviceName}/database/${databaseEngine}/${databaseId}/currentQueries/cancel`,
-        { pid: queryPid },
+        { pid: queryPid, terminate: terminateRequest },
       )
       .then(({ data }) => data);
   }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/current-queries.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/current-queries.controller.js
@@ -18,7 +18,6 @@ export default class {
     this.showIdleConnections = true;
     this.showActiveConnections = true;
     this.autorefreshPage = false;
-    this.IDLE_QUERY_STATES = IDLE_QUERY_STATES;
     this.loading = {
       queries: false,
     };
@@ -122,6 +121,7 @@ export default class {
       this.database.id,
       this.database.engine,
       query.pid,
+      true,
     )
       .then(() => {
         this.getCurrentQueries();

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/current-queries.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/current-queries.html
@@ -126,7 +126,6 @@
         <oui-action-menu data-compact data-placement="end">
             <oui-action-menu-item
                 data-on-click="$ctrl.trackAndTerminateQuery($row)"
-                data-disabled="$ctrl.IDLE_QUERY_STATES.includes($row.state)"
             >
                 <span
                     data-translate="pci_databases_current_queries_datagrid_terminate_action_label"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/current-queries/translations/Messages_fr_FR.json
@@ -15,6 +15,6 @@
   "pci_databases_current_queries_datagrid_column_application_name": "Nom d'application",
   "pci_databases_current_queries_fetch_error": "Une erreur est survenue lors du chargement des requêtes en cours. Merci d'essayer ultérieurement.",
   "pci_databases_current_queries_datagrid_terminate_action_label": "Terminer",
-  "pci_databases_current_queries_datagrid_terminate_action_success": "La requête identifiée {{pid}} est en train de se terminer.",
+  "pci_databases_current_queries_datagrid_terminate_action_success": "La requête identifiée {{pid}} est en train de se terminer et disparaîtra de la liste au prochain rafraîchissement.",
   "pci_databases_current_queries_datagrid_terminate_action_error": "Impossible de terminer la requête identifiée {{pid}}."
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/datatr-176-terminate-current-query
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-187
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Replace soft cancel per immediate termination

## Related

[DATATR-176](https://github.com/ovh/manager/pull/8782/files)
