### PR TITLE
feat(iam): restrict number of selections of resources on create

### DIFF
--- a/packages/manager/modules/iam/src/components/resourceSelect/resourceSelect.controller.js
+++ b/packages/manager/modules/iam/src/components/resourceSelect/resourceSelect.controller.js
@@ -149,6 +149,11 @@ export default class ResourceSelectController {
    * @param {Object} value
    */
   onResourcesChanged(value) {
+    // #MANAGER-11336: As backend only allow 10 resources, we limit it
+    this.form[this.resourcesName].$setValidity(
+      'limit',
+      this.model.selection.length <= 10,
+    );
     if (this.onChange) {
       this.onModelChanged();
       this.onChange({ change: { type: 'resources', value } });

--- a/packages/manager/modules/iam/src/components/resourceSelect/resourceSelect.template.html
+++ b/packages/manager/modules/iam/src/components/resourceSelect/resourceSelect.template.html
@@ -40,7 +40,8 @@
             class="w-100"
             data-label="{{:: $ctrl.resourcesLabel }}"
             data-error-messages="{
-                required: $ctrl.resourcesRequiredMessage || ('iam_resource_select_resources_error_required' | translate)
+                required: $ctrl.resourcesRequiredMessage || ('iam_resource_select_resources_error_required' | translate),
+                limit: $ctrl.resourcesLimitMessage || ('iam_resource_select_resources_error_limit' | translate),
             }"
         >
             <oui-select

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_de_DE.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_de_DE.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Wählen Sie mindestens einen Produkttyp aus.",
   "iam_resource_select_resource_types_error_resources": "Für diese Produkttypen sind keine Ressourcen verfügbar.",
-  "iam_resource_select_resources_error_required": "Wählen Sie mindestens eine Ressource aus"
+  "iam_resource_select_resources_error_required": "Wählen Sie mindestens eine Ressource aus.",
+  "iam_resource_select_resources_error_limit": "Sie können nicht mehr als 10 Ressourcen pro Richtlinie auswählen."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_en_GB.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_en_GB.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Please select one or more product types.",
   "iam_resource_select_resource_types_error_resources": "No resources are available for this product type.",
-  "iam_resource_select_resources_error_required": "Please select one or more resources"
+  "iam_resource_select_resources_error_required": "Please select one or more resources",
+  "iam_resource_select_resources_error_limit": "You cannot select more than 10 resources per policy."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_es_ES.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_es_ES.json
@@ -1,5 +1,6 @@
 {
-  "iam_resource_select_resource_types_error_required": "Seleccione uno o más tipos de producto.",
-  "iam_resource_select_resource_types_error_resources": "No hay recursos disponibles para estos tipos de productos.",
-  "iam_resource_select_resources_error_required": "Seleccione uno o varios recursos"
+  "iam_resource_select_resource_types_error_required": "Seleccione uno o más tipos de productos.",
+  "iam_resource_select_resource_types_error_resources": "No hay recursos disponibles para este tipo de productos.",
+  "iam_resource_select_resources_error_required": "Seleccione uno o varios recursos",
+  "iam_resource_select_resources_error_limit": "No es posible seleccionar más de diez recursos por política."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_fr_CA.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Veuillez sélectionner un ou plusieurs types de produits.",
   "iam_resource_select_resource_types_error_resources": "Aucune ressource n'est disponible pour ce ou ces types de produits.",
-  "iam_resource_select_resources_error_required": "Veuillez sélectionner une ou plusieurs ressources"
+  "iam_resource_select_resources_error_required": "Veuillez sélectionner une ou plusieurs ressources",
+  "iam_resource_select_resources_error_limit": "Vous ne pouvez pas sélectionner plus de 10 ressources par politique."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_fr_FR.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Veuillez sélectionner un ou plusieurs types de produits.",
   "iam_resource_select_resource_types_error_resources": "Aucune ressource n'est disponible pour ce ou ces types de produits.",
-  "iam_resource_select_resources_error_required": "Veuillez sélectionner une ou plusieurs ressources"
+  "iam_resource_select_resources_error_required": "Veuillez sélectionner une ou plusieurs ressources",
+  "iam_resource_select_resources_error_limit": "Vous ne pouvez pas sélectionner plus de 10 ressources par politique."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_it_IT.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_it_IT.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Seleziona uno o più tipi di prodotto.",
   "iam_resource_select_resource_types_error_resources": "Nessuna risorsa disponibile per questi tipi di prodotto.",
-  "iam_resource_select_resources_error_required": "Seleziona una o più risorse"
+  "iam_resource_select_resources_error_required": "Seleziona una o più risorse",
+  "iam_resource_select_resources_error_limit": "Non è possibile selezionare più di 10 risorse per politica."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_pl_PL.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Wybierz jeden lub kilka rodzajów usług.",
   "iam_resource_select_resource_types_error_resources": "Brak dostępnych zasobów dla tego lub tych typów usługów.",
-  "iam_resource_select_resources_error_required": "Wybierz jeden lub kilka zasobów"
+  "iam_resource_select_resources_error_required": "Wybierz jeden lub kilka zasobów",
+  "iam_resource_select_resources_error_limit": "Nie możesz wybrać więcej niż 10 zasobów per polityka."
 }

--- a/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/iam/src/components/resourceSelect/translations/Messages_pt_PT.json
@@ -1,5 +1,6 @@
 {
   "iam_resource_select_resource_types_error_required": "Selecione um ou vários tipos de produtos.",
   "iam_resource_select_resource_types_error_resources": "Não existem recursos disponíveis para este ou estes tipos de produtos.",
-  "iam_resource_select_resources_error_required": "Selecione um ou vários recursos"
+  "iam_resource_select_resources_error_required": "Selecione um ou vários recursos",
+  "iam_resource_select_resources_error_limit": "Não pode selecionar mais de 10 recursos por política."
 }


### PR DESCRIPTION
ref: MANAGER-11336

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-11336
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Add a limitation of 10 selectable resources while create an IAM policy

## Related

- [x] CMT-2988
