### PR TITLE
fix(web): allow both scroll right and down

### DIFF
--- a/packages/manager/apps/web/client/app/css/less/common/modal.less
+++ b/packages/manager/apps/web/client/app/css/less/common/modal.less
@@ -1,0 +1,4 @@
+.modal-scroll-auto {
+  overflow: auto;
+  max-height: 50svh;
+}

--- a/packages/manager/apps/web/client/app/css/source.less
+++ b/packages/manager/apps/web/client/app/css/source.less
@@ -14,6 +14,7 @@
 @import 'less/common/icon';
 @import 'less/common/incident';
 @import 'less/common/microsoft';
+@import 'less/common/modal';
 @import 'less/common/navbar';
 @import 'less/common/progress';
 @import 'less/common/selectList';

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
@@ -126,13 +126,12 @@
                     data-on-dismiss="$ctrl.closeVisualizeDnsPopup()"
                 >
                     <oui-spinner ng-if="$ctrl.loadingDnsZoneData"></oui-spinner>
-                    <p
-                        style="white-space: pre-wrap;overflow: auto;max-height: 50vh"
+                    <div
+                        style="white-space: pre-wrap;"
                         ng-if="!$ctrl.loadingDnsZoneData"
-                        class="mb-0"
-                    >
-                        {{ $ctrl.dnsZoneData }}
-                    </p>
+                        class="modal-scroll-auto"
+                        ng-bind-html="$ctrl.dnsZoneData"
+                    ></div>
                 </oui-modal>
             </div>
         </div>

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
@@ -126,13 +126,13 @@
                     data-on-dismiss="$ctrl.closeVisualizeDnsPopup()"
                 >
                     <oui-spinner ng-if="$ctrl.loadingDnsZoneData"></oui-spinner>
-                    <div
-                        style="white-space: pre-wrap;"
+                    <p
+                        style="white-space: pre-wrap;overflow: auto;max-height: 50vh"
                         ng-if="!$ctrl.loadingDnsZoneData"
                         class="mb-0"
                     >
                         {{ $ctrl.dnsZoneData }}
-                    </div>
+                    </p>
                 </oui-modal>
             </div>
         </div>


### PR DESCRIPTION
  ref: MANAGER-12658

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/view-dns-history-MANAGER-12199`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-12658
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)

## Description

Add both scroll right and down for big dns zone texts

## Related

<!-- Link dependencies of this PR -->

