### PR TITLE
fix(ai): update guides CLI section name

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/ai-dashboard/tabs/cli/cli.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/ai-dashboard/tabs/cli/cli.constants.js
@@ -1,5 +1,5 @@
 export const CLI_INSTALL_CODE = `curl -s https://cli.gra.training.ai.cloud.ovh.net/install.sh | bash`;
-export const CLI_GUIDES_SECTION = 'Command Line Interface';
+export const CLI_GUIDES_SECTION = 'cli';
 
 export default {
   CLI_INSTALL_CODE,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Issue         | #9677 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description

The guides API returns updated section names since moving docs to ServiceNow. This change fixes the list of tutorials that shows on the CLI tab of the AI dashboard.

It's all read-only and a very safe change.