### PR TITLE
feat(dedicated): create dedicated server bandwidth tile component

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
@@ -124,27 +124,16 @@
     </div>
 
     <div class="col-md-4 mb-5">
-        <oui-tile
-            class="h-100"
-            data-heading="{{:: 'dedicated_server_interfaces_bandwith_title' | translate}}"
-            data-description="{{:: 'dedicated_server_interfaces_bandwith_description' | translate }}"
+        <server-bandwidth-tile
+            data-bandwidth-option="$ctrl.bandwidthOption"
+            data-bandwidth-vrack-option="$ctrl.bandwidthVrackOptions"
+            data-bandwidth-vrack-order-option="$ctrl.bandwidthVrackOrderOptions"
+            data-order-private-link="$ctrl.orderPrivateBandwidthLink"
+            data-order-public-link="$ctrl.orderPublicBandwidthLink"
+            data-server="$ctrl.server"
+            data-specifications="$ctrl.specifications"
         >
-            <oui-message data-type="warning">
-                <span
-                    data-translate="dedicated_server_interfaces_bandwith_ola_warning"
-                ></span>
-            </oui-message>
-            <server-bandwidth-dashboard
-                data-bandwidth-option="$ctrl.bandwidthOption"
-                data-bandwidth-vrack-option="$ctrl.bandwidthVrackOptions"
-                data-bandwidth-vrack-order-option="$ctrl.bandwidthVrackOrderOptions"
-                data-order-private-link="$ctrl.orderPrivateBandwidthLink"
-                data-order-public-link="$ctrl.orderPublicBandwidthLink"
-                data-server="$ctrl.server"
-                data-specifications="$ctrl.specifications"
-            >
-            </server-bandwidth-dashboard>
-        </oui-tile>
+        </server-bandwidth-tile>
     </div>
 </div>
 

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.module.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.module.js
@@ -1,3 +1,4 @@
+import { serverBandwidthTile } from '@ovh-ux/manager-bm-server-components';
 import interfaceAttach from './attach/interfaces-attach.module';
 import interfaceDetach from './detach/interfaces-detach.module';
 import interfaceRename from './rename/interfaces-rename.module';
@@ -25,6 +26,7 @@ angular
     olaPendingTask,
     'ovh-api-services',
     'ui.router',
+    serverBandwidthTile,
   ])
   .component('dedicatedServerInterfaces', component)
   .component('olaStepChecker', stepCheckerComponent)

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/translations/Messages_fr_FR.json
@@ -79,11 +79,6 @@
   "dedicated_server_interfaces_detach_private_network_text": "Êtes-vous sûr de vouloir détacher le vrack «{{vrack}}» de l'interface «{{interface}}» ?",
   "dedicated_server_interfaces_resiliate_label": "Résilier",
 
-  "dedicated_server_interfaces_bandwith_title": "Bande passante",
-  "dedicated_server_interfaces_bandwith_description": "La bande passante publique (depuis et vers internet) n’est pas limitée en entrée. Vous pouvez augmenter la bande passante publique et privée en souscrivant à une option",
-  "dedicated_server_interfaces_bandwith_ola_warning": "Dans le cadre d’une configuration agrégation privée complète, votre option de bande passante sortante publique ne sera pas utilisée du fait que l’interface dédiée au réseau public sera utilisée pour le réseau privé.",
-  "dedicated_server_interfaces_bandwith_public": "Bande passante publique",
-  "dedicated_server_interfaces_bandwith_private": "Bande passante privée",
   "dedicated_server_interfaces_task_error": "Une erreur est survenue lors de la configuration : {{ errorMessage }}",
   "dedicated_server_interfaces_vrack_operation_attach": "En cours d’attachement",
   "dedicated_server_interfaces_vrack_operation_detach": "En cours de détachement",

--- a/packages/manager/modules/bm-server-components/src/bandwidth-tile/component.js
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-tile/component.js
@@ -1,0 +1,14 @@
+import template from './template.html';
+
+export default {
+  template,
+  bindings: {
+    server: '<',
+    bandwidth0ption: '<',
+    bandwidthVrackOption: '<',
+    bandwidthVrackOrderOption: '<',
+    orderPrivateLink: '<',
+    orderPublicLink: '<',
+    specifications: '<',
+  },
+};

--- a/packages/manager/modules/bm-server-components/src/bandwidth-tile/index.js
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-tile/index.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+
+import '@ovh-ux/ui-kit';
+import 'angular-translate';
+import '@ovh-ux/ng-translate-async-loader';
+import ngAtInternet from '@ovh-ux/ng-at-internet';
+import serverBandwidthDashboard from '../bandwidth-dashboard';
+import component from './component';
+
+const moduleName = 'ovhManagerBmServerComponentsBandwidthTileComponent';
+
+angular
+  .module(moduleName, [
+    ngAtInternet,
+    'oui',
+    'pascalprecht.translate',
+    'ngTranslateAsyncLoader',
+    serverBandwidthDashboard,
+  ])
+  .component('serverBandwidthTile', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/bm-server-components/src/bandwidth-tile/template.html
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-tile/template.html
@@ -1,0 +1,21 @@
+<oui-tile
+    class="h-100"
+    data-heading="{{:: 'dedicated_server_interfaces_bandwidth_title' | translate}}"
+    data-description="{{:: 'dedicated_server_interfaces_bandwidth_description' | translate }}"
+>
+    <oui-message data-type="warning">
+        <span
+            data-translate="dedicated_server_interfaces_bandwidth_ola_warning"
+        ></span>
+    </oui-message>
+    <server-bandwidth-dashboard
+        data-bandwidth-option="$ctrl.bandwidthOption"
+        data-bandwidth-vrack-option="$ctrl.bandwidthVrackOptions"
+        data-bandwidth-vrack-order-option="$ctrl.bandwidthVrackOrderOptions"
+        data-order-private-link="$ctrl.orderPrivateLink"
+        data-order-public-link="$ctrl.orderPublicLink"
+        data-server="$ctrl.server"
+        data-specifications="$ctrl.specifications"
+    >
+    </server-bandwidth-dashboard>
+</oui-tile>

--- a/packages/manager/modules/bm-server-components/src/bandwidth-tile/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-tile/translations/Messages_fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "dedicated_server_interfaces_bandwidth_title": "Bande passante",
+  "dedicated_server_interfaces_bandwidth_description": "La bande passante publique (depuis et vers internet) n'est pas limitée en entrée. Vous pouvez augmenter la bande passante publique et privée en souscrivant à une option",
+  "dedicated_server_interfaces_bandwidth_ola_warning": "Dans le cadre d'une configuration agrégation privée complète, votre option de bande passante sortante publique ne sera pas utilisée du fait que l'interface dédiée au réseau public sera utilisée pour le réseau privé."
+}

--- a/packages/manager/modules/bm-server-components/src/index.js
+++ b/packages/manager/modules/bm-server-components/src/index.js
@@ -9,3 +9,4 @@ export { default as serverNetwork } from './network-tile';
 export { default as serverTechnicalDetails } from './technical-details';
 export { default as serverOrderPrivateBandwidth } from './order-private-bandwidth';
 export { default as serverBandwidthDashboard } from './bandwidth-dashboard';
+export { default as serverBandwidthTile } from './bandwidth-tile';


### PR DESCRIPTION
ref: MANAGER-12285

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/multi-az_network-interfaces-refactor`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-12285
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Refactor network interfaces for dedicated servers. Move network bandwidth tile to a reusable component

## Related

<!-- Link dependencies of this PR -->
