### PR TITLE
feat(dedicated.nutanix): display hardware tile based on cluster type

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/constants.js
+++ b/packages/manager/modules/nutanix/src/dashboard/constants.js
@@ -11,10 +11,16 @@ export const GUIDE_URL = {
   },
 };
 
-export const NEW_CLUSTER_PLAN_CODE = [
-  'nutanix-standard',
-  'nutanix-advanced',
-  'nutanix-byol',
+export const OLD_CLUSTER_PLAN_CODE = [
+  'nutanix-21hci01-byol',
+  'nutanix-21hci02-byol',
+  'nutanix-21hci03-byol',
+  'nutanix-pro-21hci01',
+  'nutanix-pro-21hci02',
+  'nutanix-pro-21hci03',
+  'nutanix-ultimate-21hci01',
+  'nutanix-ultimate-21hci02',
+  'nutanix-ultimate-21hci03',
 ];
 
 export const LICENSE_REGISTRATION_ENDS_IN_DAYS = 90;
@@ -24,5 +30,5 @@ export default {
   SERVER_OPTIONS,
   GUIDE_URL,
   LICENSE_REGISTRATION_ENDS_IN_DAYS,
-  NEW_CLUSTER_PLAN_CODE,
+  OLD_CLUSTER_PLAN_CODE,
 };

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/component.js
@@ -17,7 +17,7 @@ export default {
     handleError: '<',
     nutanixPlans: '<',
     getTechnicalDetails: '<',
-    isNewCluster: '<',
+    isOldCluster: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
@@ -223,7 +223,7 @@
     </div>
 
     <!-- TECHNICAL DETAILS -->
-    <div class="col-md-6 col-lg-4 mb-3" data-ng-if="!$ctrl.isNewCluster">
+    <div class="col-md-6 col-lg-4 mb-3" data-ng-if="$ctrl.isOldCluster">
         <server-technical-details
             technical-details="$ctrl.technicalDetails"
         ></server-technical-details>

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/component.js
@@ -15,7 +15,7 @@ export default {
     goToNetboot: '<',
     goToNutanixNode: '<',
     goToReboot: '<',
-    isNewCluster: '<',
+    isOldCluster: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
@@ -126,7 +126,7 @@
         <!-- TECHNICAL DETAILS -->
         <div
             class="col-md-4"
-            data-ng-if="$ctrl.technicalDetails && $ctrl.isNewCluster"
+            data-ng-if="$ctrl.technicalDetails && !$ctrl.isOldCluster"
         >
             <server-technical-details
                 technical-details="$ctrl.technicalDetails"

--- a/packages/manager/modules/nutanix/src/dashboard/routing.js
+++ b/packages/manager/modules/nutanix/src/dashboard/routing.js
@@ -1,4 +1,4 @@
-import { NEW_CLUSTER_PLAN_CODE } from './constants';
+import { OLD_CLUSTER_PLAN_CODE } from './constants';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('nutanix.dashboard', {
@@ -21,10 +21,10 @@ export default /* @ngInject */ ($stateProvider) => {
         NutanixService.getServiceDetails(serviceInfo.serviceId),
       nutanixPlans: /* @ngInject */ (user, NutanixService) =>
         NutanixService.getNutanixPlans(user.ovhSubsidiary),
-      isNewCluster: /* @ngInject */ (NutanixService, serviceInfo) =>
+      isOldCluster: /* @ngInject */ (NutanixService, serviceInfo) =>
         // If the plan code is nutanix-standard or nutanix-advanced or nutanix-byol its newCluster
         NutanixService.getServicesDetails(serviceInfo.serviceId).then((data) =>
-          NEW_CLUSTER_PLAN_CODE.includes(data.billing.plan.code),
+          OLD_CLUSTER_PLAN_CODE.includes(data.billing.plan.code),
         ),
       getTechnicalDetails: /* @ngInject */ (
         NutanixService,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix-scale-up-and-down`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-11507
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description
For old catalog format : the hardware tile should be displayed on the cluster level as it is actually in production. Not displayed on node level

For new catalog format : the hardware tile shouldn't be displayed anymore on cluster level. It should be displayed only on the node level with the same values displayed on prod on cluster level.
