### PR TITLE
fix(dedicated): rescue boot mode improvements

### DIFF
--- a/packages/manager/modules/bm-server-components/src/netboot/constants.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/constants.js
@@ -1,0 +1,37 @@
+export const NETBOOT_GUIDES = {
+  ASIA: 'https://docs.ovh.com/asia/en/dedicated/hardware-diagnostics',
+  AU: 'https://docs.ovh.com/au/en/dedicated/hardware-diagnostics',
+  CA: 'https://docs.ovh.com/ca/en/dedicated/hardware-diagnostics',
+  DE:
+    'https://docs.ovh.com/de/dedicated/diagnose-hardwarefehler-dedicated-server',
+  ES:
+    'https://docs.ovh.com/es/dedicated/diagnostico-fallos-hardware-servidor-dedicado',
+  FR:
+    'https://docs.ovh.com/fr/dedicated/diagnostic-dysfonctionnements-materiels-serveur-dedie',
+  GB: 'https://docs.ovh.com/gb/en/dedicated/hardware-diagnostics',
+  IE: 'https://docs.ovh.com/ie/en/dedicated/hardware-diagnostics',
+  IN: 'https://docs.ovh.com/asia/en/dedicated/hardware-diagnostics',
+  IT:
+    'https://docs.ovh.com/it/dedicated/diagnostica-problemi-hardware-server-dedicato',
+  PL:
+    'https://docs.ovh.com/pl/dedicated/diagnostyka-usterek-sprzetowych-serwera-dedykowanego',
+  PT:
+    'https://docs.ovh.com/pt/dedicated/diagnostico-avarias-materiais-servidor-dedicado',
+  QC:
+    'https://docs.ovh.com/ca/fr/dedicated/diagnostic-dysfonctionnements-materiels-serveur-dedie',
+  SG: 'https://docs.ovh.com/sg/en/dedicated/hardware-diagnostics',
+  US:
+    'https://support.us.ovhcloud.com/hc/en-us/articles/17562733805843-Hardware-Diagnostics-for-a-Dedicated-Server',
+  WE: 'https://docs.ovh.com/us/en/dedicated/hardware-diagnostics',
+  WS:
+    'https://docs.ovh.com/us/es/dedicated/diagnostico-fallos-hardware-servidor-dedicado',
+  DEFAULT: 'https://docs.ovh.com/us/en/dedicated/hardware-diagnostics',
+};
+
+export const getNetbootGuideUrl = (subsidiary) => {
+  return NETBOOT_GUIDES[subsidiary] || NETBOOT_GUIDES.DEFAULT;
+};
+
+export default {
+  getNetbootGuideUrl,
+};

--- a/packages/manager/modules/bm-server-components/src/netboot/controller.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/controller.js
@@ -1,6 +1,8 @@
 import forEach from 'lodash/forEach';
 import isFunction from 'lodash/isFunction';
 
+import { getNetbootGuideUrl } from './constants';
+
 export default class BmServerComponentsNetbootCtrl {
   /* @ngInject */
   constructor(
@@ -8,6 +10,7 @@ export default class BmServerComponentsNetbootCtrl {
     $q,
     $translate,
     atInternet,
+    coreConfig,
     netbootService,
     $anchorScroll,
     $location,
@@ -15,6 +18,7 @@ export default class BmServerComponentsNetbootCtrl {
     this.$http = $http;
     this.$q = $q;
     this.$translate = $translate;
+    this.ovhSubsidiary = coreConfig.getUser().ovhSubsidiary;
     this.atInternet = atInternet;
     this.netbootService = netbootService;
     this.$anchorScroll = $anchorScroll;
@@ -42,6 +46,7 @@ export default class BmServerComponentsNetbootCtrl {
     this.rootDevice = {
       root: null,
     };
+    this.hardwareDiagnosticsGuide = getNetbootGuideUrl(this.ovhSubsidiary);
 
     this.loadNetboots();
   }

--- a/packages/manager/modules/bm-server-components/src/netboot/controller.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/controller.js
@@ -31,6 +31,8 @@ export default class BmServerComponentsNetbootCtrl {
     this.RESCUE = 'rescue';
     this.NETWORK = 'network';
 
+    this.DEFAULT_RESCUE = 'rescue-customer';
+
     this.loading = {
       init: true,
       setNetboot: false,
@@ -67,6 +69,12 @@ export default class BmServerComponentsNetbootCtrl {
       forEach(eachNetboot, (eachNetbootItem) => {
         if (eachNetbootItem.id === this.server.bootId) {
           this.currentNetboot.type = eachNetbootItem.type.toLowerCase();
+          this.currentNetboot[netbootType] = eachNetbootItem;
+        }
+        if (
+          netbootType === this.RESCUE &&
+          eachNetbootItem.kernel === this.DEFAULT_RESCUE
+        ) {
           this.currentNetboot[netbootType] = eachNetbootItem;
         }
       });

--- a/packages/manager/modules/bm-server-components/src/netboot/template.html
+++ b/packages/manager/modules/bm-server-components/src/netboot/template.html
@@ -76,12 +76,11 @@
                             class="form-control"
                             id="rescue"
                             name="rescue"
-                            data-ng-options="rescue.kernel + ' - ' + rescue.description for rescue in $ctrl.netboots.rescue"
+                            data-ng-options="rescue as rescue.kernel + ' - ' + rescue.description for rescue in $ctrl.netboots.rescue track by rescue.kernel"
                             data-ng-model="$ctrl.currentNetboot.rescue"
                             required
                         >
                             <option
-                                value=""
                                 data-ng-disabled="true"
                                 data-translate="select_option"
                             >

--- a/packages/manager/modules/bm-server-components/src/netboot/template.html
+++ b/packages/manager/modules/bm-server-components/src/netboot/template.html
@@ -55,7 +55,7 @@
                             class="form-control"
                             id="rescue"
                             name="rescue"
-                            data-ng-options="rescue as rescue.kernel for rescue in $ctrl.netboots.rescue"
+                            data-ng-options="rescue.kernel + ' - ' + rescue.description for rescue in $ctrl.netboots.rescue"
                             data-ng-model="$ctrl.currentNetboot.rescue"
                             required
                         >

--- a/packages/manager/modules/bm-server-components/src/netboot/template.html
+++ b/packages/manager/modules/bm-server-components/src/netboot/template.html
@@ -38,6 +38,27 @@
             </div>
 
             <div class="mt-4">
+                <p data-ng-if="$ctrl.currentNetboot.type === $ctrl.RESCUE">
+                    <i class="fa fa-info-circle" aria-hidden="true"></i>
+                    <span
+                        data-translate="server_configuration_netboot_rescue_help"
+                    ></span>
+                    <a
+                        href="{{::$ctrl.hardwareDiagnosticsGuide}}"
+                        rel="noopener"
+                        target="_blank"
+                    >
+                        <span
+                            data-translate="server_configuration_netboot_rescue_help_link"
+                        ></span>
+                        <span
+                            class="oui-icon oui-icon-external-link"
+                            aria-hidden="true"
+                        >
+                        </span>
+                    </a>
+                </p>
+
                 <p
                     data-ng-if="$ctrl.currentNetboot.type === $ctrl.RESCUE || $ctrl.currentNetboot.type === $ctrl.NETWORK"
                 >

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_de_DE.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_de_DE.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Bestätigen",
   "server_configuration_netboot_review": "Zusammenfassung",
   "server_configuration_netboot_save_in_progress": "Update wird durchgeführt...",
-  "server_configuration_netboot_invalid": "Ungültig"
+  "server_configuration_netboot_invalid": "Ungültig",
+  "server_configuration_netboot_rescue_help": "Der Rescue-Modus kann nützlich sein, um auf einem Dedicated Server Hardwareprobleme zu diagnostizieren.",
+  "server_configuration_netboot_rescue_help_link": "Sehen Sie sich die Anleitung für die Hardware-Diagnose an."
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_en_GB.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_en_GB.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Confirm",
   "server_configuration_netboot_review": "Summary",
   "server_configuration_netboot_save_in_progress": "Updating...",
-  "server_configuration_netboot_invalid": "Invalid"
+  "server_configuration_netboot_invalid": "Invalid",
+  "server_configuration_netboot_rescue_help": "Rescue mode is useful for diagnosing hardware faults on a dedicated server.",
+  "server_configuration_netboot_rescue_help_link": "Access the hardware diagnostic guide."
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_es_ES.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_es_ES.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Confirmar",
   "server_configuration_netboot_review": "Resumen",
   "server_configuration_netboot_save_in_progress": "Actualización",
-  "server_configuration_netboot_invalid": "No válido"
+  "server_configuration_netboot_invalid": "No válido",
+  "server_configuration_netboot_rescue_help": "El modo «rescue» puede resultar útil a la hora de diagnosticar fallos de hardware en un servidor dedicado.",
+  "server_configuration_netboot_rescue_help_link": "Acceder a la guía de diagnóstico de hardware."
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_CA.json
@@ -15,6 +15,8 @@
   "server_configuration_netboot_option_rescue": "Booter en mode rescue",
   "server_configuration_netboot_option_network": "Booter en mode network",
   "server_configuration_netboot_configuration": "Configuration :",
+  "server_configuration_netboot_rescue_help": "Le rescue peut-être utile pour diagnostiquer des dysfonctionnements matériels sur un serveur dédié.",
+  "server_configuration_netboot_rescue_help_link": "Accéder au guide de diagnostic matériel.",
   "server_configuration_netboot_rescue_choice": "Rescue disponible :",
   "server_configuration_netboot_rescue_mail": "Recevoir les identifiants du mode sur l'adresse e-mail :",
   "server_configuration_netboot_rescue_mail_invalid": "Invalide",

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_FR.json
@@ -15,6 +15,8 @@
   "server_configuration_netboot_option_rescue": "Booter en mode rescue",
   "server_configuration_netboot_option_network": "Booter en mode network",
   "server_configuration_netboot_configuration": "Configuration :",
+  "server_configuration_netboot_rescue_help": "Le rescue peut-être utile pour diagnostiquer des dysfonctionnements matériels sur un serveur dédié.",
+  "server_configuration_netboot_rescue_help_link": "Accéder au guide de diagnostic matériel.",
   "server_configuration_netboot_rescue_choice": "Rescue disponible :",
   "server_configuration_netboot_rescue_mail": "Recevoir les identifiants du mode sur l'adresse e-mail :",
   "server_configuration_netboot_rescue_mail_invalid": "Invalide",

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_it_IT.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_it_IT.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Conferma",
   "server_configuration_netboot_review": "Riepilogo",
   "server_configuration_netboot_save_in_progress": "Aggiornamento...",
-  "server_configuration_netboot_invalid": "Non valido"
+  "server_configuration_netboot_invalid": "Non valido",
+  "server_configuration_netboot_rescue_help": "La modalità Rescue può essere utile per diagnosticare malfunzionamenti hardware su un server dedicato.",
+  "server_configuration_netboot_rescue_help_link": "Accedi alla guida di diagnostica hardware."
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pl_PL.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Zatwierdź",
   "server_configuration_netboot_review": "Podsumowanie",
   "server_configuration_netboot_save_in_progress": "Aktualizacja...",
-  "server_configuration_netboot_invalid": "Nieprawidłowy"
+  "server_configuration_netboot_invalid": "Nieprawidłowy",
+  "server_configuration_netboot_rescue_help": "Tryb rescue może być przydatny podczas diagnozowania usterek sprzętowych na serwerze dedykowanym.",
+  "server_configuration_netboot_rescue_help_link": "Dostęp do przewodnika dotyczącego diagnostyki sprzętu."
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pt_PT.json
@@ -36,5 +36,7 @@
   "server_configuration_netboot_confirm": "Validar",
   "server_configuration_netboot_review": "Resumo",
   "server_configuration_netboot_save_in_progress": "Atualização...",
-  "server_configuration_netboot_invalid": "Inválida"
+  "server_configuration_netboot_invalid": "Inválida",
+  "server_configuration_netboot_rescue_help": "O rescue pode ser útil para diagnosticar avarias materiais num servidor dedicado.",
+  "server_configuration_netboot_rescue_help_link": "Aceder ao guia de diagnóstico de hardware."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

- added description to boot mode dropdown (MANAGER-11099)
- make rescue-customer default netboot rescue type (MANAGER-11100)
- added documentation links for rescue (MANAGER-11101)

## Related

ref: PUBM-23077: MANAGER-11099 + MANAGER-11100 + MANAGER-11101