### PR TITLE
feat(dedicated.account): add phone typeand sms consent  to account edition

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -57,6 +57,17 @@ export default class NewAccountFormFieldController {
       });
     }
 
+    // reset sms consent value when phone type is no longer 'mobile'
+    if (this.rule.fieldName === 'smsConsent') {
+      this.$scope.$on('account.smsConsent.reset', () => {
+        // switch value to false only if it is true
+        if (this.value) {
+          this.onChange();
+          this.value = false;
+        }
+      });
+    }
+
     // handle special phone prefix case
     if (this.getFieldType() === 'phone') {
       this.$scope.$watch(
@@ -218,6 +229,9 @@ export default class NewAccountFormFieldController {
     if (this.rule.fieldType) {
       return this.rule.fieldType;
     }
+    if ((this.rule.fieldName || '') === this.FIELD_NAME_LIST.phoneType) {
+      return 'radio';
+    }
     if (this.rule.in) {
       return 'select';
     }
@@ -268,8 +282,11 @@ export default class NewAccountFormFieldController {
       };
     });
 
-    result = this.$filter('orderBy')(result, 'translated', false, (a, b) =>
-      String(a.value).localeCompare(String(b.value)),
+    result = this.$filter('orderBy')(
+      result,
+      'translated',
+      this.rule.fieldName === this.FIELD_NAME_LIST.phoneType,
+      (a, b) => String(a.value).localeCompare(String(b.value)),
     );
 
     // if there is only a single value, auto select it
@@ -345,6 +362,11 @@ export default class NewAccountFormFieldController {
   // true if field is a phone number
   isPhoneNumberField() {
     return ['phone', 'fax'].includes(this.rule.fieldName);
+  }
+
+  shouldDisplayLabel() {
+    const type = this.getFieldType();
+    return type !== 'checkbox' && type !== 'radio';
   }
 
   // callback for when model changed

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -229,7 +229,7 @@ export default class NewAccountFormFieldController {
     if (this.rule.fieldType) {
       return this.rule.fieldType;
     }
-    if ((this.rule.fieldName || '') === this.FIELD_NAME_LIST.phoneType) {
+    if (this.rule.fieldName === this.FIELD_NAME_LIST.phoneType) {
       return 'radio';
     }
     if (this.rule.in) {
@@ -365,8 +365,7 @@ export default class NewAccountFormFieldController {
   }
 
   shouldDisplayLabel() {
-    const type = this.getFieldType();
-    return type !== 'checkbox' && type !== 'radio';
+    return !['checkbox', 'radio'].includes(this.getFieldType());
   }
 
   // callback for when model changed

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.html
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.html
@@ -6,10 +6,7 @@
                     'oui-field_error': $ctrl.isInvalid()
     }"
 >
-    <div
-        class="oui-field__header"
-        data-ng-if="$ctrl.getFieldType() !== 'checkbox'"
-    >
+    <div class="oui-field__header" data-ng-if="$ctrl.shouldDisplayLabel()">
         <label
             class="oui-field__label"
             data-ng-if="$ctrl.rule.fieldName !== 'area'"
@@ -162,11 +159,32 @@
             data-ng-blur="$ctrl.focused = false"
             data-ng-pattern="$ctrl.inputValidator"
             data-ng-required="$ctrl.rule.mandatory"
+            data-disabled="$ctrl.rule.disabled()"
         >
             <span
                 data-translate="{{ 'signup_field_' + $ctrl.rule.displayFieldName | translate }} {{ !$ctrl.rule.mandatory ? 'signup_not_mandatory_field' : '' | translate }}"
             ></span>
         </oui-checkbox>
+
+        <!-- RADIO INPUT -->
+        <oui-radio-group
+            data-ng-if="$ctrl.getFieldType() === 'radio'"
+            data-ng-attr-id="{{ 'ovh_field_' + $ctrl.rule.fieldName }}"
+            data-ng-attr-name="{{ 'ovh_field_' + $ctrl.rule.fieldName }}"
+            data-model="$ctrl.value"
+            data-ng-required="$ctrl.rule.mandatory"
+            data-on-change="$ctrl.onChange()"
+            data-ng-focus="$ctrl.focused = true"
+            data-ng-blur="$ctrl.focused = false"
+        >
+            <oui-radio
+                data-ng-repeat="value in $ctrl.getTranslatedEnums()"
+                data-value="value.key"
+                inline
+            >
+                <span data-ng-bind="value.translated"></span>
+            </oui-radio>
+        </oui-radio-group>
 
         <p
             class="help-block text-danger"

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.html
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.html
@@ -166,7 +166,6 @@
             ></span>
         </oui-checkbox>
 
-        <!-- RADIO INPUT -->
         <oui-radio-group
             data-ng-if="$ctrl.getFieldType() === 'radio'"
             data-ng-attr-id="{{ 'ovh_field_' + $ctrl.rule.fieldName }}"

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
@@ -377,6 +377,11 @@ export const PHONE_PREFIX = {
 
 export const FIELD_WITHOUT_MARGIN_BOTTOM = ['email', 'phoneType', 'phone'];
 
+export const FEATURES = {
+  emailConsent: 'account:email-consent',
+  smsConsent: 'account:sms-consent',
+};
+
 export default {
   ENUM_TRANSLATION_RULES,
   MODEL_DEBOUNCE_DELAY,
@@ -389,4 +394,5 @@ export default {
   CONSENT_MARKETING_EMAIL_NAME,
   FIELD_NAME_LIST,
   FIELD_WITHOUT_MARGIN_BOTTOM,
+  FEATURES,
 };

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
@@ -6,6 +6,7 @@ export const READY_ONLY_RULES_PARAMS = [
   'state',
   'commercialCommunicationsApproval',
   'managerLanguage',
+  'smsConsent',
 ];
 
 export const READY_ONLY_PARAMS = [
@@ -72,8 +73,10 @@ export const SECTIONS = {
     'city',
     'zip',
     'area',
+    'phoneType',
     'phoneCountry',
     'phone',
+    'smsConsent',
     'fax',
   ],
   language: ['language', 'managerLanguage'],
@@ -111,8 +114,10 @@ export const FIELD_NAME_LIST = {
   address: 'address',
   zip: 'zip',
   city: 'city',
+  phoneType: 'phoneType',
   phoneCountry: 'phoneCountry',
   phone: 'phone',
+  smsConsent: 'smsConsent',
   fax: 'fax',
   language: 'language',
   managerLanguage: 'managerLanguage',
@@ -370,6 +375,8 @@ export const PHONE_PREFIX = {
   ZW: '263',
 };
 
+export const FIELD_WITHOUT_MARGIN_BOTTOM = ['email', 'phoneType', 'phone'];
+
 export default {
   ENUM_TRANSLATION_RULES,
   MODEL_DEBOUNCE_DELAY,
@@ -381,4 +388,5 @@ export default {
   PHONE_PREFIX,
   CONSENT_MARKETING_EMAIL_NAME,
   FIELD_NAME_LIST,
+  FIELD_WITHOUT_MARGIN_BOTTOM,
 };

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_de_DE.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "Westbengalen",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Ihr Update wurde registriert."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Ihr Update wurde registriert.",
+  "signup_enum_phoneType_landline": "Festnetz",
+  "signup_enum_phoneType_mobile": "Mobil",
+  "signup_field_smsConsent": "Ich bin damit einverstanden, SMS zu Neuheiten und kommerziellen Angeboten von OVHcloud zu erhalten"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "West Bengal",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Your update has been processed."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Your update has been processed.",
+  "signup_enum_phoneType_landline": "Landline",
+  "signup_enum_phoneType_mobile": "Mobile",
+  "signup_field_smsConsent": "I agree to receive SMS messages regarding OVHcloud news and commercial offers"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_es_ES.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "West Bengal",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "La actualización se ha registrado correctamente."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "La actualización se ha registrado correctamente.",
+  "signup_enum_phoneType_landline": "Fijo",
+  "signup_enum_phoneType_mobile": "Móvil",
+  "signup_field_smsConsent": "Acepto recibir SMS sobre las novedades y ofertas comerciales de OVHcloud."
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -44,6 +44,7 @@
   "signup_field_timezone": "Fuseau horaire",
   "signup_field_customerCode": "Code client",
   "signup_field_italianSDI": "Numéro SDI",
+  "signup_field_smsConsent": "J'accepte de recevoir des SMS relatifs aux nouveautés et offres commerciales d'OVHcloud",
   "signup_field_required_error": "Veuillez compléter ce champ.",
   "signup_field_pattern_error": "Veuillez saisir un format valide.",
   "signup_enum_legalform_association": "Association",
@@ -759,5 +760,7 @@
   "signup_enum_IN_area_IN-TR": "Tripura",
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
-  "signup_enum_IN_area_IN-WB": "West Bengal"
+  "signup_enum_IN_area_IN-WB": "West Bengal",
+  "signup_enum_phoneType_landline": "Fixe",
+  "signup_enum_phoneType_mobile": "Mobile"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -44,6 +44,7 @@
   "signup_field_timezone": "Fuseau horaire",
   "signup_field_customerCode": "Code client",
   "signup_field_italianSDI": "Numéro SDI",
+  "signup_field_smsConsent": "J'accepte de recevoir des SMS relatifs aux nouveautés et offres commerciales d'OVHcloud",
   "signup_field_required_error": "Veuillez compléter ce champ.",
   "signup_field_pattern_error": "Veuillez saisir un format valide.",
   "signup_enum_legalform_association": "Association",
@@ -759,5 +760,7 @@
   "signup_enum_IN_area_IN-TR": "Tripura",
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
-  "signup_enum_IN_area_IN-WB": "West Bengal"
+  "signup_enum_IN_area_IN-WB": "West Bengal",
+  "signup_enum_phoneType_landline": "Fixe",
+  "signup_enum_phoneType_mobile": "Mobile"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_it_IT.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "Bengala Occidentale",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "L'aggiornamento è stato registrato correttamente."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "L'aggiornamento è stato registrato correttamente.",
+  "signup_enum_phoneType_landline": "Fisso",
+  "signup_enum_phoneType_mobile": "Cellulare",
+  "signup_field_smsConsent": "Accetto di ricevere SMS relativi a novità e offerte commerciali di OVHcloud"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pl_PL.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "Bengal Zachodni ",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Aktualizacja została przyjęta."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "Aktualizacja została przyjęta.",
+  "signup_enum_phoneType_landline": "Telefon stacjonarny",
+  "signup_enum_phoneType_mobile": "Telefon komórkowy",
+  "signup_field_smsConsent": "Wyrażam zgodę na otrzymywanie wiadomości SMS dotyczących nowości i ofert handlowych OVHcloud."
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pt_PT.json
@@ -759,5 +759,8 @@
   "signup_enum_IN_area_IN-UP": "Uttar Pradesh",
   "signup_enum_IN_area_IN-UT": "Uttarakhand",
   "signup_enum_IN_area_IN-WB": "West Bengal",
-  "signup_field_add_companyNationalIdentificationNumber_siret_success": "A sua atualização foi devidamente tida em conta."
+  "signup_field_add_companyNationalIdentificationNumber_siret_success": "A sua atualização foi devidamente tida em conta.",
+  "signup_enum_phoneType_landline": "Fixo",
+  "signup_enum_phoneType_mobile": "Telemóvel",
+  "signup_field_smsConsent": "Aceito receber SMS relativos às novidades e ofertas comerciais da OVHcloud"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.service.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.service.js
@@ -58,12 +58,7 @@ export default class UserAccountInfosService {
   }
 
   fetchMarketingConsentDecision() {
-    return this.$http.get('/me/marketing').then((response) => {
-      if (response.status < 300) {
-        return response.data;
-      }
-      return this.$q.reject(response);
-    });
+    return this.$http.get('/me/marketing').then((response) => response.data);
   }
 
   updateSmsMarketingConsentDecision(value) {

--- a/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.service.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.service.js
@@ -57,6 +57,27 @@ export default class UserAccountInfosService {
       });
   }
 
+  fetchMarketingConsentDecision() {
+    return this.$http.get('/me/marketing').then((response) => {
+      if (response.status < 300) {
+        return response.data;
+      }
+      return this.$q.reject(response);
+    });
+  }
+
+  updateSmsMarketingConsentDecision(value) {
+    return this.$http.put('/me/marketing', {
+      denyAll: false,
+      sms: {
+        events: value,
+        newProductRecommendation: value,
+        newsletter: value,
+        offerAndDiscount: value,
+      },
+    });
+  }
+
   fetchConsentDecision(campaignName) {
     return this.$http
       .get(


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-11435
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

Adding phone type and sms consent to account edition screen

## Related

- [x] TRANS-52589
