### PR TITLE
Revert "feat(pack): add modem type selection on move and migration of…

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
@@ -3,11 +3,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import map from 'lodash/map';
 
-import {
-  PROMO_DISPLAY,
-  QUANTITY,
-  MODEM_LIST,
-} from '../pack-migration.constant';
+import { PROMO_DISPLAY, QUANTITY } from '../pack-migration.constant';
 
 export default class TelecomPackMigrationConfirmCtrl {
   /* @ngInject */
@@ -30,7 +26,6 @@ export default class TelecomPackMigrationConfirmCtrl {
 
     this.PROMO_DISPLAY = PROMO_DISPLAY;
     this.QUANTITY = QUANTITY;
-    this.MODEM_LIST = MODEM_LIST;
 
     this.modemTransportPrice = 9.99;
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
@@ -91,11 +91,11 @@
                                 ></td>
                             </tr>
                             <tr
-                                data-ng-if="$ctrl.MODEM_LIST.includes($ctrl.process.selectedOffer.modem)"
+                                data-ng-if="$ctrl.process.selectedOffer.modemRental"
                             >
                                 <th
                                     scope="row"
-                                    data-translate="{{'telecom_pack_migration_confirm_modem_rental_' + $ctrl.process.selectedOffer.modem}}"
+                                    data-translate="telecom_pack_migration_confirm_modem_rental"
                                     data-title="{{ 'telecom_pack_migration_confirm_header_entitled' | translate }}"
                                 ></th>
                                 <td

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.controller.js
@@ -3,11 +3,7 @@ import get from 'lodash/get';
 import isUndefined from 'lodash/isUndefined';
 import set from 'lodash/set';
 
-import {
-  PROMO_DISPLAY,
-  MODEM_LIST,
-  MODEM_OPTION_NAME,
-} from '../pack-migration.constant';
+import { PROMO_DISPLAY } from '../pack-migration.constant';
 
 export default class TelecomPackMigrationOffersCtrl {
   /* @ngInject */
@@ -33,8 +29,6 @@ export default class TelecomPackMigrationOffersCtrl {
 
   $onInit() {
     this.PROMO_DISPLAY = PROMO_DISPLAY;
-    this.MODEM_LIST = MODEM_LIST;
-    this.MODEM_OPTION_NAME = MODEM_OPTION_NAME;
     this.process = null;
     this.loading = {
       init: true,
@@ -82,14 +76,6 @@ export default class TelecomPackMigrationOffersCtrl {
       }
     });
 
-    if (optionName === this.MODEM_OPTION_NAME) {
-      offer.modemOptions.forEach((modem) => {
-        if (modem.name === offer.modem && modem.price) {
-          totalOfferPrice += modem.price.value;
-        }
-      });
-    }
-
     set(
       offer,
       'displayedPrice',
@@ -122,10 +108,6 @@ export default class TelecomPackMigrationOffersCtrl {
   }
 
   selectOffer(offer) {
-    if (!offer.modem) {
-      set(offer, 'modemRequired', true);
-      return;
-    }
     const selectedOffer = offer;
     const params = {
       offerName: selectedOffer.offerName,
@@ -143,16 +125,6 @@ export default class TelecomPackMigrationOffersCtrl {
     if (options.length > 0) {
       params.options = options;
     }
-
-    // Update modem rental from selected modem detail
-    selectedOffer.modemOptions.forEach((modem) => {
-      if (modem.name === selectedOffer.modem) {
-        selectedOffer.modemRental = modem.price;
-      }
-      if (this.MODEM_LIST.includes(selectedOffer.modem)) {
-        selectedOffer.needNewModem = true;
-      }
-    });
 
     this.loading.init = true;
 
@@ -177,24 +149,6 @@ export default class TelecomPackMigrationOffersCtrl {
       .finally(() => {
         this.loading.init = false;
       });
-  }
-
-  getModemOptionLabel(modemOption) {
-    return this.$translate.instant(
-      `telecom_pack_migration_modem_${modemOption.name}`,
-      {
-        price: modemOption.price ? modemOption.price.text : '',
-      },
-    );
-  }
-
-  onChangeSelectModem(offer) {
-    if (offer.modemRequired && offer.modem) {
-      set(offer, 'modemRequired', false);
-    }
-    if (offer.modem) {
-      this.updateOfferDisplayedPrice(1, offer, this.MODEM_OPTION_NAME);
-    }
   }
 
   /* -----  End of ACTIONS  ------*/

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
@@ -131,34 +131,10 @@
                                     data-title="{{ offer.description }}"
                                     data-ng-repeat="offer in $ctrl.process.migrationOffers.result.offers track by $index"
                                 >
-                                    <label class="oui-select">
-                                        <select
-                                            class="oui-select__input"
-                                            data-ng-model="offer.modem"
-                                            name="modem"
-                                            data-ng-change="$ctrl.onChangeSelectModem(offer)"
-                                        >
-                                            <option
-                                                data-ng-repeat="modemOption in offer.modemOptions"
-                                                data-ng-value="modemOption.name"
-                                                data-ng-bind-html="$ctrl.getModemOptionLabel(modemOption)"
-                                            >
-                                            </option>
-                                        </select>
-                                        <span
-                                            class="oui-icon oui-icon-chevron-down"
-                                            aria-hidden="true"
-                                        ></span>
-                                    </label>
-                                    <div
-                                        role="alert"
-                                        data-ng-if="offer.modemRequired"
-                                    >
-                                        <div
-                                            class="text-danger"
-                                            data-translate="telecom_pack_migration_modem_required"
-                                        ></div>
-                                    </div>
+                                    <span
+                                        data-ng-if="offer.modemRental"
+                                        data-ng-bind-html="offer.modemRental.text | tucFormatPrice"
+                                    ></span>
                                 </td>
                             </tr>
                             <tr class="table-comparison__property">

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.constant.js
@@ -14,14 +14,4 @@ export const PROCESS_STEP = {
 
 export const QUANTITY = 1;
 
-export const MODEM_LIST = ['yes', 'recycled'];
-
-export const MODEM_OPTION_NAME = 'modem';
-
-export default {
-  PROMO_DISPLAY,
-  PROCESS_STEP,
-  QUANTITY,
-  MODEM_LIST,
-  MODEM_OPTION_NAME,
-};
+export default { PROMO_DISPLAY, PROCESS_STEP, QUANTITY };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_de_DE.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "Ce changement d’offre n’est sujet à aucun réengagement.",
   "telecom_pack_migration_confirm_commitment": "Un réengagement de {{ month }} mois débutera à la date de facturation.",
   "telecom_pack_migration_confirm_new_offer_price": "Votre nouvel abonnement mensuel s'élève à : <span class=\"text-price\">{{ price }}</span> <span class=\"text-infos\">HT/mois</span>, applicable dès livraison de votre nouvel accès. Vous en serez informé par e-mail.",
-  "telecom_pack_migration_confirm_shipping": "Sie haben den Liefermodus Ihres neuen Routers pro Luftfahrtunternehmen ausgewählt (+ {{ price }} € ohne MwSt).",
+  "telecom_pack_migration_confirm_shipping": "Sie haben den Liefermodus Ihres neuen Routers pro Luftfahrtunternehmen ausgewählt (+ {{ transportPrice }} € ohne MwSt).",
   "telecom_pack_migration_confirm_first_mensuality": "Ihre erste Monatsrate beträgt also {{ price }} ohne MwSt.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Services qui seront supprimés",
   "telecom_pack_migration_confirm_service_to_delete_total": "Beim Wechsel des Angebots werden insgesamt {{count}} Dienstleistungen gelöscht.",
@@ -158,13 +158,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Kontakt-Informationen",
   "telecom_pack_migration_confirm_resume_contact_phone": "Telefonnummer, unter der Sie bei Bedarf kontaktiert werden können",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Die angegebene Nummer muss gültig sein.",
-  "telecom_pack_migration_choose_offer_error": "Beim Abruf der Angebote ist ein Fehler aufgetreten: {{ error }}",
-  "telecom_pack_migration_modem_yes": "Neues Modem ({{ price }} ohne MwSt / Monat)",
-  "telecom_pack_migration_modem_recycled": "Recyceltes Modem ({{ price }} ohne MwSt / Monat)",
-  "telecom_pack_migration_modem_no": "Kein Modem",
-  "telecom_pack_migration_modem_required": "Die Wahl eines Modemtyps ist zwingend erforderlich",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Miete für das neue Modem",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Modem-Vermietung",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Bis zu 92 Mbit/s VDSL und 22 Mbit/s ADSL, je nach Förderfähigkeit.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit."
+  "telecom_pack_migration_choose_offer_error": "Beim Abruf der Angebote ist ein Fehler aufgetreten: {{ error }}"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_en_GB.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "This change of plan is not subject to any new commitment periods.",
   "telecom_pack_migration_confirm_commitment": "A new commitment period of {{ month }} months will begin on the billing date.",
   "telecom_pack_migration_confirm_new_offer_price": "Your new monthly subscription is: <span class=\"text-price\">{{ price }}</span><span class=\"text-infos\">/month ex. VAT</span> and will be applicable as soon as your new access is delivered. You will receive confirmation via email.",
-  "telecom_pack_migration_confirm_shipping": "You have selected the delivery method for your new modem by transporter (+ €{{ price }} ex. VAT).",
+  "telecom_pack_migration_confirm_shipping": "You have selected the delivery method for your new modem by transporter (+ €{{ transportPrice }} ex. VAT).",
   "telecom_pack_migration_confirm_first_mensuality": "Your first monthly payment will be {{ price }} ex. VAT.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Services to be deleted",
   "telecom_pack_migration_confirm_service_to_delete_total": "A total of {{count}} services will be deleted during the solution change.",
@@ -177,13 +177,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Contact information",
   "telecom_pack_migration_confirm_resume_contact_phone": "Telephone number you can be reached on, if required",
   "telecom_pack_migration_confirm_resume_phone_form_error": "The number you enter must be valid.",
-  "telecom_pack_migration_choose_offer_error": "An error occurred while retrieving the plans: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "New modem ({{ price }} ex. VAT/month)",
-  "telecom_pack_migration_modem_recycled": "Recycled modem ({{ price }} ex. VAT/month)",
-  "telecom_pack_migration_modem_no": "No modem",
-  "telecom_pack_migration_modem_required": "You must select a modem type",
-  "telecom_pack_migration_confirm_modem_rental_yes": "New modem rental",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recycled",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Up to 92 Mb/s descending in VDSL and 22 Mb/s in ADSL, depending on eligibility.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Up to 36 Mb/s VDSL and 1 Mb/s ADSL, depending on eligibility."
+  "telecom_pack_migration_choose_offer_error": "An error occurred while retrieving the plans: {{ error }}."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_es_ES.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "Este cambio de producto no está sujeto a ninguna ampliación de compromiso.",
   "telecom_pack_migration_confirm_commitment": "Un nuevo compromiso de {{ month }} meses comenzará a aplicarse en la fecha de facturación.",
   "telecom_pack_migration_confirm_new_offer_price": "Su nueva suscripción mensual es de: <span class=\"text-price\">{{ price }}</span><span class=\"text-infos\">/mes + IVA</span>, aplicable a partir de la entrega del nuevo acceso. Le informaremos por correo electrónico.",
-  "telecom_pack_migration_confirm_shipping": "Ha seleccionado el modo de entrega del nuevo módem por transportista (+ {{ price }} € + IVA).",
+  "telecom_pack_migration_confirm_shipping": "Ha seleccionado el modo de entrega del nuevo módem por transportista (+ {{ transportPrice }} € + IVA).",
   "telecom_pack_migration_confirm_first_mensuality": "Su primera cuota mensual será de {{ price }} + IVA.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Servicios que se eliminarán",
   "telecom_pack_migration_confirm_service_to_delete_total": "Al cambiar de producto, se eliminarán un total de {{count}} servicios.",
@@ -163,13 +163,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Datos de contacto",
   "telecom_pack_migration_confirm_resume_contact_phone": "Número de teléfono de contacto",
   "telecom_pack_migration_confirm_resume_phone_form_error": "El número introducido debe ser válido.",
-  "telecom_pack_migration_choose_offer_error": "Se ha producido un error al cargar las soluciones: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Módem nuevo ({{ price }}/mes + IVA)",
-  "telecom_pack_migration_modem_recycled": "Módem reciclador ({{ price }}/mes + IVA)",
-  "telecom_pack_migration_modem_no": "Sin módem",
-  "telecom_pack_migration_modem_required": "La selección de un tipo de módem es obligatoria.",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Alquiler módem nuevo",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Alquiler de módem reciclable",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Hasta 92 Mbps que descenden en VDSL y 22 Mbps en ADSL, en función de los requisitos.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos."
+  "telecom_pack_migration_choose_offer_error": "Se ha producido un error al cargar las soluciones: {{ error }}."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "Ce changement d’offre n’est sujet à aucun réengagement.",
   "telecom_pack_migration_confirm_commitment": "Un réengagement de {{ month }} mois débutera à la date de facturation.",
   "telecom_pack_migration_confirm_new_offer_price": "Votre nouvel abonnement mensuel s'élève à : <span class=\"text-price\">{{ price }}</span> <span class=\"text-infos\">HT/mois</span>, applicable dès livraison de votre nouvel accès. Vous en serez informé par e-mail.",
-  "telecom_pack_migration_confirm_shipping": "Vous avez sélectionné le mode de livraison de votre nouveau modem par transporteur (+ {{ price }} € HT).",
+  "telecom_pack_migration_confirm_shipping": "Vous avez sélectionné le mode de livraison de votre nouveau modem par transporteur (+ {{ transportPrice }} € HT).",
   "telecom_pack_migration_confirm_first_mensuality": "Votre première mensualité sera donc de {{ price }} HT.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Services qui seront supprimés",
   "telecom_pack_migration_confirm_service_to_delete_total": "Au total {{count}} services seront supprimés durant le changement d'offre.",
@@ -177,13 +177,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Informations de contact",
   "telecom_pack_migration_confirm_resume_contact_phone": "Numéro de téléphone sur lequel vous pourrez être contacté si nécessaire",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Le numéro saisi doit être valide.",
-  "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_no": "Pas de modem",
-  "telecom_pack_migration_modem_required": "La sélection d'un type de modem est obligatoire",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Location modem neuf",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recyclé",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
+  "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "Ce changement d’offre n’est sujet à aucun réengagement.",
   "telecom_pack_migration_confirm_commitment": "Un réengagement de {{ month }} mois débutera à la date de facturation.",
   "telecom_pack_migration_confirm_new_offer_price": "Votre nouvel abonnement mensuel s'élève à : <span class=\"text-price\">{{ price }}</span> <span class=\"text-infos\">HT/mois</span>, applicable dès livraison de votre nouvel accès. Vous en serez informé par e-mail.",
-  "telecom_pack_migration_confirm_shipping": "Vous avez sélectionné le mode de livraison de votre nouveau modem par transporteur (+ {{ price }} € HT).",
+  "telecom_pack_migration_confirm_shipping": "Vous avez sélectionné le mode de livraison de votre nouveau modem par transporteur (+ {{ transportPrice }} € HT).",
   "telecom_pack_migration_confirm_first_mensuality": "Votre première mensualité sera donc de {{ price }} HT.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Services qui seront supprimés",
   "telecom_pack_migration_confirm_service_to_delete_total": "Au total {{count}} services seront supprimés durant le changement d'offre.",
@@ -177,13 +177,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Informations de contact",
   "telecom_pack_migration_confirm_resume_contact_phone": "Numéro de téléphone sur lequel vous pourrez être contacté si nécessaire",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Le numéro saisi doit être valide.",
-  "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_no": "Pas de modem",
-  "telecom_pack_migration_modem_required": "La sélection d'un type de modem est obligatoire",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Location modem neuf",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recyclé",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
+  "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_it_IT.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "La modifica di questa offerta non comporta la sottoscrizione di nessun nuovo impegno contrattuale.",
   "telecom_pack_migration_confirm_commitment": "Alla data di fatturazione inizierà un nuovo impegno contrattuale di {{ month }} mesi.",
   "telecom_pack_migration_confirm_new_offer_price": "Il tuo nuovo abbonamento mensile è di <span class=\"text-price\">{{ price }}</span> <span class=\"text-infos\">+IVA/mese</span>, applicabile a partire dalla consegna del tuo nuovo accesso. Verrai informato via email.",
-  "telecom_pack_migration_confirm_shipping": "Hai selezionato la modalità di consegna del tuo nuovo modem tramite corriere (+ {{ price }} € +IVA).",
+  "telecom_pack_migration_confirm_shipping": "Hai selezionato la modalità di consegna del tuo nuovo modem tramite corriere (+ {{ transportPrice }} € +IVA).",
   "telecom_pack_migration_confirm_first_mensuality": "La tua prima mensilità sarà quindi di {{ price }} +IVA.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Servizi che verranno eliminati",
   "telecom_pack_migration_confirm_service_to_delete_total": "Durante la modifica dell'offerta verranno eliminati {{count}} servizi.",
@@ -158,13 +158,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Informazioni di contatto",
   "telecom_pack_migration_confirm_resume_contact_phone": "Numero di telefono sul quale potrai essere contattato se necessario",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Il numero inserito deve essere valido.",
-  "telecom_pack_migration_choose_offer_error": "Si è verificato un errore durante il recupero delle offerte: {{ error }}",
-  "telecom_pack_migration_modem_yes": "Modem nove ({{ price }} +IVA/mese)",
-  "telecom_pack_migration_modem_recycled": "Modem riciclato ({{ price }} +IVA/mese)",
-  "telecom_pack_migration_modem_no": "Nessun modem",
-  "telecom_pack_migration_modem_required": "La selezione di un tipo di modem è obbligatoria",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Location modem nove",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem riciclato",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Fino a 92 Mb/s discendenti in VDSL e 22 Mb/s in ADSL, secondo l'ammissibilità.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità."
+  "telecom_pack_migration_choose_offer_error": "Si è verificato un errore durante il recupero delle offerte: {{ error }}"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pl_PL.json
@@ -172,13 +172,5 @@
   "telecom_pack_migration_confirm_resume_contact_owner": "Dane kontaktu",
   "telecom_pack_migration_confirm_resume_contact_phone": "Numer telefonu, pod którym w razie potrzeby można się z Tobą w skontaktować.",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Wprowadź poprawny numer telefonu.",
-  "telecom_pack_migration_choose_offer_error": "Wystąpił błąd podczas pobierania ofert: {{error}}",
-  "telecom_pack_migration_modem_yes": "Modem dziewięć ({{ price }} netto / m-c)",
-  "telecom_pack_migration_modem_recycled": "Modem z recyklingu ({{ price }} netto / m-c)",
-  "telecom_pack_migration_modem_no": "Brak modemu",
-  "telecom_pack_migration_modem_required": "Wybór typu modemu jest obowiązkowy",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Dzierżawa modemu",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Wynajem modemu z recyklingu",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Aż do 92 Mb/s łączących się w VDSL i 22 Mb/s w ADSL, w zależności od dostępności.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Do 36 Mb/s w VDSL i 1 Mb/s w ADSL, w zależności od dostępności."
+  "telecom_pack_migration_choose_offer_error": "Wystąpił błąd podczas pobierania ofert: {{error}}"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pt_PT.json
@@ -101,7 +101,7 @@
   "telecom_pack_migration_confirm_no_commitment": "Ce changement d’offre n’est sujet à aucun réengagement.",
   "telecom_pack_migration_confirm_commitment": "Un réengagement de {{ month }} mois débutera à la date de facturation.",
   "telecom_pack_migration_confirm_new_offer_price": "Votre nouvel abonnement mensuel s'élève à : <span class=\"text-price\">{{ price }}</span> <span class=\"text-infos\">HT/mois</span>, applicable dès livraison de votre nouvel accès. Vous en serez informé par e-mail.",
-  "telecom_pack_migration_confirm_shipping": "Selecionou o modo de entrega do seu novo modem por transportador (+ {{ price }}€ + IVA).",
+  "telecom_pack_migration_confirm_shipping": "Selecionou o modo de entrega do seu novo modem por transportador (+ {{ transportPrice }}€ + IVA).",
   "telecom_pack_migration_confirm_first_mensuality": "A sua primeira mensalidade será de {{ price }} + IVA.",
   "telecom_pack_migration_confirm_service_to_delete_title": "Services qui seront supprimés",
   "telecom_pack_migration_confirm_service_to_delete_total": "No total, {{count}} serviços serão eliminados durante a alteração da oferta.",
@@ -157,14 +157,5 @@
   "telecom_pack_migration_confirm_install_fees": "As taxas de instalação são de {{ price }} + IVA",
   "telecom_pack_migration_confirm_resume_contact_owner": "Informações de contacto",
   "telecom_pack_migration_confirm_resume_contact_phone": "Número de telefone através do qual poderá ser contactado, se necessário",
-  "telecom_pack_migration_confirm_resume_phone_form_error": "O número introduzido deve ser válido.",
-  "telecom_pack_migration_choose_offer_error": "Ocorreu um erro durante a recuperação das ofertas: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem nove ({{ price }} s/IVA/mês)",
-  "telecom_pack_migration_modem_recycled": "Modem reciclado ({{ price }} s/IVA/mês)",
-  "telecom_pack_migration_modem_no": "Sem modem",
-  "telecom_pack_migration_modem_required": "A seleção de um tipo de modem é obrigatória",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Locação modem nove",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Locação modem reciclada",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Até 92 Mb/s desceram em VDSL e 22 Mb/s em ADSL, consoante a elegibilidade.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade."
+  "telecom_pack_migration_confirm_resume_phone_form_error": "O número introduzido deve ser válido."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -2,7 +2,7 @@ import find from 'lodash/find';
 import isUndefined from 'lodash/isUndefined';
 import set from 'lodash/set';
 
-import { PROMO_DISPLAY, MODEM_OPTION_NAME } from '../pack-move.constant';
+import { PROMO_DISPLAY } from '../pack-move.constant';
 
 export default class PackMoveOffersCtrl {
   /* @ngInject */
@@ -30,7 +30,6 @@ export default class PackMoveOffersCtrl {
     };
 
     this.PROMO_DISPLAY = PROMO_DISPLAY;
-    this.MODEM_OPTION_NAME = MODEM_OPTION_NAME;
 
     this.getOptions()
       .then(() => {
@@ -206,13 +205,6 @@ export default class PackMoveOffersCtrl {
         totalOfferPrice += option.choosedValue * option.optionalPrice.value;
       }
     });
-    if (optionName === this.MODEM_OPTION_NAME) {
-      offer.modemOptions.forEach((modem) => {
-        if (modem.name === offer.modem && modem.price) {
-          totalOfferPrice += modem.price.value;
-        }
-      });
-    }
 
     const displayedPrice = {
       currencyCode: offer.prices.price.price
@@ -295,10 +287,6 @@ export default class PackMoveOffersCtrl {
   }
 
   selectOffer(offer) {
-    if (!offer.modem) {
-      set(offer, 'modemRequired', true);
-      return null;
-    }
     const selectedOffer = offer;
 
     const params = {
@@ -321,13 +309,6 @@ export default class PackMoveOffersCtrl {
     if (options.length > 0) {
       params.options = options;
     }
-
-    // Update modem rental from selected modem detail
-    selectedOffer.modemOptions.forEach((modem) => {
-      if (modem.name === selectedOffer.modem) {
-        selectedOffer.modemRental = modem.price;
-      }
-    });
 
     this.loading.init = true;
 
@@ -352,25 +333,5 @@ export default class PackMoveOffersCtrl {
       .finally(() => {
         this.loading.init = false;
       });
-    return null;
-  }
-
-  getModemOptionLabel(modemOption) {
-    return this.$translate.instant(`pack_move_modem_${modemOption.name}`, {
-      price: modemOption.price ? modemOption.price.text : '',
-    });
-  }
-
-  onChangeSelectModem(offer) {
-    if (offer.modemRequired && offer.modem) {
-      set(offer, 'modemRequired', false);
-    }
-    if (offer.modem) {
-      this.constructor.updateOfferDisplayedPrice(
-        1,
-        offer,
-        this.MODEM_OPTION_NAME,
-      );
-    }
   }
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
@@ -115,34 +115,14 @@
                                 data-title="{{ offer.description }}"
                                 data-ng-repeat="offer in $ctrl.offers track by $index"
                             >
-                                <label class="oui-select">
-                                    <select
-                                        class="oui-select__input"
-                                        data-ng-model="offer.modem"
-                                        name="modem"
-                                        data-ng-change="$ctrl.onChangeSelectModem(offer)"
-                                    >
-                                        <option
-                                            data-ng-repeat="modemOption in offer.modemOptions"
-                                            data-ng-value="modemOption.name"
-                                            data-ng-bind-html="$ctrl.getModemOptionLabel(modemOption)"
-                                        >
-                                        </option>
-                                    </select>
-                                    <span
-                                        class="oui-icon oui-icon-chevron-down"
-                                        aria-hidden="true"
-                                    ></span>
-                                </label>
-                                <div
-                                    role="alert"
-                                    data-ng-if="offer.modemRequired"
-                                >
-                                    <div
-                                        class="text-danger"
-                                        data-translate="pack_move_modem_required"
-                                    ></div>
-                                </div>
+                                <span
+                                    data-ng-if="!offer.prices.modemRental.price"
+                                    data-translate="pack_move_no_install_fees"
+                                ></span>
+                                <span
+                                    data-ng-if="offer.prices.modemRental.price"
+                                    data-ng-bind-html="offer.prices.modemRental.price.text | tucFormatPrice"
+                                ></span>
                             </td>
                         </tr>
                         <tr class="table-comparison__property">

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/pack-move.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/pack-move.constant.js
@@ -39,10 +39,6 @@ const PROMO_DISPLAY = {
   },
 };
 
-const MODEM_LIST = ['yes', 'recycled'];
-
-const MODEM_OPTION_NAME = 'modem';
-
 export {
   ELIGIBILITY_LINE_STATUS,
   LINE_STATUS,
@@ -50,6 +46,4 @@ export {
   STEPS,
   UNBUNDLING,
   PROMO_DISPLAY,
-  MODEM_LIST,
-  MODEM_OPTION_NAME,
 };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
@@ -5,7 +5,7 @@ import set from 'lodash/set';
 import values from 'lodash/values';
 import moment from 'moment';
 
-import { PROMO_DISPLAY, MODEM_LIST } from '../pack-move.constant';
+import { PROMO_DISPLAY } from '../pack-move.constant';
 
 export default class MoveResumeCtrl {
   /* @ngInject */
@@ -23,7 +23,6 @@ export default class MoveResumeCtrl {
       acceptContracts: false,
     };
     this.PROMO_DISPLAY = PROMO_DISPLAY;
-    this.MODEM_LIST = MODEM_LIST;
 
     this.modemTransportPrice = 9.99;
     this.choosedAdditionalOptions = filter(
@@ -39,7 +38,8 @@ export default class MoveResumeCtrl {
       ? 1
       : 0;
 
-    const modemRental = this.offer.selected.offer.modemRental?.value || 0;
+    const modemRental =
+      this.offer.selected.offer.prices.modemRental.price?.value || 0;
     const providerOrange =
       this.offer.selected.offer.prices.providerOrange.price?.value || 0;
     const providerAI =
@@ -218,13 +218,6 @@ export default class MoveResumeCtrl {
         engageMonths: this.offer.selected.offer.engageMonths,
         acceptContracts: this.offer.selected.acceptContracts,
       };
-
-      // Set modem if one type is selected
-      if (this.MODEM_LIST.includes(this.offer.selected.offer.modem)) {
-        assign(moveData, {
-          modem: this.offer.selected.offer.modem,
-        });
-      }
 
       if (this.offer.selected.buildingDetails) {
         assign(moveData, {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
@@ -96,16 +96,16 @@
                                 ></td>
                             </tr>
                             <tr
-                                data-ng-if="$ctrl.offer.selected.offer.modemRental"
+                                data-ng-if="$ctrl.offer.selected.offer.prices.modemRental.price"
                             >
                                 <th
                                     scope="row"
-                                    data-translate="{{'pack_move_confirm_modem_rental_' + $ctrl.offer.selected.offer.modem}}"
+                                    data-translate="pack_move_modem_rental"
                                     data-title="{{ 'pack_move_confirm_header_entitled' | translate }}"
                                 ></th>
                                 <td
                                     class="text-price text-right"
-                                    data-ng-bind="$ctrl.offer.selected.offer.modemRental.text"
+                                    data-ng-bind="$ctrl.offer.selected.offer.prices.modemRental.price.text"
                                     data-title="{{ 'pack_move_confirm_header_price' | translate }}"
                                 ></td>
                                 <td
@@ -116,7 +116,7 @@
                                 </td>
                                 <td
                                     class="text-price text-right"
-                                    data-ng-bind="$ctrl.offer.selected.offer.modemRental.text"
+                                    data-ng-bind="$ctrl.offer.selected.offer.prices.modemRental.price.text"
                                     data-title="{{ 'pack_move_confirm_header_total' | translate }}"
                                 ></td>
                             </tr>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_de_DE.json
@@ -117,14 +117,6 @@
   "pack_move_confirm_first_mensuality": "Ihre erste Monatsrate beträgt also {{ price }} ohne MwSt.",
   "pack_move_resume_comfort_activation": "Die Aktivierungsgebühr für die Komfortoption beträgt {{ price }} zzgl. MwSt.",
   "pack_move_resume_install_fees": "Die Einrichtungsgebühr beträgt {{ price }} ohne MwSt.",
-  "pack_move_resume_creation_line_fees": "Die Kosten für die Erstellung einer Leitung belaufen sich auf {{ price }} ohne MwSt.",
   "pack_move_resume_promotion": "Die Einrichtungsgebühr und die ersten {{ duration }} Monate Ihres neuen Abos sind kostenlos (mit Ausnahme der Modem-Miete, Zusatzoptionen oder Transportkosten).",
-  "pack_move_modem_yes": "Neues Modem ({{ price }} ohne MwSt / Monat)",
-  "pack_move_modem_recycled": "Recyceltes Modem ({{ price }} ohne MwSt / Monat)",
-  "pack_move_modem_no": "Kein Modem",
-  "pack_move_modem_required": "Die Wahl eines Modemtyps ist zwingend erforderlich",
-  "pack_move_confirm_modem_rental_yes": "Miete für das neue Modem",
-  "pack_move_confirm_modem_rental_recycled": "Modem-Vermietung",
-  "pack_move_offers_debit_mention_1": "(1) Bis zu 92 Mbit/s VDSL und 22 Mbit/s ADSL, je nach Förderfähigkeit.",
-  "pack_move_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit."
+  "pack_move_resume_creation_line_fees": "Die Kosten für die Erstellung einer Leitung belaufen sich auf {{ price }} ohne MwSt."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_en_GB.json
@@ -274,13 +274,5 @@
   "pack_move_resume_promotion": "The setup fees and the first {{ duration }} months of your new subscription are included (excluding modem rental, additional options and transportation).",
   "pack_move_resume_comfort_activation": "The Comfort option activation fee is {{ price }} ex. VAT.",
   "pack_move_resume_install_fees": "Setup fees are {{ price }} ex. VAT.",
-  "pack_move_resume_creation_line_fees": "Line creation costs are {{ price }} ex. VAT.",
-  "pack_move_modem_yes": "New modem ({{ price }} ex. VAT/month)",
-  "pack_move_modem_recycled": "Recycled modem ({{ price }} ex. VAT/month)",
-  "pack_move_modem_no": "No modem",
-  "pack_move_modem_required": "You must select a modem type",
-  "pack_move_confirm_modem_rental_yes": "New modem rental",
-  "pack_move_confirm_modem_rental_recycled": "Location modem recycled",
-  "pack_move_offers_debit_mention_1": "(1) Up to 92 Mb/s descending in VDSL and 22 Mb/s in ADSL, depending on eligibility.",
-  "pack_move_offers_debit_mention_2": "(2) Up to 36 Mb/s VDSL and 1 Mb/s ADSL, depending on eligibility."
+  "pack_move_resume_creation_line_fees": "Line creation costs are {{ price }} ex. VAT."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_es_ES.json
@@ -272,13 +272,5 @@
   "pack_move_resume_comfort_activation": "Los gastos de activación de la opción Confort son de {{ price }} + IVA.",
   "pack_move_resume_install_fees": "Los gastos de instalación son de {{ price }} + IVA.",
   "pack_move_resume_creation_line_fees": "Los gastos de creación de líneas son de {{ price }} + IVA.",
-  "pack_move_resume_promotion": "Los gastos de instalación y los {{ duration }} primeros meses de la nueva suscripción son gratuitos (sin incluir el alquiler de módem, las opciones adicionales o los gastos de transporte).",
-  "pack_move_modem_yes": "Módem nuevo ({{ price }}/mes + IVA)",
-  "pack_move_modem_recycled": "Módem reciclador ({{ price }}/mes + IVA)",
-  "pack_move_modem_no": "Sin módem",
-  "pack_move_modem_required": "La selección de un tipo de módem es obligatoria.",
-  "pack_move_confirm_modem_rental_yes": "Alquiler módem nuevo",
-  "pack_move_confirm_modem_rental_recycled": "Alquiler de módem reciclable",
-  "pack_move_offers_debit_mention_1": "(1) Hasta 92 Mbps que descenden en VDSL y 22 Mbps en ADSL, en función de los requisitos.",
-  "pack_move_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos."
+  "pack_move_resume_promotion": "Los gastos de instalación y los {{ duration }} primeros meses de la nueva suscripción son gratuitos (sin incluir el alquiler de módem, las opciones adicionales o los gastos de transporte)."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
@@ -274,13 +274,5 @@
   "pack_move_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
   "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
-  "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
-  "pack_move_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "pack_move_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "pack_move_modem_no": "Pas de modem",
-  "pack_move_modem_required": "La sélection d'un type de modem est obligatoire",
-  "pack_move_confirm_modem_rental_yes": "Location modem neuf",
-  "pack_move_confirm_modem_rental_recycled": "Location modem recyclé",
-  "pack_move_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
-  "pack_move_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
+  "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport)."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
@@ -274,13 +274,5 @@
   "pack_move_promotion_description": "Promotion disponible jusqu'au {{ endDate }}",
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
   "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
-  "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
-  "pack_move_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "pack_move_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "pack_move_modem_no": "Pas de modem",
-  "pack_move_modem_required": "La sélection d'un type de modem est obligatoire",
-  "pack_move_confirm_modem_rental_yes": "Location modem neuf",
-  "pack_move_confirm_modem_rental_recycled": "Location modem recyclé",
-  "pack_move_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
-  "pack_move_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
+  "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport)."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_it_IT.json
@@ -119,13 +119,5 @@
   "pack_move_resume_comfort_activation": "Le spese di attivazione dell'opzione Confort sono di {{ price }} +IVA.",
   "pack_move_resume_install_fees": "Le spese di installazione sono di {{ price }} +IVA.",
   "pack_move_resume_creation_line_fees": "Le spese di creazione della linea sono di {{ price }} +IVA.",
-  "pack_move_resume_promotion": "Le spese di installazione e i primi {{ duration }} mesi del nuovo abbonamento sono incluse (locazione del modem, opzioni aggiuntive o spese di trasporto escluse).",
-  "pack_move_modem_yes": "Modem nove ({{ price }} +IVA/mese)",
-  "pack_move_modem_recycled": "Modem riciclato ({{ price }} +IVA/mese)",
-  "pack_move_modem_no": "Nessun modem",
-  "pack_move_modem_required": "La selezione di un tipo di modem è obbligatoria",
-  "pack_move_confirm_modem_rental_yes": "Location modem nove",
-  "pack_move_confirm_modem_rental_recycled": "Location modem riciclato",
-  "pack_move_offers_debit_mention_1": "(1) Fino a 92 Mb/s discendenti in VDSL e 22 Mb/s in ADSL, secondo l'ammissibilità.",
-  "pack_move_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità."
+  "pack_move_resume_promotion": "Le spese di installazione e i primi {{ duration }} mesi del nuovo abbonamento sono incluse (locazione del modem, opzioni aggiuntive o spese di trasporto escluse)."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pl_PL.json
@@ -128,13 +128,5 @@
   "pack_move_confirm_first_mensuality": "Twoim pierwszym miesięcznym terminem rozliczenia jest {{ price }} netto.",
   "pack_move_resume_comfort_activation": "Opłata aktywacyjna dla opcji Comfort wynosi {{ price }} netto.",
   "pack_move_resume_install_fees": "Opłata instalacyjna to {{ price }} netto.",
-  "pack_move_resume_creation_line_fees": "Opłata za utworzenie linii wynosi {{ price }} netto.",
-  "pack_move_modem_yes": "Modem dziewięć ({{ price }} netto / m-c)",
-  "pack_move_modem_recycled": "Modem z recyklingu ({{ price }} netto / m-c)",
-  "pack_move_modem_no": "Brak modemu",
-  "pack_move_modem_required": "Wybór typu modemu jest obowiązkowy",
-  "pack_move_confirm_modem_rental_yes": "Dzierżawa modemu",
-  "pack_move_confirm_modem_rental_recycled": "Wynajem modemu z recyklingu",
-  "pack_move_offers_debit_mention_1": "(1) Aż do 92 Mb/s łączących się w VDSL i 22 Mb/s w ADSL, w zależności od dostępności.",
-  "pack_move_offers_debit_mention_2": "(2) Do 36 Mb/s w VDSL i 1 Mb/s w ADSL, w zależności od dostępności."
+  "pack_move_resume_creation_line_fees": "Opłata za utworzenie linii wynosi {{ price }} netto."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pt_PT.json
@@ -117,13 +117,5 @@
   "pack_move_resume_comfort_activation": "As taxas de ativação da opção Confort são de {{ price }} + IVA.",
   "pack_move_resume_install_fees": "As taxas de instalação são de {{ price }} + IVA.",
   "pack_move_resume_creation_line_fees": "Os custos de criação da linha são de {{ price }} + IVA.",
-  "pack_move_resume_promotion": "As taxas de instalação e os {{ duration }} primeiros meses da sua nova subscrição são oferecidos (sem locação do modem, opções suplementares ou custos de transporte).",
-  "pack_move_modem_yes": "Modem nove ({{ price }} s/IVA/mês)",
-  "pack_move_modem_recycled": "Modem reciclado ({{ price }} s/IVA/mês)",
-  "pack_move_modem_no": "Sem modem",
-  "pack_move_modem_required": "A seleção de um tipo de modem é obrigatória",
-  "pack_move_confirm_modem_rental_yes": "Locação modem nove",
-  "pack_move_confirm_modem_rental_recycled": "Locação modem reciclada",
-  "pack_move_offers_debit_mention_1": "(1) Até 92 Mb/s desceram em VDSL e 22 Mb/s em ADSL, consoante a elegibilidade.",
-  "pack_move_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade."
+  "pack_move_resume_promotion": "As taxas de instalação e os {{ duration }} primeiros meses da sua nova subscrição são oferecidos (sem locação do modem, opções suplementares ou custos de transporte)."
 }

--- a/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.constant.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.constant.js
@@ -1,5 +1,3 @@
 export const OPTION_NAME = 'voip_line';
 
-export const MODEM_LIST = ['yes', 'recycled'];
-
-export default { OPTION_NAME, MODEM_LIST };
+export default { OPTION_NAME };

--- a/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.service.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.service.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
 import set from 'lodash/set';
 import values from 'lodash/values';
 
-import { OPTION_NAME, MODEM_LIST } from './pack-migration-process.constant';
+import { OPTION_NAME } from './pack-migration-process.constant';
 
 /**
  *  Service used to share data between differents steps of the pack migration process.
@@ -169,13 +169,6 @@ export default /* @ngInject */ function($q, OvhApiPackXdsl, Poller) {
     if (migrationProcess.contactPhone) {
       Object.assign(postParams, {
         contactPhone: migrationProcess.contactPhone,
-      });
-    }
-
-    // Set modem if one type is selected
-    if (MODEM_LIST.includes(migrationProcess.selectedOffer.modem)) {
-      assign(postParams, {
-        modem: migrationProcess.selectedOffer.modem,
       });
     }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/components-w9`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-460
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Revert of :
Add modem type selection (new, recycled or no modem) on move and migration internet access offer.
#UXCT-460
