### PR TITLE
feat(telecom): add new security level for wifi on modem

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.controller.js
@@ -235,7 +235,7 @@ export default /* @ngInject */ function XdslModemWifiConfigCtrl(
           self.fields.securityType =
             self.modem.model === 'TG799VAC'
               ? ['None', 'WPA2', 'WPAandWPA2']
-              : ['None', 'WEP', 'WPA', 'WPA2', 'WPAandWPA2'];
+              : ['WPA2', 'WPA2andWPA3', 'WPA3'];
         },
         (err) => {
           TucToast.error($translate.instant('xdsl_modem_wifi_read_error'));

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_de_DE.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA et WPA2",
   "xdsl_modem_wifi_read_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre wifi.",
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 und WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_en_GB.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA and WPA2",
   "xdsl_modem_wifi_read_error": "Oops! We were unable to retrieve your WiFi information.",
   "xdsl_modem_wifi_write_error": "Oops! We were unable to update your WiFi.",
-  "xdsl_modem_wifi_config_info": "A WiFi network configuration change is already in progress. The changes you make will be applied once this change is complete."
+  "xdsl_modem_wifi_config_info": "A WiFi network configuration change is already in progress. The changes you make will be applied once this change is complete.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 and WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_es_ES.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA y WPA2",
   "xdsl_modem_wifi_read_error": "¡Vaya! No hemos podido cargar los datos de su wifi.",
   "xdsl_modem_wifi_write_error": "¡Vaya! No hemos podido actualizar su wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 y WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_CA.json
@@ -37,11 +37,10 @@
   "xdsl_modem_wifi_config_success_single": "Configuration Wi-Fi mis à jour avec succès ! Vous allez être redirigé(e).",
   "xdsl_modem_wifi_config_error_missing": "Wi-Fi non existant!",
   "xdsl_modem_wifi_None": "Aucune",
-  "xdsl_modem_wifi_WEP": "WEP",
-  "xdsl_modem_wifi_WPA": "WPA",
   "xdsl_modem_wifi_WPA2": "WPA2",
-  "xdsl_modem_wifi_WPAandWPA2": "WPA et WPA2",
   "xdsl_modem_wifi_read_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre wifi.",
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 et WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_FR.json
@@ -37,11 +37,10 @@
   "xdsl_modem_wifi_config_success_single": "Configuration Wi-Fi mis à jour avec succès ! Vous allez être redirigé(e).",
   "xdsl_modem_wifi_config_error_missing": "Wi-Fi non existant!",
   "xdsl_modem_wifi_None": "Aucune",
-  "xdsl_modem_wifi_WEP": "WEP",
-  "xdsl_modem_wifi_WPA": "WPA",
   "xdsl_modem_wifi_WPA2": "WPA2",
-  "xdsl_modem_wifi_WPAandWPA2": "WPA et WPA2",
   "xdsl_modem_wifi_read_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre wifi.",
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 et WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_it_IT.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA e WPA2",
   "xdsl_modem_wifi_read_error": "Ops! Impossibile recuperare le informazioni relative al tuo Wi-Fi.",
   "xdsl_modem_wifi_write_error": "Ops! Impossibile aggiornare il tuo Wi-Fi. ",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 e WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pl_PL.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA et WPA2",
   "xdsl_modem_wifi_read_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre wifi.",
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 i WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pt_PT.json
@@ -43,5 +43,7 @@
   "xdsl_modem_wifi_WPAandWPA2": "WPA et WPA2",
   "xdsl_modem_wifi_read_error": "Oups ! Nous n'avons pas pu récupérer les informations relatives à votre wifi.",
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
-  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée."
+  "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
+  "xdsl_modem_wifi_WPA2andWPA3": "WPA2 e WPA3",
+  "xdsl_modem_wifi_WPA3": "WPA3"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-476
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Add WPA3 and WPA2andWPA3 security level for wifi configuration on modem

## Related

- [x] TRANS-52115  
