### PR TITLE
fix(web.domain): missing translation key on add free hosting

### DIFF
--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_de_DE.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Aktivieren",
   "domain_configuration_enable_web_hosting_success": "Das Hosting wird aktiviert. Dies kann einige Minuten in Anspruch nehmen.",
   "domain_configuration_enable_web_hosting_checkout_error": "Ein Fehler ist aufgetreten: {{message}}",
-  "domain_configuration_enable_web_hosting_error": "Bei der Aktivierung Ihres Hostings ist ein Fehler aufgetreten. {{ message }}"
+  "domain_configuration_enable_web_hosting_error": "Bei der Aktivierung Ihres Hostings ist ein Fehler aufgetreten. {{ message }}",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Kostenloses Hosting 100M"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_en_GB.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Activate",
   "domain_configuration_enable_web_hosting_success": "Your web hosting plan is being activated. This may take a few minutes.",
   "domain_configuration_enable_web_hosting_checkout_error": "An error has occurred {{ message }}",
-  "domain_configuration_enable_web_hosting_error": "An error has occurred activating your web hosting plan. {{ message }}"
+  "domain_configuration_enable_web_hosting_error": "An error has occurred activating your web hosting plan. {{ message }}",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "100 MB free hosting"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_es_ES.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Activar",
   "domain_configuration_enable_web_hosting_success": "Activando el alojamiento... La operación podría tardar unos minutos.",
   "domain_configuration_enable_web_hosting_checkout_error": "Se ha producido un error: {{ message }}",
-  "domain_configuration_enable_web_hosting_error": "Se ha producido un error al activar el alojamiento: {{ message }}"
+  "domain_configuration_enable_web_hosting_error": "Se ha producido un error al activar el alojamiento: {{ message }}",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Alojamiento gratuito 100 MB"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_fr_CA.json
@@ -2,6 +2,7 @@
   "domain_configuration_enable_web_hosting": "Activer votre hébergement web",
   "domain_configuration_enable_web_hosting_offer": "Votre offre",
   "domain_configuration_enable_web_hosting_offer_START_hosting-start10m": "Start 10M",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Hébergement gratuit 100M",
   "domain_configuration_web_hosting_offer_START_explain": "L'offre Start10m est incluse dans votre offre mais dispose de fonctionnalités basiques.",
   "domain_configuration_web_hosting_choose_offer_explain": "Pour en savoir plus sur nos offres et connaître leurs spécifications techniques ainsi que leurs différentes options, rendez-vous sur <a href=\"{{url}}\" target=\"_blank\">notre site</a>.",
   "domain_configuration_enable_web_hosting_dns_configuration": "Configuration de vos DNS",

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_fr_FR.json
@@ -2,6 +2,7 @@
   "domain_configuration_enable_web_hosting": "Activer votre hébergement web",
   "domain_configuration_enable_web_hosting_offer": "Votre offre",
   "domain_configuration_enable_web_hosting_offer_START_hosting-start10m": "Start 10M",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Hébergement gratuit 100M",
   "domain_configuration_web_hosting_offer_START_explain": "L'offre Start10m est incluse dans votre offre mais dispose de fonctionnalités basiques.",
   "domain_configuration_web_hosting_choose_offer_explain": "Pour en savoir plus sur nos offres et connaître leurs spécifications techniques ainsi que leurs différentes options, rendez-vous sur <a href=\"{{url}}\" target=\"_blank\">notre site</a>.",
   "domain_configuration_enable_web_hosting_dns_configuration": "Configuration de vos DNS",

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_it_IT.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Attiva",
   "domain_configuration_enable_web_hosting_success": "L’attivazione dell’hosting è in corso. L’operazione potrebbe richiedere alcuni minuti.",
   "domain_configuration_enable_web_hosting_checkout_error": "Si è verificato un errore: {{message}}",
-  "domain_configuration_enable_web_hosting_error": "Si è verificato un errore durante l'attivazione dell’hosting. {{ message }}"
+  "domain_configuration_enable_web_hosting_error": "Si è verificato un errore durante l'attivazione dell’hosting. {{ message }}",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Hosting gratuito 100M"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_pl_PL.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Włącz",
   "domain_configuration_enable_web_hosting_success": "Trwa włączanie hostingu. Może to zająć kilka minut.",
   "domain_configuration_enable_web_hosting_checkout_error": "Wystąpił błąd: {{message}}",
-  "domain_configuration_enable_web_hosting_error": "Wystąpił błąd podczas włączania Twojego hostingu:{{message}}."
+  "domain_configuration_enable_web_hosting_error": "Wystąpił błąd podczas włączania Twojego hostingu:{{message}}.",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Darmowy hosting 100M"
 }

--- a/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/domain/general-informations/webhosting-enable/translations/Messages_pt_PT.json
@@ -17,5 +17,6 @@
   "domain_configuration_enable_web_hosting_activate": "Ativar",
   "domain_configuration_enable_web_hosting_success": "A ativação do alojamento está em curso. Esta operação poderá demorar alguns minutos.",
   "domain_configuration_enable_web_hosting_checkout_error": "Ocorreu um erro: {{ message }}",
-  "domain_configuration_enable_web_hosting_error": "Ocorreu um erro ao ativar o seu alojamento: {{ message }}"
+  "domain_configuration_enable_web_hosting_error": "Ocorreu um erro ao ativar o seu alojamento: {{ message }}",
+  "domain_configuration_enable_web_hosting_offer_START_hosting-free-100m": "Alojamento gratuito 100M"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-11953 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I added a missing translation key on add free hosting
<!-- Write a brief description of the changes introduced by this PR -->

## Related
:flags: Translation:
- [x] TRANS-52584
<!-- Link dependencies of this PR -->
