### PR TITLE
fix(pci.storages.databases):datatr-231 checked username duplicate with fullname comparison

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -155,9 +155,10 @@ export default class AddUserCtrl {
   }
 
   checkUsernameExist(username) {
-    return this.users.some((user) =>
-      user.username.toLowerCase().includes(username),
-    );
+    if (!username) {
+      return true;
+    }
+    return this.users.some((user) => user.username.toLowerCase() === username);
   }
 
   addUser() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/datatr-197-create-user-already-exist`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-231
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- checked username duplicate with fullname comparison

## Related

- [PR 8967](https://github.com/ovh/manager/pull/8967)
