### PR TITLE
fix(ldp): object ownership on link usage

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/link/aliases-link.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/link/aliases-link.controller.js
@@ -59,12 +59,13 @@ export default class LogsAliasesLinkCtrl {
 
     this.streams = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>
-        this.LogsStreamsService.getStreams(this.serviceName),
+        this.LogsStreamsService.getOwnStreams(this.serviceName),
     });
     this.streams.load();
 
     this.indices = this.CucControllerHelper.request.getArrayLoader({
-      loaderFunction: () => this.LogsIndexService.getIndices(this.serviceName),
+      loaderFunction: () =>
+        this.LogsIndexService.getOwnIndices(this.serviceName),
     });
     this.indices.load();
 
@@ -77,9 +78,8 @@ export default class LogsAliasesLinkCtrl {
 
     this.$q.all([this.alias.promise, this.streams.promise]).then((result) => {
       const diff = filter(
-        result[1].data,
+        result[1],
         (stream) =>
-          stream.isEditable &&
           !find(
             result[0].streams,
             (attachedAapiStream) =>
@@ -99,7 +99,6 @@ export default class LogsAliasesLinkCtrl {
       const diff = filter(
         result[1],
         (aapiIndex) =>
-          aapiIndex.info.isEditable &&
           !find(
             result[0].indexes,
             (attachedAapiIndex) =>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/edit/logs-inputs-add-edit.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/inputs/add/edit/logs-inputs-add-edit.controller.js
@@ -89,7 +89,7 @@ export default class LogsInputsAddEditCtrl {
     });
     this.streams = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>
-        this.LogsStreamsService.getStreams(this.serviceName),
+        this.LogsStreamsService.getOwnStreams(this.serviceName),
     });
     this.catalog = this.CucControllerHelper.request.getArrayLoader({
       loaderFunction: () =>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.controller.js
@@ -71,7 +71,6 @@ export default class LogsRolesPermissionsCtrl {
             filter(
               result,
               (alias) =>
-                alias.info.isEditable &&
                 !find(
                   permissionList,
                   (permission) => permission.aliasId === alias.info.aliasId,
@@ -93,7 +92,6 @@ export default class LogsRolesPermissionsCtrl {
             filter(
               result,
               (index) =>
-                index.info.isEditable &&
                 !find(
                   permissionList,
                   (permission) => permission.indexId === index.info.indexId,
@@ -116,7 +114,6 @@ export default class LogsRolesPermissionsCtrl {
               filter(
                 result,
                 (dashboard) =>
-                  dashboard.info.isEditable &&
                   !find(
                     permissionList,
                     (permission) =>
@@ -139,7 +136,6 @@ export default class LogsRolesPermissionsCtrl {
           const search = filter(
             result,
             (stream) =>
-              stream.isEditable &&
               !find(
                 permissionList,
                 (permission) => permission.streamId === stream.streamId,
@@ -159,7 +155,6 @@ export default class LogsRolesPermissionsCtrl {
             filter(
               result,
               (kibana) =>
-                kibana.info.isEditable &&
                 !find(
                   permissionList,
                   (permission) => permission.kibanaId === kibana.info.kibanaId,


### PR DESCRIPTION
ref: DTRSD-108237

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-108237 #OB-4950
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

This PR will fix code regarding object ownership on LDP object. 
Indeed only objects (streams, dashboards, index, ...) created by the current customer can be attached or link with others (alias, input, roles).
