### PR TITLE
feat(telecom.xdsl.access): add modem profile

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.constants.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.constants.js
@@ -13,8 +13,33 @@ export const VDSL_PROFILE = {
   perf2: 'SNR 1',
 };
 
+export const MODEM_PROFILE = {
+  standard: 'standard',
+  orange: 'orange',
+  bouygues: 'bouygues',
+};
+
+export const PROVIDER = {
+  kosc: 'kosc',
+  bouygues: 'bouygues',
+};
+
+export const PROVIDER_INFRA = {
+  or: 'OR',
+  orange: 'ORANGE',
+};
+
+export const ACCESS_TYPE = {
+  vdsl: 'vdsl',
+  ftth: 'ftth',
+};
+
 export default {
   XDSL_NO_INCIDENT_CODE,
   XDSL_EXCHANGE_MODEM,
   VDSL_PROFILE,
+  MODEM_PROFILE,
+  PROVIDER,
+  PROVIDER_INFRA,
+  ACCESS_TYPE,
 };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.controller.js
@@ -11,6 +11,10 @@ import {
   XDSL_NO_INCIDENT_CODE,
   XDSL_EXCHANGE_MODEM,
   VDSL_PROFILE,
+  MODEM_PROFILE,
+  PROVIDER,
+  PROVIDER_INFRA,
+  ACCESS_TYPE,
 } from './pack-xdsl-access.constants';
 
 export default class XdslAccessCtrl {
@@ -392,6 +396,33 @@ export default class XdslAccessCtrl {
               if (!this.$scope.access.xdsl.isFiber) {
                 this.getAvailableProfiles();
               }
+
+              // Set modem profile
+              this.modemProfile = this.$translate.instant(
+                `xdsl_details_modem_profile_${MODEM_PROFILE.standard}`,
+              );
+              if (
+                access.provider === PROVIDER.bouygues &&
+                access.accessType === ACCESS_TYPE.ftth
+              ) {
+                this.modemProfile = this.$translate.instant(
+                  `xdsl_details_modem_profile_${MODEM_PROFILE.bouygues}`,
+                );
+              }
+              if (
+                access.provider === PROVIDER.kosc &&
+                [ACCESS_TYPE.ftth, ACCESS_TYPE.vdsl].includes(
+                  access.accessType,
+                ) &&
+                [PROVIDER_INFRA.or, PROVIDER_INFRA.orange].includes(
+                  access.providerInfra,
+                )
+              ) {
+                this.modemProfile = this.$translate.instant(
+                  `xdsl_details_modem_profile_${MODEM_PROFILE.orange}`,
+                );
+              }
+
               return this.$scope.access.xdsl;
             },
             (err) => {

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/pack-xdsl-access.html
@@ -864,6 +864,16 @@
                                             ></span>
                                         </div>
                                     </div>
+
+                                    <div
+                                        class="oui-tile__term"
+                                        data-translate="xdsl_details_modem_profile"
+                                    ></div>
+                                    <div class="oui-tile__description">
+                                        <span
+                                            data-ng-bind="$ctrl.modemProfile"
+                                        ></span>
+                                    </div>
                                 </div>
                             </li>
                         </ul>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_de_DE.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_description_part3": "Das neue Modem wird automatisch an die Anschlussadresse versandt.",
   "xdsl_modem_comfort_exchange_already_opened_rma": "Es wird bereits eine Anfrage zum Austausch von Hardware gestellt.",
   "xdsl_modem_comfort_exchange_already_last_model": "Sie haben bereits das letzte Modem-Modell.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Es ist nicht möglich, dieses Modem für einen SDSL Zugang zu ersetzen."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Es ist nicht möglich, dieses Modem für einen SDSL Zugang zu ersetzen.",
+  "xdsl_details_modem_profile": "Modemprofil",
+  "xdsl_details_modem_profile_orange": "Orangefarbenes Profil",
+  "xdsl_details_modem_profile_bouygues": "Bouygues Profil",
+  "xdsl_details_modem_profile_standard": "Standardprofil"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_en_GB.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "This modem cannot be upgraded for SDSL access.",
   "xdsl_details_diagnostic_known_incident": "We have detected an incident on your line, and we are working to re-establish your connection. We apologise for any inconvenience this may cause you.",
   "xdsl_details_diagnostic_known_incident_details": "You can read more information on this incident by clicking the following link:",
-  "xdsl_details_diagnostic_get_incident_error": "An error occurred while retrieving information on the incidents."
+  "xdsl_details_diagnostic_get_incident_error": "An error occurred while retrieving information on the incidents.",
+  "xdsl_details_modem_profile": "Modem profile",
+  "xdsl_details_modem_profile_orange": "Orange Profile",
+  "xdsl_details_modem_profile_bouygues": "Bouygues Profile",
+  "xdsl_details_modem_profile_standard": "Standard Profile"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_es_ES.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_already_last_model": "Ya dispone del último modelo de módem.",
   "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "No es posible sustituir este modem por un acceso SDSL.",
   "xdsl_modem_exchange": "Cambiar mi módem",
-  "xdsl_modem_exchange_title": "Cambiar"
+  "xdsl_modem_exchange_title": "Cambiar",
+  "xdsl_details_modem_profile": "Perfil del módem",
+  "xdsl_details_modem_profile_orange": "Perfil Orange",
+  "xdsl_details_modem_profile_bouygues": "Perfil Bouygues",
+  "xdsl_details_modem_profile_standard": "Perfil Standard"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_fr_CA.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_description_part3": "Le nouveau modem sera envoyé automatiquement à l'adresse de raccordement.",
   "xdsl_modem_comfort_exchange_already_opened_rma": "Il y a déjà une demande d'échange de matériel en cours.",
   "xdsl_modem_comfort_exchange_already_last_model": "Vous possédez déjà le dernier modèle de modem.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Il n'est pas possible de remplacer ce modem pour un accès SDSL."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Il n'est pas possible de remplacer ce modem pour un accès SDSL.",
+  "xdsl_details_modem_profile": "Profil du modem",
+  "xdsl_details_modem_profile_orange": "Profil Orange",
+  "xdsl_details_modem_profile_bouygues": "Profil Bouygues",
+  "xdsl_details_modem_profile_standard": "Profil Standard"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_fr_FR.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_description_part3": "Le nouveau modem sera envoyé automatiquement à l'adresse de raccordement.",
   "xdsl_modem_comfort_exchange_already_opened_rma": "Il y a déjà une demande d'échange de matériel en cours.",
   "xdsl_modem_comfort_exchange_already_last_model": "Vous possédez déjà le dernier modèle de modem.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Il n'est pas possible de remplacer ce modem pour un accès SDSL."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Il n'est pas possible de remplacer ce modem pour un accès SDSL.",
+  "xdsl_details_modem_profile": "Profil du modem",
+  "xdsl_details_modem_profile_orange": "Profil Orange",
+  "xdsl_details_modem_profile_bouygues": "Profil Bouygues",
+  "xdsl_details_modem_profile_standard": "Profil Standard"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_it_IT.json
@@ -115,5 +115,9 @@
   "xdsl_modem_exchange_title": "Sostituisci",
   "xdsl_modem_comfort_exchange_already_opened_rma": "È già in corso una richiesta di sostituzione dell’hardware.",
   "xdsl_modem_comfort_exchange_already_last_model": "Disponi già dell’ultimo modello di modem.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Non è possibile sostituire questo modem per un accesso SDSL."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Non è possibile sostituire questo modem per un accesso SDSL.",
+  "xdsl_details_modem_profile": "Profilo modem",
+  "xdsl_details_modem_profile_orange": "Profilo Orange",
+  "xdsl_details_modem_profile_bouygues": "Profilo Bouygues",
+  "xdsl_details_modem_profile_standard": "Profilo Standard"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_pl_PL.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_description_part3": "Nowy modem zostanie automatycznie wysłany na adres przyłączenia.",
   "xdsl_modem_comfort_exchange_already_opened_rma": "Istnieje już wniosek o wymianę sprzętu w trakcie.",
   "xdsl_modem_comfort_exchange_already_last_model": "Posiadasz już najnowszy model modemu.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Nie można zastąpić tego modemu dla dostępu SDSL."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Nie można zastąpić tego modemu w celu uzyskania dostępu SDSL.",
+  "xdsl_details_modem_profile": "Profil modemu",
+  "xdsl_details_modem_profile_orange": "Profil Pomarańczowy",
+  "xdsl_details_modem_profile_bouygues": "Profil Bouygues",
+  "xdsl_details_modem_profile_standard": "Profil Standard"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/access/translations/Messages_pt_PT.json
@@ -115,5 +115,9 @@
   "xdsl_modem_comfort_exchange_description_part3": "O novo modem será enviado automaticamente para o endereço de ligação.",
   "xdsl_modem_comfort_exchange_already_opened_rma": "Já existe um pedido de troca de hardware em curso.",
   "xdsl_modem_comfort_exchange_already_last_model": "Já possui o último modelo de modem.",
-  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Não é possível substituir este modem por um acesso SDSL."
+  "xdsl_modem_comfort_exchange_not_replace_modem_sdsl": "Esse modem não pode ser substituído para acesso SDSL.",
+  "xdsl_details_modem_profile": "Perfil do modem",
+  "xdsl_details_modem_profile_orange": "Perfil Laranja",
+  "xdsl_details_modem_profile_bouygues": "Perfil Bouygues",
+  "xdsl_details_modem_profile_standard": "Perfil Standard"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-507
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Add modem profile into access informations.

## Related

<!-- Link dependencies of this PR -->
:flags: Translation

- [x] CMT-6136
