### PR TITLE
feat(dedicated): enable modify bandwidth based on cluster type

### DIFF
--- a/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.component.js
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.component.js
@@ -12,5 +12,6 @@ export default {
     resiliatePublicLink: '<',
     server: '<',
     specifications: '<',
+    isOldCluster: '<',
   },
 };

--- a/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.html
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/dashboard.html
@@ -90,7 +90,7 @@
     </oui-tile-description>
 </oui-tile-definition>
 <oui-tile-button
-    data-ng-if="!$ctrl.server.isExpired && $ctrl.server.canOrderVrackBandwith"
+    data-ng-if="!$ctrl.server.isExpired && $ctrl.server.canOrderVrackBandwith && !$ctrl.isOldCluster"
     data-disabled="$ctrl.server.state === 'HACKED' || $ctrl.server.state === 'HACKED_BLOCKED'"
     data-href="{{ $ctrl.orderPrivateLink }}"
 >

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/component.js
@@ -13,6 +13,7 @@ export default {
     user: '<',
     onError: '&?',
     onSuccess: '&?',
+    isClusterNode: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.html
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.html
@@ -64,6 +64,10 @@
 
             <oui-message data-type="warning">
                 <span data-translate="server_order_bandwidth_warning"></span>
+                <span
+                    data-ng-if="$ctrl.isClusterNode"
+                    data-translate="server_node_order_bandwidth_warning"
+                ></span>
             </oui-message>
         </form>
     </div>

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_FR.json
@@ -15,6 +15,7 @@
   "server_order_bandwidth_declaration": "La date de renouvellement de votre option sera alignée avec celle de votre serveur. Le montant affiché correspond au premier mois de facturation de votre option, calculé au prorata temporis du mois en cours.",
   "server_order_bandwidth_info": "Le montant indiqué correspond au montant facturé au prochain renouvellement de votre option.",
   "server_order_bandwidth_warning": "La modification de votre bande passante sera appliquée quelques minutes après l’activation de l’option.",
+  "server_node_order_bandwidth_warning": "Pour le bon fonctionnement de votre cluster, il est impératif d'activer la même option de bande passante sur chaque nœud de votre cluster.",
   "server_order_bandwidth_auto_pay": "Payer avec le moyen de paiement par défaut",
   "plan_vrack-bandwidth-1000-option": "1 Gbps de bande passante privée garantie - Trafic illimité - Option vRack",
   "plan_vrack-bandwidth-3000-option": "3 Gbps de bande passante privée garantie - Trafic illimité - Option vRack",

--- a/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/component/network-tile/network-tile.component.js
@@ -7,6 +7,7 @@ export default {
     goToUpgradePrivateBandwidth: '<',
     onError: '&?',
     privateBandwidthServiceId: '<',
+    isOldCluster: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/component/network-tile/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/component/network-tile/template.html
@@ -51,7 +51,7 @@
                 <oui-button
                     data-variant="link"
                     data-icon-right="oui-icon-arrow-right"
-                    data-ng-if="$ctrl.privateBandwidthUpgradable && !$ctrl.loadingUpgradeOptions"
+                    data-ng-if="$ctrl.privateBandwidthUpgradable && !$ctrl.loadingUpgradeOptions && $ctrl.isOldCluster"
                     data-on-click="$ctrl.goToUpgradePrivateBandwidth()"
                 >
                     <span

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/private-bandwidth-upgrade/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/private-bandwidth-upgrade/component.js
@@ -11,5 +11,6 @@ export default {
     trackingPrefix: '<',
     user: '<',
     handleError: '<',
+    isOldCluster: '<',
   },
 };

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/private-bandwidth-upgrade/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/private-bandwidth-upgrade/template.html
@@ -6,4 +6,5 @@
     tracking-prefix="$ctrl.trackingPrefix"
     user="$ctrl.user"
     on-error="$ctrl.handleError(error)"
+    is-old-cluster="$ctrl.isOldCluster"
 ></nutanix-cluster-order-private-bandwidth>

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
@@ -218,6 +218,7 @@
             on-error="$ctrl.handleError(error)"
             go-to-upgrade-private-bandwidth="$ctrl.goToUpgradePrivateBandwidth"
             private-bandwidth-service-id="$ctrl.privateBandwidthServiceId"
+            is-old-cluster="$ctrl.isOldCluster"
         >
         </nutanix-network-tile>
     </div>

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/bandwidth-private-order/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/bandwidth-private-order/template.html
@@ -10,4 +10,5 @@
     specifications="$ctrl.specifications"
     user="$ctrl.user"
     service-id="$ctrl.serviceId"
+    is-cluster-node="true"
 ></server-order-private-bandwidth>

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
@@ -171,6 +171,7 @@
                         data-order-public-link="$ctrl.orderPublicBandwidthLink"
                         data-server="$ctrl.server"
                         data-specifications="$ctrl.specifications"
+                        data-is-old-cluster="$ctrl.isOldCluster"
                     >
                     </server-bandwidth-dashboard>
                 </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix-scale-up-and-down`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-11514
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description
For old catalog format : In the network tile modify private bandwidth should be displayed on the cluster level.

For new catalog format : In the network tile modify private bandwidth should be displayed on the node level.
