### PR TITLE
fix(public-cloud): add missing translation key for project status

### DIFF
--- a/packages/manager/modules/pci/src/projects/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/translations/Messages_fr_FR.json
@@ -9,6 +9,7 @@
   "pci_projects_status_creating": "Création en cours",
   "pci_projects_status_suspended": "Suspendu",
   "pci_projects_status_pendingDebt": "Facture à payer",
+  "pci_projects_status_deleted": "Supprimé",
   "pci_projects_project_pay_bill": "Régler ma facture",
   "pci_projects_project_show": "Visualiser",
   "pci_projects_project_view": "Voir le projet",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-112345
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Add translation for missing key "pci_projects_status_deleted" for project status

## Related

<!-- Link dependencies of this PR -->
