### PR TITLE
fix(hosting.ftp): fix user display for cloudweb

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_de_DE.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Inaktiv",
   "hosting_dashboard_email_offer_get_error": "Es ist unmöglich, die E-Mail-Adresse wiederherzustellen.",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Mehr"
+  "hosting_dashboard_tabs_dropdown": "Mehr",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP und SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_en_GB.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Disabled",
   "hosting_dashboard_email_offer_get_error": "Unable to retrieve email address",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "More"
+  "hosting_dashboard_tabs_dropdown": "More",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP and SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_es_ES.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Inactivo",
   "hosting_dashboard_email_offer_get_error": "No se ha podido cargar la dirección de correo.",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Más"
+  "hosting_dashboard_tabs_dropdown": "Más",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP y SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_CA.json
@@ -728,6 +728,8 @@
   "hosting_tab_FTP_FTP_port": "Port FTP :",
   "hosting_tab_FTP_SFTP_port": "Port SFTP :",
   "hosting_tab_FTP_SSH_port": "Port SSH :",
+  "hosting_tab_FTP_FTP_user": "FTP :",
+  "hosting_tab_FTP_SSH_user": "SFTP et SSH :",
   "hosting_tab_FTP_dashboard_login": "Login principal :",
   "hosting_tab_FTP_dashboard_login_enabled": "Login principal activé :",
   "hosting_tab_FTP_dashboard_homez": "Chemin du répertoire home :",

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_fr_FR.json
@@ -728,6 +728,8 @@
   "hosting_tab_FTP_FTP_port": "Port FTP :",
   "hosting_tab_FTP_SFTP_port": "Port SFTP :",
   "hosting_tab_FTP_SSH_port": "Port SSH :",
+  "hosting_tab_FTP_FTP_user": "FTP :",
+  "hosting_tab_FTP_SSH_user": "SFTP et SSH :",
   "hosting_tab_FTP_dashboard_login": "Login principal :",
   "hosting_tab_FTP_dashboard_login_enabled": "Login principal activé :",
   "hosting_tab_FTP_dashboard_homez": "Chemin du répertoire home :",

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_it_IT.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Disattivo",
   "hosting_dashboard_email_offer_get_error": "Impossibile recuperare l’indirizzo email",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Più"
+  "hosting_dashboard_tabs_dropdown": "Più",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP e SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pl_PL.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Nieaktywny",
   "hosting_dashboard_email_offer_get_error": "Nie można pobrać adresu e-mail",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Więcej"
+  "hosting_dashboard_tabs_dropdown": "Więcej",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP i SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/hosting/dashboard/translations/Messages_pt_PT.json
@@ -1353,5 +1353,7 @@
   "hosting_dashboard_service_common_inactive": "Inativo",
   "hosting_dashboard_email_offer_get_error": "Não é possível recuperar o endereço de e-mail",
   "hosting_dashboard_stats_status": "Beta",
-  "hosting_dashboard_tabs_dropdown": "Mais"
+  "hosting_dashboard_tabs_dropdown": "Mais",
+  "hosting_tab_FTP_FTP_user": "FTP:",
+  "hosting_tab_FTP_SSH_user": "SFTP e SSH:"
 }

--- a/packages/manager/apps/web/client/app/hosting/ftp/FTP.html
+++ b/packages/manager/apps/web/client/app/hosting/ftp/FTP.html
@@ -41,11 +41,18 @@
                                 ></oui-clipboard>
                             </dd>
 
-                            <dt data-translate="hosting_tab_FTP_FTP_port"></dt>
-                            <dd data-ng-bind="ftp.port"></dd>
-
-                            <dt data-translate="hosting_tab_FTP_SFTP_port"></dt>
-                            <dd data-ng-bind="ssh.port"></dd>
+                            <dl
+                                class="w-50 oui-description oui-description_horizontal"
+                            >
+                                <dt
+                                    data-translate="hosting_tab_FTP_FTP_port"
+                                ></dt>
+                                <dd data-ng-bind="ftp.port"></dd>
+                                <dt
+                                    data-translate="hosting_tab_FTP_SFTP_port"
+                                ></dt>
+                                <dd data-ng-bind="ssh.port"></dd>
+                            </dl>
                         </dl>
                     </div>
 
@@ -358,6 +365,28 @@
                             data-translate="hosting_tab_FTP_dashboard_login"
                         ></dt>
                         <dd
+                            data-ng-if="ctrlHostingTabFTP.primaryUser.ftp.user !== ctrlHostingTabFTP.primaryUser.ssh.user"
+                            class="mb-3"
+                        >
+                            <div>
+                                <span
+                                    data-translate="hosting_tab_FTP_FTP_user"
+                                ></span>
+                                <span
+                                    data-ng-bind="ctrlHostingTabFTP.primaryUser.ftp.user"
+                                ></span>
+                            </div>
+                            <div>
+                                <span
+                                    data-translate="hosting_tab_FTP_SSH_user"
+                                ></span>
+                                <span
+                                    data-ng-bind="ctrlHostingTabFTP.primaryUser.ssh.user"
+                                ></span>
+                            </div>
+                        </dd>
+                        <dd
+                            data-ng-if="ctrlHostingTabFTP.primaryUser.ftp.user === ctrlHostingTabFTP.primaryUser.ssh.user"
                             class="mb-3"
                             data-ng-bind="ctrlHostingTabFTP.primaryUser.ftp.user"
                         ></dd>
@@ -539,10 +568,34 @@
                                 <tr
                                     data-ng-repeat="element in ctrlHostingTabFTP.ftpInformations.list.results track by $index"
                                 >
-                                    <th
-                                        scope="row"
+                                    <td
+                                        data-ng-if="element.ftp.user === element.ssh.user"
+                                        class="text-nowrap"
                                         data-ng-bind="element.ftp.user"
-                                    ></th>
+                                    ></td>
+
+                                    <td
+                                        data-ng-if="element.ftp.user !== element.ssh.user"
+                                        class="text-nowrap"
+                                    >
+                                        <div>
+                                            <span
+                                                data-translate="hosting_tab_FTP_FTP_user"
+                                            ></span>
+                                            <span
+                                                data-ng-bind="element.ftp.user"
+                                            ></span>
+                                        </div>
+                                        <div>
+                                            <span
+                                                data-translate="hosting_tab_FTP_SSH_user"
+                                            ></span>
+                                            <span
+                                                data-ng-bind="element.ssh.user"
+                                            ></span>
+                                        </div>
+                                    </td>
+
                                     <td data-ng-bind="element.home"></td>
                                     <td>
                                         <span


### PR DESCRIPTION
WEB-12938, WEB-12618

Signed-off-by: Lucas Chaigne <lucas.chaigne@ovhcloud.com>

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/components-w7`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #WEB-12618, Fix #WEB-12938
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

2 changes  : 
- harmonize perso and pro offer display (ports info display was slightly different)
- display both ftp and sftp/ssh user for cloudweb offers (for other offers there is a unique user name for both ftp and sftp/ssh)

## i18n
- [x] - TRANS-49468