### PR TITLE
fix(additional-ips.order): in public IP creation display only v4 ip addresses in step 3

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/additional-ips/order/order.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/additional-ips/order/order.controller.js
@@ -208,8 +208,9 @@ export default class AdditionalIpController {
   instanceChange(instance) {
     this.privateNetworks = filter(
       instance.ipAddresses,
-      (network) => network.type === 'private',
+      (network) => network.type === 'private' && network.version === 4,
     );
+
     if (this.privateNetworks.length === 1) {
       [this.ip.network] = this.privateNetworks;
     }


### PR DESCRIPTION
ref: MANAGER-11506

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-11506 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
