### PR TITLE
fix(ai): fix private registry creation

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/training/registries/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/training/registries/add/add.html
@@ -37,7 +37,7 @@
                 id="username"
                 name="username"
                 required
-                maxlength="50"
+                maxlength="300"
                 data-ng-model="$ctrl.registry.username"
             />
         </oui-field>
@@ -51,7 +51,7 @@
                 id="password"
                 name="password"
                 required
-                maxlength="50"
+                maxlength="300"
                 data-ng-model="$ctrl.registry.password"
             />
         </oui-field>

--- a/packages/manager/modules/pci/src/projects/project/training/registries/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/training/registries/add/translations/Messages_fr_FR.json
@@ -6,6 +6,6 @@
   "pci_projects_project_training_registries_add_common_add": "Ajouter",
   "pci_projects_project_training_registries_add_common_cancel": "Annuler",
   "pci_projects_project_training_registries_add_password": "Mot de passe",
-  "pci_projects_project_training_registries_add_user": "Identifiant",
+  "pci_projects_project_training_registries_add_user": "Nom d'utilisateur",
   "pci_projects_project_training_registries_add_region": "Région"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Issues | #9674 #9675
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

## Description

Two small fixes to the AI private registry creation form:
- the password field max length (50) was too low for some customers, also raised the username field, we have no limit on the API for both of these fields
- the username field was called "Identifiant" and then translated to "ID" while it's a username, all translations must be updated to reflect that