### PR TITLE
fix: display shipping page only when user order new modem

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
@@ -43,7 +43,11 @@ export default class TelecomPackMigrationConfirmCtrl {
       ? 1
       : 0;
 
-    const modemRental = this.process.selectedOffer.modemRental?.value || 0;
+    const modemRental = this.MODEM_LIST.includes(
+      this.process.selectedOffer.modem,
+    )
+      ? this.process.selectedOffer.modemRental.value
+      : 0;
     const firstYearPromo = this.process.selectedOffer.firstYearPromo
       ? this.process.selectedOffer.price.value -
         this.process.selectedOffer.firstYearPromo.value

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
@@ -95,7 +95,7 @@
                             >
                                 <th
                                     scope="row"
-                                    data-translate="{{'telecom_pack_migration_confirm_modem_rental_' + $ctrl.process.selectedOffer.modem}}"
+                                    data-translate="telecom_pack_migration_confirm_modem_rental"
                                     data-title="{{ 'telecom_pack_migration_confirm_header_entitled' | translate }}"
                                 ></th>
                                 <td

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.html
@@ -141,7 +141,7 @@
                                             <option
                                                 data-ng-repeat="modemOption in offer.modemOptions"
                                                 data-ng-value="modemOption.name"
-                                                data-ng-bind-html="$ctrl.getModemOptionLabel(modemOption)"
+                                                data-ng-bind-html="modemOption.label"
                                             >
                                             </option>
                                         </select>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_de_DE.json
@@ -159,12 +159,14 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Telefonnummer, unter der Sie bei Bedarf kontaktiert werden können",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Die angegebene Nummer muss gültig sein.",
   "telecom_pack_migration_choose_offer_error": "Beim Abruf der Angebote ist ein Fehler aufgetreten: {{ error }}",
-  "telecom_pack_migration_modem_yes": "Neues Modem ({{ price }} ohne MwSt / Monat)",
-  "telecom_pack_migration_modem_recycled": "Recyceltes Modem ({{ price }} ohne MwSt / Monat)",
-  "telecom_pack_migration_modem_no": "Kein Modem",
+  "telecom_pack_migration_modem_yes": "Ich möchte ein neues Modem verwenden ({{ price }} ohne MwSt / Monat)",
+  "telecom_pack_migration_modem_recycled": "Ich möchte ein recyceltes Modem verwenden ({{ price }} ohne MwSt / Monat)",
+  "telecom_pack_migration_modem_no": "Ich möchte kein Modem",
   "telecom_pack_migration_modem_required": "Die Wahl eines Modemtyps ist zwingend erforderlich",
   "telecom_pack_migration_confirm_modem_rental_yes": "Miete für das neue Modem",
   "telecom_pack_migration_confirm_modem_rental_recycled": "Modem-Vermietung",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Bis zu 92 Mbit/s VDSL und 22 Mbit/s ADSL, je nach Förderfähigkeit.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit."
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit.",
+  "telecom_pack_migration_modem_keep": "Ich möchte mein Modem ({{ price }} ohne MwSt / Monat) beibehalten",
+  "telecom_pack_migration_confirm_modem_rental": "Modem-Miete"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_en_GB.json
@@ -178,12 +178,13 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Telephone number you can be reached on, if required",
   "telecom_pack_migration_confirm_resume_phone_form_error": "The number you enter must be valid.",
   "telecom_pack_migration_choose_offer_error": "An error occurred while retrieving the plans: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "New modem ({{price}} ex. VAT/month)",
-  "telecom_pack_migration_modem_recycled": "Recycled modem ({{price}} ex. VAT/month)",
-  "telecom_pack_migration_modem_no": "No modem",
+  "telecom_pack_migration_modem_yes": "I want to use a new modem ({{ price }} ex. VAT/month)",
+  "telecom_pack_migration_modem_recycled": "I want to use a recycled modem ({{ price }} ex. VAT/month)",
+  "telecom_pack_migration_modem_no": "I do not want a modem",
   "telecom_pack_migration_modem_required": "You must select a modem type",
   "telecom_pack_migration_confirm_modem_rental_yes": "New modem rental",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Recycled modem rental",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Up to 92Mb/s downstream bandwidth in VDSL and 22Mb/s in ADSL, depending on eligibility.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Up to 36Mb/s upstream bandwidth in VDSL and 1Mb/s in ADSL, depending on eligibility."
+  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recycled",
+  "telecom_pack_migration_offers_debit_mention_1": "(1) Up to 92 Mb/s descending in VDSL and 22 Mb/s in ADSL, depending on eligibility.",
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Up to 36 Mb/s VDSL and 1 Mb/s ADSL, depending on eligibility.",
+  "telecom_pack_migration_modem_keep": "I want to keep my modem ({{ price }} ex. VAT/month)"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_es_ES.json
@@ -164,12 +164,14 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Número de teléfono de contacto",
   "telecom_pack_migration_confirm_resume_phone_form_error": "El número introducido debe ser válido.",
   "telecom_pack_migration_choose_offer_error": "Se ha producido un error al cargar las soluciones: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Módem nuevo ({{ price }}/mes + IVA)",
-  "telecom_pack_migration_modem_recycled": "Módem reciclador ({{ price }}/mes + IVA)",
-  "telecom_pack_migration_modem_no": "Sin módem",
+  "telecom_pack_migration_modem_yes": "Quiero contratar un módem nuevo ({{ price }}/mes + IVA)",
+  "telecom_pack_migration_modem_recycled": "Quiero contratar un módem reciclable ({{ price }}/mes + IVA)",
+  "telecom_pack_migration_modem_no": "No quiero un módem",
   "telecom_pack_migration_modem_required": "La selección de un tipo de módem es obligatoria.",
   "telecom_pack_migration_confirm_modem_rental_yes": "Alquiler módem nuevo",
   "telecom_pack_migration_confirm_modem_rental_recycled": "Alquiler de módem reciclable",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Hasta 92 Mbps que descenden en VDSL y 22 Mbps en ADSL, en función de los requisitos.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos."
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos.",
+  "telecom_pack_migration_modem_keep": "Quiero conservar mi módem ({{ price }}/mes + IVA)",
+  "telecom_pack_migration_confirm_modem_rental": "Alquiler módem"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_CA.json
@@ -178,12 +178,12 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Numéro de téléphone sur lequel vous pourrez être contacté si nécessaire",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Le numéro saisi doit être valide.",
   "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_no": "Pas de modem",
+  "telecom_pack_migration_modem_yes": "Je souhaite prendre un modem neuf ({{ price }} HT / mois)",
+  "telecom_pack_migration_modem_recycled": "Je souhaite prendre un modem recyclé ({{ price }} HT / mois)",
+  "telecom_pack_migration_modem_no": "Je ne souhaite pas de modem",
+  "telecom_pack_migration_modem_keep": "Je souhaite conserver mon modem ({{ price }} HT/mois)",
   "telecom_pack_migration_modem_required": "La sélection d'un type de modem est obligatoire",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Location modem neuf",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recyclé",
+  "telecom_pack_migration_confirm_modem_rental": "Location modem",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
   "telecom_pack_migration_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_fr_FR.json
@@ -178,12 +178,12 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Numéro de téléphone sur lequel vous pourrez être contacté si nécessaire",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Le numéro saisi doit être valide.",
   "telecom_pack_migration_choose_offer_error": "Une erreur est survenue durant la récupération des offres : {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "telecom_pack_migration_modem_no": "Pas de modem",
+  "telecom_pack_migration_modem_yes": "Je souhaite prendre un modem neuf ({{ price }} HT / mois)",
+  "telecom_pack_migration_modem_recycled": "Je souhaite prendre un modem recyclé ({{ price }} HT / mois)",
+  "telecom_pack_migration_modem_no": "Je ne souhaite pas de modem",
+  "telecom_pack_migration_modem_keep": "Je souhaite conserver mon modem ({{ price }} HT/mois)",
   "telecom_pack_migration_modem_required": "La sélection d'un type de modem est obligatoire",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Location modem neuf",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem recyclé",
+  "telecom_pack_migration_confirm_modem_rental": "Location modem",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
   "telecom_pack_migration_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_it_IT.json
@@ -159,12 +159,14 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Numero di telefono sul quale potrai essere contattato se necessario",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Il numero inserito deve essere valido.",
   "telecom_pack_migration_choose_offer_error": "Si è verificato un errore durante il recupero delle offerte: {{ error }}",
-  "telecom_pack_migration_modem_yes": "Modem nuovo ({{ price }} +IVA/mese)",
-  "telecom_pack_migration_modem_recycled": "Modem riciclato ({{ price }} +IVA/mese)",
-  "telecom_pack_migration_modem_no": "Nessun modem",
+  "telecom_pack_migration_modem_yes": "Vorrei prendere un modem nove ({{ price }} +IVA/mese)",
+  "telecom_pack_migration_modem_recycled": "Vorrei prendere un modem riciclato ({{ price }} +IVA/mese)",
+  "telecom_pack_migration_modem_no": "Non voglio un modem",
   "telecom_pack_migration_modem_required": "La selezione di un tipo di modem è obbligatoria",
   "telecom_pack_migration_confirm_modem_rental_yes": "Location modem nove",
   "telecom_pack_migration_confirm_modem_rental_recycled": "Location modem riciclato",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Fino a 92 Mb/s discendenti in VDSL e 22 Mb/s in ADSL, secondo l'ammissibilità.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità."
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità.",
+  "telecom_pack_migration_modem_keep": "Voglio conservare il mio modem ({{ price }} +IVA/mese)",
+  "telecom_pack_migration_confirm_modem_rental": "Locazione modem"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pl_PL.json
@@ -173,12 +173,13 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Numer telefonu, pod którym w razie potrzeby można się z Tobą w skontaktować.",
   "telecom_pack_migration_confirm_resume_phone_form_error": "Wprowadź poprawny numer telefonu.",
   "telecom_pack_migration_choose_offer_error": "Wystąpił błąd podczas pobierania ofert: {{error}}",
-  "telecom_pack_migration_modem_yes": "Nowy modem ({{price}} netto/m-c)",
-  "telecom_pack_migration_modem_recycled": "Modem z recyklingu ({{price}} netto/m-c)",
-  "telecom_pack_migration_modem_no": "Brak modemu",
+  "telecom_pack_migration_modem_yes": "Chcę zamówić nowy modem ({{ price }} netto / m-c)",
+  "telecom_pack_migration_modem_recycled": "Chcę skorzystać z modemu z recyklingu ({{ price }} netto / m-c)",
+  "telecom_pack_migration_modem_no": "Nie chcę modemu",
   "telecom_pack_migration_modem_required": "Wybór typu modemu jest obowiązkowy",
-  "telecom_pack_migration_confirm_modem_rental_yes": "Dzierżawa nowego modemu",
-  "telecom_pack_migration_confirm_modem_rental_recycled": "Dzierżawa modemu z recyklingu",
-  "telecom_pack_migration_offers_debit_mention_1": "(1) Prędkość pobierania do 92 Mbps w VDSL i 22 Mbps w ADSL, pod warunkiem dostępności.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Prędkość pobierania do 36 Mbps w VDSL i 1 Mbps w ADSL, pod warunkiem dostępności."
+  "telecom_pack_migration_confirm_modem_rental_yes": "Dzierżawa modemu",
+  "telecom_pack_migration_confirm_modem_rental_recycled": "Wynajem modemu z recyklingu",
+  "telecom_pack_migration_offers_debit_mention_1": "(1) Aż do 92 Mb/s łączących się w VDSL i 22 Mb/s w ADSL, w zależności od dostępności.",
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Do 36 Mb/s w VDSL i 1 Mb/s w ADSL, w zależności od dostępności.",
+  "telecom_pack_migration_modem_keep": "Chcę zachować modem ({{ price }} netto/m-c)"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/translations/Messages_pt_PT.json
@@ -159,12 +159,14 @@
   "telecom_pack_migration_confirm_resume_contact_phone": "Número de telefone através do qual poderá ser contactado, se necessário",
   "telecom_pack_migration_confirm_resume_phone_form_error": "O número introduzido deve ser válido.",
   "telecom_pack_migration_choose_offer_error": "Ocorreu um erro durante a recuperação das ofertas: {{ error }}.",
-  "telecom_pack_migration_modem_yes": "Modem nove ({{ price }} s/IVA/mês)",
-  "telecom_pack_migration_modem_recycled": "Modem reciclado ({{ price }} s/IVA/mês)",
-  "telecom_pack_migration_modem_no": "Sem modem",
+  "telecom_pack_migration_modem_yes": "Pretendo escolher um modem nove ({{ price }} s/IVA/mês)",
+  "telecom_pack_migration_modem_recycled": "Pretendo efetuar um modem reciclado ({{ price }} s/IVA/mês)",
+  "telecom_pack_migration_modem_no": "Não desejo nenhum modem",
   "telecom_pack_migration_modem_required": "A seleção de um tipo de modem é obrigatória",
   "telecom_pack_migration_confirm_modem_rental_yes": "Locação modem nove",
   "telecom_pack_migration_confirm_modem_rental_recycled": "Locação modem reciclada",
   "telecom_pack_migration_offers_debit_mention_1": "(1) Até 92 Mb/s desceram em VDSL e 22 Mb/s em ADSL, consoante a elegibilidade.",
-  "telecom_pack_migration_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade."
+  "telecom_pack_migration_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade.",
+  "telecom_pack_migration_modem_keep": "Desejo manter o meu modem ({{ price }} s/IVA/mês)",
+  "telecom_pack_migration_confirm_modem_rental": "Locação modem"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.html
@@ -125,7 +125,7 @@
                                         <option
                                             data-ng-repeat="modemOption in offer.modemOptions"
                                             data-ng-value="modemOption.name"
-                                            data-ng-bind-html="$ctrl.getModemOptionLabel(modemOption)"
+                                            data-ng-bind-html="modemOption.label"
                                         >
                                         </option>
                                     </select>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
@@ -39,7 +39,11 @@ export default class MoveResumeCtrl {
       ? 1
       : 0;
 
-    const modemRental = this.offer.selected.offer.modemRental?.value || 0;
+    const modemRental = this.MODEM_LIST.includes(
+      this.offer.selected.offer.modem,
+    )
+      ? this.offer.selected.offer.prices.modemRental.price.value
+      : 0;
     const providerOrange =
       this.offer.selected.offer.prices.providerOrange.price?.value || 0;
     const providerAI =

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.controller.js
@@ -223,12 +223,10 @@ export default class MoveResumeCtrl {
         acceptContracts: this.offer.selected.acceptContracts,
       };
 
-      // Set modem if one type is selected
-      if (this.MODEM_LIST.includes(this.offer.selected.offer.modem)) {
-        assign(moveData, {
-          modem: this.offer.selected.offer.modem,
-        });
-      }
+      // Set modem
+      assign(moveData, {
+        modem: this.offer.selected.offer.modem,
+      });
 
       if (this.offer.selected.buildingDetails) {
         assign(moveData, {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
@@ -96,16 +96,16 @@
                                 ></td>
                             </tr>
                             <tr
-                                data-ng-if="$ctrl.offer.selected.offer.modemRental"
+                                data-ng-if="$ctrl.MODEM_LIST.includes($ctrl.offer.selected.offer.modem)"
                             >
                                 <th
                                     scope="row"
-                                    data-translate="{{'pack_move_confirm_modem_rental_' + $ctrl.offer.selected.offer.modem}}"
+                                    data-translate="pack_move_confirm_modem_rental"
                                     data-title="{{ 'pack_move_confirm_header_entitled' | translate }}"
                                 ></th>
                                 <td
                                     class="text-price text-right"
-                                    data-ng-bind="$ctrl.offer.selected.offer.modemRental.text"
+                                    data-ng-bind="$ctrl.offer.selected.offer.prices.modemRental.price.text"
                                     data-title="{{ 'pack_move_confirm_header_price' | translate }}"
                                 ></td>
                                 <td
@@ -116,7 +116,7 @@
                                 </td>
                                 <td
                                     class="text-price text-right"
-                                    data-ng-bind="$ctrl.offer.selected.offer.modemRental.text"
+                                    data-ng-bind="$ctrl.offer.selected.offer.prices.modemRental.price.text"
                                     data-title="{{ 'pack_move_confirm_header_total' | translate }}"
                                 ></td>
                             </tr>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_de_DE.json
@@ -119,12 +119,14 @@
   "pack_move_resume_install_fees": "Die Einrichtungsgebühr beträgt {{ price }} ohne MwSt.",
   "pack_move_resume_creation_line_fees": "Die Kosten für die Erstellung einer Leitung belaufen sich auf {{ price }} ohne MwSt.",
   "pack_move_resume_promotion": "Die Einrichtungsgebühr und die ersten {{ duration }} Monate Ihres neuen Abos sind kostenlos (mit Ausnahme der Modem-Miete, Zusatzoptionen oder Transportkosten).",
-  "pack_move_modem_yes": "Neues Modem ({{ price }} ohne MwSt / Monat)",
-  "pack_move_modem_recycled": "Recyceltes Modem ({{ price }} ohne MwSt / Monat)",
-  "pack_move_modem_no": "Kein Modem",
+  "pack_move_modem_yes": "Ich möchte ein neues Modem verwenden ({{ price }} ohne MwSt / Monat)",
+  "pack_move_modem_recycled": "Ich möchte ein recyceltes Modem verwenden ({{ price }} ohne MwSt / Monat)",
+  "pack_move_modem_no": "Ich möchte kein Modem",
   "pack_move_modem_required": "Die Wahl eines Modemtyps ist zwingend erforderlich",
   "pack_move_confirm_modem_rental_yes": "Miete für das neue Modem",
   "pack_move_confirm_modem_rental_recycled": "Modem-Vermietung",
   "pack_move_offers_debit_mention_1": "(1) Bis zu 92 Mbit/s VDSL und 22 Mbit/s ADSL, je nach Förderfähigkeit.",
-  "pack_move_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit."
+  "pack_move_offers_debit_mention_2": "(2) Bis zu 36 Mbit/s VDSL und 1 Mbit/s ADSL, je nach Förderfähigkeit.",
+  "pack_move_modem_keep": "Ich möchte mein Modem ({{ price }} ohne MwSt / Monat) beibehalten",
+  "pack_move_confirm_modem_rental": "Modem-Miete"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_en_GB.json
@@ -275,12 +275,14 @@
   "pack_move_resume_comfort_activation": "The Comfort option activation fee is {{ price }} ex. VAT.",
   "pack_move_resume_install_fees": "Setup fees are {{ price }} ex. VAT.",
   "pack_move_resume_creation_line_fees": "Line creation costs are {{ price }} ex. VAT.",
-  "pack_move_modem_yes": "New modem ({{price}} ex. VAT/month)",
-  "pack_move_modem_recycled": "Recycled modem ({{price}} ex. VAT/month)",
-  "pack_move_modem_no": "No modem",
+  "pack_move_modem_yes": "I want to use a new modem ({{ price }} ex. VAT/month)",
+  "pack_move_modem_recycled": "I want to use a recycled modem ({{ price }} ex. VAT/month)",
+  "pack_move_modem_no": "I do not want a modem",
   "pack_move_modem_required": "You must select a modem type",
   "pack_move_confirm_modem_rental_yes": "New modem rental",
-  "pack_move_confirm_modem_rental_recycled": "Recycled modem rental",
-  "pack_move_offers_debit_mention_1": "(1) Up to 92Mb/s downstream bandwidth in VDSL and 22Mb/s in ADSL, depending on eligibility.",
-  "pack_move_offers_debit_mention_2": "(2) Up to 36Mb/s upstream bandwidth in VDSL and 1Mb/s in ADSL, depending on eligibility."
+  "pack_move_confirm_modem_rental_recycled": "Location modem recycled",
+  "pack_move_offers_debit_mention_1": "(1) Up to 92 Mb/s descending in VDSL and 22 Mb/s in ADSL, depending on eligibility.",
+  "pack_move_offers_debit_mention_2": "(2) Up to 36 Mb/s VDSL and 1 Mb/s ADSL, depending on eligibility.",
+  "pack_move_modem_keep": "I want to keep my modem ({{ price }} ex. VAT/month)",
+  "pack_move_confirm_modem_rental": "Modem location"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_es_ES.json
@@ -273,12 +273,14 @@
   "pack_move_resume_install_fees": "Los gastos de instalación son de {{ price }} + IVA.",
   "pack_move_resume_creation_line_fees": "Los gastos de creación de líneas son de {{ price }} + IVA.",
   "pack_move_resume_promotion": "Los gastos de instalación y los {{ duration }} primeros meses de la nueva suscripción son gratuitos (sin incluir el alquiler de módem, las opciones adicionales o los gastos de transporte).",
-  "pack_move_modem_yes": "Módem nuevo ({{ price }}/mes + IVA)",
-  "pack_move_modem_recycled": "Módem reciclador ({{ price }}/mes + IVA)",
-  "pack_move_modem_no": "Sin módem",
+  "pack_move_modem_yes": "Quiero contratar un módem nuevo ({{ price }}/mes + IVA)",
+  "pack_move_modem_recycled": "Quiero contratar un módem reciclable ({{ price }}/mes + IVA)",
+  "pack_move_modem_no": "No quiero un módem",
   "pack_move_modem_required": "La selección de un tipo de módem es obligatoria.",
   "pack_move_confirm_modem_rental_yes": "Alquiler módem nuevo",
   "pack_move_confirm_modem_rental_recycled": "Alquiler de módem reciclable",
   "pack_move_offers_debit_mention_1": "(1) Hasta 92 Mbps que descenden en VDSL y 22 Mbps en ADSL, en función de los requisitos.",
-  "pack_move_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos."
+  "pack_move_offers_debit_mention_2": "(2) Hasta 36 MB/s en VDSL y 1 Mb/s en ADSL, en función de los requisitos.",
+  "pack_move_modem_keep": "Quiero conservar mi módem ({{ price }}/mes + IVA)",
+  "pack_move_confirm_modem_rental": "Alquiler módem"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_CA.json
@@ -275,12 +275,12 @@
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
   "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
-  "pack_move_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "pack_move_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "pack_move_modem_no": "Pas de modem",
+  "pack_move_modem_yes": "Je souhaite prendre un modem neuf ({{ price }} HT / mois)",
+  "pack_move_modem_recycled": "Je souhaite prendre un modem recyclé ({{ price }} HT / mois)",
+  "pack_move_modem_no": "Je ne souhaite pas de modem",
+  "pack_move_modem_keep": "Je souhaite conserver mon modem ({{ price }} HT/mois)",
   "pack_move_modem_required": "La sélection d'un type de modem est obligatoire",
-  "pack_move_confirm_modem_rental_yes": "Location modem neuf",
-  "pack_move_confirm_modem_rental_recycled": "Location modem recyclé",
+  "pack_move_confirm_modem_rental": "Location modem",
   "pack_move_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
   "pack_move_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
@@ -275,12 +275,12 @@
   "pack_move_promotion_subscription_months_offered": "{{ duration }} mois offerts",
   "pack_move_promotion_installation_fees_offered": "Frais de mise en service offerts",
   "pack_move_resume_promotion": "Les frais d'installation et les {{ duration }} premiers mois de votre nouvel abonnement sont offerts (hors location de modem, options supplémentaires ou frais de transport).",
-  "pack_move_modem_yes": "Modem neuf ({{ price }} HT / mois)",
-  "pack_move_modem_recycled": "Modem recyclé ({{ price }} HT / mois)",
-  "pack_move_modem_no": "Pas de modem",
+  "pack_move_modem_yes": "Je souhaite prendre un modem neuf ({{ price }} HT / mois)",
+  "pack_move_modem_recycled": "Je souhaite prendre un modem recyclé ({{ price }} HT / mois)",
+  "pack_move_modem_no": "Je ne souhaite pas de modem",
+  "pack_move_modem_keep": "Je souhaite conserver mon modem ({{ price }} HT/mois)",
   "pack_move_modem_required": "La sélection d'un type de modem est obligatoire",
-  "pack_move_confirm_modem_rental_yes": "Location modem neuf",
-  "pack_move_confirm_modem_rental_recycled": "Location modem recyclé",
+  "pack_move_confirm_modem_rental": "Location modem",
   "pack_move_offers_debit_mention_1": "(1) Jusqu'à 92 Mb/s descendant en VDSL et 22 Mb/s en ADSL, selon éligibilité.",
   "pack_move_offers_debit_mention_2": "(2) Jusqu'à 36 Mb/s montant en VDSL et 1 Mb/s en ADSL, selon éligibilité."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_it_IT.json
@@ -120,12 +120,14 @@
   "pack_move_resume_install_fees": "Le spese di installazione sono di {{ price }} +IVA.",
   "pack_move_resume_creation_line_fees": "Le spese di creazione della linea sono di {{ price }} +IVA.",
   "pack_move_resume_promotion": "Le spese di installazione e i primi {{ duration }} mesi del nuovo abbonamento sono incluse (locazione del modem, opzioni aggiuntive o spese di trasporto escluse).",
-  "pack_move_modem_yes": "Modem nuovo ({{ price }} +IVA/mese)",
-  "pack_move_modem_recycled": "Modem riciclato ({{ price }} +IVA/mese)",
-  "pack_move_modem_no": "Nessun modem",
+  "pack_move_modem_yes": "Vorrei prendere un modem nove ({{ price }} +IVA/mese)",
+  "pack_move_modem_recycled": "Vorrei prendere un modem riciclato ({{ price }} +IVA/mese)",
+  "pack_move_modem_no": "Non voglio un modem",
   "pack_move_modem_required": "La selezione di un tipo di modem è obbligatoria",
   "pack_move_confirm_modem_rental_yes": "Location modem nove",
   "pack_move_confirm_modem_rental_recycled": "Location modem riciclato",
   "pack_move_offers_debit_mention_1": "(1) Fino a 92 Mb/s discendenti in VDSL e 22 Mb/s in ADSL, secondo l'ammissibilità.",
-  "pack_move_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità."
+  "pack_move_offers_debit_mention_2": "(2) Fino a 36 Mb/s importo in VDSL e 1 Mb/s in ADSL, secondo l'ammissibilità.",
+  "pack_move_modem_keep": "Voglio conservare il mio modem ({{ price }} +IVA/mese)",
+  "pack_move_confirm_modem_rental": "Locazione modem"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pl_PL.json
@@ -129,12 +129,14 @@
   "pack_move_resume_comfort_activation": "Opłata aktywacyjna dla opcji Comfort wynosi {{ price }} netto.",
   "pack_move_resume_install_fees": "Opłata instalacyjna to {{ price }} netto.",
   "pack_move_resume_creation_line_fees": "Opłata za utworzenie linii wynosi {{ price }} netto.",
-  "pack_move_modem_yes": "Nowy modem ({{price}} netto/m-c)",
-  "pack_move_modem_recycled": "Modem z recyklingu ({{price}} netto/m-c)",
-  "pack_move_modem_no": "Brak modemu",
+  "pack_move_modem_yes": "Chcę zamówić nowy modem ({{ price }} netto / m-c)",
+  "pack_move_modem_recycled": "Chcę skorzystać z modemu z recyklingu ({{ price }} netto / m-c)",
+  "pack_move_modem_no": "Nie chcę modemu",
   "pack_move_modem_required": "Wybór typu modemu jest obowiązkowy",
-  "pack_move_confirm_modem_rental_yes": "Dzierżawa nowego modemu",
-  "pack_move_confirm_modem_rental_recycled": "Dzierżawa modemu z recyklingu",
-  "pack_move_offers_debit_mention_1": "(1) Prędkość pobierania do 92 Mbps w VDSL i 22 Mbps w ADSL, pod warunkiem dostępności.",
-  "pack_move_offers_debit_mention_2": "(2) Prędkość pobierania do 36 Mbps w VDSL i 1 Mbps w ADSL, pod warunkiem dostępności."
+  "pack_move_confirm_modem_rental_yes": "Dzierżawa modemu",
+  "pack_move_confirm_modem_rental_recycled": "Wynajem modemu z recyklingu",
+  "pack_move_offers_debit_mention_1": "(1) Aż do 92 Mb/s łączących się w VDSL i 22 Mb/s w ADSL, w zależności od dostępności.",
+  "pack_move_offers_debit_mention_2": "(2) Do 36 Mb/s w VDSL i 1 Mb/s w ADSL, w zależności od dostępności.",
+  "pack_move_modem_keep": "Chcę zachować modem ({{ price }} netto/m-c)",
+  "pack_move_confirm_modem_rental": "Dzierżawa modemu"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_pt_PT.json
@@ -118,12 +118,14 @@
   "pack_move_resume_install_fees": "As taxas de instalação são de {{ price }} + IVA.",
   "pack_move_resume_creation_line_fees": "Os custos de criação da linha são de {{ price }} + IVA.",
   "pack_move_resume_promotion": "As taxas de instalação e os {{ duration }} primeiros meses da sua nova subscrição são oferecidos (sem locação do modem, opções suplementares ou custos de transporte).",
-  "pack_move_modem_yes": "Modem nove ({{ price }} s/IVA/mês)",
-  "pack_move_modem_recycled": "Modem reciclado ({{ price }} s/IVA/mês)",
-  "pack_move_modem_no": "Sem modem",
+  "pack_move_modem_yes": "Pretendo escolher um modem nove ({{ price }} s/IVA/mês)",
+  "pack_move_modem_recycled": "Pretendo efetuar um modem reciclado ({{ price }} s/IVA/mês)",
+  "pack_move_modem_no": "Não desejo nenhum modem",
   "pack_move_modem_required": "A seleção de um tipo de modem é obrigatória",
   "pack_move_confirm_modem_rental_yes": "Locação modem nove",
   "pack_move_confirm_modem_rental_recycled": "Locação modem reciclada",
   "pack_move_offers_debit_mention_1": "(1) Até 92 Mb/s desceram em VDSL e 22 Mb/s em ADSL, consoante a elegibilidade.",
-  "pack_move_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade."
+  "pack_move_offers_debit_mention_2": "(2) Até 36 Mb/s montante em VDSL e 1 Mb/s em ADSL, consoante a elegibilidade.",
+  "pack_move_modem_keep": "Desejo manter o meu modem ({{ price }} s/IVA/mês)",
+  "pack_move_confirm_modem_rental": "Locação modem"
 }

--- a/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.service.js
+++ b/packages/manager/modules/telecom-universe-components/src/telecom/pack/migration/pack-migration-process.service.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
 import set from 'lodash/set';
 import values from 'lodash/values';
 
-import { OPTION_NAME, MODEM_LIST } from './pack-migration-process.constant';
+import { OPTION_NAME } from './pack-migration-process.constant';
 
 /**
  *  Service used to share data between differents steps of the pack migration process.
@@ -172,12 +172,10 @@ export default /* @ngInject */ function($q, OvhApiPackXdsl, Poller) {
       });
     }
 
-    // Set modem if one type is selected
-    if (MODEM_LIST.includes(migrationProcess.selectedOffer.modem)) {
-      assign(postParams, {
-        modem: migrationProcess.selectedOffer.modem,
-      });
-    }
+    // Set modem
+    assign(postParams, {
+      modem: migrationProcess.selectedOffer.modem,
+    });
 
     return OvhApiPackXdsl.v6().migrate(
       {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #NASD-6058
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Display shipping for order modem only when it's necessary.

## Related
- [X] TRANS-50271

