### PR TITLE
fix(pci.octavia): change breadcrumb to use breadcrumb prefix

### DIFF
--- a/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.service.js
+++ b/packages/components/ng-ui-router-breadcrumb/src/ng-ui-router-breadcrumb.service.js
@@ -26,8 +26,8 @@ export default class BreadcrumbService {
         this.breadcrumb = [];
 
         while (state.parent && !hideBreadcrumb) {
-          const breadcrumbUrlResolvable = state.resolvables.find(
-            (resolvable) => resolvable.token === 'breadcrumbUrl',
+          const breadcrumbPrefixResolvable = state.resolvables.find(
+            (resolvable) => resolvable.token === 'breadcrumbPrefix',
           );
           const breadcrumbResolvable = state.resolvables.find(
             (resolvable) => resolvable.token === 'breadcrumb',
@@ -58,15 +58,19 @@ export default class BreadcrumbService {
                 );
               }
             });
+          }
 
-            if (breadcrumbUrlResolvable) {
-              transition
-                .injector(state.name)
-                .getAsync('breadcrumbUrl')
-                .then((url) => {
-                  entry.url = url;
+          if (breadcrumbPrefixResolvable) {
+            transition
+              .injector(state.name)
+              .getAsync('breadcrumbPrefix')
+              .then(({ name, url }) => {
+                this.breadcrumb.unshift({
+                  name,
+                  url,
+                  active: false,
                 });
-            }
+              });
           }
 
           state = state.parent.self.$$state();

--- a/packages/manager/apps/octavia-load-balancer/package.json
+++ b/packages/manager/apps/octavia-load-balancer/package.json
@@ -25,6 +25,7 @@
     "@ovh-ux/manager-error-page": "^2.3.1",
     "@ovh-ux/manager-ng-layout-helpers": "^2.6.1",
     "@ovh-ux/manager-octavia-load-balancer": "^0.0.0 || ^1.0.0",
+    "@ovh-ux/ng-at-internet": "^5.10.3",
     "@ovh-ux/ng-ovh-api-wrappers": "^5.0.0",
     "@ovh-ux/ng-ovh-http": "^5.0.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.1.7",

--- a/packages/manager/modules/octavia-load-balancer/src/octavia-load-balancer.routing.js
+++ b/packages/manager/modules/octavia-load-balancer/src/octavia-load-balancer.routing.js
@@ -8,26 +8,35 @@ export default /* @ngInject */ ($stateProvider) => {
         $transition$.params().projectId,
       project: /* @ngInject */ ($http, projectId) =>
         $http.get(`/cloud/project/${projectId}`).then(({ data }) => data),
-      breadcrumb: (project) =>
-        project.status !== 'creating' ? project.description : null,
-      breadcrumbUrl: /* @ngInject */ (
+      breadcrumb: ($translate) => $translate.instant('octavia_load_balancer'),
+      breadcrumbPrefix: /* @ngInject */ (
         $injector,
         $q,
         coreURLBuilder,
-        projectId,
+        project,
       ) => {
         if ($injector.has('shellClient')) {
           return $injector
             .get('shellClient')
-            .navigation.getURL('public-cloud', `#/pci/projects/${projectId}`)
-            .then((url) => url);
+            .navigation.getURL(
+              'public-cloud',
+              `#/pci/projects/${project.project_id}`,
+            )
+            .then((url) => {
+              return {
+                name:
+                  project.status !== 'creating' ? project.description : null,
+                url,
+              };
+            });
         }
-        return $q.when(
-          coreURLBuilder.buildURL(
+        return $q.when({
+          name: 'projectNAME',
+          url: coreURLBuilder.buildURL(
             'public-cloud',
-            `#/pci/projects/${projectId}`,
+            `#/pci/projects/${project.project_id}`,
           ),
-        );
+        });
       },
     },
   });

--- a/packages/manager/modules/octavia-load-balancer/src/onboarding/routing.js
+++ b/packages/manager/modules/octavia-load-balancer/src/onboarding/routing.js
@@ -5,7 +5,7 @@ export default /* @ngInject */ ($stateProvider) => {
     url: '/onboarding',
     component: 'octaviaLoadBalancerOnboarding',
     resolve: {
-      breadcrumb: ($translate) => $translate.instant('octavia_load_balancer'),
+      breadcrumb: () => null,
     },
     atInternet: {
       rename: TRACKING_NAME,


### PR DESCRIPTION
ref: MANAGER-11944

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/lbaas-octavia`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-11944
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Update octavia parent state to works with the new breadcrumb as breadcrumbUrl is replaced by breadcrumbPrefix

## Related

breaking change from https://github.com/ovh/manager/pull/9668
