### PR TITLE
fix(*): fix scrolling position on transition from datagrid

### DIFF
--- a/packages/components/ng-ovh-utils/src/index.js
+++ b/packages/components/ng-ovh-utils/src/index.js
@@ -30,6 +30,7 @@ import tooltipBox from './tooltipBox/tooltipBox';
 import triStateCheckbox from './triStateCheckbox/triStateCheckbox';
 import wizard from './wizard/wizard';
 import wizardForm from './wizardForm/wizardForm';
+import scroll from './scroll/scroll';
 
 const moduleName = 'ngOvhUtils';
 
@@ -43,6 +44,7 @@ angular.module(moduleName, [
   poll,
   popover,
   price,
+  scroll,
   storage,
   tooltipBox,
   triStateCheckbox,

--- a/packages/components/ng-ovh-utils/src/scroll/scroll-service.js
+++ b/packages/components/ng-ovh-utils/src/scroll/scroll-service.js
@@ -1,0 +1,36 @@
+/**
+ * @type service
+ * @name ovhServices:ScrollService
+ * @description
+ * Provide scroll methods
+ * @example
+ * # Usage
+ * <code:js>
+ * export default class PciStoragesContainersContainerController {
+ *  */ /* @ngInject */ /*
+ *  constructor(ScrollService) {
+ *    this.ScrollService = ScrollService
+ *  }
+ *
+ *  $onInit() {
+ *    ScrollService.scrollTop();
+ *  };
+ *};
+ *
+ * </code>
+ */
+export default /* @ngInject */ function scrollService(
+  $document,
+  $timeout,
+  $anchorScroll,
+) {
+  this.scrollTop = function scrollTop() {
+    $document[0].body.style.setProperty('height', 'auto', 'important');
+    $document[0].body.style.setProperty('overflow', 'auto');
+    $anchorScroll();
+    $timeout(function() {
+      $document[0].body.style.removeProperty('height');
+      $document[0].body.style.removeProperty('overflow');
+    });
+  };
+}

--- a/packages/components/ng-ovh-utils/src/scroll/scroll.js
+++ b/packages/components/ng-ovh-utils/src/scroll/scroll.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import scrollService from './scroll-service';
+
+const moduleName = 'ua.scroll';
+
+angular
+  .module(moduleName, ['ui.router'])
+  .service('ScrollService', scrollService);
+
+export default moduleName;

--- a/packages/manager/apps/public-cloud/src/index.html
+++ b/packages/manager/apps/public-cloud/src/index.html
@@ -25,10 +25,7 @@
             data-ng-controller="PublicCloudController as $ctrl"
         >
             <div class="d-flex w-100 h-100 position-relative">
-                <div
-                    class="w-100 h-100 position-absolute"
-                    style="top: 0; left: 0;"
-                >
+                <div class="w-100 h-100" style="top: 0; left: 0;">
                     <div class="h-100 w-100" data-ui-view></div>
                 </div>
             </div>

--- a/packages/manager/modules/pci/src/projects/project/project.module.js
+++ b/packages/manager/modules/pci/src/projects/project/project.module.js
@@ -8,6 +8,7 @@ import '@ovh-ux/ui-kit';
 import ovhManagerAdvices from '@ovh-ux/manager-advices';
 import trustedNic from '@ovh-ux/manager-trusted-nic';
 
+import ngOvhUtils from '@ovh-ux/ng-ovh-utils';
 import billing from './billing';
 import contacts from './contacts';
 import creating from './creating';
@@ -67,6 +68,7 @@ angular
     quotaExceedError,
     regions,
     privateRegistry,
+    ngOvhUtils,
     'oui',
     'ovhManagerCore',
     'ovh-api-services',

--- a/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/containers/container/container.controller.js
@@ -16,6 +16,7 @@ export default class PciStoragesContainersContainerController {
     atInternet,
     CucCloudMessage,
     PciProjectStorageContainersService,
+    ScrollService,
   ) {
     this.$q = $q;
     this.$translate = $translate;
@@ -24,6 +25,7 @@ export default class PciStoragesContainersContainerController {
     this.atInternet = atInternet;
     this.CucCloudMessage = CucCloudMessage;
     this.PciProjectStorageContainersService = PciProjectStorageContainersService;
+    this.ScrollService = ScrollService;
 
     this.guides = CONTAINER_GUIDES.map((guide) => ({
       ...guide,
@@ -42,6 +44,8 @@ export default class PciStoragesContainersContainerController {
   }
 
   $onInit() {
+    this.ScrollService.scrollTop();
+
     this.columnsParameters = [
       {
         name: 'retrievalState',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD94224
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~~- [ ] Only FR translations have been updated~~[n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~~- [ ] Breaking change is mentioned in relevant commits~~[n/a]

## Description

Resolve some scroll issue when we click on large datagrid to go to a page with lot of information.
Scroll was staying in the same position.
- Add a new module to handle scroll top if the transition have the custom option {scrollTop: true}
- Need to temporary remove height: 100% and overflow hidden in order to make scrollTo works
- Remove position absolute in public cloud container as it does nothing and prevent scroll top to work 
- Change href and ui-sref to $state.go as is the only way to use custom options

## Related

<!-- Link dependencies of this PR -->
