### PR TITLE
fix(ldp): handle resource name

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.controller.js
@@ -1,3 +1,4 @@
+import startCase from 'lodash/startCase';
 import datagridToIcebergFilter from '../../logs-iceberg.utils';
 
 export default class LogsStreamsSubscriptionsCtrl {
@@ -31,6 +32,17 @@ export default class LogsStreamsSubscriptionsCtrl {
         this.LogsStreamsService.getStream(this.serviceName, this.streamId),
     });
     this.stream.load();
+  }
+
+  getResourceName(subscription) {
+    const key = `streams_subscriptions_resource_products_${subscription.resource.type}`;
+    const translated = this.$translate.instant(key);
+    if (translated === key) {
+      return startCase(
+        subscription.resource.type.replace('-', ' ').toLowerCase(),
+      );
+    }
+    return translated;
   }
 
   /**

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/subscriptions/streams-subscriptions.html
@@ -36,10 +36,7 @@
             data-searchable
             data-filterable
         >
-            <span>
-                {{ ::'streams_subscriptions_resource_products_' +
-                $row.resource.type | translate }}
-            </span>
+            <span data-ng-bind=":: $ctrl.getResourceName($row)"> </span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title="::'logs_col_last_modified' | translate"

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Beim Löschen des Abonnements für die Ressource „{{resourceName}}“ ist ein Fehler aufgetreten: {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Webhosting",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "streams_subscriptions_resource_products_account-api": "OVHcloud Kundencenter und OVHcloud API",
+  "streams_subscriptions_resource_products_account-audit": "OVHcloud Audit-Logs"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "An error occurred while deleting the subscription to the resource ‘{{resourceName}}’: {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "streams_subscriptions_resource_products_account-api": "OVHcloud &amp; OVHcloud API Control Panel",
+  "streams_subscriptions_resource_products_account-audit": "OVHcloud Logs Audit"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Se ha producido un error al eliminar la suscripción al recurso «{{resourceName}}»: {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Web hosting",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
+  "streams_subscriptions_resource_products_account-api": "Área de cliente OVHcloud y API OVHcloud",
+  "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Une erreur est survenue lors de la suppression de l'abonnement à la ressource '{{resourceName}}': {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
+  "streams_subscriptions_resource_products_account-api": "Espace client OVHcloud & OVHcloud API",
+  "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Une erreur est survenue lors de la suppression de l'abonnement à la ressource '{{resourceName}}': {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
+  "streams_subscriptions_resource_products_account-api": "Espace client OVHcloud & OVHcloud API",
+  "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Si è verificato un errore durante l'eliminazione dell'abbonamento alla risorsa '{{resourceName}}': {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Hosting Web",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
+  "streams_subscriptions_resource_products_account-api": "Spazio Cliente OVHcloud e API OVHcloud",
+  "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Wystąpił błąd podczas usuwania subskrypcji zasobu '{{resourceName}}': {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Hosting",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "streams_subscriptions_resource_products_account-api": "Panel klienta OVHcloud &amp; OVHcloud API",
+  "streams_subscriptions_resource_products_account-audit": "Audyt logów OVHcloud"
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
@@ -781,5 +781,7 @@
   "streams_subscriptions_delete_error": "Ocorreu um erro aquando da eliminação da subscrição do recurso '{{resourceName}}': {{message}}",
   "streams_subscriptions_resource_products_ldp": "Logs Data Platform",
   "streams_subscriptions_resource_products_webhosting": "Alojamento web",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
+  "streams_subscriptions_resource_products_account-api": "Área de Cliente OVHcloud &amp; OVHcloud API",
+  "streams_subscriptions_resource_products_account-audit": "Auditoria Logs OVHcloud"
 }


### PR DESCRIPTION
ref: OB-5258

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #OB-5258
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated, because already made here: https://github.com/ovh/manager/pull/10111
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

We expect to have new units to forward their logs anytime. Actually, the way that the related resource is translated on subscription page display a raw key not user friendly.

translation : 
- [x] CMT-4796

fork of: https://github.com/ovh/manager/pull/10111