### PR TITLE
feat(web.hosting): change the order of DBMS versions for webcloud DB

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/database/order/public/components/steps/db-categories-offers/controller.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order/public/components/steps/db-categories-offers/controller.js
@@ -17,18 +17,14 @@ export default class WebHostingDatabaseOrderComponentsDbCategoriesOffersControll
   }
 
   getDbEngines() {
-    const engines = this.model.dbCategory?.selectVersion?.engines;
-    if (engines && engines.length) {
-      angular.forEach(engines, (engine) => {
-        engine.versions.sort((a, b) => {
-          // Order versions in descending order
-          return b.dbVersion.localeCompare(a.dbVersion, undefined, {
-            numeric: true,
-          });
+    return this.model.dbCategory?.selectVersion?.engines?.map((engine) => {
+      engine.versions.sort((a, b) => {
+        // Order versions in descending order
+        return b.dbVersion.localeCompare(a.dbVersion, undefined, {
+          numeric: true,
         });
       });
-    }
-    return engines || [];
+    });
   }
 
   getDbVersionPrice(dbCategoryVersion) {

--- a/packages/manager/apps/web/client/app/hosting/database/order/public/components/steps/db-categories-offers/controller.js
+++ b/packages/manager/apps/web/client/app/hosting/database/order/public/components/steps/db-categories-offers/controller.js
@@ -17,7 +17,18 @@ export default class WebHostingDatabaseOrderComponentsDbCategoriesOffersControll
   }
 
   getDbEngines() {
-    return this.model.dbCategory?.selectVersion?.engines || [];
+    const engines = this.model.dbCategory?.selectVersion?.engines;
+    if (engines && engines.length) {
+      angular.forEach(engines, (engine) => {
+        engine.versions.sort((a, b) => {
+          // Order versions in descending order
+          return b.dbVersion.localeCompare(a.dbVersion, undefined, {
+            numeric: true,
+          });
+        });
+      });
+    }
+    return engines || [];
   }
 
   getDbVersionPrice(dbCategoryVersion) {


### PR DESCRIPTION
ref: MANAGER-12098

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `new-web-hosting-b2`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12098
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Put database technology versions in descending order for web cloud databases

## Related

<!-- Link dependencies of this PR -->
