### PR TITLE
ci(github): remove team-manager-core from MAINTAINERS, update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,5 @@
 # Default owners
 * @ovh/team-manager-dev
-yarn.lock @ovh/team-manager-core
-
-# Documentation
-*.md
-/docs/ @ovh/team-manager-core
 
 # Components
 /packages/components/ @ovh/team-manager-dev

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,10 +12,7 @@
 
 Anoop N <anoop.n@ovhcloud.com>
 Cyril Biencourt <cyril.biencourt@ovhcloud.com>
-Cyrille Bourgois <cyrille.bourgois@ovhcloud.com>
-Florian Renaut <florian.renaut@ovhcloud.com>
 Guillaume Hyenne <guillaume.hyenne@ovhcloud.com>
-Jean-Christophe Alleman <jean-christophe.alleman@ovhcloud.com>
 Mohammed Zahaf <mohammed.zahaf.ext@ovhcloud.com>
 Sachin Ramesh <sachin.ramesh@ovhcloud.com>
 Vikash Singhd <vikash.singh@ovhcloud.com>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-622
| License          | BSD 3-Clause

## Description

update CODEOWNERS & MAINTAINERS for team manager core