### PR TITLE
fix(ldp): update en_gb translation related to encryption keys

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -730,7 +730,7 @@
   "logs_encryption_keys_goto_1": "Manage my",
   "logs_encryption_keys_goto_2": "PGP encryption keys",
   "logs_encryption_keys_add": "Add a PGP encryption key",
-  "logs_encryption_keys_col_title": "Surname",
+  "logs_encryption_keys_col_title": "Name",
   "logs_encryption_keys_col_fingerprint": "Fingerprint",
   "logs_encryption_keys_col_algorithm": "Algorithm",
   "logs_encryption_keys_col_uid": "UID",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

A recent english translation is erroneous (`Surname` instead of `Name`). It refers to an object (an encryption key), and not a real person, so `Name` should be the good translation. Other languages translations seems OK.

## Related

PR #8249
