### PR TITLE
feat(pci.storages.databases): datatr-302 - allow storage decrease

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.component.js
@@ -8,6 +8,7 @@ export default {
     max: '<',
     step: '<',
     model: '=',
+    lowLimitValue: '<?',
     initialValue: '<?',
     onChange: '&?',
     prices: '<',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.controller.js
@@ -4,8 +4,8 @@ export default class DiskSizeController {
   }
 
   checkRange() {
-    if (this.initialValue && this.model < this.initialValue) {
-      this.model = this.initialValue;
+    if (this.lowLimitValue && this.model < this.lowLimitValue) {
+      this.model = this.lowLimitValue;
     }
     if (this.model < this.min) {
       this.model = this.min;

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/components/disk-size/disk-size.html
@@ -26,7 +26,20 @@
                 step="{{$ctrl.step}}"
                 data-ng-model="$ctrl.model"
                 data-ng-change="$ctrl.checkRange()"
+                list="markers"
             />
+            <datalist id="markers">
+                <option
+                    data-ng-if="$ctrl.lowLimitValue"
+                    ng-value="$ctrl.lowLimitValue"
+                    data-ng-bind="$ctrl.lowLimitValue"
+                ></option>
+                <option
+                    data-ng-if="$ctrl.initialValue"
+                    ng-value="$ctrl.initialValue"
+                    data-ng-bind="$ctrl.initialValue"
+                ></option>
+            </datalist>
         </div>
         <div class="text-center">
             <span data-ng-bind="$ctrl.model | bytes:2:false:'GB'"></span>

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/translations/Messages_fr_FR.json
@@ -1,15 +1,16 @@
 {
-  "pci_databases_general_information_upgrade_storage": "Ajouter du stockage supplémentaire",
+  "pci_databases_general_information_upgrade_storage": "Éditer le stockage",
   "pci_databases_general_information_upgrade_storage_back": "Informations générales",
   "pci_databases_general_information_upgrade_storage_confirm": "Valider",
   "pci_databases_general_information_upgrade_storage_cancel": "Annuler",
   "pci_databases_general_information_upgrade_storage_description": "Votre modèle de noeud {{flavorName}} inclut {{includedStorage}} de stockage auxquels vous pouvez ajouter jusqu'à {{addableStorage}} de stockage supplémentaire par pas de {{step}}.",
-  "pci_databases_general_information_upgrade_storage_warning": "Une fois la modification réalisée, vous ne pourrez plus revenir à un stockage inférieur.",
-  "pci_databases_general_information_upgrade_storage_success": "Votre ajout de stockage supplémentaire a bien été pris en compte. Il sera effectif dans quelques minutes.",
-  "pci_databases_general_information_upgrade_storage_error": "Votre ajout de stockage supplémentaire n’a pas été correctement effectué : {{message}}",
-  "pci_databases_general_information_upgrade_storage_processing": "Ajout de stockage supplémentaire...",
+  "pci_databases_general_information_upgrade_storage_warning": "La modification du stockage peut prendre du temps en fonction du service.",
+  "pci_databases_general_information_upgrade_storage_success": "Votre modification de stockage supplémentaire a bien été pris en compte. Elle sera effective dans quelques minutes.",
+  "pci_databases_general_information_upgrade_storage_error": "Votre modification de stockage supplémentaire n’a pas été correctement effectuée : {{message}}",
+  "pci_databases_general_information_upgrade_storage_processing": "Modification du stockage supplémentaire...",
   "pci_databases_general_information_upgrade_storage_summary_title": "Votre cluster",
   "pci_databases_general_information_upgrade_storage_summary_storage": "Stockage",
   "pci_databases_general_information_upgrade_storage_summary_price": "Prix",
-  "pci_databases_general_information_upgrade_storage_summary_price_hourly_unit": "/heure"
+  "pci_databases_general_information_upgrade_storage_summary_price_hourly_unit": "/heure",
+  "pci_databases_general_information_upgrade_storage_summary_price_monthly_unit": "/mois"
 }

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.component.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.component.js
@@ -12,6 +12,7 @@ const component = {
     projectId: '<',
     trackDashboard: '<',
     trackDatabases: '<',
+    minStorageLimit: '<',
   },
   template,
   controller,

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.constants.js
@@ -1,0 +1,9 @@
+export const DISK_USAGE_METRICS = 'disk_usage_percent';
+export const DISK_USAGE_METRICS_PERIOD = 'lastHour';
+export const DISK_USAGE_MARGIN = 1.2;
+
+export default {
+  DISK_USAGE_METRICS,
+  DISK_USAGE_METRICS_PERIOD,
+  DISK_USAGE_MARGIN,
+};

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.controller.js
@@ -12,6 +12,8 @@ export default class UpgradeStorageCtrl {
   $onInit() {
     this.trackDatabases('config_upgrade_storage', 'page');
 
+    this.showMonthlyPrices = false;
+
     this.originallyAddedDiskSize =
       this.database.disk.size - this.flavor.minDiskSize;
     this.additionalDiskSize = this.originallyAddedDiskSize;
@@ -21,36 +23,58 @@ export default class UpgradeStorageCtrl {
     );
     this.nbNodes = this.database.nodes.length;
     this.storageNodeFactor = engine.isDistributedStorage ? 1 : this.nbNodes;
+  }
 
-    // compute initial price and tax
-    this.initialPrice =
-      this.nbNodes * this.flavor.hourlyPrice.priceInUcents +
-      this.flavor.hourlyPricePerGB.priceInUcents *
-        this.originallyAddedDiskSize *
-        this.storageNodeFactor;
+  get flavorPrice() {
+    return this.showMonthlyPrices
+      ? this.flavor.monthlyPrice
+      : this.flavor.hourlyPrice;
+  }
 
-    this.initialTax =
-      this.nbNodes * this.flavor.hourlyPrice.tax +
-      this.flavor.hourlyPricePerGB.tax *
-        this.originallyAddedDiskSize *
-        this.storageNodeFactor;
+  get additionalDiskPrice() {
+    return this.showMonthlyPrices
+      ? this.flavor.monthlyPricePerGB
+      : this.flavor.hourlyPricePerGB;
+  }
+
+  computeStoragePrice(flavorPrice, additionalDiskPrice, storage) {
+    return (
+      this.nbNodes * flavorPrice +
+      additionalDiskPrice * storage * this.storageNodeFactor
+    );
+  }
+
+  get initialPrice() {
+    return this.computeStoragePrice(
+      this.flavorPrice.priceInUcents,
+      this.additionalDiskPrice.priceInUcents,
+      this.originallyAddedDiskSize,
+    );
+  }
+
+  get initialTax() {
+    return this.computeStoragePrice(
+      this.flavorPrice.tax,
+      this.additionalDiskPrice.tax,
+      this.originallyAddedDiskSize,
+    );
   }
 
   get priceDelta() {
-    const newPrice =
-      this.nbNodes * this.flavor.hourlyPrice.priceInUcents +
-      this.flavor.hourlyPricePerGB.priceInUcents *
-        this.additionalDiskSize *
-        this.storageNodeFactor;
+    const newPrice = this.computeStoragePrice(
+      this.flavorPrice.priceInUcents,
+      this.additionalDiskPrice.priceInUcents,
+      this.additionalDiskSize,
+    );
     return newPrice - this.initialPrice;
   }
 
   get taxDelta() {
-    const newTax =
-      this.nbNodes * this.flavor.hourlyPrice.tax +
-      this.flavor.hourlyPricePerGB.tax *
-        this.additionalDiskSize *
-        this.storageNodeFactor;
+    const newTax = this.computeStoragePrice(
+      this.flavorPrice.tax,
+      this.additionalDiskPrice.tax,
+      this.additionalDiskSize,
+    );
     return newTax - this.initialTax;
   }
 

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.html
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.html
@@ -8,7 +8,7 @@
 </oui-back-button>
 <div class="row bm-4">
     <div class="col-md-7 col-xl-9 mb-2">
-        <oui-message data-type="warning">
+        <oui-message data-type="info">
             <span
                 data-translate="pci_databases_general_information_upgrade_storage_warning"
             ></span>
@@ -25,6 +25,7 @@
         <pci-projects-project-database-disk-size
             data-min="0"
             data-max="($ctrl.flavor.maxDiskSize - $ctrl.flavor.minDiskSize)"
+            data-low-limit-value="$ctrl.minStorageLimit"
             data-initial-value="$ctrl.originallyAddedDiskSize"
             data-step="$ctrl.flavor.stepDiskSize"
             data-model="$ctrl.additionalDiskSize"
@@ -57,16 +58,25 @@
                                 class="oui-color-as-500 bold"
                                 data-ng-bind="'+ ' + ($ctrl.additionalDiskSize - $ctrl.originallyAddedDiskSize | bytes:2:false:'GB')"
                             ></span>
+                            <span
+                                data-ng-if="$ctrl.additionalDiskSize - $ctrl.originallyAddedDiskSize < 0"
+                                class="oui-color-aw-500 bold"
+                                data-ng-bind="'- ' + ($ctrl.originallyAddedDiskSize - $ctrl.additionalDiskSize | bytes:2:false:'GB')"
+                            ></span>
                         </div>
                     </oui-tile-description>
                 </oui-tile-definition>
 
-                <oui-tile-definition
-                    data-term="{{:: 'pci_databases_general_information_upgrade_storage_summary_price' | translate}}"
-                >
+                <oui-tile-definition>
                     <oui-tile-description>
+                        <pci-projects-project-database-switch-price
+                            data-show-monthly-prices="$ctrl.showMonthlyPrices"
+                        ></pci-projects-project-database-switch-price>
+                        <strong
+                            data-translate="pci_databases_general_information_upgrade_storage_summary_price"
+                        ></strong>
                         <div class="d-flex flex-column">
-                            <span>
+                            <div>
                                 <ovh-manager-catalog-price
                                     data-price="$ctrl.initialPrice"
                                     data-tax="$ctrl.initialTax"
@@ -77,10 +87,10 @@
                                 >
                                 </ovh-manager-catalog-price>
                                 <span
-                                    data-translate="pci_databases_general_information_upgrade_storage_summary_price_hourly_unit"
+                                    data-ng-bind="($ctrl.showMonthlyPrices ? 'pci_databases_general_information_upgrade_storage_summary_price_monthly_unit' : 'pci_databases_general_information_upgrade_storage_summary_price_hourly_unit') | translate"
                                 ></span>
-                            </span>
-                            <span
+                            </div>
+                            <div
                                 class="oui-color-as-500 bold"
                                 data-ng-if="$ctrl.additionalDiskSize - $ctrl.originallyAddedDiskSize > 0"
                             >
@@ -94,9 +104,26 @@
                                 >
                                 </ovh-manager-catalog-price>
                                 <span
-                                    data-translate="pci_databases_general_information_upgrade_storage_summary_price_hourly_unit"
+                                    data-ng-bind="($ctrl.showMonthlyPrices ? 'pci_databases_general_information_upgrade_storage_summary_price_monthly_unit' : 'pci_databases_general_information_upgrade_storage_summary_price_hourly_unit') | translate"
                                 ></span>
-                            </span>
+                            </div>
+                            <div
+                                class="oui-color-aw-500 bold"
+                                data-ng-if="$ctrl.additionalDiskSize - $ctrl.originallyAddedDiskSize < 0"
+                            >
+                                <ovh-manager-catalog-price
+                                    data-price="$ctrl.priceDelta"
+                                    data-tax="$ctrl.taxDelta"
+                                    data-user="$ctrl.user"
+                                    data-show-zero-price="true"
+                                    data-perform-rounding="false"
+                                    data-maximum-fraction-digits="3"
+                                >
+                                </ovh-manager-catalog-price>
+                                <span
+                                    data-ng-bind="($ctrl.showMonthlyPrices ? 'pci_databases_general_information_upgrade_storage_summary_price_monthly_unit' : 'pci_databases_general_information_upgrade_storage_summary_price_hourly_unit') | translate"
+                                ></span>
+                            </div>
                         </div>
                     </oui-tile-description>
                 </oui-tile-definition>
@@ -105,7 +132,7 @@
                     data-variant="primary"
                     block
                     data-on-click="$ctrl.upgradeStorage()"
-                    data-disabled="(($ctrl.flavor.minDiskSize + $ctrl.additionalDiskSize) <= $ctrl.database.disk.size) || $ctrl.upgradingStorage"
+                    data-disabled="(($ctrl.flavor.minDiskSize + $ctrl.additionalDiskSize) === $ctrl.database.disk.size) || $ctrl.upgradingStorage"
                 >
                     <span
                         data-ng-if="!$ctrl.upgradingStorage"

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.module.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.module.js
@@ -4,12 +4,13 @@ import component from './upgrade-storage.component';
 import routing from './upgrade-storage.routing';
 
 import diskSizeComponent from '../../../components/disk-size';
+import switchPriceComponent from '../../../components/switch-price';
 
 const moduleName =
   'ovhManagerPciStoragesDatabaseGeneralInformationUpgradeStorage';
 
 angular
-  .module(moduleName, [diskSizeComponent])
+  .module(moduleName, [diskSizeComponent, switchPriceComponent])
   .config(routing)
   .component(
     'ovhManagerPciProjectDatabaseGeneralInformationUpgradeStorage',

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/general-information/upgrade-storage/upgrade-storage.routing.js
@@ -1,3 +1,9 @@
+import {
+  DISK_USAGE_MARGIN,
+  DISK_USAGE_METRICS,
+  DISK_USAGE_METRICS_PERIOD,
+} from './upgrade-storage.constants';
+
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state(
     'pci.projects.project.storages.databases.dashboard.general-information.upgrade-storage',
@@ -11,6 +17,32 @@ export default /* @ngInject */ ($stateProvider) => {
           ),
         flavor: /* @ngInject */ (getCurrentFlavor) => getCurrentFlavor(),
         onStorageUpgrade: /* @ngInject */ (goBackAndPoll) => goBackAndPoll,
+        minStorageLimit: /* @ngInject */ (
+          DatabaseService,
+          projectId,
+          database,
+          flavor,
+        ) =>
+          DatabaseService.getMetrics(
+            projectId,
+            database.engine,
+            database.id,
+            DISK_USAGE_METRICS,
+            DISK_USAGE_METRICS_PERIOD,
+          ).then((data) => {
+            const usedDiskPercent = Math.max(
+              ...data.metrics.map((metric) => metric.dataPoints[0].value),
+            );
+            let lowValue = 0;
+            if (usedDiskPercent > 0) {
+              const usedGb = (database.disk.size * usedDiskPercent) / 100;
+              const withMargin = usedGb * DISK_USAGE_MARGIN;
+              const minAdditionalGb = withMargin - flavor.minDiskSize;
+              const nbStep = Math.ceil(minAdditionalGb / flavor.stepDiskSize);
+              lowValue = flavor.stepDiskSize * nbStep;
+            }
+            return lowValue;
+          }),
       },
       atInternet: {
         ignore: true,


### PR DESCRIPTION
DATATR-302

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #DATATR-302
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Allow to select a lower storage, limited by the disk usage