### PR TITLE
fix(dedicated.nutanix): hide pack type from cluster info view

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/component/licence-tile/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/component/licence-tile/component.js
@@ -8,6 +8,7 @@ export default {
     licenceName: '<',
     onError: '&?',
     packType: '<',
+    showPackType: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/component/licence-tile/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/component/licence-tile/template.html
@@ -3,7 +3,10 @@
     data-heading="{{:: 'nutanix_cluster_licence_title' | translate }}"
     data-loading="$ctrl.loadingTechnicalDetails"
 >
-    <oui-tile-definition term="{{$ctrl.packType}}"> </oui-tile-definition>
+    <oui-tile-definition
+        data-ng-if="$ctrl.showPackType"
+        term="{{$ctrl.packType}}"
+    ></oui-tile-definition>
     <oui-tile-definition
         data-ng-repeat="licence in $ctrl.licences.getFeatures() | limitTo: ($ctrl.expand ? $ctrl.licences.getFeatures().length : $ctrl.defaultLicenseLength) track by licence.name"
     >

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/component.js
@@ -18,6 +18,7 @@ export default {
     nutanixPlans: '<',
     getTechnicalDetails: '<',
     isOldCluster: '<',
+    isPackTypeAvailable: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/constants.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/constants.js
@@ -26,6 +26,10 @@ export const GENERAL_INFO_TILE_TITLE = {
 
 export const NUTANIX_PERSONAL_LICENSE_EDITION = 'Personal license';
 
+export const FEATURES = {
+  PACK_TYPE: 'nutanix:pack-type',
+};
+
 export default {
   TRAVAUX_LINK,
   PRIVATE_BANDWIDTH_SERVICE_PREFIX,
@@ -34,4 +38,5 @@ export default {
   NUTANIX_INVOICE_TYPE,
   NUTANIX_PERSONAL_LICENSE_EDITION,
   GENERAL_INFO_TILE_TITLE,
+  FEATURES,
 };

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/routing.js
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/routing.js
@@ -1,3 +1,5 @@
+import { FEATURES } from './constants';
+
 const STATUS_DONE = 'DONE';
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('nutanix.dashboard.general-info', {
@@ -44,6 +46,13 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.go('nutanix.dashboard.general-info.redeploy'),
       breadcrumb: /* @ngInject */ ($translate) =>
         $translate.instant('nutanix_dashboard_general_info'),
+      isPackTypeAvailable: /* @ngInject */ (ovhFeatureFlipping) =>
+        ovhFeatureFlipping
+          .checkFeatureAvailability([FEATURES.PACK_TYPE])
+          .then((featureAvailability) =>
+            featureAvailability.isFeatureAvailable(FEATURES.PACK_TYPE),
+          )
+          .catch(() => false),
     },
     atInternet: {
       rename: 'hpc::nutanix::cluster::dashboard',

--- a/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/general-info/template.html
@@ -97,6 +97,7 @@
             <!-- type of pack -->
             <oui-tile-definition
                 term="{{:: 'nutanix_dashboard_cluster_type_of_pack' | translate }}"
+                data-ng-if="$ctrl.isPackTypeAvailable"
             >
                 <oui-tile-description>
                     <span data-ng-bind="$ctrl.typeOfPack"></span>
@@ -182,6 +183,7 @@
             service-id="$ctrl.serviceInfo.serviceId"
             licence-name="$ctrl.cluster.targetSpec.license"
             pack-type="$ctrl.typeOfPack"
+            show-pack-type="$ctrl.isPackTypeAvailable"
             on-error="$ctrl.handleError(error)"
         >
         </nutanix-licence-tile>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/nutanix-us`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-12071
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Hidding pack type on cluster info view

## Related
