### PR TITLE
fix(pci.ai): fixing mysql queries metrics format

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database.service.js
@@ -10,7 +10,10 @@ import {
   ENGINES_STATUS,
   ENGINES_PRICE_SUFFIX,
 } from '../../../../components/project/storages/databases/engines.constants';
-import { DATABASE_TYPES } from './databases.constants';
+import {
+  DATABASE_TYPES,
+  MYSQL_QUERY_STATISTICS_TO_MS,
+} from './databases.constants';
 
 import Backup from '../../../../components/project/storages/databases/backup.class';
 import Database from '../../../../components/project/storages/databases/database.class';
@@ -910,11 +913,11 @@ export default class DatabaseService {
                 query.digestText,
                 query.sumRowsSent,
                 query.countStar,
-                query.minTimerWait,
-                query.maxTimerWait,
-                query.avgTimerWait,
+                query.minTimerWait / MYSQL_QUERY_STATISTICS_TO_MS,
+                query.maxTimerWait / MYSQL_QUERY_STATISTICS_TO_MS,
+                query.avgTimerWait / MYSQL_QUERY_STATISTICS_TO_MS,
                 0,
-                query.sumTimerWait,
+                query.sumTimerWait / MYSQL_QUERY_STATISTICS_TO_MS,
               );
         }),
       );

--- a/packages/manager/modules/pci/src/projects/project/storages/databases/databases.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/databases.constants.js
@@ -151,3 +151,5 @@ export default {
   SSL_MODE_NA,
   SSL_MODE_SSL_TLS,
 };
+
+export const MYSQL_QUERY_STATISTICS_TO_MS = 1000000000;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #datatr-301 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
fixing mysql queries statistics format as metrics were displayed in pictoseconds.

## Related

<!-- Link dependencies of this PR -->
