### PR TITLE
fix(pci.storage.database): datatr-243 - disable links when service is not ready

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/dashboard.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/dashboard.html
@@ -135,6 +135,7 @@
             data-ng-if="$ctrl.isFeatureActivated('replicationsTab')"
             data-href="{{ $ctrl.replicationsLink }}"
             data-active="$ctrl.currentActiveLink() === $ctrl.replicationsLink"
+            data-disabled="!$ctrl.database.isActive()"
             ><span
                 data-translate="pci_databases_dashboard_replications_tab_title"
             ></span>
@@ -152,6 +153,7 @@
             data-ng-if="$ctrl.isFeatureActivated('connectorsTab')"
             data-href="{{ $ctrl.connectorsLink }}"
             data-active="$ctrl.currentActiveLink() === $ctrl.connectorsLink"
+            data-disabled="!$ctrl.database.isActive()"
             ><span
                 data-translate="pci_databases_dashboard_connectors_tab_title"
             ></span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/general-information.html
@@ -29,6 +29,7 @@
             type="button"
             data-ng-if="$ctrl.getWarningMessage().userLink"
             data-ng-click="$ctrl.manageUsers()"
+            data-ng-disabled="!$ctrl.database.isActive()"
             data-translate="{{$ctrl.getWarningMessage().linkMessage}}"
         ></button>
     </oui-message>
@@ -371,6 +372,7 @@
                         <button
                             class="oui-tile__button oui-button oui-button_ghost oui-button_block"
                             data-ng-click="$ctrl.manageUsers()"
+                            data-ng-disabled="!$ctrl.database.isActive()"
                         >
                             <span
                                 data-translate="pci_databases_general_information_manage_users"


### PR DESCRIPTION
datatr-243

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #datatr-243
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Disable shortcut links when database is not ready
