### PR TITLE
feat(web): allow both clic and escape for modals

### DIFF
--- a/packages/manager/apps/web/client/app/css/less/common/modal.less
+++ b/packages/manager/apps/web/client/app/css/less/common/modal.less
@@ -1,4 +1,0 @@
-.modal-scroll-auto {
-  overflow: auto;
-  max-height: 50svh;
-}

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.component.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.component.js
@@ -7,5 +7,7 @@ export default {
   bindings: {
     goBack: '<',
     goToDiffViewer: '<',
+    goToDnsRestore: '<',
+    goToDnsData: '<',
   },
 };

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.controller.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.controller.js
@@ -24,47 +24,8 @@ export default class DomainDnsZoneHistoryDashboardController {
     this.coreConfig = coreConfig;
   }
 
-  closeVisualizeDnsPopup() {
-    this.vizualizeDnsZoneDataPopup = false;
-  }
-
   checkTwoElementsAreSelected() {
     return this.dnsEntriesForComparison.filter((u) => u.active).length === 2;
-  }
-
-  visualizeDnsDataInPopup(url) {
-    this.loadingDnsZoneData = true;
-    this.DNSZoneService.getDnsFile(url)
-      .then((res) => {
-        this.dnsZoneData = res;
-        this.loadingDnsZoneData = false;
-      })
-      .catch(({ message }) => {
-        this.Alerter.error(
-          this.$translate.instant('dashboard_history_error', { message }),
-        );
-      });
-    this.vizualizeDnsZoneDataPopup = true;
-  }
-
-  closeDnsRestorePopup() {
-    this.vizualizeDnsRestorePopup = false;
-  }
-
-  openModalDnsRestore(creationDate) {
-    this.chosenDateForRestoreDns = creationDate;
-    this.vizualizeDnsRestorePopup = true;
-  }
-
-  confirmRestoreDnsAtDate(creationDate) {
-    this.DNSZoneService.restore(this.zoneId, creationDate)
-      .catch(({ data: { message } }) => {
-        this.Alerter.error(
-          this.$translate.instant('dashboard_history_error', { message }),
-          'dnsZoneAlert',
-        );
-      })
-      .finally(() => this.closeDnsRestorePopup());
   }
 
   downloadDnsZoneFile(url) {
@@ -122,8 +83,6 @@ export default class DomainDnsZoneHistoryDashboardController {
     this.loadingDnsZoneData = false;
     this.zoneId = '';
     this.loading = true;
-    this.vizualizeDnsZoneDataPopup = false;
-    this.vizualizeDnsRestorePopup = false;
 
     this.zoneId = this.$stateParams.productId;
     this.getZoneHistory(this.$stateParams.productId)

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/dashboard.html
@@ -10,8 +10,6 @@
     </oui-button>
 </div>
 
-<div data-ovh-alert="dnsZoneAlert"></div>
-
 <div class="row table-responsive">
     <table class="table table-hover">
         <thead>
@@ -69,7 +67,7 @@
                         type="button"
                         data-oui-tooltip="{{:: 'dashboard_history_view_zone' | translate }}"
                         aria-label="{{:: 'dashboard_history_view_zone' | translate }}"
-                        data-ng-click="$ctrl.visualizeDnsDataInPopup(dnsZone.zoneFileUrl)"
+                        data-ng-click="$ctrl.goToDnsData(dnsZone.zoneFileUrl)"
                     >
                         <span
                             style="font-size: 24px;"
@@ -100,7 +98,7 @@
                         type="button"
                         aria-label="{{:: 'dashboard_history_restore' | translate }}"
                         data-oui-tooltip="{{:: 'dashboard_history_restore' | translate }}"
-                        data-ng-click="$ctrl.openModalDnsRestore(dnsZone.creationDate)"
+                        data-ng-click="$ctrl.goToDnsRestore(dnsZone.zoneFileUrl, dnsZone.creationDate)"
                     >
                         <span
                             style="font-size: 24px;"
@@ -112,61 +110,4 @@
             </tr>
         </tbody>
     </table>
-</div>
-
-<div data-ng-if="$ctrl.vizualizeDnsZoneDataPopup">
-    <div class="modal d-block" role="dialog" id="modal-dns-zone-data">
-        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-            <div class="modal-content">
-                <oui-modal
-                    data-heading="{{:: 'dashboard_history_popup_title' | translate }}"
-                    data-primary-action="$ctrl.closeVisualizeDnsPopup()"
-                    data-primary-label="{{:: 'dashboard_history_close_popup' | translate }}"
-                    data-secondary-disabled="true"
-                    data-on-dismiss="$ctrl.closeVisualizeDnsPopup()"
-                >
-                    <oui-spinner ng-if="$ctrl.loadingDnsZoneData"></oui-spinner>
-                    <div
-                        style="white-space: pre-wrap;"
-                        ng-if="!$ctrl.loadingDnsZoneData"
-                        class="modal-scroll-auto"
-                        ng-bind-html="$ctrl.dnsZoneData"
-                    ></div>
-                </oui-modal>
-            </div>
-        </div>
-    </div>
-    <div class="oui-modal-backdrop"></div>
-</div>
-
-<div data-ng-if="$ctrl.vizualizeDnsRestorePopup">
-    <div class="modal d-block" role="dialog" id="modal-dns-zone-data">
-        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-            <div class="modal-content">
-                <oui-modal
-                    heading="{{:: 'dashboard_history_restore_modal_title' | translate }}"
-                    primary-action="$ctrl.confirmRestoreDnsAtDate($ctrl.chosenDateForRestoreDns)"
-                    primary-label="{{ :: 'dashboard_history_restore_modal_primary_label' | translate }}"
-                    secondary-action="$ctrl.closeDnsRestorePopup()"
-                    secondary-label="{{ :: 'dashboard_history_restore_modal_secondary_label' | translate }}"
-                    on-dismiss="$ctrl.closeDnsRestorePopup()"
-                >
-                    <p
-                        data-ng-bind-html="'dashboard_history_restore_modal_content' | translate: { date: $ctrl.chosenDateForRestoreDns }"
-                    ></p>
-                    <div
-                        class="alert alert-warning"
-                        role="alert"
-                        data-ng-bind-html="'dashboard_history_restore_modal_warning_message' | translate"
-                    ></div>
-                    <div
-                        class="alert alert-info"
-                        role="alert"
-                        data-ng-bind-html="'dashboard_history_restore_modal_info_message' | translate"
-                    ></div>
-                </oui-modal>
-            </div>
-        </div>
-    </div>
-    <div class="oui-modal-backdrop"></div>
 </div>

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.component.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.component.js
@@ -1,0 +1,12 @@
+import controller from './restore.controller';
+import template from './restore.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    goBack: '<',
+    zoneId: '<',
+    chosenDate: '<',
+  },
+};

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.constants.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.constants.js
@@ -1,0 +1,4 @@
+export const ALERT_DNS_RESTORE_ID = 'dnsZoneAlert';
+export default {
+  ALERT_DNS_RESTORE_ID,
+};

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.controller.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.controller.js
@@ -1,0 +1,21 @@
+import { ALERT_DNS_RESTORE_ID } from './restore.constants';
+
+export default class RestoreDnsZoneController {
+  /* @ngInject */
+  constructor($translate, Alerter, DNSZoneService) {
+    this.DNSZoneService = DNSZoneService;
+    this.Alerter = Alerter;
+    this.$translate = $translate;
+  }
+
+  confirmRestoreDnsAtDate() {
+    return this.DNSZoneService.restore(this.zoneId, this.chosenDate)
+      .then(() => this.goBack())
+      .catch(({ data: { message } }) =>
+        this.Alerter.error(
+          this.$translate.instant('dashboard_history_error', { message }),
+          ALERT_DNS_RESTORE_ID,
+        ),
+      );
+  }
+}

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.html
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/restore/restore.html
@@ -1,0 +1,22 @@
+<oui-modal
+    data-heading="{{:: 'dashboard_history_restore_modal_title' | translate }}"
+    data-primary-action="$ctrl.confirmRestoreDnsAtDate()"
+    data-primary-label="{{ :: 'dashboard_history_restore_modal_primary_label' | translate }}"
+    data-secondary-action="$ctrl.goBack()"
+    data-secondary-label="{{ :: 'dashboard_history_restore_modal_secondary_label' | translate }}"
+    data-on-dismiss="$ctrl.goBack()"
+>
+    <p
+        data-translate="dashboard_history_restore_modal_content"
+        data-translate-values="{ date: $ctrl.chosenDate }"
+    ></p>
+    <oui-message type="warning">
+        <p data-translate="dashboard_history_restore_modal_warning_message"></p>
+    </oui-message>
+
+    <oui-message type="info">
+        <p data-translate="dashboard_history_restore_modal_info_message"></p>
+    </oui-message>
+
+    <div data-ovh-alert="dnsZoneAlert"></div>
+</oui-modal>

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.component.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.component.js
@@ -1,0 +1,12 @@
+import controller from './view.controller';
+import template from './view.html';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    url: '<',
+    goBack: '<',
+    getDnsZoneData: '<',
+  },
+};

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.controller.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.controller.js
@@ -1,0 +1,17 @@
+export default class ViewDnsZoneController {
+  $onInit() {
+    this.dnsZoneData = null;
+    this.loadingDnsZoneData = true;
+
+    this.getDnsZoneData(this.url)
+      .then((res) => {
+        this.dnsZoneData = res;
+      })
+      .catch(() => {
+        this.goBack();
+      })
+      .finally(() => {
+        this.loadingDnsZoneData = false;
+      });
+  }
+}

--- a/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.html
+++ b/packages/manager/apps/web/client/app/dns-zone/history/dashboard/view/view.html
@@ -1,0 +1,10 @@
+<oui-modal
+    data-heading="{{:: 'dashboard_history_popup_title' | translate }}"
+    data-primary-action="$ctrl.goBack()"
+    data-primary-label="{{:: 'dashboard_history_close_popup' | translate }}"
+    data-secondary-disabled="true"
+    data-on-dismiss="$ctrl.goBack()"
+    data-loading="$ctrl.loadingDnsZoneData"
+>
+    <pre data-ng-bind="$ctrl.dnsZoneData"></pre>
+</oui-modal>

--- a/packages/manager/apps/web/client/app/dns-zone/history/history.module.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/history.module.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import 'angular-translate';
 import componentDiff from './dns-zone-diff-tool-viewer/history.component';
 import componentDashboard from './dashboard/dashboard.component';
+import zoneHistoryView from './dashboard/view/view.component';
+import zoneHistoryRestore from './dashboard/restore/restore.component';
 import routing from './history.routing';
 
 const moduleName = 'ovhManagerWebDomainZoneHistoryModule';
@@ -10,6 +12,8 @@ angular
   .module(moduleName, ['oui', 'pascalprecht.translate'])
   .component('domainZoneDashboardHistory', componentDashboard)
   .component('domainZoneDiffToolViewerHistory', componentDiff)
+  .component('zoneHistoryView', zoneHistoryView)
+  .component('zoneHistoryRestore', zoneHistoryRestore)
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);
 

--- a/packages/manager/apps/web/client/app/dns-zone/history/history.routing.js
+++ b/packages/manager/apps/web/client/app/dns-zone/history/history.routing.js
@@ -21,6 +21,47 @@ export default /* @ngInject */ ($stateProvider) => {
       productId: null,
     },
   });
+  $stateProvider.state('app.zone.details.zone-history.view', {
+    url: '/view',
+    layout: { name: 'modal', keyboard: true },
+    views: {
+      modal: {
+        component: 'zoneHistoryView',
+      },
+    },
+    params: {
+      url: {
+        type: 'string',
+        value: null,
+      },
+    },
+    resolve: {
+      url: /* @ngInject */ ($stateParams) => $stateParams.url,
+      goBack: /* @ngInject */ ($state) => () => $state.go('^'),
+      getDnsZoneData: /* @ngInject */ (DNSZoneService) => (url) =>
+        DNSZoneService.getDnsFile(url),
+    },
+  });
+  $stateProvider.state('app.zone.details.zone-history.restore', {
+    url: '/restore',
+    layout: { name: 'modal', keyboard: true },
+    views: {
+      modal: {
+        component: 'zoneHistoryRestore',
+      },
+    },
+    params: {
+      chosenDate: {
+        type: 'string',
+        value: null,
+      },
+    },
+    resolve: {
+      chosenDate: /* @ngInject */ ($stateParams) => $stateParams.chosenDate,
+      zoneId: /* @ngInject */ ($stateParams) => $stateParams.productId,
+      goBack: /* @ngInject */ ($state) => () => $state.go('^'),
+    },
+  });
   $stateProvider.state('app.zone.details.zone-history', {
     url: '/zone-history',
     views: {
@@ -30,6 +71,13 @@ export default /* @ngInject */ ($stateProvider) => {
     },
     resolve: {
       ...commonResolves,
+      goToDnsData: /* @ngInject */ ($state) => (url) =>
+        $state.go('app.zone.details.zone-history.view', { url }),
+      goToDnsRestore: /* @ngInject */ ($state) => (url, chosenDate) =>
+        $state.go('app.zone.details.zone-history.restore', {
+          url,
+          chosenDate,
+        }),
       goBack: /* @ngInject */ ($state, $stateParams) => () =>
         $state.go('app.zone.details.dashboard', $stateParams),
       goToDiffViewer: /* @ngInject */ ($state) => (


### PR DESCRIPTION
  ref: MANAGER-12646
  ref: MANAGER-12648

| Question         | Answer
| ---------------- | ---
| Branch?          | `view-dns-history-MANAGER-12199`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Feat #MANAGER-12646 Feat #MANAGER-12648
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)

## Description

Allows to close modals both on escape or click outside (for those inside the new dns dashboard history page)

## Related

<!-- Link dependencies of this PR -->
