### PR TITLE
Add precision about number of char required for a k8s pool name

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/details/node-pool/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/details/node-pool/add/translations/Messages_fr_FR.json
@@ -9,7 +9,7 @@
   "kube_add_node_pool_error_InsufficientPortsQuota": "Le quota de ports de votre projet est insuffisant pour réaliser l'opération. Merci d'augmenter votre quota ou demander moins de ressources.",
   "kube_add_node_pool_error_InsufficientInstancesQuota": "Le quota d'instances de votre projet est insuffisant pour réaliser l'opération. Merci d'augmenter votre quota ou demander moins de ressources.",
   "kube_add_node_pool_error_quota_link": "Augmenter mon quota.",
-  "kube_add_node_pool_name_input_pattern_validation_error": "Le nom doit commencer par un caractère alphabétique, se terminer par un caractère alphanumérique et les seuls caractères spéciaux autorisés sont les tirets et les underscores.",
+  "kube_add_node_pool_name_input_pattern_validation_error": "Le nom doit être composé au moins d'un caractère, commencer par un caractère alphabétique, se terminer par un caractère alphanumérique et les seuls caractères spéciaux autorisés sont les tirets et les underscores.",
   "kube_add_billing_type_description": "Tous les nœuds futurs de ce pool de nœuds se verront appliquer ce mode de facturation. Vous pourrez ultérieurement passer chacun de vos nœuds individuellement de la facturation horaire à mensuelle.",
   "kube_add_billing_auto_scaling_monthly_warning": "Attention : Vous activez simultanément l'autoscaling et le forfait mensuel pour ce nodepool. Chaque création de nœud par l'autoscaling va entrainer la facturation immédiate d'un nœud au prorata du temps restant sur le mois en cours. Nous vous conseillons d'éviter cette combinaison si vous anticipez que la taille de votre nodepool sera fréquemment réduite.",
   "kube_add_billing_type_payment_method": "Vous serez facturé sur votre mode de paiement par défaut",


### PR DESCRIPTION
## Description

Missing info in error message when creating k8s node pool.

## Related

https://github.com/ovh/manager/issues/9045

