### PR TITLE
feat(telecom.voip): add banner to customers with a mgcp phone

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/line-main.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/line-main.html
@@ -19,6 +19,21 @@
             </div>
         </header>
 
+        <oui-message
+            data-type="warning"
+            data-ng-if="LineCtrl.displayMgcpBanner"
+        >
+            <span
+                data-translate="telephony_line_mgcp_banner_description"
+            ></span>
+            <a
+                class="oui-link_icon"
+                data-ng-href="{{:: LineCtrl.orderPhoneLink}}"
+            >
+                <span data-translate="telephony_line_mgcp_banner_link"> </span>
+            </a>
+        </oui-message>
+
         <!-- LINE ACTIONS -->
         <oui-header-tabs>
             <oui-header-tabs-item

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/line.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/line.controller.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import { PHONE_PROTOCOL } from './phone/order/choice/choice.constant';
 
 export default /* @ngInject */ function TelecomTelephonyLineCtrl(
   $q,
@@ -13,6 +14,7 @@ export default /* @ngInject */ function TelecomTelephonyLineCtrl(
   faxLink,
   lineLink,
   phoneLink,
+  orderPhoneLink,
   shellClient,
   TelephonyMediator,
   tonesLink,
@@ -28,6 +30,7 @@ export default /* @ngInject */ function TelecomTelephonyLineCtrl(
   self.line = null;
   self.fax = null;
   self.links = null;
+  self.displayMgcpBanner = false;
 
   self.lineLink = lineLink;
   self.currentActiveLink = currentActiveLink;
@@ -36,6 +39,7 @@ export default /* @ngInject */ function TelecomTelephonyLineCtrl(
   self.tonesLink = tonesLink;
   self.answerLink = answerLink;
   self.phoneLink = phoneLink;
+  self.orderPhoneLink = orderPhoneLink;
   self.assistLink = assistLink;
   self.contactLink = contactLink;
   self.faxLink = faxLink;
@@ -94,6 +98,13 @@ export default /* @ngInject */ function TelecomTelephonyLineCtrl(
         promises.push(
           self.line.getConvertionTask().then((task) => {
             self.converting = task;
+          }),
+        );
+
+        promises.push(
+          self.line.getPhone().then(() => {
+            self.displayMgcpBanner =
+              self.line.phone.protocol === PHONE_PROTOCOL.MGCP;
           }),
         );
 

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/line.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/line.routing.js
@@ -111,6 +111,11 @@ export default /* @ngInject */ ($stateProvider) => {
           'telecom.telephony.billingAccount.line.dashboard.phone',
           $transition$.params(),
         ),
+      orderPhoneLink: /* @ngInject */ ($state, $transition$) =>
+        $state.href(
+          'telecom.telephony.billingAccount.line.dashboard.phone.order',
+          $transition$.params(),
+        ),
       assistLink: /* @ngInject */ ($state, $transition$) =>
         $state.href(
           'telecom.telephony.billingAccount.line.dashboard.assist',

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_de_DE.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "Vous pouvez annuler en cliquant ici.",
   "telephony_line_convert_date": "Cette ligne sera convertie en numéro le {{ date }}.",
   "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
-  "telephony_line_breacrumb": "Leitungen"
+  "telephony_line_breacrumb": "Leitungen",
+  "telephony_line_mgcp_banner_link": "Klicken Sie hier.",
+  "telephony_line_mgcp_banner_description": "Das verwendete MGCP-Terminal ist veraltet: Bitte ersetzen Sie das Terminal."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_en_GB.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "You can cancel by clicking here.",
   "telephony_line_convert_date": "This line will be converted into a number on {{ date }}.",
   "telephony_line_convert_link": "You can cancel in the next section.",
-  "telephony_line_breacrumb": "Lines"
+  "telephony_line_breacrumb": "Lines",
+  "telephony_line_mgcp_banner_link": "Click here.",
+  "telephony_line_mgcp_banner_description": "The MGCP terminal used is deprecated: please replace the terminal."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_es_ES.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "Puede cancelar haciendo clic aquí.",
   "telephony_line_convert_date": "Esta línea se convertirá en número el {{ date }}.",
   "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
-  "telephony_line_breacrumb": "Líneas"
+  "telephony_line_breacrumb": "Líneas",
+  "telephony_line_mgcp_banner_link": "Haga clic aquí.",
+  "telephony_line_mgcp_banner_description": "El terminal MGCP utilizado está obsoleto. Por favor, sustituya el terminal."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_fr_CA.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_date": "Le service expire le {{date}}.",
   "telephony_line_expire_link": "Vous pouvez annuler en cliquant ici.",
   "telephony_line_convert_date": "Cette ligne sera convertie en numéro le {{ date }}.",
-  "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante."
+  "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
+  "telephony_line_mgcp_banner_link": "Cliquez ici.",
+  "telephony_line_mgcp_banner_description": "Le terminal MGCP utilisé est déprécié : veuillez effectuer un remplacement de terminal."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_fr_FR.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_date": "Le service expire le {{date}}.",
   "telephony_line_expire_link": "Vous pouvez annuler en cliquant ici.",
   "telephony_line_convert_date": "Cette ligne sera convertie en numéro le {{ date }}.",
-  "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante."
+  "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
+  "telephony_line_mgcp_banner_link": "Cliquez ici.",
+  "telephony_line_mgcp_banner_description": "Le terminal MGCP utilisé est déprécié : veuillez effectuer un remplacement de terminal."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_it_IT.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "Per annullare, clicca qui.",
   "telephony_line_convert_date": "Questa linea sarà convertita in numero il {{ date }}.",
   "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
-  "telephony_line_breacrumb": "Linee"
+  "telephony_line_breacrumb": "Linee",
+  "telephony_line_mgcp_banner_link": "Cliccare qui.",
+  "telephony_line_mgcp_banner_description": "Il terminale MGCP utilizzato è obsoleto: effettuare una sostituzione del terminale."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_pl_PL.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "Możesz anulować kilkając tutaj.",
   "telephony_line_convert_date": "Cette ligne sera convertie en numéro le {{ date }}.",
   "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
-  "telephony_line_breacrumb": "Linie telefoniczne"
+  "telephony_line_breacrumb": "Linie telefoniczne",
+  "telephony_line_mgcp_banner_link": "Kliknij tutaj.",
+  "telephony_line_mgcp_banner_description": "Użyty terminal MGCP jest przestarzały: prosimy o wymianę terminala."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/translations/Messages_pt_PT.json
@@ -16,5 +16,7 @@
   "telephony_line_expire_link": "Vous pouvez annuler en cliquant ici.",
   "telephony_line_convert_date": "Cette ligne sera convertie en numéro le {{ date }}.",
   "telephony_line_convert_link": "Vous pourrez annuler dans la section suivante.",
-  "telephony_line_breacrumb": "Linhas"
+  "telephony_line_breacrumb": "Linhas",
+  "telephony_line_mgcp_banner_link": "Clique aqui.",
+  "telephony_line_mgcp_banner_description": "O terminal MGCP utilizado está desvalorizado: queira efetuar uma substituição do terminal."
 }


### PR DESCRIPTION
ref: MANAGER-12253

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? |no
| Tickets          | Feat MANAGER-12253
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

when consulting a line, add banner if the line's phone's protocol is mgcp, with an orderPhoneLink

## Related

<!-- Link dependencies of this PR -->
