### PR TITLE
feat(dedicated): restrict +explain windows install max 2 disks gabarits

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/gabarit/dedicated-server-installation-gabarit.controller.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/gabarit/dedicated-server-installation-gabarit.controller.js
@@ -28,6 +28,7 @@ angular
         selectFamily: null,
         selectGabarit: null,
         selectLanguage: null,
+        selectSoftRaidOnlyMirroring: null,
 
         diskGroupId: null,
         hasData: false,
@@ -78,6 +79,7 @@ angular
         $scope.installation.selectGabarit = null;
         $scope.installation.selectFamily = null;
         $scope.installation.selectLanguage = null;
+        $scope.installation.selectSoftRaidOnlyMirroring = null;
         $scope.installation.deleteGabarit = null;
 
         Server.getPersonalTemplates($stateParams.productId)
@@ -123,6 +125,8 @@ angular
         $scope.installation.selectGabarit = gabarit;
         $scope.installation.selectLanguage =
           $scope.installation.selectGabarit.defaultLanguage;
+        $scope.installation.selectSoftRaidOnlyMirroring =
+          $scope.installation.selectGabarit.softRaidOnlyMirroring;
       };
 
       $scope.clearErrorPersonalTemplate = function clearErrorPersonalTemplate() {
@@ -411,8 +415,16 @@ angular
 
       // return range between 1 and nbdisque of server if > 1
       $scope.getNbDisqueList = function getNbDisqueList(nbdisk) {
-        if (nbdisk > 1) {
+        if (nbdisk > 1 && !$scope.installation.selectSoftRaidOnlyMirroring) {
           return range(1, nbdisk + 1);
+        }
+        if (nbdisk > 1 && $scope.installation.selectSoftRaidOnlyMirroring) {
+          // For softRaidOnlyMirroring: Disks used for installation list should be limited to 2
+          $scope.installation.nbDiskUse =
+            $scope.installation.nbDiskUse === 1
+              ? $scope.installation.nbDiskUse
+              : 2;
+          return range(1, 3);
         }
         return [nbdisk];
       };

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/gabarit/dedicated-server-installation-gabarit.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/gabarit/dedicated-server-installation-gabarit.html
@@ -477,7 +477,7 @@
 
                     <!-- nbDisk -->
                     <div
-                        class="form-group"
+                        class="form-inline"
                         data-ng-if="informations.nbDisk > 1"
                     >
                         <label
@@ -486,6 +486,17 @@
                             data-translate="server_configuration_installation_form_nbdisk"
                         >
                         </label>
+                        <span
+                            data-ng-if="installation.selectSoftRaidOnlyMirroring && installation.server.nbDisk > 2"
+                        >
+                            <i
+                                class="fa fa-info-circle"
+                                data-oui-tooltip="{{:: 'server_configuration_installation_ovh_step2_type_disk_warning_windows' | translate:{ t0: installation.server.nbDisk } }}"
+                                data-oui-tooltip-placement="bottom"
+                                aria-hidden="true"
+                            >
+                            </i>
+                        </span>
                         <select
                             class="form-control"
                             id="nbDiskUse"

--- a/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/installation/ovh/dedicated-server-installation-ovh.html
@@ -1925,7 +1925,7 @@
 
                         <!-- nbDisk -->
                         <div
-                            class="form-group"
+                            class="form-inline"
                             data-ng-show="informations.nbDisk > 1 && !installation.customInstall"
                         >
                             <label
@@ -1934,6 +1934,17 @@
                                 data-translate="server_configuration_installation_form_nbdisk"
                             >
                             </label>
+                            <span
+                                data-ng-if="informations.softRaidOnlyMirroring && installation.diskGroup.numberOfDisks > 2"
+                            >
+                                <i
+                                    class="fa fa-info-circle"
+                                    data-oui-tooltip="{{:: 'server_configuration_installation_ovh_step2_type_disk_warning_windows' | translate:{ t0: installation.diskGroup.numberOfDisks } }}"
+                                    data-oui-tooltip-placement="bottom"
+                                    aria-hidden="true"
+                                >
+                                </i>
+                            </span>
                             <select
                                 class="form-control"
                                 id="nbDiskUse"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

When a Windows OS is chosen for OS installation (OS with `softRaidOnlyMirroring` flag) on a dedicated server with more than 2 disks:
- from ovh template, when not customizing partitioning: restrict and explain why not possible to install on more than 2 disks
- from ovh template, when customizing partitioning: already prodded by [!9242](https://github.com/ovh/manager/pull/9242)
- from customer template: restrict and explain why not possible to install on more than 2 disks

## Related

ref: MANAGER-11594