### PR TITLE
fix(pci.storages.databases):datatr-234 check username duplicate with fullname mongodb

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/add/add.controller.js
@@ -158,6 +158,12 @@ export default class AddUserCtrl {
     if (!username) {
       return true;
     }
+    if (this.database.engine === DATABASE_TYPES.MONGO_DB) {
+      return this.users.some(
+        (user) =>
+          user.username.toLowerCase().split('@')[0] === username.split('@')[0],
+      );
+    }
     return this.users.some((user) => user.username.toLowerCase() === username);
   }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/datatr-197-create-user-already-exist`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-234
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- checked username duplicate with fullname comparison mongodb

## Related

- [PR 8967](https://github.com/ovh/manager/pull/8967)
