### PR TITLE
feat(dedicated): improve message no bandwidth addons available

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.controller.js
@@ -12,34 +12,33 @@ export default class {
   $onInit() {
     this.model = {};
     this.plans = null;
-    this.isLoading = false;
+    this.isLoading = true;
+
+    this.Server.getBareMetalPublicBandwidthOptions(this.serviceId)
+      .then((plans) => {
+        this.plans = this.Server.getValidBandwidthPlans(plans);
+        this.plans.sort(
+          (a, b) =>
+            a.prices.find((el) => el.capacities.includes('renew'))
+              .priceInUcents -
+            b.prices.find((el) => el.capacities.includes('renew'))
+              .priceInUcents,
+        );
+      })
+      .catch((error) => {
+        this.goBack().then(() =>
+          this.alertError('server_error_bandwidth_order', error.data),
+        );
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
 
     this.steps = [
       {
-        isValid: () => this.model.plan,
+        isValid: () =>
+          !this.isLoading && (this.plans?.length === 0 || this.model.plan),
         isLoading: () => this.isLoading,
-        load: () => {
-          this.isLoading = true;
-          return this.Server.getBareMetalPublicBandwidthOptions(this.serviceId)
-            .then((plans) => {
-              this.plans = this.Server.getValidBandwidthPlans(plans);
-              this.plans.sort(
-                (a, b) =>
-                  a.prices.find((el) => el.capacities.includes('renew'))
-                    .priceInUcents -
-                  b.prices.find((el) => el.capacities.includes('renew'))
-                    .priceInUcents,
-              );
-            })
-            .catch((error) => {
-              this.goBack().then(() =>
-                this.alertError('server_error_bandwidth_order', error.data),
-              );
-            })
-            .finally(() => {
-              this.isLoading = false;
-            });
-        },
       },
       {
         isValid: () => this.model.plan,

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/bandwidth/public-order/public-order.html
@@ -1,129 +1,143 @@
-<div
-    data-ng-if="!$ctrl.model.orderUrl"
-    data-wizard
-    data-wizard-on-cancel="$ctrl.cancel.bind($ctrl)"
-    data-wizard-on-finish="$ctrl.order.bind($ctrl)"
-    data-wizard-hide-cancel-button="$ctrl.isLoading"
-    data-wizard-hide-previous-button="$ctrl.isLoading"
-    data-wizard-hide-confirm-button="!$ctrl.isLoading"
-    data-wizard-title=":: 'server_order_bandwidth_title' | translate"
-    data-wizard-bread-crumb
-    data-wizard-confirm-button-text=":: 'wizard_pay' | translate"
+<!-- Data loading modal -->
+<oui-modal
+    data-ng-if="$ctrl.isLoading"
+    data-heading="{{:: 'server_order_bandwidth_title' | translate}}"
 >
+    <div class="text-center">
+        <oui-spinner></oui-spinner>
+        <p data-translate="server_order_bandwidth_load"></p>
+    </div>
+</oui-modal>
+<!-- Bandwidth addons order modal -->
+<div data-ng-if="!$ctrl.isLoading && $ctrl.plans.length > 0">
     <div
-        data-wizard-step
-        data-wizard-step-valid="$ctrl.steps[0].isValid()"
-        data-wizard-step-on-load="$ctrl.initFirstStep.bind($ctrl)"
+        data-ng-if="!$ctrl.model.orderUrl"
+        data-wizard
+        data-wizard-on-cancel="$ctrl.cancel.bind($ctrl)"
+        data-wizard-on-finish="$ctrl.order.bind($ctrl)"
+        data-wizard-hide-cancel-button="$ctrl.isLoading"
+        data-wizard-hide-previous-button="$ctrl.isLoading"
+        data-wizard-hide-confirm-button="!$ctrl.isLoading"
+        data-wizard-title=":: 'server_order_bandwidth_title' | translate"
+        data-wizard-bread-crumb
+        data-wizard-confirm-button-text=":: 'wizard_pay' | translate"
     >
-        <div class="text-center" data-ng-if="$ctrl.steps[0].isLoading()">
-            <oui-spinner></oui-spinner>
-            <span
-                data-translate="server_order_bandwidth_load"
-                class="d-block"
-            ></span>
-        </div>
-        <span
-            data-ng-if="$ctrl.plans.length === 0"
-            data-translate="server_order_bandwidth_empty_plans"
-        ></span>
-        <form
-            data-ng-if="!$ctrl.steps[0].isLoading() && $ctrl.plans.length > 0"
+        <div
+            data-wizard-step
+            data-wizard-step-valid="$ctrl.steps[0].isValid()"
+            data-wizard-step-on-load="$ctrl.initFirstStep.bind($ctrl)"
         >
-            <p data-translate="select_bandwidth_type_label"></p>
-            <div data-ng-repeat="plan in $ctrl.plans track by $index">
+            <form>
+                <p data-translate="select_bandwidth_type_label"></p>
+                <div data-ng-repeat="plan in $ctrl.plans track by $index">
+                    <div class="row">
+                        <div class="col-md-9 pr-0 pb-2">
+                            <oui-radio
+                                data-name="bandwidth-plan"
+                                data-model="$ctrl.model.plan"
+                                data-value="plan.planCode"
+                            >
+                                <span
+                                    data-translate="plan_bandwidth"
+                                    data-translate-values="{ bandwidth: plan.bandwidth / 1000 }"
+                                ></span>
+                            </oui-radio>
+                        </div>
+                        <div class="col-md-3 pl-0">
+                            <ovh-manager-catalog-price
+                                data-price="plan.prices[2].priceInUcents / plan.prices[2].interval"
+                                data-tax="plan.prices[2].tax"
+                                data-interval-unit="{{plan.prices[2].intervalUnit}}"
+                                data-user="$ctrl.user"
+                                data-perform-rounding="false"
+                                data-maximum-fraction-digits="3"
+                            >
+                            </ovh-manager-catalog-price>
+                        </div>
+                    </div>
+                </div>
+
+                <oui-message class="mb-3" data-type="info">
+                    <span data-translate="server_order_bandwidth_info"></span>
+                </oui-message>
+
+                <oui-message data-type="warning">
+                    <span
+                        data-translate="server_order_bandwidth_warning"
+                    ></span>
+                </oui-message>
+            </form>
+        </div>
+        <div
+            data-wizard-step
+            data-wizard-step-valid="$ctrl.steps[1].isValid()"
+            data-wizard-step-on-load="$ctrl.initSecondStep.bind($ctrl)"
+        >
+            <div class="text-center" data-ng-if="$ctrl.steps[1].isLoading()">
+                <oui-spinner></oui-spinner>
+                <span
+                    data-translate="server_order_bandwidth_vrack_load"
+                    class="d-block"
+                ></span>
+            </div>
+            <form data-ng-if="!$ctrl.steps[1].isLoading()">
+                <p data-translate="select_bandwidth_plan_summary"></p>
                 <div class="row">
-                    <div class="col-md-9 pr-0 pb-2">
+                    <div class="col-md-8 pr-0">
                         <oui-radio
                             data-name="bandwidth-plan"
                             data-model="$ctrl.model.plan"
-                            data-value="plan.planCode"
+                            data-value="$ctrl.provisionalPlan.planCode"
                         >
                             <span
                                 data-translate="plan_bandwidth"
-                                data-translate-values="{ bandwidth: plan.bandwidth / 1000 }"
+                                data-translate-values="{ bandwidth: $ctrl.provisionalPlan.bandwidth / 1000 }"
                             ></span>
                         </oui-radio>
                     </div>
-                    <div class="col-md-3 pl-0">
-                        <ovh-manager-catalog-price
-                            data-price="plan.prices[2].priceInUcents / plan.prices[2].interval"
-                            data-tax="plan.prices[2].tax"
-                            data-interval-unit="{{plan.prices[2].intervalUnit}}"
-                            data-user="$ctrl.user"
-                            data-perform-rounding="false"
-                            data-maximum-fraction-digits="3"
-                        >
-                        </ovh-manager-catalog-price>
+                    <div class="col-md-4 pl-0">
+                        <span
+                            data-ng-bind-html="$ctrl.provisionalPlan.order.prices | ducPrice:$ctrl.user.ovhSubsidiary"
+                        ></span>
                     </div>
                 </div>
-            </div>
-
-            <oui-message class="mb-3" data-type="info">
-                <span data-translate="server_order_bandwidth_info"></span>
-            </oui-message>
-
-            <oui-message data-type="warning">
-                <span data-translate="server_order_bandwidth_warning"></span>
-            </oui-message>
-        </form>
-    </div>
-    <div
-        data-wizard-step
-        data-wizard-step-valid="$ctrl.steps[1].isValid()"
-        data-wizard-step-on-load="$ctrl.initSecondStep.bind($ctrl)"
-    >
-        <div class="text-center" data-ng-if="$ctrl.steps[1].isLoading()">
-            <oui-spinner></oui-spinner>
-            <span
-                data-translate="server_order_bandwidth_vrack_load"
-                class="d-block"
-            ></span>
-        </div>
-        <form data-ng-if="!$ctrl.steps[1].isLoading()">
-            <p data-translate="select_bandwidth_plan_summary"></p>
-            <div class="row">
-                <div class="col-md-8 pr-0">
-                    <oui-radio
-                        data-name="bandwidth-plan"
-                        data-model="$ctrl.model.plan"
-                        data-value="$ctrl.provisionalPlan.planCode"
-                    >
-                        <span
-                            data-translate="plan_bandwidth"
-                            data-translate-values="{ bandwidth: $ctrl.provisionalPlan.bandwidth / 1000 }"
-                        ></span>
-                    </oui-radio>
-                </div>
-                <div class="col-md-4 pl-0">
+                <oui-checkbox
+                    data-model="$ctrl.model.autoPay"
+                    class="mt-3"
+                    data-ng-if="$ctrl.region !== 'US' && $ctrl.hasDefaultPaymentMethod"
+                >
                     <span
-                        data-ng-bind-html="$ctrl.provisionalPlan.order.prices | ducPrice:$ctrl.user.ovhSubsidiary"
+                        data-translate="server_order_bandwidth_auto_pay"
                     ></span>
-                </div>
-            </div>
-            <oui-checkbox
-                data-model="$ctrl.model.autoPay"
-                class="mt-3"
-                data-ng-if="$ctrl.region !== 'US' && $ctrl.hasDefaultPaymentMethod"
-            >
-                <span data-translate="server_order_bandwidth_auto_pay"></span>
-            </oui-checkbox>
+                </oui-checkbox>
 
-            <oui-message data-type="info">
-                <span
-                    data-translate="server_order_bandwidth_declaration"
-                ></span>
-            </oui-message>
-        </form>
+                <oui-message data-type="info">
+                    <span
+                        data-translate="server_order_bandwidth_declaration"
+                    ></span>
+                </oui-message>
+            </form>
+        </div>
     </div>
-</div>
 
+    <oui-modal
+        data-ng-if="$ctrl.model.orderUrl"
+        data-primary-label="{{:: 'server_order_bandwidth_see_order' | translate }}"
+        data-primary-action=":: $ctrl.seeOrder()"
+        data-secondary-label="{{:: 'wizard_close' | translate }}"
+        data-secondary-action=":: $ctrl.goBack()"
+        data-on-dismiss="$ctrl.goBack()"
+    >
+        <p data-translate="server_order_bandwidth_ready"></p>
+    </oui-modal>
+</div>
+<!-- No bandwidth plan modal -->
 <oui-modal
-    data-ng-if="$ctrl.model.orderUrl"
-    data-primary-label="{{:: 'server_order_bandwidth_see_order' | translate }}"
-    data-primary-action=":: $ctrl.seeOrder()"
-    data-secondary-label="{{:: 'wizard_close' | translate }}"
-    data-secondary-action=":: $ctrl.goBack()"
+    data-ng-if="!$ctrl.isLoading && $ctrl.plans.length === 0"
+    data-heading="{{:: 'server_order_bandwidth_title' | translate}}"
+    data-primary-label="{{:: 'wizard_close' | translate }}"
+    data-primary-action=":: $ctrl.goBack()"
     data-on-dismiss="$ctrl.goBack()"
 >
-    <p data-translate="server_order_bandwidth_ready"></p>
+    <p data-translate="server_order_bandwidth_empty_plans"></p>
 </oui-modal>

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_de_DE.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Bestellübersicht",
   "plan_bandwidth": "{{bandwidth}} Gbit/s unbegrenzt und garantiert",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbit/s unbegrenzt und garantiert - vRack-Option",
-  "server_order_bandwidth_empty_plans": "Es konnte kein Angebot zum Upgraden gefunden werden",
+  "server_order_bandwidth_empty_plans": "Für Ihren Dedicated Server ist kein Bandbreitenangebot verfügbar.",
   "select_traffic_type_label": "Wählen Sie ein Angebot aus",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_en_GB.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Order summary",
   "plan_bandwidth": "{{bandwidth}} Gbit/s unlimited and guaranteed",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbit/s unlimited and guaranteed - vRack option",
-  "server_order_bandwidth_empty_plans": "Unable to find plans to upgrade",
+  "server_order_bandwidth_empty_plans": "No bandwidth solution available for your dedicated server",
   "select_traffic_type_label": "Select a solution",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_es_ES.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Resumen del pedido",
   "plan_bandwidth": "{{bandwidth}} Gb/s ilimitado y garantizado",
   "plan_vrack-bandwidth": "{{bandwidth}} Gb/s ilimitado y garantizado - Opción vRack",
-  "server_order_bandwidth_empty_plans": "No se han podido encontrar planes para mejorar el existente.",
+  "server_order_bandwidth_empty_plans": "No hay ningún servicio de ancho de banda disponible para su servidor dedicado.",
   "select_traffic_type_label": "Seleccione un servicio",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_fr_CA.json
@@ -767,7 +767,7 @@
   "select_bandwidth_plan_summary": "Récapitulatif de la commande",
   "plan_bandwidth": "{{bandwidth}} Gbit/s illimitée et garantie",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbit/s illimitée et garantie - Option vRack",
-  "server_order_bandwidth_empty_plans": "Impossible de trouver des plans pour mettre à niveau",
+  "server_order_bandwidth_empty_plans": "Aucune offre de bande passante disponible pour votre serveur dédié",
   "select_traffic_type_label": "Sélectionnez une offre",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_fr_FR.json
@@ -767,7 +767,7 @@
   "select_bandwidth_plan_summary": "Récapitulatif de la commande",
   "plan_bandwidth": "{{bandwidth}} Gbit/s illimitée et garantie",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbit/s illimitée et garantie - Option vRack",
-  "server_order_bandwidth_empty_plans": "Impossible de trouver des plans pour mettre à niveau",
+  "server_order_bandwidth_empty_plans": "Aucune offre de bande passante disponible pour votre serveur dédié",
   "select_traffic_type_label": "Sélectionnez une offre",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_it_IT.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Riepilogo dell’ordine",
   "plan_bandwidth": "{{bandwidth}} 50 Gbps illimitata e garantita",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbps illimitata e garantita - Opzione vRack",
-  "server_order_bandwidth_empty_plans": "Impossibile trovare soluzioni per eseguire l’aggiornamento",
+  "server_order_bandwidth_empty_plans": "Non sono disponibili soluzioni di banda passante disponibili per il tuo server dedicato.",
   "select_traffic_type_label": "Seleziona un'offerta",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_pl_PL.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Podsumowanie zamówienia",
   "plan_bandwidth": "{{bandwidth}} Gbps bez limitu i z gwarancją przepustowości",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbps bez limitu i z gwarancją przepustowości - opcja vRack",
-  "server_order_bandwidth_empty_plans": "Nie można znaleźć planów aktualizacji",
+  "server_order_bandwidth_empty_plans": "Brak dostępnych ofert przepustowości dla serwera dedykowanego",
   "select_traffic_type_label": "Wybierz ofertę",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/details/translations/Messages_pt_PT.json
@@ -805,7 +805,7 @@
   "select_bandwidth_plan_summary": "Resumo da encomenda",
   "plan_bandwidth": "{{bandwidth}} Gbps ilimitados e garantidos",
   "plan_vrack-bandwidth": "{{bandwidth}} Gbps ilimitados e garantidos - Opção vRack",
-  "server_order_bandwidth_empty_plans": "Não foi possível encontrar planos para atualizar",
+  "server_order_bandwidth_empty_plans": "Nenhuma oferta de largura de banda disponível para o seu servidor dedicado",
   "select_traffic_type_label": "Selecionar uma oferta",
   "toggle_button_label_ultimate": "Ultimate",
   "toggle_button_label_premium": "Premium",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.controller.js
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.controller.js
@@ -18,43 +18,37 @@ export default class BmServerComponentsOrderPrivateBandwidthCtrl {
   $onInit() {
     this.model = {};
     this.plans = null;
-    this.isLoading = false;
+    this.isLoading = true;
 
+    this.OrderPrivateBandwidthService.getBareMetalPrivateBandwidthOptions(
+      this.serviceId,
+    )
+      .then((plans) => {
+        this.plans = BmServerComponentsOrderPrivateBandwidthCtrl.getValidBandwidthPlans(
+          plans,
+        );
+        this.plans.sort(
+          (a, b) =>
+            a.prices.find((el) => el.capacities.includes('renew'))
+              .priceInUcents -
+            b.prices.find((el) => el.capacities.includes('renew'))
+              .priceInUcents,
+        );
+      })
+      .catch((error) => {
+        this.handleError(
+          error,
+          this.$translate.instant('server_error_bandwidth_order', error.data),
+        );
+        this.goBack();
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
     this.steps = [
       {
         isValid: () => this.model.plan,
         isLoading: () => this.isLoading,
-        load: () => {
-          this.isLoading = true;
-          return this.OrderPrivateBandwidthService.getBareMetalPrivateBandwidthOptions(
-            this.serviceId,
-          )
-            .then((plans) => {
-              this.plans = BmServerComponentsOrderPrivateBandwidthCtrl.getValidBandwidthPlans(
-                plans,
-              );
-              this.plans.sort(
-                (a, b) =>
-                  a.prices.find((el) => el.capacities.includes('renew'))
-                    .priceInUcents -
-                  b.prices.find((el) => el.capacities.includes('renew'))
-                    .priceInUcents,
-              );
-            })
-            .catch((error) => {
-              this.handleError(
-                error,
-                this.$translate.instant(
-                  'server_error_bandwidth_order',
-                  error.data,
-                ),
-              );
-              this.goBack();
-            })
-            .finally(() => {
-              this.isLoading = false;
-            });
-        },
       },
       {
         isValid: () => this.model.plan,

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.html
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/private-order.html
@@ -1,129 +1,143 @@
-<div
-    data-ng-if="!$ctrl.model.orderUrl"
-    data-wizard
-    data-wizard-on-cancel="$ctrl.cancel.bind($ctrl)"
-    data-wizard-on-finish="$ctrl.order.bind($ctrl)"
-    data-wizard-hide-cancel-button="$ctrl.isLoading"
-    data-wizard-hide-previous-button="$ctrl.isLoading"
-    data-wizard-hide-confirm-button="!$ctrl.isLoading"
-    data-wizard-title=":: 'server_order_bandwidth_vrack_title' | translate"
-    data-wizard-bread-crumb
-    data-wizard-confirm-button-text=":: 'wizard_pay' | translate"
+<!-- Data loading modal -->
+<oui-modal
+    data-ng-if="$ctrl.isLoading"
+    data-heading="{{:: 'server_order_bandwidth_title' | translate}}"
 >
+    <div class="text-center">
+        <oui-spinner></oui-spinner>
+        <p data-translate="server_order_bandwidth_load"></p>
+    </div>
+</oui-modal>
+<!-- Bandwidth addons order modal -->
+<div data-ng-if="!$ctrl.isLoading && $ctrl.plans.length > 0">
     <div
-        data-wizard-step
-        data-wizard-step-valid="$ctrl.steps[0].isValid()"
-        data-wizard-step-on-load="$ctrl.initFirstStep.bind($ctrl)"
+        data-ng-if="!$ctrl.model.orderUrl"
+        data-wizard
+        data-wizard-on-cancel="$ctrl.cancel.bind($ctrl)"
+        data-wizard-on-finish="$ctrl.order.bind($ctrl)"
+        data-wizard-hide-cancel-button="$ctrl.isLoading"
+        data-wizard-hide-previous-button="$ctrl.isLoading"
+        data-wizard-hide-confirm-button="!$ctrl.isLoading"
+        data-wizard-title=":: 'server_order_bandwidth_vrack_title' | translate"
+        data-wizard-bread-crumb
+        data-wizard-confirm-button-text=":: 'wizard_pay' | translate"
     >
-        <div class="text-center" data-ng-if="$ctrl.steps[0].isLoading()">
-            <oui-spinner></oui-spinner>
-            <span
-                data-translate="server_order_bandwidth_vrack_load"
-                class="d-block"
-            ></span>
-        </div>
-        <span
-            data-ng-if="$ctrl.plans.length === 0"
-            data-translate="server_order_bandwidth_empty_plans"
-        ></span>
-        <form
-            data-ng-if="!$ctrl.steps[0].isLoading() && $ctrl.plans.length > 0"
+        <div
+            data-wizard-step
+            data-wizard-step-valid="$ctrl.steps[0].isValid()"
+            data-wizard-step-on-load="$ctrl.initFirstStep.bind($ctrl)"
         >
-            <p data-translate="select_bandwidth_vrack_type_label"></p>
-            <div data-ng-repeat="plan in $ctrl.plans track by $index">
+            <form>
+                <p data-translate="select_bandwidth_vrack_type_label"></p>
+                <div data-ng-repeat="plan in $ctrl.plans track by $index">
+                    <div class="row">
+                        <div class="col-md-9 pr-0 pb-2">
+                            <oui-radio
+                                data-name="bandwidth-plan"
+                                data-model="$ctrl.model.plan"
+                                data-value="plan.planCode"
+                            >
+                                <span
+                                    data-translate="plan_vrack-bandwidth"
+                                    data-translate-values="{ bandwidth: plan.bandwidth / 1000 }"
+                                ></span>
+                            </oui-radio>
+                        </div>
+                        <div class="col-md-3 pl-0">
+                            <ovh-manager-catalog-price
+                                data-price="plan.prices[2].priceInUcents / plan.prices[2].interval"
+                                data-tax="plan.prices[2].tax"
+                                data-interval-unit="{{plan.prices[2].intervalUnit}}"
+                                data-user="$ctrl.user"
+                                data-perform-rounding="false"
+                                data-maximum-fraction-digits="3"
+                            >
+                            </ovh-manager-catalog-price>
+                        </div>
+                    </div>
+                </div>
+
+                <oui-message class="mb-3" data-type="info">
+                    <span data-translate="server_order_bandwidth_info"></span>
+                </oui-message>
+
+                <oui-message data-type="warning">
+                    <span
+                        data-translate="server_order_bandwidth_warning"
+                    ></span>
+                </oui-message>
+            </form>
+        </div>
+        <div
+            data-wizard-step
+            data-wizard-step-valid="$ctrl.steps[1].isValid()"
+            data-wizard-step-on-load="$ctrl.initSecondStep.bind($ctrl)"
+        >
+            <div class="text-center" data-ng-if="$ctrl.steps[1].isLoading()">
+                <oui-spinner></oui-spinner>
+                <span
+                    data-translate="server_order_bandwidth_vrack_load"
+                    class="d-block"
+                ></span>
+            </div>
+            <form data-ng-if="!$ctrl.steps[1].isLoading()">
+                <p data-translate="select_bandwidth_plan_summary"></p>
                 <div class="row">
-                    <div class="col-md-9 pr-0 pb-2">
+                    <div class="col-md-8 pr-0">
                         <oui-radio
                             data-name="bandwidth-plan"
                             data-model="$ctrl.model.plan"
-                            data-value="plan.planCode"
+                            data-value="$ctrl.provisionalPlan.planCode"
                         >
                             <span
                                 data-translate="plan_vrack-bandwidth"
-                                data-translate-values="{ bandwidth: plan.bandwidth / 1000 }"
+                                data-translate-values="{ bandwidth: $ctrl.provisionalPlan.bandwidth / 1000 }"
                             ></span>
                         </oui-radio>
                     </div>
-                    <div class="col-md-3 pl-0">
-                        <ovh-manager-catalog-price
-                            data-price="plan.prices[2].priceInUcents / plan.prices[2].interval"
-                            data-tax="plan.prices[2].tax"
-                            data-interval-unit="{{plan.prices[2].intervalUnit}}"
-                            data-user="$ctrl.user"
-                            data-perform-rounding="false"
-                            data-maximum-fraction-digits="3"
-                        >
-                        </ovh-manager-catalog-price>
+                    <div class="col-md-4 pl-0">
+                        <span
+                            data-ng-bind-html="$ctrl.provisionalPlan.order.prices | ducPrice: $ctrl.user.ovhSubsidiary:'verbose'"
+                        ></span>
                     </div>
                 </div>
-            </div>
-
-            <oui-message class="mb-3" data-type="info">
-                <span data-translate="server_order_bandwidth_info"></span>
-            </oui-message>
-
-            <oui-message data-type="warning">
-                <span data-translate="server_order_bandwidth_warning"></span>
-            </oui-message>
-        </form>
-    </div>
-    <div
-        data-wizard-step
-        data-wizard-step-valid="$ctrl.steps[1].isValid()"
-        data-wizard-step-on-load="$ctrl.initSecondStep.bind($ctrl)"
-    >
-        <div class="text-center" data-ng-if="$ctrl.steps[1].isLoading()">
-            <oui-spinner></oui-spinner>
-            <span
-                data-translate="server_order_bandwidth_vrack_load"
-                class="d-block"
-            ></span>
-        </div>
-        <form data-ng-if="!$ctrl.steps[1].isLoading()">
-            <p data-translate="select_bandwidth_plan_summary"></p>
-            <div class="row">
-                <div class="col-md-8 pr-0">
-                    <oui-radio
-                        data-name="bandwidth-plan"
-                        data-model="$ctrl.model.plan"
-                        data-value="$ctrl.provisionalPlan.planCode"
-                    >
-                        <span
-                            data-translate="plan_vrack-bandwidth"
-                            data-translate-values="{ bandwidth: $ctrl.provisionalPlan.bandwidth / 1000 }"
-                        ></span>
-                    </oui-radio>
-                </div>
-                <div class="col-md-4 pl-0">
+                <oui-checkbox
+                    data-model="$ctrl.model.autoPay"
+                    class="mt-3"
+                    data-ng-if="$ctrl.region !== 'US' && $ctrl.hasDefaultPaymentMethod"
+                >
                     <span
-                        data-ng-bind-html="$ctrl.provisionalPlan.order.prices | ducPrice: $ctrl.user.ovhSubsidiary:'verbose'"
+                        data-translate="server_order_bandwidth_auto_pay"
                     ></span>
-                </div>
-            </div>
-            <oui-checkbox
-                data-model="$ctrl.model.autoPay"
-                class="mt-3"
-                data-ng-if="$ctrl.region !== 'US' && $ctrl.hasDefaultPaymentMethod"
-            >
-                <span data-translate="server_order_bandwidth_auto_pay"></span>
-            </oui-checkbox>
+                </oui-checkbox>
 
-            <oui-message data-type="info">
-                <span
-                    data-translate="server_order_bandwidth_declaration"
-                ></span>
-            </oui-message>
-        </form>
+                <oui-message data-type="info">
+                    <span
+                        data-translate="server_order_bandwidth_declaration"
+                    ></span>
+                </oui-message>
+            </form>
+        </div>
     </div>
-</div>
 
+    <oui-modal
+        data-ng-if="$ctrl.model.orderUrl"
+        data-primary-label="{{:: 'server_order_bandwidth_see_order' | translate }}"
+        data-primary-action=":: $ctrl.seeOrder()"
+        data-secondary-label="{{:: 'wizard_close' | translate }}"
+        data-secondary-action=":: $ctrl.goBack()"
+        data-on-dismiss="$ctrl.goBack()"
+    >
+        <p data-translate="server_order_bandwidth_ready"></p>
+    </oui-modal>
+</div>
+<!-- No bandwidth plan modal -->
 <oui-modal
-    data-ng-if="$ctrl.model.orderUrl"
-    data-primary-label="{{:: 'server_order_bandwidth_see_order' | translate }}"
-    data-primary-action=":: $ctrl.seeOrder()"
-    data-secondary-label="{{:: 'wizard_close' | translate }}"
-    data-secondary-action=":: $ctrl.goBack()"
+    data-ng-if="!$ctrl.isLoading && $ctrl.plans.length === 0"
+    data-heading="{{:: 'server_order_bandwidth_title' | translate}}"
+    data-primary-label="{{:: 'wizard_close' | translate }}"
+    data-primary-action=":: $ctrl.goBack()"
     data-on-dismiss="$ctrl.goBack()"
 >
-    <p data-translate="server_order_bandwidth_ready"></p>
+    <p data-translate="server_order_bandwidth_empty_plans"></p>
 </oui-modal>

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_de_DE.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_de_DE.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Ihre Bestellung ist fertig. Sofern der Zahlungsprozess abgeschlossen ist, sollte die Bandbreite in Kürze verfügbar sein.",
   "server_order_bandwidth_see_order": "Bestellschein anzeigen",
   "server_order_bandwidth_vrack_load": "Angebote werden geladen...",
-  "server_order_bandwidth_empty_plans": "Es konnte kein Angebot zum Upgraden gefunden werden",
+  "server_order_bandwidth_empty_plans": "Für Ihren Dedicated Server ist kein Bandbreitenangebot verfügbar.",
   "select_bandwidth_type_label": "Wählen Sie ein Angebot aus",
   "select_bandwidth_vrack_type_label": "Wählen Sie ein Angebot aus",
   "select_bandwidth_plan_summary": "Bestellübersicht",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_en_GB.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_en_GB.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Your order is ready. Depending on when payment is processed, the bandwidth should be available shortly.",
   "server_order_bandwidth_see_order": "View purchase order",
   "server_order_bandwidth_vrack_load": "Loading solutions...",
-  "server_order_bandwidth_empty_plans": "Unable to find plans to upgrade",
+  "server_order_bandwidth_empty_plans": "No bandwidth solution available for your dedicated server",
   "select_bandwidth_type_label": "Select a solution",
   "select_bandwidth_vrack_type_label": "Select a solution",
   "select_bandwidth_plan_summary": "Order summary",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_es_ES.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_es_ES.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "El pedido está vacío. Una vez abonado el pedido, su ancho de banda enseguida debería estar disponible.",
   "server_order_bandwidth_see_order": "Ver la orden de pedido",
   "server_order_bandwidth_vrack_load": "Cargando ofertas...",
-  "server_order_bandwidth_empty_plans": "No se han podido encontrar planes para mejorar el existente.",
+  "server_order_bandwidth_empty_plans": "No hay ningún servicio de ancho de banda disponible para su servidor dedicado.",
   "select_bandwidth_type_label": "Seleccione un servicio",
   "select_bandwidth_vrack_type_label": "Seleccione un servicio",
   "select_bandwidth_plan_summary": "Resumen del pedido",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_CA.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Votre commande est prête. Sous réserve de paiement, votre bande passante devrait être disponible prochainement.",
   "server_order_bandwidth_see_order": "Voir le bon de commande",
   "server_order_bandwidth_vrack_load": "Chargement des offres en cours...",
-  "server_order_bandwidth_empty_plans": "Impossible de trouver des plans pour mettre à niveau",
+  "server_order_bandwidth_empty_plans": "Aucune offre de bande passante disponible pour votre serveur dédié",
   "select_bandwidth_type_label": "Sélectionnez une offre",
   "select_bandwidth_vrack_type_label": "Sélectionnez une offre",
   "select_bandwidth_plan_summary": "Récapitulatif de la commande",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_fr_FR.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Votre commande est prête. Sous réserve de paiement, votre bande passante devrait être disponible prochainement.",
   "server_order_bandwidth_see_order": "Voir le bon de commande",
   "server_order_bandwidth_vrack_load": "Chargement des offres en cours...",
-  "server_order_bandwidth_empty_plans": "Impossible de trouver des plans pour mettre à niveau",
+  "server_order_bandwidth_empty_plans": "Aucune offre de bande passante disponible pour votre serveur dédié",
   "select_bandwidth_type_label": "Sélectionnez une offre",
   "select_bandwidth_vrack_type_label": "Sélectionnez une offre",
   "select_bandwidth_plan_summary": "Récapitulatif de la commande",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_it_IT.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_it_IT.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Il tuo ordine è pronto. Subito dopo il saldo dell’ordine, la banda passante dovrebbe essere disponibile.",
   "server_order_bandwidth_see_order": "Visualizza il buono d'ordine",
   "server_order_bandwidth_vrack_load": "Caricamento delle offerte in corso...",
-  "server_order_bandwidth_empty_plans": "Impossibile trovare soluzioni per effettuare l’aggiornamento",
+  "server_order_bandwidth_empty_plans": "Non sono disponibili soluzioni di banda passante disponibili per il tuo server dedicato.",
   "select_bandwidth_type_label": "Seleziona una soluzione",
   "select_bandwidth_vrack_type_label": "Seleziona una soluzione",
   "select_bandwidth_plan_summary": "Riepilogo dell’ordine",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_pl_PL.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "Twoje zamówienie jest gotowe. Usługa powinna być dostępna wkrótce po uregulowaniu należności.",
   "server_order_bandwidth_see_order": "Wyświetl zamówienie",
   "server_order_bandwidth_vrack_load": "Trwa pobieranie informacji o usługach...",
-  "server_order_bandwidth_empty_plans": "Nie można znaleźć planów aktualizacji",
+  "server_order_bandwidth_empty_plans": "Brak dostępnych ofert przepustowości dla serwera dedykowanego",
   "select_bandwidth_type_label": "Wybierz ofertę",
   "select_bandwidth_vrack_type_label": "Wybierz ofertę",
   "select_bandwidth_plan_summary": "Podsumowanie zamówienia",

--- a/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/bm-server-components/src/order-private-bandwidth/translations/Messages_pt_PT.json
@@ -7,7 +7,7 @@
   "server_order_bandwidth_ready": "A sua encomenda está pronta. Dependendo do processamento do pagamento, a largura de banda deverá ficar disponível em breve.",
   "server_order_bandwidth_see_order": "Consultar a nota de encomenda",
   "server_order_bandwidth_vrack_load": "Alteração das ofertas em curso ...",
-  "server_order_bandwidth_empty_plans": "Não foi possível encontrar planos para atualizar",
+  "server_order_bandwidth_empty_plans": "Nenhuma oferta de largura de banda disponível para o seu servidor dedicado",
   "select_bandwidth_type_label": "Selecionar uma oferta",
   "select_bandwidth_vrack_type_label": "Selecionar uma oferta",
   "select_bandwidth_plan_summary": "Resumo da encomenda",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-10749
| License          | BSD 3-Clause

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Improved message displayed if no bandwidth addons are available
Adapted the process of retrieving plans to avoid displaying a list of step when user cannot order any plan

## Related
