### PR TITLE
fix(domain): show authCode when domain is expired

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/packages/manager/apps/web/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -344,7 +344,7 @@
                             type="button"
                             data-translate="domain_dashboard_show_authinfo"
                             data-ng-click="setAction('authinfo/domain-authinfo', $ctrl.domain)"
-                            data-ng-if="!$ctrl.domain.isExpired && $ctrl.domain.protection === 'unlocked'"
+                            data-ng-if="$ctrl.domain.protection === 'unlocked'"
                             data-oui-tooltip="{{ ::'domain_dashboard_show_authinfo_title' | translate }}"
                         ></button>
                         <button


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          |  DTRSD-108558
| License          | BSD 3-Clause


- [x] Try to keep pull requests small so they can be easily reviewed.
- [] Commits are signed-off
- [] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [] Breaking change is mentioned in relevant commits

## Description

When a domain name is in expire status it is important to be able to display the authInfo in the client manager. Some extensions allow an outgoing transfer even if the domain is expired.
