### PR TITLE
fix(pci): add asia guide url in blockstorage onboarding page

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/onboarding/onboarding.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/onboarding/onboarding.constants.js
@@ -1,19 +1,27 @@
 export const GUIDES = [
   {
     id: 'create-attach-volume',
-    link:
+    defaultlink:
       'https://docs.ovh.com/gb/en/public-cloud/create-an-additional-volume-and-attach-it-to-an-instance/',
+    asialink:
+      'https://docs.ovh.com/asia/en/public-cloud/create_and_configure_an_additional_disk_on_an_instance/',
   },
   {
     id: 'configure-volume',
-    link:
+    defaultlink:
       'https://docs.ovh.com/gb/en/public-cloud/configure-an-additional-volume/',
+    asialink:
+      'https://docs.ovh.com/asia/en/public-cloud/configure-an-additional-volume/',
   },
   {
     id: 'increase-volume-size',
-    link:
+    defaultlink:
       'https://docs.ovh.com/gb/en/public-cloud/increase_the_size_of_an_additional_disk/',
+    asialink:
+      'https://docs.ovh.com/asia/en/public-cloud/increase_the_size_of_an_additional_disk/',
   },
 ];
 
-export default { GUIDES };
+export const IN_SUBSIDIARY = 'IN';
+
+export default { GUIDES, IN_SUBSIDIARY };

--- a/packages/manager/modules/pci/src/projects/project/storages/blocks/onboarding/onboarding.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/blocks/onboarding/onboarding.controller.js
@@ -1,12 +1,13 @@
 import reduce from 'lodash/reduce';
 import illustration from './assets/blocks.png';
 
-import { GUIDES } from './onboarding.constants';
+import { GUIDES, IN_SUBSIDIARY } from './onboarding.constants';
 
 export default class PciStorageBlocksOnboardingController {
   /* @ngInject */
-  constructor($translate) {
+  constructor($translate, coreConfig) {
     this.$translate = $translate;
+    this.coreConfig = coreConfig;
   }
 
   $onInit() {
@@ -16,7 +17,11 @@ export default class PciStorageBlocksOnboardingController {
       (list, guide) => [
         ...list,
         {
-          ...guide,
+          id: guide.id,
+          link:
+            this.coreConfig.getUser().ovhSubsidiary === IN_SUBSIDIARY
+              ? guide.asialink
+              : guide.defaultlink,
           title: this.$translate.instant(
             `pci_projects_project_storages_blocks_onboarding_guides_${guide.id}_title`,
           ),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-11146
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Add asia specific guide url in block storage onboarding page

## Related

<!-- Link dependencies of this PR -->
