### PR TITLE
dedicated: fix broken link to cloud-init documentation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/server/install/image/components/config-drive/constants.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/server/install/image/components/config-drive/constants.js
@@ -1,5 +1,5 @@
 export const DOCUMENTATION_LINK =
-  'https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html';
+  'https://cloudinit.readthedocs.io/en/latest/reference/datasources/configdrive.html';
 
 export const SUPPORTED_SSH_KEY_FORMATS = [
   {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          |  MANAGER-11719
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [] Lint has passed locally → I didn't run it
- [] Standalone app was ran and tested locally → I didn't test locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Hi, this fixes a link to cloud-init's website.

## Related

