### PR TITLE
fix(web.clouddb): fix rules to create a database

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_de_DE.json
@@ -257,7 +257,7 @@
   "privateDatabase_add_bdd_name": "Name der Datenbank",
   "privateDatabase_add_bdd_error_name_pattern": "Der Name entspricht nicht den Bedingungen.",
   "privateDatabase_add_bdd_error_name_required": "Pflichtangabe.",
-  "privateDatabase_create_bdd_conditions": "Achtung, der Name muss folgende Bedingungen erfüllen: <br/>- Mindestens {{t0}} Zeichen<br/>- Höchstens {{t1}} Zeichen<br/>- Darf ausschließlich aus Buchstaben und Ziffern bestehen.",
+  "privateDatabase_create_bdd_conditions": "Achtung, der Name muss folgende Bedingungen erfüllen: <br/>- mindestens {{t0}} Zeichen<br/>- höchstens {{t1}} Zeichen<br/>- Darf nur mit einer Ziffer oder einem Buchstaben beginnen.<br/>- Darf nur Ziffern, Buchstaben oder die Zeichen_` und Kfz.",
   "privateDatabase_add_bdd_success": "Die Anfrage zur Erstellung der Datenbank wurde erfolgreich durchgeführt",
   "privateDatabase_add_bdd_fail": "Bei der Erstellung der Datenbank ist ein Fehler aufgetreten.",
   "privateDatabase_tabs_bdd_adding": "Datenbank wird hinzugefügt...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_en_GB.json
@@ -255,7 +255,7 @@
   "privateDatabase_add_bdd_name": "Database name",
   "privateDatabase_add_bdd_error_name_pattern": "The name does not follow the conditions.",
   "privateDatabase_add_bdd_error_name_required": "Required fields.",
-  "privateDatabase_create_bdd_conditions": "Please note: the name must comply with the following conditions: <br/>- Minimum {{t0}} characters<br/>- Maximum {{t1}} characters<br/>- Must contain only numbers and letters.",
+  "privateDatabase_create_bdd_conditions": "Warning: the name must meet the following conditions: <br/>- Minimum {{t0}} characters<br/>- Maximum {{t1}} characters<br/>- Must start only with a number or a letter.<br/>- May only contain numbers, letters or the characters '_' and '-'.",
   "privateDatabase_add_bdd_success": "The database creation request has been processed.",
   "privateDatabase_add_bdd_fail": "An error has occurred creating the database.",
   "privateDatabase_tabs_bdd_adding": "Adding database...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_es_ES.json
@@ -257,7 +257,7 @@
   "privateDatabase_add_bdd_name": "Nombre de la BD",
   "privateDatabase_add_bdd_error_name_pattern": "El nombre no cumple los criterios.",
   "privateDatabase_add_bdd_error_name_required": "Campos obligatorios.",
-  "privateDatabase_create_bdd_conditions": "Atención, el nombre debe cumplir los siguientes criterios: <br/>- solo caracteres alfanuméricos<br/>- mínimo {{t0}} caracter(es)<br/>- máximo {{t1}} caracteres",
+  "privateDatabase_create_bdd_conditions": "Atención: El nombre debe cumplir los siguientes criterios: <br/>- mínimo {{t0}} caracteres<br/>- máximo {{t1}} caracteres<br/>- Debe empezar únicamente por una cifra o una letra.<br/>- Sólo puede contener números, letras o caracteres_` y-`.",
   "privateDatabase_add_bdd_success": "La solicitud de creación de la base de datos se ha enviado.",
   "privateDatabase_add_bdd_fail": "Se ha producido un error al crear la base de datos.",
   "privateDatabase_tabs_bdd_adding": "Creando la base de datos...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_CA.json
@@ -269,7 +269,7 @@
   "privateDatabase_add_bdd_name": "Nom de la base",
   "privateDatabase_add_bdd_error_name_pattern": "Le nom ne respecte pas les règles.",
   "privateDatabase_add_bdd_error_name_required": "Champs requis.",
-  "privateDatabase_create_bdd_conditions": "Attention, le nom doit respecter les conditions suivantes : <br/>- Minimum {{t0}} caractères<br/>- Maximum {{t1}} caractères<br/>- Doit être composé uniquement de chiffres et de lettres.",
+  "privateDatabase_create_bdd_conditions": "Attention, le nom doit respecter les conditions suivantes : <br/>- Minimum {{t0}} caractères.<br/>- Maximum {{t1}} caractères.<br/>- Doit commencer uniquement par un chiffre ou une lettre.<br/>- Ne peut contenir que des chiffres, des lettres ou les caractères `_` et `-`.",
   "privateDatabase_add_bdd_success": "La demande de création de la base a été prise en compte",
   "privateDatabase_add_bdd_fail": "Une erreur est survenue lors la création de la base de données.",
   "privateDatabase_tabs_bdd_adding": "Ajout de la base de données en cours...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_fr_FR.json
@@ -269,7 +269,7 @@
   "privateDatabase_add_bdd_name": "Nom de la base",
   "privateDatabase_add_bdd_error_name_pattern": "Le nom ne respecte pas les règles.",
   "privateDatabase_add_bdd_error_name_required": "Champs requis.",
-  "privateDatabase_create_bdd_conditions": "Attention, le nom doit respecter les conditions suivantes : <br/>- Minimum {{t0}} caractères<br/>- Maximum {{t1}} caractères<br/>- Doit être composé uniquement de chiffres et de lettres.",
+  "privateDatabase_create_bdd_conditions": "Attention, le nom doit respecter les conditions suivantes : <br/>- Minimum {{t0}} caractères.<br/>- Maximum {{t1}} caractères.<br/>- Doit commencer uniquement par un chiffre ou une lettre.<br/>- Ne peut contenir que des chiffres, des lettres ou les caractères `_` et `-`.",
   "privateDatabase_add_bdd_success": "La demande de création de la base a été prise en compte",
   "privateDatabase_add_bdd_fail": "Une erreur est survenue lors la création de la base de données.",
   "privateDatabase_tabs_bdd_adding": "Ajout de la base de données en cours...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_it_IT.json
@@ -257,7 +257,7 @@
   "privateDatabase_add_bdd_name": "Nome del database",
   "privateDatabase_add_bdd_error_name_pattern": "Il nome non rispetta le condizioni richieste. ",
   "privateDatabase_add_bdd_error_name_required": "Campo richiesto ",
-  "privateDatabase_create_bdd_conditions": "Attenzione, il nome deve rispettare queste condizioni: <br/>- Min {{t0}} caratteri<br/>- Max {{t1}} caratteri<br/>- Deve essere composto soltanto da numeri e lettere. ",
+  "privateDatabase_create_bdd_conditions": "Attenzione, il nome deve rispettare queste condizioni: <br/>- minimo {{t0}} caratteri<br/>- massimo {{t1}} caratteri<br/>- Deve iniziare solo con una cifra o una lettera.<br/>- Può contenere solo cifre, lettere o i caratteri `_` e `-`.",
   "privateDatabase_add_bdd_success": "La richiesta di creazione del database è stata presa in carico",
   "privateDatabase_add_bdd_fail": "Si è verificato un errore nella creazione del database. ",
   "privateDatabase_tabs_bdd_adding": "Aggiunta del database in corso...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pl_PL.json
@@ -257,7 +257,7 @@
   "privateDatabase_add_bdd_name": "Nazwa bazy",
   "privateDatabase_add_bdd_error_name_pattern": "Nazwa nie spełnia zasad.",
   "privateDatabase_add_bdd_error_name_required": "Pole wymagane",
-  "privateDatabase_create_bdd_conditions": "Uwaga, nazwa musi spełniać następujące warunki: <br/>- Ilość znaków: minimalnie: {{t0}} <br/>- maksymalnie: {{t1}} <br/>- Musi składać się tylko z cyfr i liter.",
+  "privateDatabase_create_bdd_conditions": "Uwaga: nazwa musi spełniać następujące warunki: <br/>- Minimalna liczba znaków: {{t0}}<br/>- Maksymalna liczba znaków: {{t1}}<br/>- Powinien rozpoczynać się od cyfry lub litery.<br/>- Może zawierać tylko cyfry, litery lub znaki `_`-`.",
   "privateDatabase_add_bdd_success": "Zlecenie utworzenia bazy danych zostało zarejestrowane w systemie.",
   "privateDatabase_add_bdd_fail": "Wystąpił błąd podczas zakładania bazy danych.",
   "privateDatabase_tabs_bdd_adding": "Trwa dodawanie bazy danych...",

--- a/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/private-database/dashboard/translations/Messages_pt_PT.json
@@ -257,7 +257,7 @@
   "privateDatabase_add_bdd_name": "Nome da base de dados",
   "privateDatabase_add_bdd_error_name_pattern": "O nome não cumpre os requisitos.",
   "privateDatabase_add_bdd_error_name_required": "Campos obrigatórios.",
-  "privateDatabase_create_bdd_conditions": "Atenção, o nome deve cumprir as seguintes condições: <br/>- Mínimo {{t0}} caracteres<br/>- Máximo {{t1}} caracteres<br/>- Deve ser composto apenas por letras e números.",
+  "privateDatabase_create_bdd_conditions": "Atenção, o nome deve respeitar as seguintes condições: <br/>- Mínimo de {{t0}} caracteres<br/>- Máximo de {{t1}} caracteres<br/>- Deve começar unicamente por um número ou uma letra.<br/>- Só pode conter números, letras ou os caracteres \" ^_`\" e \"-`\".",
   "privateDatabase_add_bdd_success": "O pedido de criação da base de dados foi registado",
   "privateDatabase_add_bdd_fail": "Erro ao processar criação da base de dados.",
   "privateDatabase_tabs_bdd_adding": "Criação da base de dados em curso...",

--- a/packages/manager/apps/web/client/app/private-database/database/add/private-database-database-add.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/database/add/private-database-database-add.controller.js
@@ -46,7 +46,7 @@ angular.module('App').controller(
               min: 1,
               max: 50,
             },
-            reg: /^([\d\w-]){1,50}$/,
+            reg: /^[a-zA-Z0-9]([\w-]){0,49}$/,
           },
         },
         user: {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | PUDBLOW-1906
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

The check on database name, when creating a database inside a web cloudb DB did not reflect the warning message
Moreover the check allowed a database name starting by other characters than [a-zA-Z0-9] which is not supported.

Both have been fixed

## i18n

- [x] TRANS-51535
