### PR TITLE
fix: set need new modem flag to false when no modem selected

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/offers/pack-migration-offers.controller.js
@@ -167,6 +167,9 @@ export default class TelecomPackMigrationOffersCtrl {
               selectedOffer.needNewModem = true;
             }
           }
+        } else {
+          // Selected modem = no, no display shipping page
+          selectedOffer.needNewModem = false;
         }
       }
     });

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/offers/move-offers.controller.js
@@ -368,6 +368,9 @@ export default class PackMoveOffersCtrl {
               selectedOffer.needNewModem = true;
             }
           }
+        } else {
+          // Selected modem = no, no display shipping page
+          selectedOffer.needNewModem = false;
         }
       }
     });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-477
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Set needNewModem flag to false when no modem is selected in offers page

## Related

<!-- Link dependencies of this PR -->
