### PR TITLE
fix(pci.storages.databases): datatr-153 - remove spaces around slashes in prices

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/translations/Messages_fr_FR.json
@@ -69,7 +69,7 @@
   "pci_database_add_storage_sizing": "Stockage additionnel",
   "pci_database_add_storage_sizing_offer": "Votre modèle de nœud {{flavorName}} inclut {{includedStorage}} de stockage auxquels vous pouvez ajouter jusqu'à {{addableStorage}} de stockage supplémentaire par pas de {{step}}.",
   "pci_database_add_spec_storage_added": "{{total}} (dont {{included}} inclus)",
-  "pci_database_add_price_unit_month": "/ mois",
-  "pci_database_add_price_unit_hour": "/ heure",
+  "pci_database_add_price_unit_month": "/mois",
+  "pci_database_add_price_unit_hour": "/heure",
   "pci_database_add_price_unit_switch_label": "Afficher les prix au mois"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
   "pci_database_disk_size_none": "Aucun",
-  "pci_database_disk_size_price_unit_hour": "/ heure",
-  "pci_database_disk_size_price_unit_month": "/ mois"
+  "pci_database_disk_size_price_unit_hour": "/heure",
+  "pci_database_disk_size_price_unit_month": "/mois"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/flavors-list/translations/Messages_fr_FR.json
@@ -2,8 +2,8 @@
   "pci_database_flavors_list_header_type": "Type",
   "pci_database_flavors_list_header_memory": "Mémoire",
   "pci_database_flavors_list_header_storage": "Stockage utile",
-  "pci_database_flavors_list_header_price_hour": "Coût / heure / nœud (estimé)",
-  "pci_database_flavors_list_header_price_month": "Coût / mois / nœud (estimé)",
+  "pci_database_flavors_list_header_price_hour": "Coût/heure/nœud (estimé)",
+  "pci_database_flavors_list_header_price_month": "Coût/mois/nœud (estimé)",
   "pci_database_flavors_list_storage_range": "De {{min}} à {{max}}",
   "pci_database_flavors_list_table_description": "Liste des types de nœuds",
   "pci_database_flavors_list_current_offer": "Offre actuelle"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/plans-list/translations/Messages_fr_FR.json
@@ -12,6 +12,6 @@
   "pci_database_plans_list_spec_storage_unique": "{{storage}} de stockage",
   "pci_database_plans_list_current_offer": "Offre actuelle",
   "pci_database_plans_list_spec_private_network": "Réseaux privés",
-  "pci_database_plans_list_spec_price_unit_hour": " / heure",
-  "pci_database_plans_list_spec_price_unit_month": " / mois"
+  "pci_database_plans_list_spec_price_unit_hour": "/heure",
+  "pci_database_plans_list_spec_price_unit_month": "/mois"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/fork/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/backups/fork/translations/Messages_fr_FR.json
@@ -56,8 +56,8 @@
   "pci_databases_backups_fork_storage_sizing": "Stockage additionnel",
   "pci_databases_backups_fork_storage_sizing_offer": "Votre modèle de nœud {{flavorName}} inclut {{includedStorage}} de stockage auxquels vous pouvez ajouter jusqu'à {{addableStorage}} de stockage supplémentaire par pas de {{step}}.",
   "pci_databases_backups_fork_spec_storage_added": "{{total}} (dont {{included}} inclus)",
-  "pci_databases_backups_fork_price_unit_month": "/ mois",
-  "pci_databases_backups_fork_price_unit_hour": "/ heure",
+  "pci_databases_backups_fork_price_unit_month": "/mois",
+  "pci_databases_backups_fork_price_unit_hour": "/heure",
   "pci_databases_backups_fork_price_unit_switch_label": "Afficher les prix au mois",
   "pci_databases_backups_fork_restore_mode_title": "Point de restauration",
   "pci_databases_backups_fork_restore_mode_description": "Sélectionnez le point de restauration à partir duquel le service sera dupliqué."


### PR DESCRIPTION
DATATR-153

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DATATR-153
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

As requested by translation team, remove the spaces around slashes in prices for French translations