### PR TITLE
build(release): add signed-off-by line

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -64,7 +64,7 @@ create_release_note() (
 push_and_release() {
   printf "%s\n" "Commit and tag"
   git add .
-  git commit -m "release: $1"
+  git commit -s -m "release: $1"
   git tag -a -m "release: $1" "$1"
   if ! "${DRY_RELEASE}"; then
     gh config set prompt disabled


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | none
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (not applicable)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ (not applicable)
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~ (not applicable)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (not applicable)

## Description

### :construction_worker: Build

0a97a78 - build(release): add signed-off-by line

## Related

#7973

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>
