### PR TITLE
feat(octavia): adding listener deletion modale

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/component.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/component.js
@@ -1,11 +1,12 @@
-import controller from './edit-name.controller';
-import template from './edit-name.html';
+import controller from './controller';
+import template from './template.html';
 
 export default {
   bindings: {
     projectId: '<',
-    loadbalancer: '<',
     region: '<',
+    listenerId: '<',
+    listenerName: '<',
     goBack: '<',
     trackAction: '<',
     trackPage: '<',

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/controller.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/controller.js
@@ -1,0 +1,51 @@
+export default class OctaviaLoadBalancerDeleteCtrl {
+  /* @ngInject */
+  constructor(Alerter, $translate, OctaviaLoadBalancerListenersService) {
+    this.isLoading = false;
+    this.Alerter = Alerter;
+    this.$translate = $translate;
+    this.OctaviaLoadBalancerListenersService = OctaviaLoadBalancerListenersService;
+  }
+
+  cancel() {
+    this.trackAction(`cancel`);
+    this.goBack();
+  }
+
+  delete() {
+    this.isLoading = true;
+    this.trackAction(`confirm`);
+    this.OctaviaLoadBalancerListenersService.deleteListener(
+      this.projectId,
+      this.region,
+      this.listenerId,
+    )
+      .then(() => {
+        this.trackPage(`success`);
+        this.Alerter.set(
+          'alert-success',
+          this.$translate.instant(
+            'octavia_load_balancer_listener_delete_success',
+            { listener: this.listenerName },
+          ),
+          null,
+          'octavia.alerts.global',
+        );
+        this.goBack(true);
+      })
+      .catch((error) => {
+        this.trackPage(`error`);
+        this.Alerter.error(
+          this.$translate.instant('octavia_load_balancer_global_error', {
+            message: error.data.message,
+            requestId: error.config.headers['X-OVH-MANAGER-REQUEST-ID'],
+          }),
+          'octavia.alerts.global',
+        );
+        this.goBack();
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+}

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/index.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/index.js
@@ -1,0 +1,24 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerOctaviaLoadbalancerListenerDeleteLazyloading';
+
+angular.module(moduleName, ['oc.lazyLoad', 'ui.router']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state(
+      'octavia-load-balancer.loadbalancer.listeners.list.delete.**',
+      {
+        url: '/delete',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+          return import('./module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      },
+    );
+  },
+);
+
+export default moduleName;

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/module.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/module.js
@@ -1,0 +1,16 @@
+import angular from 'angular';
+
+import '@ovh-ux/ng-ui-router-layout';
+
+import component from './component';
+import routing from './routing';
+
+const moduleName = 'ovhManagerOctaviaLoadbalancerListenerDeleteModule';
+
+angular
+  .module(moduleName, ['ngUiRouterLayout'])
+  .config(routing)
+  .component('octaviaLoadBalancerListenerDelete', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/routing.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/routing.js
@@ -1,0 +1,44 @@
+import { TRACKING_CHAPTER_1, TRACKING_NAME } from '../../constants';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state(
+    'octavia-load-balancer.loadbalancer.listeners.list.delete',
+    {
+      url: '/delete?listenerId&listenerName',
+      views: {
+        modal: {
+          component: 'octaviaLoadBalancerListenerDelete',
+        },
+      },
+      layout: 'modal',
+      resolve: {
+        breadcrumb: () => null,
+        listenerId: /* @ngInject */ ($transition$) =>
+          $transition$.params().listenerId,
+        listenerName: /* @ngInject */ ($transition$) =>
+          $transition$.params().listenerName,
+        goBack: /* @ngInject */ ($state) => (reload) =>
+          $state.go(
+            'octavia-load-balancer.loadbalancer.listeners.list',
+            {},
+            reload
+              ? { reload: 'octavia-load-balancer.loadbalancer.listeners.list' }
+              : null,
+          ),
+        trackBase: () => `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::delete`,
+        trackAction: /* @ngInject */ (atInternet, trackBase) => (hit) =>
+          atInternet.trackClick({
+            name: `${trackBase}::${hit}`,
+            type: 'action',
+          }),
+        trackPage: /* @ngInject */ (atInternet, trackBase) => (hit) =>
+          atInternet.trackPage({
+            name: `${trackBase}-${hit}`,
+          }),
+      },
+      atInternet: {
+        rename: `${TRACKING_NAME}::delete`,
+      },
+    },
+  );
+};

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/template.html
@@ -1,0 +1,15 @@
+<oui-modal
+    data-on-dismiss="$ctrl.cancel()"
+    data-primary-action="$ctrl.delete()"
+    data-secondary-action="$ctrl.cancel()"
+    data-type="info"
+    data-loading="$ctrl.isLoading"
+    data-primary-label="{{:: 'octavia_load_balancer_listener_delete_confirm' | translate }}"
+    data-secondary-label="{{:: 'octavia_load_balancer_listener_delete_cancel' | translate }}"
+    data-heading="{{:: 'octavia_load_balancer_listener_delete_title' | translate }}"
+>
+    <p
+        data-translate="octavia_load_balancer_listener_delete_description"
+        data-translate-values="{ listener: $ctrl.listenerName }"
+    ></p>
+</oui-modal>

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/delete/translations/Messages_fr_FR.json
@@ -1,0 +1,6 @@
+{
+  "octavia_load_balancer_listener_delete_title": "Supprimer un listener",
+  "octavia_load_balancer_listener_delete_description": "Vous allez définitivement supprimer \"{{listener}}\" avec sa configuration.",
+  "octavia_load_balancer_listener_delete_cancel": "Annuler",
+  "octavia_load_balancer_listener_delete_confirm": "Supprimer"
+}

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/component.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     listeners: '<',
     goToListenerCreation: '<',
+    goToListenerDeletion: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/routing.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/routing.js
@@ -27,6 +27,18 @@ export default /* @ngInject */ ($stateProvider) => {
         });
         $state.go('octavia-load-balancer.loadbalancer.listeners.create');
       },
+      goToListenerDeletion: /* @ngInject */ ($state, atInternet) => (
+        listener,
+      ) => {
+        atInternet.trackClick({
+          name: `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::delete`,
+          type: 'action',
+        });
+        $state.go('octavia-load-balancer.loadbalancer.listeners.list.delete', {
+          listenerId: listener.id,
+          listenerName: listener.name,
+        });
+      },
     },
     atInternet: {
       rename: `${TRACKING_NAME}::${TRACKING_SUFFIX}`,

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/list/template.html
@@ -78,13 +78,12 @@
         ></span>
     </oui-datagrid-column>
     <oui-action-menu compact data-placement="end">
-        <oui-action-menu-item
-            data-on-click="$ctrl.goToListenerFromElipsis($row)"
+        <oui-action-menu-item data-on-click="$ctrl.goToListener($row)"
             ><span
                 data-translate="octavia_load_balancer_listeners_actions_detail"
             ></span>
         </oui-action-menu-item>
-        <oui-action-menu-item data-on-click="$ctrl.deleteListener($row)"
+        <oui-action-menu-item data-on-click="$ctrl.goToListenerDeletion($row)"
             ><span
                 data-translate="octavia_load_balancer_listeners_actions_delete"
             ></span>

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/module.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/module.js
@@ -6,11 +6,12 @@ import service from './service';
 
 import list from './list';
 import create from './create';
+import deletion from './delete';
 
 const moduleName = 'ovhManagerOctaviaLoadBalancerListeners';
 
 angular
-  .module(moduleName, [list, create])
+  .module(moduleName, [list, create, deletion])
   .config(routing)
   .component('octaviaLoadBalancerListeners', component)
   .service('OctaviaLoadBalancerListenersService', service)

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/service.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/service.js
@@ -25,6 +25,12 @@ export default class OctaviaLoadBalancerListenersService {
     );
   }
 
+  deleteListener(projectId, region, listenerId) {
+    return this.$http.delete(
+      `/cloud/project/${projectId}/region/${region}/loadbalancing/listener/${listenerId}`,
+    );
+  }
+
   getListeners(projectId, region, loadbalancerId) {
     return this.$http
       .get(

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_fr_FR.json
@@ -27,5 +27,6 @@
   "octavia_load_balancer_listeners_operating_status_online": "online",
   "octavia_load_balancer_listeners_operating_status_offline": "offline",
   "octavia_load_balancer_listeners_actions_detail": "Editer/Voir",
-  "octavia_load_balancer_listeners_actions_delete": "Supprimer"
+  "octavia_load_balancer_listeners_actions_delete": "Supprimer",
+  "octavia_load_balancer_listener_delete_success": "Votre listener {{ listener }} a été supprimé avec succès."
 }

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/overview/edit-name/edit-name.controller.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/overview/edit-name/edit-name.controller.js
@@ -12,12 +12,12 @@ export default class OctaviaLoadBalancerEditNameCtrl {
   }
 
   cancel() {
-    this.trackAction('::cancel');
+    this.trackAction('cancel');
     this.goBack();
   }
 
   update() {
-    this.trackAction('::confirm');
+    this.trackAction('confirm');
     this.isLoading = true;
     this.OctaviaLoadBalancerService.updateName(
       this.projectId,
@@ -26,7 +26,7 @@ export default class OctaviaLoadBalancerEditNameCtrl {
       this.name,
     )
       .then(() => {
-        this.trackAction('-success');
+        this.trackPage('success');
         this.Alerter.set(
           'alert-success',
           this.$translate.instant('octavia_load_balancer_edit_name_success'),
@@ -36,7 +36,7 @@ export default class OctaviaLoadBalancerEditNameCtrl {
         this.goBack(true);
       })
       .catch((error) => {
-        this.trackAction('-error');
+        this.trackPage('error');
         this.Alerter.error(
           this.$translate.instant('octavia_load_balancer_global_error', {
             message: error.data?.message,

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/overview/edit-name/edit-name.routing.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/overview/edit-name/edit-name.routing.js
@@ -19,10 +19,15 @@ export default /* @ngInject */ ($stateProvider) => {
             {},
             reload ? { reload: 'octavia-load-balancer.loadbalancer' } : null,
           ),
-        trackAction: /* @ngInject */ (atInternet) => (hit) =>
+        trackBase: () => `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::rename`,
+        trackAction: /* @ngInject */ (atInternet, trackBase) => (hit) =>
           atInternet.trackClick({
-            name: `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::rename${hit}`,
+            name: `${trackBase}::${hit}`,
             type: 'action',
+          }),
+        trackPage: /* @ngInject */ (atInternet, trackBase) => (hit) =>
+          atInternet.trackPage({
+            name: `${trackBase}-${hit}`,
           }),
       },
       atInternet: {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? |no
| Tickets          | MANAGER-12229
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Adding a modal to delete a listener and fixing incorrect tracking for loadbalancer name edition.

## Related
