### PR TITLE
fix(dedicated.nutanix): node guide link incorrect in nutanix node

### DIFF
--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/constants.js
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/constants.js
@@ -6,7 +6,8 @@ export const DEDICATED_SERVER_GUIDE = {
   IT: 'https://docs.ovh.com/it/dedicated/',
   PL: 'https://docs.ovh.com/pl/dedicated/',
   PT: 'https://docs.ovh.com/pt/dedicated/',
-  US: 'https://docs.ovh.com/us/es/dedicated/',
+  US:
+    'https://support.us.ovhcloud.com/hc/en-us/categories/115000423390-Dedicated-Servers',
   CA: 'https://docs.ovh.com/ca/en/dedicated/',
   QC: 'https://docs.ovh.com/ca/fr/dedicated/',
   AU: 'https://docs.ovh.com/au/en/dedicated/',


### PR DESCRIPTION
ref: MANAGER-12251

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     |no
| Breaking change? |no
| Tickets          | Fix MANAGER-12251
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

node guide link incorrect in nutanix node in US scope

## Related

<!-- Link dependencies of this PR -->
