### PR TITLE
fix(pci.storages.databases): datatr-205 - fix sort for queries statistics table

### DIFF
--- a/packages/manager/modules/pci/src/components/project/storages/databases/queryStatistics.class.js
+++ b/packages/manager/modules/pci/src/components/project/storages/databases/queryStatistics.class.js
@@ -19,10 +19,5 @@ export default class QueryStatistics {
       stddevTime,
       totalTime,
     });
-    this.minTime = this.minTime?.toFixed(1);
-    this.maxTime = this.maxTime?.toFixed(1);
-    this.stddevTime = this.stddevTime?.toFixed(1);
-    this.totalTime = this.totalTime?.toFixed(1);
-    this.meanTime = this.meanTime?.toFixed(1);
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/query-statistics/query-statistics.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/query-statistics/query-statistics.html
@@ -45,31 +45,41 @@
             data-property="minTime"
             data-type="number"
             data-sortable
-        ></oui-datagrid-column>
+        >
+            <span data-ng-bind="$value  | number : 2"></span>
+        </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_databases_query_statistics_datagrid_max' | translate"
             data-property="maxTime"
             data-type="number"
             data-sortable
-        ></oui-datagrid-column>
+        >
+            <span data-ng-bind="$value  | number : 2"></span>
+        </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_databases_query_statistics_datagrid_mean' | translate"
             data-property="meanTime"
             data-type="number"
             data-sortable
-        ></oui-datagrid-column>
+        >
+            <span data-ng-bind="$value  | number : 2"></span>
+        </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_databases_query_statistics_datagrid_stddev' | translate"
             data-property="stddevTime"
             data-type="number"
             data-sortable
-        ></oui-datagrid-column>
+        >
+            <span data-ng-bind="$value  | number : 2"></span>
+        </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'pci_databases_query_statistics_datagrid_total' | translate"
             data-property="totalTime"
             data-type="number"
             data-sortable
-        ></oui-datagrid-column>
+        >
+            <span data-ng-bind="$value  | number : 2"></span>
+        </oui-datagrid-column>
         <oui-datagrid-topbar>
             <oui-button
                 class="float-right"


### PR DESCRIPTION
datatr-205

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #datatr-205
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Correctly sort numerics fields in queries statistics table