### PR TITLE
feat(tracking): remove "Full URL" property encoding

### DIFF
--- a/packages/components/ng-at-internet-ui-router-plugin/src/index.js
+++ b/packages/components/ng-at-internet-ui-router-plugin/src/index.js
@@ -32,12 +32,10 @@ angular
             const ignore = options && options.ignore;
             const trackPage = {};
             if (atInternetUiRouterPlugin.isStateTrackEnabled() && !ignore) {
-              trackPage.pageUrl = encodeURIComponent(
-                transition.router.stateService.href(
-                  state.name,
-                  transition.params(),
-                  { absolute: true },
-                ),
+              trackPage.pageUrl = transition.router.stateService.href(
+                state.name,
+                transition.params(),
+                { absolute: true },
               );
               trackPage.name = state.name;
               if (options) {

--- a/packages/components/ovh-at-internet/src/ovh-at-internet.ts
+++ b/packages/components/ovh-at-internet/src/ovh-at-internet.ts
@@ -71,7 +71,7 @@ export default class OvhAtInternet extends OvhAtInternetConfig {
       ...customProps,
       country: params.subsidiary,
       website: AT_INTERNET_WEBSITE[params.subsidiary],
-      full_url: data.pageUrl || encodeURIComponent(window.top.location.href),
+      full_url: data.pageUrl || window.top.location.href,
       site_name_1: params.siteName,
       site_level2: AT_INTERNET_LEVEL2[params.level2] || '',
       user_agent: params.userAgent || window.navigator.userAgent,
@@ -347,7 +347,6 @@ export default class OvhAtInternet extends OvhAtInternetConfig {
           'atinternet.trackImpression missing data attribute: ',
           data,
         );
-        return;
       }
     } else {
       this.trackQueue.push({ type: 'trackImpression', data });
@@ -363,7 +362,6 @@ export default class OvhAtInternet extends OvhAtInternetConfig {
           'atinternet.trackClickImpression missing data attribute: ',
           data,
         );
-        return;
       }
     } else {
       this.trackQueue.push({ type: 'trackClickImpression', data });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-11714
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

On the tracking side, removal of the encoding of the 'full_url' property. It contains the full URL of the current page.

## Related

<!-- Link dependencies of this PR -->
