### PR TITLE
fix(dedicated): allow user define raid higher than 1 on / partition

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -1556,11 +1556,6 @@ angular
           $scope.installation.nbDiskUse > 1 &&
           !$scope.informations.raidController
         ) {
-          $scope.errorInst.raid0 =
-            partition.raid !== $scope.constants.warningRaid1 &&
-            partition.raid !== $scope.constants.warningRaid0 &&
-            (partition.mountPoint === $scope.constants.warningBoot ||
-              partition.mountPoint === $scope.constants.warningRoot);
           $scope.warning.raid0 =
             !$scope.errorInst.raid0 &&
             partition.raid === $scope.constants.warningRaid0;

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.controller.js
@@ -548,7 +548,7 @@ angular
           }
         }
 
-        return realRemainingSize;
+        return Math.floor(realRemainingSize);
       }
 
       function showPartition() {

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
@@ -757,6 +757,7 @@
                                     </span>
                                     <input
                                         type="text"
+                                        class="form-control"
                                         data-ng-show="isSetPartition(partition) && partition.typePartition == constants.warningLV"
                                         data-ng-model="partition.volumeName"
                                         data-ng-required="partition.typePartition == constants.warningLV"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

- Allow user to define RAID level higher than 1 on / partition (major)
- Added missing CSS class for lvm input (minor)
- Fixed historical rounding issue in partitioning (major)

## Related

ref: MANAGER-11414