### PR TITLE
fix(container): restore account sidebar state

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/Sidebar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/Sidebar.tsx
@@ -32,7 +32,7 @@ export default function ServerSidebar({ menu }: { menu: SidebarMenuItem }) {
   useEffect(() => {
     if (menu && location) {
       const appHash = location.pathname.replace(/^\/[^/]+/, '');
-      selectActiveItem(menu, appHash, refreshMenu);
+      selectActiveItem(menu, appHash, location.pathname, refreshMenu);
     }
   }, [menu, location]);
 

--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/index.tsx
@@ -24,23 +24,27 @@ export default function ServerSidebarIndex() {
   const location = useLocation();
   const isUniverseMenu =
     ['public-cloud', 'server', 'telecom', 'web'].indexOf(universe) >= 0;
+  const accountMenuPath: Record<string, string[] | '*'> = {
+    dedicated: [
+      '/billing',
+      '/contact',
+      '/contacts',
+      '/support',
+      '/ticket',
+      '/useraccount',
+    ],
+    iam: '*',
+    'carbon-calculator': '*',
+  }
 
   useEffect(() => {
-    if (application?.container?.path === 'dedicated') {
-      setIsAccountMenu(
-        [
-          '/useraccount',
-          '/billing',
-          '/contact',
-          '/contacts',
-          '/support',
-          '/ticket',
-        ].some((route) =>
-          location.pathname.startsWith(
-            `/${application.container.path}${route}`,
-          ),
-        ),
-      );
+    const accountMenuPathEntry = Object.entries(accountMenuPath)
+      .find(([path]) => path === application?.container?.path);
+    if (accountMenuPathEntry) {
+      const [path, routes] = accountMenuPathEntry;
+      routes === '*'
+        ? setIsAccountMenu(true)
+        : setIsAccountMenu(routes.some((route) => location.pathname.startsWith(`/${path}${route}`)))
     } else {
       setIsAccountMenu(false);
     }

--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/sidebarMenu.ts
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/sidebarMenu.ts
@@ -5,8 +5,8 @@ export type SidebarMenuItem = {
   href?: string;
   isExternal?: boolean;
   routeMatcher?: RegExp;
+  pathMatcher?: RegExp;
   subItems?: SidebarMenuItem[];
-
   parent?: SidebarMenuItem;
   depth?: number;
 
@@ -211,6 +211,7 @@ export async function selectItem(
 export async function selectActiveItem(
   menu: SidebarMenuItem,
   route: string,
+  path: string,
   onMenuChange: CallableFunction,
 ): Promise<SidebarMenuItem> {
   const findMatchingItem = async (
@@ -219,10 +220,14 @@ export async function selectActiveItem(
     if (
       item.depth < 0 ||
       item.routeMatcher?.test(route) ||
+      item.pathMatcher?.test(path) ||
       (item.serviceName && route.indexOf(item.serviceName) >= 0) ||
       item.href?.endsWith(route)
     ) {
-      if (item.routeMatcher && !item.routeMatcher.test(route)) {
+      if (
+        (item.routeMatcher && !item.routeMatcher.test(route)) ||
+        (item.pathMatcher && !item.pathMatcher.test(path))
+      ) {
         return null;
       }
       selectItem(menu, item);

--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/AccountSidebar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/AccountSidebar.tsx
@@ -61,7 +61,7 @@ export default function AccountSidebar() {
         'dedicated',
         `/billing/autorenew${isEnterprise ? '/ssh' : '/'}`,
       ),
-      routeMatcher: new RegExp('^/billing/autorenew'),
+      routeMatcher: new RegExp('^/billing/autorenew', 'i'),
     });
 
     if (!isEnterprise) {

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/utils.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/utils.ts
@@ -160,7 +160,7 @@ export function findPathToNodeByApp(
   appHash: string,
 ): Node[] {
   const path = findPathToNode(rootNode, comparatorFn, appId, appHash);
-  if (!path.length && appHash.split('/').length - 1 > 1) {
+  if (!path.length && appHash.includes('/')) {
     return findPathToNodeByApp(
       rootNode,
       comparatorFn,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #N/A
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

### New standalone apps IAM and Carbon Calculator
- The legacy account sidebar is not loaded
- The link of the reshuffled navigation is not active
