### PR TITLE
fix(pci.storages.databases): datatr-299 - display correct value for vcores number

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/add/add.html
@@ -386,8 +386,8 @@
                                     data-ng-pluralize
                                     data-count="$ctrl.model.flavor.core"
                                     data-when="{
-                                        '1': ('pci_database_add_spec_flavor_CPU_one' | translate: { cpu: $ctrl.model.flavor.core }),
-                                        'other': ('pci_database_add_spec_flavor_CPU_many' | translate: { cpu: $ctrl.model.flavor.core }),
+                                        '1': ('pci_database_add_spec_flavor_CPU_one' | translate: { cpu: {} }),
+                                        'other': ('pci_database_add_spec_flavor_CPU_many' | translate: { cpu: {} }),
                                     }"
                                 ></span>
                             </div>


### PR DESCRIPTION
DATATR-299

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #datatr-299
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix number of cores displayed in order funnel summary