### PR TITLE
fix(dedicated): windows partition minimum size is for c: only

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -1054,8 +1054,8 @@ angular
         if (validationTypePrimary(true)) {
           $scope.errorInst.typePrimary = true;
         } else if (
-          $scope.installation.selectDistribution.family ===
-            $scope.constants.warningWindows &&
+          $scope.informations.softRaidOnlyMirroring &&
+          $scope.newPartition.mountPoint === $scope.constants.warningCwin &&
           $scope.newPartition.partitionSize < $scope.constants.minSizeWindows
         ) {
           $scope.errorInst.partitionSizeWindows = true;
@@ -1722,8 +1722,8 @@ angular
       // windows size < 20Go = error
       function validationSizeWindowsMin(partition) {
         $scope.errorInst.partitionSizeWindows =
-          $scope.installation.selectDistribution.family ===
-            $scope.constants.warningWindows &&
+          $scope.informations.softRaidOnlyMirroring &&
+          partition.mountPoint === $scope.constants.warningCwin &&
           $scope.getRealDisplaySize({
             partition,
             notDisplay: true,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

Windows partition minimum requirement of 32,8 GiB should be for system c: only

## Related

ref: MANAGER-11396
