### PR TITLE
fix(public-cloud): wrong guide url in private networks

### DIFF
--- a/packages/manager/modules/pci/src/components/project/guides-header/guides-header.constants.js
+++ b/packages/manager/modules/pci/src/components/project/guides-header/guides-header.constants.js
@@ -730,6 +730,9 @@ export const GUIDES_LIST = {
       tracking: '::guides::go_to_export_tensorflow_models',
     },
   },
+  private_network: {
+    ...DEFAULT_GUIDES,
+  },
 };
 
 export default {

--- a/packages/manager/modules/pci/src/projects/project/private-networks/legacy/private-networks.html
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/legacy/private-networks.html
@@ -6,9 +6,14 @@
         <oui-guide-menu
             data-text="{{:: 'pci_project_guides_header' | translate }}"
         >
-            <oui-guide-menu-item href="{{ $ctrl.guideUrl }}" data-external>
+            <oui-guide-menu-item
+                data-ng-repeat="guide in $ctrl.guideUrl.private_network track by $index"
+                data-href="{{:: guide.url }}"
+                data-on-click="$ctrl.trackClick($ctrl.guideTrackingSectionTags.private_network + guide.tracking)"
+                data-external
+            >
                 <span
-                    data-translate="pci_project_guides_header_all_guides"
+                    data-translate="{{:: 'pci_project_guides_header_' + guide.key }}"
                 ></span>
             </oui-guide-menu-item>
         </oui-guide-menu>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-11246
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

Fixed the Public Cloud Private Network guides acces

## Related
