### PR TITLE
fix(dbaas-logs): display only editable streams

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/link/aliases-link.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/link/aliases-link.controller.js
@@ -59,7 +59,7 @@ export default class LogsAliasesLinkCtrl {
 
     this.streams = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>
-        this.LogsStreamsService.getStreams(this.serviceName),
+        this.LogsStreamsService.getOwnStreams(this.serviceName),
     });
     this.streams.load();
 
@@ -77,9 +77,8 @@ export default class LogsAliasesLinkCtrl {
 
     this.$q.all([this.alias.promise, this.streams.promise]).then((result) => {
       const diff = filter(
-        result[1].data,
+        result[1],
         (stream) =>
-          stream.isEditable &&
           !find(
             result[0].streams,
             (attachedAapiStream) =>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/edit/logs-inputs-add-edit.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/edit/logs-inputs-add-edit.controller.js
@@ -89,7 +89,7 @@ export default class LogsInputsAddEditCtrl {
     });
     this.streams = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>
-        this.LogsStreamsService.getStreams(this.serviceName),
+        this.LogsStreamsService.getOwnStreams(this.serviceName),
     });
     this.catalog = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-107962
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Display only editable streams while Linking content alias and add/edit inputs
