### PR TITLE
build(deps): bump ui-kit to 6.5.3

### DIFF
--- a/packages/components/ng-ovh-contacts/package.json
+++ b/packages/components/ng-ovh-contacts/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
     "@ovh-ux/translate-async-loader": "^1.0.8",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.5.0",
     "angular-translate": "^2.17.0",
     "bootstrap": "~3.3.7",

--- a/packages/components/ng-ovh-contracts/package.json
+++ b/packages/components/ng-ovh-contracts/package.json
@@ -41,7 +41,7 @@
     "@ovh-ux/component-rollup-config": "^12.0.2"
   },
   "peerDependencies": {
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.6.10",
     "angular-translate": "^2.17.0",
     "angular-ui-bootstrap": "~1.3.3",

--- a/packages/components/ng-ovh-line-diagnostics/package.json
+++ b/packages/components/ng-ovh-line-diagnostics/package.json
@@ -46,7 +46,7 @@
     "@ovh-ux/ng-at-internet": "^5.9.1",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^6.0.0 || ^7.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.22",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",

--- a/packages/components/ng-ovh-mondial-relay/package.json
+++ b/packages/components/ng-ovh-mondial-relay/package.json
@@ -40,7 +40,7 @@
     "set-value": "^2.0.1"
   },
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "~3.4.1",
     "lodash": "^4.17.15",
     "ovh-ui-kit-bs": "^4.2.0"

--- a/packages/components/ng-ovh-payment-method/package.json
+++ b/packages/components/ng-ovh-payment-method/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.5.0",
     "angular-translate": "^2.17.0",
     "bootstrap4": "twbs/bootstrap#v4.0.0"

--- a/packages/components/ng-ovh-sidebar-menu/package.json
+++ b/packages/components/ng-ovh-sidebar-menu/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.12",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.9",
     "angular-translate": "^2.18.1",

--- a/packages/components/ng-pagination-front/package.json
+++ b/packages/components/ng-pagination-front/package.json
@@ -43,7 +43,7 @@
     "@ovh-ux/component-rollup-config": "^12.0.2"
   },
   "peerDependencies": {
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-ui-bootstrap": "~1.3.3",
     "ovh-ui-kit-bs": "^4.1.5"

--- a/packages/components/ng-ui-router-layout/package.json
+++ b/packages/components/ng-ui-router-layout/package.json
@@ -44,7 +44,7 @@
     "@ovh-ux/component-rollup-config": "^12.0.2"
   },
   "peerDependencies": {
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.22",
     "angular": "^1.5.0",
     "angular-ui-bootstrap": "~1.3.3"

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/ng-ovh-telecom-universe-components": "^7.20.2",
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.22",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.8",

--- a/packages/manager/apps/cda/package.json
+++ b/packages/manager/apps/cda/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/container/package.json
+++ b/packages/manager/apps/container/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ovh-reket": "^2.0.0",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@popperjs/core": "^2.11.4",
     "@tanem/react-nprogress": "^5.0.0",
     "@tanstack/react-query": "^4.9.0",

--- a/packages/manager/apps/dbaas-logs/package.json
+++ b/packages/manager/apps/dbaas-logs/package.json
@@ -43,7 +43,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -86,7 +86,7 @@
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
     "@ovh-ux/sign-up": "^2.6.2",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "1.7.x",
     "angular-aria": "1.7.x",

--- a/packages/manager/apps/email-domain/package.json
+++ b/packages/manager/apps/email-domain/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/email-pro/package.json
+++ b/packages/manager/apps/email-pro/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/exchange/package.json
+++ b/packages/manager/apps/exchange/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -48,7 +48,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@ovh-ux/url-builder": "^1.1.1",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -41,7 +41,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/metrics/package.json
+++ b/packages/manager/apps/metrics/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/netapp/package.json
+++ b/packages/manager/apps/netapp/package.json
@@ -44,7 +44,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/nutanix/package.json
+++ b/packages/manager/apps/nutanix/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/office/package.json
+++ b/packages/manager/apps/office/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.7",
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.22",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-title": "^3.0.6",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "~1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -52,7 +52,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -58,7 +58,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/sharepoint/package.json
+++ b/packages/manager/apps/sharepoint/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/sign-up": "^2.6.2",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.8",
     "angular-cookies": "^1.7.8",

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-ovh-user-pref": "^2.0.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.8",
     "angular-sanitize": "^1.7.8",

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-title": "^3.0.6",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-title": "^3.0.6",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -70,7 +70,7 @@
     "@ovh-ux/ng-ui-router-title": "^3.0.6",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.0.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.6",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-cookies": "^1.7.8",

--- a/packages/manager/apps/web-paas/package.json
+++ b/packages/manager/apps/web-paas/package.json
@@ -42,7 +42,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.8",
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -66,7 +66,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.1.2",
     "@ovh-ux/request-tagger": "^0.1.1",
     "@ovh-ux/shell": "^2.0.0",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "URIjs": "^1.14.0",
     "angular": "^1.6.10",

--- a/packages/manager/modules/account-migration/package.json
+++ b/packages/manager/modules/account-migration/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.5",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.5",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.5",
     "angular-translate": "^2.11.0",

--- a/packages/manager/modules/advices/package.json
+++ b/packages/manager/modules/advices/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.1",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1"

--- a/packages/manager/modules/billing-components/package.json
+++ b/packages/manager/modules/billing-components/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.5",
     "@ovh-ux/ng-ovh-payment-method": "^9.3.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "bootstrap": "~3.3.7",

--- a/packages/manager/modules/billing/package.json
+++ b/packages/manager/modules/billing/package.json
@@ -15,7 +15,7 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "^4.4.1",
     "lodash-es": "^4.17.15"
   },
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "1.7.x",
     "angular-route": "1.7.x",

--- a/packages/manager/modules/bm-server-components/package.json
+++ b/packages/manager/modules/bm-server-components/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.5",
     "@ovh-ux/ng-ovh-utils": "^14.0.17",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/carrier-sip/package.json
+++ b/packages/manager/modules/carrier-sip/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-ovh-telecom-universe-components": "^6.0.0 || ^7.0.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "ovh-api-services": "^15.0.0",

--- a/packages/manager/modules/cda/package.json
+++ b/packages/manager/modules/cda/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ovh-doc-url": "^2.0.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/cloud-connect/package.json
+++ b/packages/manager/modules/cloud-connect/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.3",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^12.0.2",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "~3.3.7",
     "font-awesome": "^4.0.0",
     "ovh-common-style": "^3.2.2",

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -34,7 +34,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-cloud-universe-components' --include-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "~3.3.0",
     "jsurl": "^0.1.5",
     "lodash": "^4.17.15",
@@ -47,7 +47,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^2.0.4",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.22",
     "angular": "^1.5.0",
     "angular-translate": "^2.11.0",

--- a/packages/manager/modules/cookie-policy/package.json
+++ b/packages/manager/modules/cookie-policy/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/manager-config": "^5.0.1",
     "@ovh-ux/manager-core": "^11.0.0 || ^12.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "1.3.3"

--- a/packages/manager/modules/core/package.json
+++ b/packages/manager/modules/core/package.json
@@ -41,7 +41,7 @@
     "@ovh-ux/ng-ovh-http": "^5.0.4",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.0",
     "@ovh-ux/ng-ovh-sso-auth": "^4.6.2",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/modules/dbaas-logs/package.json
+++ b/packages/manager/modules/dbaas-logs/package.json
@@ -28,7 +28,7 @@
     "@ovh-ux/ng-ovh-doc-url": "^2.0.4",
     "@ovh-ux/ng-tail-logs": "^2.0.7",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-chart.js": "^1.1.1",

--- a/packages/manager/modules/email-domain/package.json
+++ b/packages/manager/modules/email-domain/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/emailpro/package.json
+++ b/packages/manager/modules/emailpro/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/error-page/package.json
+++ b/packages/manager/modules/error-page/package.json
@@ -19,7 +19,7 @@
     "popper.js": "^1.14.7"
   },
   "peerDependencies": {
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.5",
     "angular-dynamic-locale": "^0.1.37",

--- a/packages/manager/modules/exchange/package.json
+++ b/packages/manager/modules/exchange/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^8.0.0 || ^9.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/freefax/package.json
+++ b/packages/manager/modules/freefax/package.json
@@ -29,7 +29,7 @@
     "@ovh-ux/ng-ovh-ui-confirm-modal": "^2.0.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-title": "^3.0.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/hub/package.json
+++ b/packages/manager/modules/hub/package.json
@@ -15,7 +15,7 @@
     "@ovh-ux/manager-models": "^1.14.6"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "^4.4.1",
     "lodash-es": "^4.17.15"
   },
@@ -32,7 +32,7 @@
     "@ovh-ux/ng-ovh-sso-auth": "^4.6.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.5",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/iplb/package.json
+++ b/packages/manager/modules/iplb/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.6 || ^6.0.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^10.3.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-chart.js": "^1.1.1",

--- a/packages/manager/modules/manager-components/package.json
+++ b/packages/manager/modules/manager-components/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.4",
     "moment": "^2.24.0"

--- a/packages/manager/modules/metrics/package.json
+++ b/packages/manager/modules/metrics/package.json
@@ -24,7 +24,7 @@
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.6 || ^6.0.0",
     "@ovh-ux/ng-ovh-sidebar-menu": "^10.3.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/mfa-enrollment/package.json
+++ b/packages/manager/modules/mfa-enrollment/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.1",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/modules/nasha/package.json
+++ b/packages/manager/modules/nasha/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/netapp/package.json
+++ b/packages/manager/modules/netapp/package.json
@@ -33,7 +33,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/ng-layout-helpers/package.json
+++ b/packages/manager/modules/ng-layout-helpers/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.9",
     "angular-translate": "^2.18.1",
     "bootstrap4": "^4.0.0"

--- a/packages/manager/modules/ng-ovh-order-tracking/package.json
+++ b/packages/manager/modules/ng-ovh-order-tracking/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.1",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",
     "ovh-api-services": "^14.0.6"

--- a/packages/manager/modules/nutanix/package.json
+++ b/packages/manager/modules/nutanix/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-ovh-utils": "^14.0.17",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/office/package.json
+++ b/packages/manager/modules/office/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^8.0.0 || ^9.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/overthebox/package.json
+++ b/packages/manager/modules/overthebox/package.json
@@ -31,7 +31,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-title": "^3.0.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.11.0",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -58,7 +58,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/modules/product-offers/package.json
+++ b/packages/manager/modules/product-offers/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/ng-ovh-payment-method": "^9.2.0",
     "@ovh-ux/ng-ovh-web-universe-components": "^6.0.1",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.9",
     "angular-translate": "^2.18.2",
     "bootstrap": "^4.3.1",

--- a/packages/manager/modules/sharepoint/package.json
+++ b/packages/manager/modules/sharepoint/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^9.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-route": "^1.7.5",

--- a/packages/manager/modules/sign-up/package.json
+++ b/packages/manager/modules/sign-up/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/manager-core": "^12.0.0 || ^13.0.0",
     "@ovh-ux/ng-at-internet": "^5.9.1",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.20",
     "angular": "^1.7.8",
     "angular-translate": "^2.18.1"

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^12.0.2",
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "~3.3.7"
   },
   "peerDependencies": {
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-pagination-front": "^10.1.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-messages": "^1.7.6",

--- a/packages/manager/modules/support/package.json
+++ b/packages/manager/modules/support/package.json
@@ -22,7 +22,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.8",
     "angular-sanitize": "^1.7.8",

--- a/packages/manager/modules/telecom-dashboard/package.json
+++ b/packages/manager/modules/telecom-dashboard/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/ng-ovh-telecom-universe-components": "^6.0.0 || ^7.0.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-title": "^3.0.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/telecom-styles/package.json
+++ b/packages/manager/modules/telecom-styles/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "~3.3.7",
     "ovh-ui-kit-bs": "^4.2.0"
   },

--- a/packages/manager/modules/telecom-task/package.json
+++ b/packages/manager/modules/telecom-task/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/ng-ovh-telecom-universe-components": "^6.0.0 || ^7.0.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-title": "^3.0.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "^3.4.1",
     "bootstrap4": "twbs/bootstrap#v4.0.0",
     "lodash": "^4.17.15"
@@ -22,7 +22,7 @@
     "@ovh-ux/ng-ovh-mondial-relay": "^8.3.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.5",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.20",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.5",

--- a/packages/manager/modules/trusted-nic/package.json
+++ b/packages/manager/modules/trusted-nic/package.json
@@ -13,7 +13,7 @@
   "main": "./src/index.js",
   "peerDependencies": {
     "@ovh-ux/manager-core": "^10.0.0 || ^11.0.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1"
   }

--- a/packages/manager/modules/veeam-cloud-connect/package.json
+++ b/packages/manager/modules/veeam-cloud-connect/package.json
@@ -25,7 +25,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/veeam-enterprise/package.json
+++ b/packages/manager/modules/veeam-enterprise/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/ng-ovh-cloud-universe-components": "^2.0.0",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/vps/package.json
+++ b/packages/manager/modules/vps/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-chart.js": "^1.1.1",

--- a/packages/manager/modules/vrack/package.json
+++ b/packages/manager/modules/vrack/package.json
@@ -40,7 +40,7 @@
     "@ovh-ux/ng-ovh-toaster": "^2.0.4",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.1.6",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.15",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/web-paas/package.json
+++ b/packages/manager/modules/web-paas/package.json
@@ -33,7 +33,7 @@
     "@ovh-ux/ng-ovh-web-universe-components": "^9.0.0",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
     "@ovh-ux/ng-ui-router-layout": "^4.1.0",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.3.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "bootstrap": "^3.3.7"
   },
   "peerDependencies": {
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-user-pref": "^2.0.4",
     "@ovh-ux/ng-ovh-utils": "^14.0.17",
     "@ovh-ux/ng-translate-async-loader": "^2.1.4",
-    "@ovh-ux/ui-kit": "^6.1.0",
+    "@ovh-ux/ui-kit": "^6.5.3",
     "@uirouter/angularjs": "^1.0.0",
     "URIjs": "^1.14.0",
     "angular": "^1.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6483,10 +6483,10 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
   integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
 
-"@ovh-ux/ui-kit@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.3.0.tgz#d88ec8e58022de2a9269a364b0c946f9c8a8252d"
-  integrity sha512-Vy74YQYFdT+d5O7FPETDZ5Yp5dmk+ifZbhlEToaCg1lflBOhnzqT3+cQf1BkbYDt4+X6M4jc4qKYit79tHC7FA==
+"@ovh-ux/ui-kit@^6.5.3":
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.5.3.tgz#f18abcce1b49d672b448ceff40beb850a57281b3"
+  integrity sha512-opCtuNe4FGPMF+wW0iqfb49O/cYWXatfTNKRF9AQi5nx5j5zfJrTniHtEeN4ySIOge+EzwowXo3W2sfeWBXx+Q==
 
 "@ovhcloud/reket-axios-client@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-115509, DTRSD-115207
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

Bump @ovh-ux/ui-kit dependencies to version 6.5.3 to have access to fixed versions of the timepicker / calendar and action menu dropdown

## Related
