### PR TITLE
feat(manager.script): add cmd to display the missing translation keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "husky install",
     "release": "scripts/release/release.sh",
     "start": "node -r esm scripts/start-application.js",
+    "translation:check": "node scripts/translation-check.js",
     "test:jest": "jest --runInBand",
     "test": "yarn lint",
     "test:scripts": "make test"

--- a/scripts/translation-check.js
+++ b/scripts/translation-check.js
@@ -1,0 +1,96 @@
+/**
+ * This Script generates, in the terminal, the YAML file content for the
+ * translation request regarding the french translations keys that
+ * miss their english counterparts.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const rootPath = 'packages';
+const LANGUAGE_FILES = {
+  EN: 'Messages_en_GB.json',
+  FR: 'Messages_fr_FR.json',
+};
+
+/**
+ * @param {[FR|EN]} lang language of the translation file
+ * @param {string} filePath absolute path to the translation file
+ * @returns translation keys array of a translation file
+ */
+function getTranslationKeys(lang, filePath) {
+  const translationKeysFile = fs.readFileSync(
+    path.resolve(filePath, LANGUAGE_FILES[lang]),
+  );
+  return Object.keys(JSON.parse(translationKeysFile));
+}
+
+/**
+ * display, in the terminal, the relative path to the translation file
+ * respecting the YAML indentiations
+ * @param {string} filePath absolute path to the translation file.
+ */
+function displayTranslationFile(filePath) {
+  // the short path contains the absolute translation file path minus
+  // the project base directory path '/<project_directory>/manager'.
+  const shortPath = filePath.substring(path.resolve().length + 1);
+  console.info(`\x1b[33m- ${shortPath}: \x1b[0m`);
+}
+
+/**
+ * display, in the terminal, the list of the translation keys
+ * associated to the translation file while respecting the YAML indentiations.
+ * @param {[string]} array list of the translation keys
+ * @returns null
+ */
+function displayTranslationKeys(array) {
+  array.map((key) => {
+    console.info(`  - ${key}`);
+    return key;
+  });
+  return null;
+}
+
+function displayTranslation(directoryPath, file, array) {
+  displayTranslationFile(path.resolve(directoryPath, file));
+  displayTranslationKeys(array);
+}
+
+/**
+ * Recursive function to navigate in the Manager project looking for and
+ * displaying the missing translation keys.
+ * @param {string} directoryPath absolute path of the current directory.
+ * @returns null
+ */
+function displayFile(directoryPath) {
+  fs.readdir(directoryPath, (err, files) => {
+    if (err) {
+      return console.error(`Unable to scan directory: ${err}`);
+    }
+    files.forEach((file) => {
+      const fileDetails = fs.lstatSync(path.resolve(directoryPath, file));
+      if (fileDetails.isDirectory()) {
+        // recusive function call
+        displayFile(path.resolve(directoryPath, file));
+      } else if (file === LANGUAGE_FILES.FR) {
+        const frTranslationKeys = getTranslationKeys('FR', directoryPath);
+        try {
+          const enTranslationKeys = getTranslationKeys('EN', directoryPath);
+          const diff = frTranslationKeys.filter(
+            (key) => !enTranslationKeys.includes(key),
+          );
+
+          if (diff.length) {
+            displayTranslation(directoryPath, file, diff);
+          }
+        } catch (error) {
+          displayTranslation(directoryPath, file, frTranslationKeys);
+        }
+      }
+    });
+    return null;
+  });
+  return null;
+}
+
+displayFile(rootPath);

--- a/scripts/translation-check.js
+++ b/scripts/translation-check.js
@@ -6,15 +6,25 @@
 
 const path = require('path');
 const fs = require('fs');
+const process = require('process');
 
 const rootPath = 'packages';
+
 const LANGUAGE_FILES = {
-  EN: 'Messages_en_GB.json',
   FR: 'Messages_fr_FR.json',
+  EN: 'Messages_en_GB.json',
+  ES: 'Messages_es_ES.json',
+  CA: 'Messages_fr_CA.json',
+  IT: 'Messages_it_IT.json',
+  PL: 'Messages_pl_PL.json',
+  PT: 'Messages_pt_PT.json',
 };
 
+// cmd parameter
+const LANG = process.argv[2];
+
 /**
- * @param {[FR|EN]} lang language of the translation file
+ * @param {[FR | EN | ES | CA | IT | PL | PT]} lang language of the translation file
  * @param {string} filePath absolute path to the translation file
  * @returns translation keys array of a translation file
  */
@@ -75,9 +85,9 @@ function displayFile(directoryPath) {
       } else if (file === LANGUAGE_FILES.FR) {
         const frTranslationKeys = getTranslationKeys('FR', directoryPath);
         try {
-          const enTranslationKeys = getTranslationKeys('EN', directoryPath);
+          const langTranslationKeys = getTranslationKeys(LANG, directoryPath);
           const diff = frTranslationKeys.filter(
-            (key) => !enTranslationKeys.includes(key),
+            (key) => !langTranslationKeys.includes(key),
           );
 
           if (diff.length) {
@@ -93,4 +103,18 @@ function displayFile(directoryPath) {
   return null;
 }
 
-displayFile(rootPath);
+function main() {
+  if (!Object.keys(LANGUAGE_FILES).includes(LANG)) {
+    console.error(
+      'Incorrect argument: authorized arguments are < EN | ES | CA | IT | PL | PT >',
+    );
+    return null;
+  }
+  console.info(
+    `YAML translation content for the missing ${LANG} translation keys : `,
+  );
+  displayFile(rootPath);
+  return null;
+}
+
+main();


### PR DESCRIPTION
ref: MANAGER-10844

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`  <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-10844 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
check the description in the JIRA ticket MANAGER-10844

## Related

<!-- Link dependencies of this PR -->
