### PR TITLE
fix(storages.cold-archive): generate user + cred on enter button

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/add.controller.js
@@ -1,3 +1,5 @@
+import set from 'lodash/set';
+
 import {
   COLD_ARCHIVE_TRACKING,
   COLD_ARCHIVE_STATES,
@@ -174,5 +176,14 @@ export default class ColdArchiveConfigurationController {
       type: 'action',
     });
     return this.createArchive();
+  }
+
+  onLinkOrCreateStepSubmit(linkUserArchiveStep) {
+    if (
+      this.userModel.createMode?.user ||
+      this.userModel.linkedMode?.selected
+    ) {
+      set(linkUserArchiveStep, 'display', false);
+    }
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/add.html
@@ -58,7 +58,7 @@
         data-name="{{:: linkUserArchiveStep.name}}"
         data-header="{{:: 'pci_projects_project_storages_cold_archive_add_step_link_user_archive_header' | translate }}"
         data-on-focus="linkUserArchiveStep.display = true"
-        data-on-submit="linkUserArchiveStep.display = false"
+        data-on-submit="$ctrl.onLinkOrCreateStepSubmit(linkUserArchiveStep)"
         data-editable="!$ctrl.isArchiveCreationInProgress"
         data-valid="$ctrl.isReadyForValidation()"
         data-navigation="$ctrl.isReadyForValidation()"

--- a/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/components/steps/link-user-archive/controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/components/steps/link-user-archive/controller.js
@@ -189,34 +189,38 @@ export default class ColdArchiveLinkUserArchiveController {
     this.CucCloudMessage.flushMessages(ARCHIVE_MESSAGES_ID);
   }
 
-  onCreateUserClicked(description) {
-    let newUser;
-    this.trackClick(
-      `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}::${COLD_ARCHIVE_TRACKING.ACTIONS.CONFIRM}`,
-    );
-    this.userModel.createMode.isInProgress = true;
-    return this.createUser(description)
-      .then((user) => {
-        newUser = user;
-        return this.generateUserS3Credentials(user).then((credential) => {
-          newUser.s3Credentials = credential;
-          this.users.push(newUser);
-          this.userModel.createMode.user = newUser;
-          this.userModel.createMode.credential = credential;
+  onCreateUserClicked(description, $event) {
+    if (description && (!$event || $event.keyCode === 13)) {
+      let newUser;
+      this.trackClick(
+        `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}::${COLD_ARCHIVE_TRACKING.ACTIONS.CONFIRM}`,
+      );
+      this.userModel.createMode.isInProgress = true;
+      return this.createUser(description)
+        .then((user) => {
+          newUser = user;
+          return this.generateUserS3Credentials(user).then((credential) => {
+            newUser.s3Credentials = credential;
+            this.users.push(newUser);
+            this.userModel.createMode.user = newUser;
+            this.userModel.createMode.credential = credential;
+            this.trackPage(
+              `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}_${COLD_ARCHIVE_TRACKING.STATUS.SUCCESS}`,
+            );
+            return credential;
+          });
+        })
+        .catch(() => {
           this.trackPage(
-            `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}_${COLD_ARCHIVE_TRACKING.STATUS.SUCCESS}`,
+            `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}_${COLD_ARCHIVE_TRACKING.STATUS.ERROR}`,
           );
-          return credential;
+        })
+        .finally(() => {
+          this.userModel.createMode.isInProgress = false;
         });
-      })
-      .catch(() => {
-        this.trackPage(
-          `${COLD_ARCHIVE_TRACKING.ADD_USER.ASSOCIATE.NEW_USER}_${COLD_ARCHIVE_TRACKING.STATUS.ERROR}`,
-        );
-      })
-      .finally(() => {
-        this.userModel.createMode.isInProgress = false;
-      });
+    }
+
+    return Promise.resolve();
   }
 
   onCancelLinkedUserClicked() {

--- a/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/components/steps/link-user-archive/template.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/cold-archive/add/components/steps/link-user-archive/template.html
@@ -123,7 +123,9 @@
                     class="oui-input mr-2"
                     type="text"
                     name="username"
+                    data-ng-disabled="$ctrl.userModel.createMode.isInProgress"
                     data-ng-model="$ctrl.userModel.createMode.description"
+                    data-ng-keyup="$ctrl.onCreateUserClicked($ctrl.userModel.createMode.description, $event)"
                     required
                 />
                 <oui-spinner


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/tape-ga-batch-2` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-112315<!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
Avoid that enter button switch to next step
Instead it must generate the user+cred if creation mode selected