### PR TITLE
Revert "Revert "fix(telecom): fix incorrect level2 tracking for telec…

### DIFF
--- a/packages/components/ng-ovh-line-diagnostics/src/controller.js
+++ b/packages/components/ng-ovh-line-diagnostics/src/controller.js
@@ -322,7 +322,7 @@ export default class LineDiagnosticsCtrl {
       name: `telecom::pack::xdsl::${action}`,
       type: 'action',
       chapter1: 'telecom',
-      level2: 'Telecom',
+      level2: '87',
     });
   }
 
@@ -331,7 +331,7 @@ export default class LineDiagnosticsCtrl {
       name: `telecom::pack::xdsl::${page}`,
       type: 'navigation',
       chapter1: 'telecom',
-      level2: 'Telecom',
+      level2: '87',
     });
   }
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/configuration.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/alias/configuration/configuration.controller.js
@@ -43,7 +43,7 @@ export default class TelecomTelephonyAliasConfigurationCtrl {
           this.atInternet.trackPage({
             name: 'configuration',
             type: 'navigation',
-            level2: 'Telecom',
+            level2: '87',
             chapter1: 'telecom',
           });
         });

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/order-alias.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/orderAlias/order-alias.controller.js
@@ -33,7 +33,7 @@ export default class TelecomTelephonyBillingAccountOrderAliasCtrl {
         this.atInternet.trackPage({
           name: 'orders-PhoneNumb',
           type: 'navigation',
-          level2: 'Telecom',
+          level2: '87',
           chapter1: 'telecom',
         });
       });

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/fax/fax.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/fax/fax.controller.js
@@ -83,7 +83,7 @@ export default /* @ngInject */ function TelecomTelephonyFaxCtrl(
         atInternet.trackPage({
           name: 'Fax',
           type: 'navigation',
-          level2: 'Telecom',
+          level2: '87',
           chapter: 'telecom',
         });
       });

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/accessories/accessories.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/phone/accessories/accessories.controller.js
@@ -63,7 +63,7 @@ export default class TelephonyLinePhoneAccessoriesCtrl {
         return this.atInternet.trackPage({
           name: 'accessories-Tel',
           type: 'navigation',
-          level2: 'Telecom',
+          level2: '87',
           chapter1: 'telecom',
         });
       });

--- a/packages/manager/modules/telecom-dashboard/src/guides/telecom-dashboard-guides.controller.js
+++ b/packages/manager/modules/telecom-dashboard/src/guides/telecom-dashboard-guides.controller.js
@@ -25,7 +25,7 @@ export default class TelecomDashboardGuidesCtrl {
     return this.atInternet.trackClick({
       name: `TopGuide-Telecom-${index}`,
       type: 'navigation',
-      level2: 'Telecom',
+      level2: '87',
       chapter1: 'telecom',
     });
   }

--- a/packages/manager/modules/telecom-dashboard/src/index.js
+++ b/packages/manager/modules/telecom-dashboard/src/index.js
@@ -90,7 +90,7 @@ angular
             atInternet.trackPage({
               name: 'dashboard',
               type: 'navigation',
-              level2: 'Telecom',
+              level2: '87',
               chapter1: 'telecom',
             });
           },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/sprint-ww2328`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-10774
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Some tracking event had bad level2 'Telecom' instead of corresponding 87 code.

## Related

<!-- Link dependencies of this PR -->
