### PR TITLE
feat(dedicated): hide carbon calculator cta when no data

### DIFF
--- a/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/component.js
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/component.js
@@ -3,6 +3,9 @@ import template from './template.html';
 import 'font-awesome/css/font-awesome.css';
 
 export default {
+  bindings: {
+    hasInvoice: '<',
+  },
   controller,
   template,
 };

--- a/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/constants.js
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/constants.js
@@ -4,7 +4,11 @@ export const TASK_STATUS_ENUM = {
   SUCCESS: 'SUCCESS',
 };
 
-export const API_PATH = '/me/carbonCalculator/task';
+export const API_ROOT_PATH = '/me/carbonCalculator/';
+
+export const INVOICE_API_PATH = `${API_ROOT_PATH}invoice`;
+
+export const TASK_API_PATH = `${API_ROOT_PATH}task`;
 
 export const TRACKING_NAME = 'dedicated::account::carbon_consumption';
 
@@ -12,7 +16,8 @@ export const API_FETCH_INTERVAL = 3000;
 
 export default {
   TASK_STATUS_ENUM,
-  API_PATH,
+  INVOICE_API_PATH,
+  TASK_API_PATH,
   API_FETCH_INTERVAL,
   TRACKING_NAME,
 };

--- a/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/service.js
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/service.js
@@ -1,4 +1,4 @@
-import { API_PATH } from './constants';
+import { INVOICE_API_PATH, TASK_API_PATH } from './constants';
 
 export default class CarbonFootprintService {
   /* @ngInject */
@@ -23,7 +23,9 @@ export default class CarbonFootprintService {
   }
 
   getTask(taskID) {
-    return this.$http.get(`${API_PATH}/${taskID}`).then(({ data }) => data);
+    return this.$http
+      .get(`${TASK_API_PATH}/${taskID}`)
+      .then(({ data }) => data);
   }
 
   computeBilling() {
@@ -31,10 +33,17 @@ export default class CarbonFootprintService {
     const now = new Date();
     now.setUTCDate(0); // sets the date to the last date of the previous month
     const date = now.toISOString().substring(0, 10);
-    return this.$http.post(API_PATH, { date }).then(({ data }) => data);
+    return this.$http.post(TASK_API_PATH, { date }).then(({ data }) => data);
   }
 
   downloadBilling(url) {
     this.$window.location = url;
+  }
+
+  hasInvoice() {
+    return this.$http
+      .get(INVOICE_API_PATH)
+      .then(({ data }) => data.hasInvoice)
+      .catch(() => false);
   }
 }

--- a/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/template.html
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/carbon-footprint/template.html
@@ -7,6 +7,7 @@
         data-variant="primary"
         data-on-click="$ctrl.computeBilling()"
         data-disabled="$ctrl.$asyncFetching"
+        data-ng-if="$ctrl.hasInvoice"
     >
         <oui-spinner
             data-size="s"

--- a/packages/manager/modules/carbon-calculator/src/dashboard/component.js
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/component.js
@@ -4,6 +4,7 @@ export default {
   bindings: {
     currentActiveLink: '<',
     dashboardLink: '<',
+    hasInvoice: '<',
   },
   template,
 };

--- a/packages/manager/modules/carbon-calculator/src/dashboard/routing.js
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/routing.js
@@ -9,6 +9,8 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href($state.current.name, $transition$.params()),
       dashboardLink: /* @ngInject */ ($state) => $state.href('app.dashboard'),
       breadcrumb: () => null,
+      hasInvoice: /* @ngInject */ (carbonFootprintService) =>
+        carbonFootprintService.hasInvoice(),
     },
     atInternet: {
       rename: TRACKING_NAME,

--- a/packages/manager/modules/carbon-calculator/src/dashboard/template.html
+++ b/packages/manager/modules/carbon-calculator/src/dashboard/template.html
@@ -8,5 +8,5 @@
         data-translate="carbon_calculator_dashboard_carbon_footprint_explanation"
     ></p>
     <carbon-balance-composition></carbon-balance-composition>
-    <carbon-footprint></carbon-footprint>
+    <carbon-footprint data-has-invoice="$ctrl.hasInvoice"></carbon-footprint>
 </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12356
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Hide the download carbon footprint when no data are available

## Related
