### PR TITLE
fix(pci.storages.databases):datatr-230 ad hoc validation username duplicate

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -155,19 +155,15 @@ export default class AddUserCtrl {
   }
 
   checkUsernameExist(username) {
-    this.usernameCheck = username;
     return this.users.some((user) =>
-      user.username.toLowerCase().includes(this.usernameCheck),
+      user.username.toLowerCase().includes(username),
     );
   }
 
   addUser() {
-    if (this.checkUsernameExist(this.model.username)) {
-      this.usernameExist = true;
-    } else {
+    if (this.model.username) {
       this.trackDashboard('users::add_a_user::validate');
       this.processing = true;
-      this.usernameExist = false;
       this.DatabaseService.addUser(
         this.projectId,
         this.database.engine,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.html
@@ -5,12 +5,6 @@
 
 <form name="addUserForm" novalidate>
     <h2 data-translate="pci_databases_users_add"></h2>
-    <oui-message data-type="error" data-ng-if="$ctrl.usernameExist">
-        <span
-            data-translate="pci_databases_users_add_error_username_exist"
-            data-translate-values="{ user: '<b>' + $ctrl.usernameCheck + '</b>' }"
-        ></span>
-    </oui-message>
     <oui-field
         data-label="{{:: 'pci_databases_users_add_username_label' | translate }}"
         data-size="xl"
@@ -38,6 +32,10 @@
             <pci-storage-database-input-rule
                 valid="$ctrl.checkPattern(addUserForm.username.$viewValue, $ctrl.inputRules.name.pattern)"
                 data-label="{{:: 'pci_databases_users_add_username_pattern_rule' | translate }}"
+            ></pci-storage-database-input-rule>
+            <pci-storage-database-input-rule
+                valid="!$ctrl.checkUsernameExist(addUserForm.username.$viewValue)"
+                data-label="{{:: 'pci_databases_users_add_error_username_exist' | translate }}"
             ></pci-storage-database-input-rule>
         </div>
     </oui-field>
@@ -271,7 +269,7 @@
             data-size="l"
             data-variant="primary"
             data-icon-right="oui-icon-arrow-right"
-            data-disabled="$ctrl.processing || !$ctrl.model.username"
+            data-disabled="$ctrl.processing || !$ctrl.model.username || $ctrl.checkUsernameExist($ctrl.model.username)"
             data-on-click="$ctrl.addUser()"
         >
             <span data-translate="pci_databases_users_add_create"></span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/translations/Messages_fr_FR.json
@@ -8,7 +8,7 @@
   "pci_databases_users_add_create": "Créer un utilisateur",
   "pci_databases_users_add_success_message": "L'utilisateur {{ username }} a été ajouté avec le mot de passe <code>{{password}}</code>",
   "pci_databases_users_add_error_save": "Une erreur est survenue lors de la création de l'utilisateur {{ user }} : {{ message }}.",
-  "pci_databases_users_add_error_username_exist": "L'utilisateur {{ user }} existe déjà.",
+  "pci_databases_users_add_error_username_exist": "Doit être unique",
   "pci_databases_users_add_cancel": "Annuler",
   "pci_databases_users_add_categories_label": "Catégories",
   "pci_databases_users_add_commands_label": "Commandes",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/datatr-197-create-user-already-exist`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-230
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- ad hoc validation username duplicate

## Related

- [PR 8967](https://github.com/ovh/manager/pull/8967)