### PR TITLE
feat(ldp): add stream subscriptions

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.controller.js
@@ -186,14 +186,28 @@ export default class LogsStreamsHomeCtrl {
   }
 
   /**
-   * navigates to the alerts page
+   * navigates to the archives page
    *
-   * @param {any} stream, stream for which alerts should be managed
+   * @param {any} stream, stream for which archives should be managed
    * @memberof LogsStreamsHomeCtrl
    */
-  gotoArchives(stream) {
+  goToArchives(stream) {
     this.CucCloudMessage.flushChildMessage();
     this.$state.go('dbaas-logs.detail.streams.stream.archives', {
+      serviceName: this.serviceName,
+      streamId: stream.streamId,
+    });
+  }
+
+  /**
+   * navigates to the subscriptions page
+   *
+   * @param {object} stream, stream for which subscriptions should be managed
+   * @memberof LogsStreamsHomeCtrl
+   */
+  goToSubscriptions(stream) {
+    this.CucCloudMessage.flushChildMessage();
+    this.$state.go('dbaas-logs.detail.streams.stream.subscriptions', {
       serviceName: this.serviceName,
       streamId: stream.streamId,
     });

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/home/logs-streams-home.html
@@ -90,6 +90,15 @@
             {{ $row.nbAlertCondition || "-" }}
         </oui-datagrid-column>
         <oui-datagrid-column
+            data-title="::'logs_streams_col_subscriptions' | translate"
+            property="nbSubscription"
+            sortable
+            type="number"
+            filterable
+        >
+            {{ $row.nbSubscription || "-" }}
+        </oui-datagrid-column>
+        <oui-datagrid-column
             data-title="::'logs_col_last_modified' | translate"
             property="updatedAt"
             sortable
@@ -141,8 +150,13 @@
             ></oui-action-menu-item>
             <oui-action-menu-item
                 disabled="!$row.coldStorageEnabled && $row.nbArchive === 0"
-                on-click="ctrl.gotoArchives($row)"
+                on-click="ctrl.goToArchives($row)"
                 ><span data-translate="logs_streams_archives"></span
+            ></oui-action-menu-item>
+            <oui-action-menu-item
+                disabled="!$row.isEditable || $row.nbSubscription === 0"
+                on-click="ctrl.goToSubscriptions($row)"
+                ><span data-translate="logs_streams_subscriptions"></span
             ></oui-action-menu-item>
             <oui-action-menu-item
                 disabled="!$row.isEditable"

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/streams.module.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/streams.module.js
@@ -18,6 +18,7 @@ import follow from './follow/follow.module';
 import home from './home/home.module';
 import routing from './streams.routing';
 import service from './logs-streams.service';
+import subscriptions from './subscriptions/subscriptions.module';
 
 const moduleName = 'ovhManagerDbaasLogsDetailStreams';
 
@@ -35,6 +36,7 @@ angular
     edit,
     follow,
     home,
+    subscriptions,
   ])
   .config(routing)
   .service('LogsStreamsService', service)

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.controller.js
@@ -1,0 +1,119 @@
+import datagridToIcebergFilter from '../../logs-iceberg.utils';
+
+export default class LogsStreamsSubscriptionsCtrl {
+  /* @ngInject */
+  constructor(
+    $stateParams,
+    $translate,
+    ouiDatagridService,
+    CucCloudMessage,
+    CucControllerHelper,
+    LogsHelperService,
+    LogsStreamsService,
+    LogsStreamsSubscriptionsService,
+  ) {
+    this.$stateParams = $stateParams;
+    this.$translate = $translate;
+    this.ouiDatagridService = ouiDatagridService;
+    this.CucCloudMessage = CucCloudMessage;
+    this.CucControllerHelper = CucControllerHelper;
+    this.LogsHelperService = LogsHelperService;
+    this.LogsStreamsService = LogsStreamsService;
+    this.LogsStreamsSubscriptionsService = LogsStreamsSubscriptionsService;
+
+    this.serviceName = this.$stateParams.serviceName;
+    this.streamId = this.$stateParams.streamId;
+  }
+
+  $onInit() {
+    this.stream = this.CucControllerHelper.request.getHashLoader({
+      loaderFunction: () =>
+        this.LogsStreamsService.getStream(this.serviceName, this.streamId),
+    });
+    this.stream.load();
+  }
+
+  /**
+   * Retrieve subscription list, according to pagination/sort/filter
+   *
+   * @param offset int element offset to retrieve results from
+   * @param pageSize int Number of results to retrieve
+   * @param sort Object Sort object from ovh-ui datagrid
+   * @param criteria Object Criteria object from ovh-ui datagrid
+   * @return {*|Promise<any>}
+   */
+  loadSubscriptions({ offset, pageSize = 1, sort, criteria }) {
+    const filters = criteria.map((criterion) => {
+      const name = criterion.property || 'resource.name';
+      return datagridToIcebergFilter(name, criterion.operator, criterion.value);
+    });
+    const pageOffset = Math.ceil(offset / pageSize);
+    return this.LogsStreamsSubscriptionsService.getPaginatedStreamSubscriptions(
+      this.serviceName,
+      this.streamId,
+      pageOffset,
+      pageSize,
+      { name: sort.property, dir: sort.dir === -1 ? 'DESC' : 'ASC' },
+      filters,
+    );
+  }
+
+  /**
+   * Display a modal to confirm subscription deletion
+   *
+   * @param subscription Object Subscription object from API
+   * @return {*|Promise<any>}
+   */
+  showSubscriptionDeleteConfirm(subscription) {
+    this.CucCloudMessage.flushChildMessage();
+    return this.CucControllerHelper.modal
+      .showDeleteModal({
+        titleText: this.$translate.instant(
+          'streams_subscriptions_delete_modal_title',
+        ),
+        textHtml: this.$translate.instant(
+          'streams_subscriptions_delete_modal_content',
+          {
+            resourceName: `<strong>${subscription.resource.name}</strong>`,
+          },
+        ),
+      })
+      .then(() => this.removeSubscription(subscription));
+  }
+
+  /**
+   * Delete a subscription on API
+   * Update datagrid accordingly
+   *
+   * @param subscription Object Subscription object from API
+   */
+  removeSubscription(subscription) {
+    this.CucCloudMessage.flushChildMessage();
+    this.deleteSubscriptionLoading = true;
+    this.LogsStreamsSubscriptionsService.deleteSubscription(
+      this.serviceName,
+      this.streamId,
+      subscription,
+    )
+      .then((operation) =>
+        this.LogsHelperService.handleOperation(
+          this.serviceName,
+          operation.data,
+          'streams_subscriptions_delete_success',
+          { resourceName: subscription.resource.name },
+        ),
+      )
+      .catch((err) => {
+        this.LogsHelperService.handleError(
+          'streams_subscriptions_delete_error',
+          err,
+          { resourceName: subscription.resource.name },
+        );
+      })
+      .finally(() => {
+        this.deleteSubscriptionLoading = false;
+        this.ouiDatagridService.refresh('subscriptions-datagrid', true);
+        this.CucControllerHelper.scrollPageToTop();
+      });
+  }
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.html
@@ -1,0 +1,65 @@
+<section class="subscriptions-home">
+    <oui-back-button
+        ><span data-translate="logs_streams_subscriptions"></span
+    ></oui-back-button>
+
+    <h6>
+        {{'streams_subscriptions_current_title' | translate:{ name:
+        $ctrl.stream.data.title } }}
+    </h6>
+    <p data-translate="streams_subscriptions_intro_text"></p>
+
+    <oui-datagrid
+        id="subscriptions-datagrid"
+        rows-loader="$ctrl.loadSubscriptions($config)"
+    >
+        <oui-datagrid-topbar>
+            <oui-spinner
+                size="s"
+                data-ng-if="$ctrl.deleteSubscriptionLoading"
+            ></oui-spinner>
+        </oui-datagrid-topbar>
+
+        <oui-datagrid-column
+            data-title="::'streams_subscriptions_resource_name_label' | translate"
+            data-property="resource.name"
+            data-type="string"
+            data-sortable
+            data-searchable
+            data-filterable
+        ></oui-datagrid-column>
+        <oui-datagrid-column
+            data-title="::'streams_subscriptions_resource_type_label' | translate"
+            data-property="resource.type"
+            data-type="string"
+            data-sortable="asc"
+            data-searchable
+            data-filterable
+        >
+            <span>
+                {{ ::'streams_subscriptions_resource_products_' +
+                $row.resource.type | translate }}
+            </span>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-title="::'logs_col_last_modified' | translate"
+            data-property="updatedAt"
+            data-sortable
+            data-type="date"
+        >
+            {{ $row.updatedAt | cucMomentFormat:'L'}}
+        </oui-datagrid-column>
+        <oui-datagrid-column>
+            <button
+                type="button"
+                class="btn btn-secondary float-right mr-2"
+                data-ng-click="$ctrl.showSubscriptionDeleteConfirm($row)"
+            >
+                <span
+                    class="oui-icon oui-icon-trash_concept"
+                    aria-hidden="true"
+                ></span>
+            </button>
+        </oui-datagrid-column>
+    </oui-datagrid>
+</section>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.service.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.service.js
@@ -1,0 +1,60 @@
+export default class LogsStreamsSubscriptionsService {
+  /* @ngInject */
+  constructor($http, iceberg) {
+    this.$http = $http;
+    this.iceberg = iceberg;
+  }
+
+  /**
+   * Retrieve list of stream's subscription with pagination, sorts, filters etc.
+   * @param serviceName string LDP service name
+   * @param streamId string LDP stream UUID
+   * @param offset int Offset to start from
+   * @param pageSize int Number of results to retrieve from API
+   * @param sort string Name of field to sort from
+   * @param filters Array List of Iceberg filters to apply
+   * @return {Object}
+   */
+  getPaginatedStreamSubscriptions(
+    serviceName,
+    streamId,
+    offset = 0,
+    pageSize = 25,
+    sort = { name: 'nbArchive', dir: 'desc' },
+    filters = null,
+  ) {
+    let res = this.iceberg(
+      `/dbaas/logs/${serviceName}/output/graylog/stream/${streamId}/subscription`,
+    )
+      .query()
+      .expand('CachedObjectList-Pages')
+      .limit(pageSize)
+      .offset(offset)
+      .sort(sort.name, sort.dir);
+    if (filters !== null) {
+      filters.forEach((filter) => {
+        res = res.addFilter(filter.name, filter.operator, filter.value);
+      });
+    }
+    return res.execute().$promise.then((response) => ({
+      data: response.data,
+      meta: {
+        totalCount:
+          parseInt(response.headers['x-pagination-elements'], 10) || 0,
+      },
+    }));
+  }
+
+  /**
+   * Delete a subscription on the API side
+   * @param serviceName string LDP service name
+   * @param streamId string LDP stream UUID
+   * @param subscription Object Subscription object to delete
+   * @return {Promise<any>}
+   */
+  deleteSubscription(serviceName, streamId, subscription) {
+    return this.$http.delete(
+      `/dbaas/logs/${serviceName}/output/graylog/stream/${streamId}/subscription/${subscription.subscriptionId}`,
+    );
+  }
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.component.js
@@ -1,0 +1,7 @@
+import controller from './streams-subscriptions.controller';
+import template from './streams-subscriptions.html';
+
+export default {
+  controller,
+  template,
+};

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.module.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.module.js
@@ -1,0 +1,28 @@
+import angular from 'angular';
+
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ovh-cloud-universe-components';
+import '@uirouter/angularjs';
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
+
+import component from './subscriptions.component';
+import routing from './subscriptions.routing';
+import service from './streams-subscriptions.service';
+
+const moduleName = 'ovhManagerDbaasLogsDetailStreamsSubscriptions';
+
+angular
+  .module(moduleName, [
+    'ngOvhCloudUniverseComponents',
+    'oui',
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+  ])
+  .config(routing)
+  .service('LogsStreamsSubscriptionsService', service)
+  .component('dbaasLogsDetailStreamsSubscriptions', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.routing.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/subscriptions.routing.js
@@ -1,0 +1,10 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('dbaas-logs.detail.streams.stream.subscriptions', {
+    url: '/subscriptions',
+    component: 'dbaasLogsDetailStreamsSubscriptions',
+    resolve: {
+      breadcrumb: /* @ngInject */ ($translate) =>
+        $translate.instant('dbaas_logs_streams_subscriptions'),
+    },
+  });
+};

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_de_DE.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_de_DE.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Abonnements"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_en_GB.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Subscriptions"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_es_ES.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_es_ES.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Suscripciones"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_fr_CA.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Abonnements"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_fr_FR.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Abonnements"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_it_IT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_it_IT.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Abbonamenti"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_pl_PL.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Subskrypcje"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/translations/Messages_pt_PT.json
@@ -1,0 +1,3 @@
+{
+  "dbaas_logs_streams_subscriptions": "Assinaturas"
+}

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Mich per E-Mail benachrichtigen, wenn ein automatisches Skalieren stattfindet.",
   "inputs_logs_edit_min_instance_field": "Mindestanzahl an Instanzen",
   "inputs_logs_edit_max_instance_field": "Maximale Anzahl an Instanzen",
-  "inputs_info_ca_certificate": "Zertifikat der Zertifizierungsstelle"
+  "inputs_info_ca_certificate": "Zertifikat der Zertifizierungsstelle",
+  "logs_streams_subscriptions": "Abonnements",
+  "logs_streams_col_subscriptions": "Abonnements",
+  "streams_subscriptions_current_title": "Verwaltung Ihrer Abonnements für den Stream „{{ name }}“",
+  "streams_subscriptions_intro_text": "Mit diesen Abonnements können Sie die Logs Ihrer OVHcloud Produkte in Ihren eigenen Streams abrufen.",
+  "streams_subscriptions_resource_type_label": "Dienst",
+  "streams_subscriptions_resource_name_label": "Name des Dienstes",
+  "streams_subscriptions_delete_modal_title": "Abonnement löschen",
+  "streams_subscriptions_delete_modal_content": "Möchten Sie das Abonnement für die Ressource {{resourceName}} wirklich löschen?",
+  "streams_subscriptions_delete_success": "Das Abonnement für die Ressource „{{resourceName}}“ wurde erfolgreich gelöscht.",
+  "streams_subscriptions_delete_error": "Beim Löschen des Abonnements für die Ressource „{{resourceName}}“ ist ein Fehler aufgetreten: {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Webhosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Notify me via email when an automatic scaling occurs.",
   "inputs_logs_edit_min_instance_field": "Minimum number of instances",
   "inputs_logs_edit_max_instance_field": "Maximum number of instances",
-  "inputs_info_ca_certificate": "Certification authority certificate"
+  "inputs_info_ca_certificate": "Certificate authority certificate",
+  "logs_streams_subscriptions": "Subscriptions",
+  "logs_streams_col_subscriptions": "Subscriptions",
+  "streams_subscriptions_current_title": "Manage your subscriptions for the ‘{{ name }}’ data stream",
+  "streams_subscriptions_intro_text": "These subscriptions allow you to retrieve logs of your OVHcloud products from your own data streams.",
+  "streams_subscriptions_resource_type_label": "Service",
+  "streams_subscriptions_resource_name_label": "Service name",
+  "streams_subscriptions_delete_modal_title": "Remove the subscription",
+  "streams_subscriptions_delete_modal_content": "Are you sure you want to delete the resource subscription ‘{{resourceName}}’?",
+  "streams_subscriptions_delete_success": "The subscription to the resource ‘{{resourceName}}’ has been deleted.",
+  "streams_subscriptions_delete_error": "An error occurred while deleting the subscription to the resource ‘{{resourceName}}’: {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Web Hosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Avisarme por correo electrónico cuando se realice un escalado automático.",
   "inputs_logs_edit_min_instance_field": "Número mínimo de instancias",
   "inputs_logs_edit_max_instance_field": "Número máximo de instancias",
-  "inputs_info_ca_certificate": "Certificado de la autoridad de certificación"
+  "inputs_info_ca_certificate": "Certificado de la autoridad de certificación",
+  "logs_streams_subscriptions": "Suscripciones",
+  "logs_streams_col_subscriptions": "Suscripciones",
+  "streams_subscriptions_current_title": "Gestión de sus suscripciones para el flujo «{{ name }}»",
+  "streams_subscriptions_intro_text": "Estas suscripciones le permiten recuperar los logs de sus productos OVHcloud en sus propios flujos de datos.",
+  "streams_subscriptions_resource_type_label": "Servicio",
+  "streams_subscriptions_resource_name_label": "Nombre del servicio",
+  "streams_subscriptions_delete_modal_title": "Eliminar la suscripción",
+  "streams_subscriptions_delete_modal_content": "¿Seguro/a que quiere eliminar la suscripción al recurso «{{resourceName}}»?",
+  "streams_subscriptions_delete_success": "La suscripción al recurso «{{resourceName}}» se ha eliminado correctamente.",
+  "streams_subscriptions_delete_error": "Se ha producido un error al eliminar la suscripción al recurso «{{resourceName}}»: {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Web hosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
@@ -768,5 +768,18 @@
   "logs_tile_subscription_contact_admin": "Administrateur",
   "logs_tile_subscription_contact_billing": "Facturation",
   "logs_tile_subscription_contact_technical": "Technique",
-  "logs_order": "Commander"
+  "logs_order": "Commander",
+  "logs_streams_subscriptions": "Abonnements",
+  "logs_streams_col_subscriptions": "Abonnements",
+  "streams_subscriptions_current_title": "Gestion de vos abonnements pour le flux '{{ name }}'",
+  "streams_subscriptions_intro_text": "Ces abonnements vous permettent de récupérer les logs de vos produits OVHcloud dans vos propres flux de données.",
+  "streams_subscriptions_resource_type_label": "Service",
+  "streams_subscriptions_resource_name_label": "Nom du service",
+  "streams_subscriptions_delete_modal_title": "Supprimer l'abonnement",
+  "streams_subscriptions_delete_modal_content": "Êtes-vous sûr de vouloir supprimer l'abonnement à la ressource {{resourceName}} ?",
+  "streams_subscriptions_delete_success": "L'abonnement à la ressource '{{resourceName}}' a été supprimée avec succès.",
+  "streams_subscriptions_delete_error": "Une erreur est survenue lors de la suppression de l'abonnement à la ressource '{{resourceName}}': {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Web Hosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
@@ -768,5 +768,18 @@
   "logs_tile_subscription_contact_admin": "Administrateur",
   "logs_tile_subscription_contact_billing": "Facturation",
   "logs_tile_subscription_contact_technical": "Technique",
-  "logs_order": "Commander"
+  "logs_order": "Commander",
+  "logs_streams_subscriptions": "Abonnements",
+  "logs_streams_col_subscriptions": "Abonnements",
+  "streams_subscriptions_current_title": "Gestion de vos abonnements pour le flux '{{ name }}'",
+  "streams_subscriptions_intro_text": "Ces abonnements vous permettent de récupérer les logs de vos produits OVHcloud dans vos propres flux de données.",
+  "streams_subscriptions_resource_type_label": "Service",
+  "streams_subscriptions_resource_name_label": "Nom du service",
+  "streams_subscriptions_delete_modal_title": "Supprimer l'abonnement",
+  "streams_subscriptions_delete_modal_content": "Êtes-vous sûr de vouloir supprimer l'abonnement à la ressource {{resourceName}} ?",
+  "streams_subscriptions_delete_success": "L'abonnement à la ressource '{{resourceName}}' a été supprimée avec succès.",
+  "streams_subscriptions_delete_error": "Une erreur est survenue lors de la suppression de l'abonnement à la ressource '{{resourceName}}': {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Web Hosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Ricevere una notifica via email quando viene effettuato uno scaling automatico.",
   "inputs_logs_edit_min_instance_field": "Numero minimo di istanze",
   "inputs_logs_edit_max_instance_field": "Numero massimo di istanze",
-  "inputs_info_ca_certificate": "Certificato dell'autorità di certificazione"
+  "inputs_info_ca_certificate": "Certificato dell'autorità di certificazione",
+  "logs_streams_subscriptions": "Abbonamenti",
+  "logs_streams_col_subscriptions": "Abbonamenti",
+  "streams_subscriptions_current_title": "Gestione degli abbonamenti per il flusso '{{ name }}'",
+  "streams_subscriptions_intro_text": "Questi abbonamenti permettono di recuperare i log dei tuoi prodotti OVHcloud nei flussi di dati.",
+  "streams_subscriptions_resource_type_label": "Servizio",
+  "streams_subscriptions_resource_name_label": "Nome del servizio",
+  "streams_subscriptions_delete_modal_title": "Elimina l'abbonamento",
+  "streams_subscriptions_delete_modal_content": "Vuoi davvero eliminare l'abbonamento alla risorsa {{resourceName}} ?",
+  "streams_subscriptions_delete_success": "L'abbonamento alla risorsa '{{resourceName}}' è stato eliminato correttamente.",
+  "streams_subscriptions_delete_error": "Si è verificato un errore durante l'eliminazione dell'abbonamento alla risorsa '{{resourceName}}': {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Hosting Web",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Powiadom mnie w wiadomości e-mail, jeśli nastąpi automatyczne skalowanie.",
   "inputs_logs_edit_min_instance_field": "Minimalna liczba instancji",
   "inputs_logs_edit_max_instance_field": "Maksymalna liczba instancji",
-  "inputs_info_ca_certificate": "Certyfikat instytucji certyfikującej"
+  "inputs_info_ca_certificate": "Certyfikat urzędu certyfikacji",
+  "logs_streams_subscriptions": "Subskrypcje",
+  "logs_streams_col_subscriptions": "Subskrypcje",
+  "streams_subscriptions_current_title": "Zarządzanie subskrypcjami dla strumienia '{{name}}'",
+  "streams_subscriptions_intro_text": "Subskrypcje te pozwalają na pobieranie logów produktów OVHcloud z Twoich własnych strumieni danych.",
+  "streams_subscriptions_resource_type_label": "Usługa",
+  "streams_subscriptions_resource_name_label": "Nazwa usługi",
+  "streams_subscriptions_delete_modal_title": "Usuń subskrypcję",
+  "streams_subscriptions_delete_modal_content": "Czy na pewno chcesz usunąć subskrypcję zasobu {{resourceName}}?",
+  "streams_subscriptions_delete_success": "Subskrypcja zasobu '{{resourceName}}' została usunięta.",
+  "streams_subscriptions_delete_error": "Wystąpił błąd podczas usuwania subskrypcji zasobu '{{resourceName}}': {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Hosting",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
@@ -768,5 +768,18 @@
   "inputs_autoscaled_notification_detail": "Notificar-me por e-mail quando ocorrer uma escalabilidade automática.",
   "inputs_logs_edit_min_instance_field": "Número mínimo de instâncias",
   "inputs_logs_edit_max_instance_field": "Número máximo de instâncias",
-  "inputs_info_ca_certificate": "Certificado da autoridade de certificação"
+  "inputs_info_ca_certificate": "Certificado da autoridade de certificação",
+  "logs_streams_subscriptions": "Assinaturas",
+  "logs_streams_col_subscriptions": "Assinaturas",
+  "streams_subscriptions_current_title": "Gestão das suas subscrições para o fluxo '{{ name }}'",
+  "streams_subscriptions_intro_text": "Estas subscrições permitem-lhe recuperar os logs dos produtos OVHcloud nos seus próprios fluxos de dados.",
+  "streams_subscriptions_resource_type_label": "Serviço",
+  "streams_subscriptions_resource_name_label": "Nome do serviço",
+  "streams_subscriptions_delete_modal_title": "Eliminar a subscrição",
+  "streams_subscriptions_delete_modal_content": "Tem a certeza de que quer eliminar a subscrição do recurso {{resourceName}}?",
+  "streams_subscriptions_delete_success": "A subscrição do recurso '{{resourceName}}' foi eliminada com sucesso.",
+  "streams_subscriptions_delete_error": "Ocorreu um erro aquando da eliminação da subscrição do recurso '{{resourceName}}': {{message}}",
+  "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
+  "streams_subscriptions_resource_products_webhosting": "Alojamento web",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
 }


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |`develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | OB-5034
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Hello :wave: 

We (Logs Data Platform) are working on a new feature where we'll enable logs observability *inside* OVHcloud products.

The aim for managed products (Web Hosting, Managed Kubernetes Service, CDN etc.) is to allow customer to forward the logs of their managed products inside their own Logs Data Platform stream. Like this customer will be able to orchestrate their OVHcloud products logs, search in their products logs, create dashboard from it etc.

To do so, in each Manager product section (Web Hosting, Managed Kubernetes Service, CDN etc.) customer will have a kind of "Forwards logs to my own LDP stream" button. Once activated, this is create a "logs subscription".

Once done, customer should be able to see all their subscriptions, and should be able to delete them (aka unsubscribe).

This PR bring this last part: list & delete subscriptions in the Logs Data Platform section of the Manager.

Full details about this feature is available in the linked internal ticket