### PR TITLE
fix(hosting.ssl): do not send empty body to apiv6

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/ssl/hosting-ssl.service.js
+++ b/packages/manager/apps/web/client/app/hosting/ssl/hosting-ssl.service.js
@@ -5,8 +5,14 @@ import isString from 'lodash/isString';
 angular.module('services').service(
   'hostingSSLCertificate',
   class HostingSSLCertificate {
-    constructor($rootScope, hostingSSLCertificateType, OvhApiHostingWebSsl) {
+    constructor(
+      $rootScope,
+      $http,
+      hostingSSLCertificateType,
+      OvhApiHostingWebSsl,
+    ) {
       this.$rootScope = $rootScope;
+      this.$http = $http;
 
       this.hostingSSLCertificateType = hostingSSLCertificateType;
       this.OvhApiHostingWebSsl = OvhApiHostingWebSsl;
@@ -34,8 +40,7 @@ angular.module('services').service(
     }
 
     regeneratingCertificate(serviceName) {
-      return this.OvhApiHostingWebSsl.v6().regenerate({ serviceName }, {})
-        .$promise;
+      return this.$http.post(`/hosting/web/${serviceName}/ssl/regenerate`);
     }
 
     deletingCertificate(serviceName) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #WEB-15392
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

api v6 call hosting/web/{servicenName}/ssl/regenerate is being moved from rip to iceberg. During this migration we noticed an issue : manager sends empty body, it is not supported by Iceberg.

## Related

WEB-15392
