### PR TITLE
fix(dedicated.account): missing a translation on the state field

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -197,7 +197,11 @@ export default class NewAccountFormFieldController {
             this.rule.fieldName === this.FIELD_NAME_LIST.timezone
               ? value
               : this.$translate.instant(
-                  `signup_enum_${this.rule.fieldName}_${value}`,
+                  `signup_enum_${
+                    this.rule.fieldName === this.FIELD_NAME_LIST.area
+                      ? `${this.newAccountForm.model.country}_`
+                      : ''
+                  }${this.rule.fieldName}_${value}`,
                 ),
         };
       } else if (this.getFieldType() === 'date') {

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
@@ -29,7 +29,7 @@
   "signup_field_gst": "Goods and Services Tax number (GST)",
   "signup_field_address": "Address",
   "signup_field_area": "Region",
-  "signup_field_state": "Status",
+  "signup_field_state": "State",
   "signup_field_zip": "Postcode",
   "signup_field_city": "City",
   "signup_field_birthDay": "Date of birth",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/components-w13` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-110213 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I add missing a translation on the state field (default value enum was already done)
One ask is doing for fix the english translation for "Etat" (in french) => "Status" => "State"
<!-- Write a brief description of the changes introduced by this PR -->

## Related
:flags: Translation:
- [x] TRANS-50644
<!-- Link dependencies of this PR -->
