### PR TITLE
fix: rework on display meeting if not fiber offer selected

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/pack-migration.controller.js
@@ -113,12 +113,8 @@ export default class TelecomPackMigrationCtrl {
           } else if (buildings && buildings.length === 1) {
             const [building] = buildings;
 
-            // check if the building name is empty to set a name to display in the select component
-            building.name =
-              building.name ||
-              this.$translate.instant(
-                'telecom_pack_migration_building_details_unknown',
-              );
+            // check if the building name is empty to set a name or the building reference to display in the select component
+            building.name = building.name || building.reference;
 
             this.TucPackMigrationProcess.setSelectedBuilding(building);
 

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
@@ -39,9 +39,7 @@ export default class MoveBuildingDetailsCtrl {
 
     // check if the building name is empty to set a name to display in the select component
     this.building.name =
-      this.building.name === ''
-        ? this.$translate.instant('pack_move_building_details_unknown')
-        : this.building.name;
+      this.building.name === '' ? this.building.reference : this.building.name;
 
     this.OvhApiConnectivityEligibilitySearch.v6()
       .pollerBuildingDetails(this.$scope, {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/resume/move-resume.html
@@ -259,7 +259,7 @@
             ></p>
 
             <div
-                data-ng-if="!$ctrl.offer.selected.form.futureLandline.lineNumber"
+                data-ng-if="!$ctrl.offer.selected.form.futureLandline.lineNumber && $ctrl.offer.selected.product.type !== 'FTTH'"
             >
                 <p
                     class="mb-3 font-weight-bold"
@@ -281,24 +281,16 @@
                         data-ng-bind="$ctrl.offer.selected.address.city"
                     ></strong>
                 </div>
-                <div data-ng-if="$ctrl.offer.selected.product.type !== 'FTTH'">
-                    <p
-                        class="mb-3 font-weight-bold"
-                        data-ng-if="$ctrl.offer.selected.meetingSlots.fakeMeeting"
-                        data-translate="pack_move_contract_meeting_contact"
-                    ></p>
-                    <p
-                        class="mb-3 font-weight-bold"
-                        data-ng-if="!$ctrl.offer.selected.meetingSlots.fakeMeeting"
-                        data-ng-bind="$ctrl.getMeeting()"
-                    ></p>
-                </div>
-                <div data-ng-if="$ctrl.offer.selected.product.type === 'FTTH'">
-                    <p
-                        class="mb-3 font-weight-bold"
-                        data-translate="pack_move_contract_meeting_contact"
-                    ></p>
-                </div>
+                <p
+                    class="mb-3 font-weight-bold"
+                    data-ng-if="$ctrl.offer.selected.meetingSlots.fakeMeeting"
+                    data-translate="pack_move_contract_meeting_contact"
+                ></p>
+                <p
+                    class="mb-3 font-weight-bold"
+                    data-ng-if="!$ctrl.offer.selected.meetingSlots.fakeMeeting"
+                    data-ng-bind="$ctrl.getMeeting()"
+                ></p>
             </div>
 
             <div data-ng-if="$ctrl.offer.selected.moveOutDate">


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-474
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Rework on display meeting on resume if not fiber offer selected and display building reference if building name is empty.

## Related

<!-- Link dependencies of this PR -->
