### PR TITLE
feat(web.hosting): db order: retrieve ram sizes from new api

### DIFF
--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.controller.js
@@ -1,6 +1,5 @@
 import get from 'lodash/get';
 import orderBy from 'lodash/orderBy';
-import sortBy from 'lodash/sortBy';
 
 import { PRODUCT_NAME } from './private-database-order-clouddb.constants';
 
@@ -45,16 +44,6 @@ export default class PrivateDatabaseOrderCloudDbCtrl {
       }),
       ['engineLabel', 'engineVersion'],
       ['asc', 'desc'],
-    );
-
-    this.ramSizeList = sortBy(
-      this.ramSizes
-        .map((ram) => parseInt(ram, 10))
-        .map((ram) => ({
-          label: this.$filter('bytes')(ram, undefined, false, 'MB'),
-          value: ram,
-        })),
-      'value',
     );
   }
 

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.html
@@ -40,7 +40,7 @@
                 data-name="ram"
                 data-match="label"
                 data-model="$ctrl.model.ramSize"
-                data-items="$ctrl.ramSizeList"
+                data-items="$ctrl.ramSizes"
                 data-placeholder="{{:: 'private_database_order_clouddb_ram_option_placeholder' | translate }}"
                 data-on-change="$ctrl.canGoToDurationStep()"
             >

--- a/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.routing.js
+++ b/packages/manager/apps/web/client/app/private-database/order/clouddb/private-database-order-clouddb.routing.js
@@ -27,15 +27,10 @@ export default /* @ngInject */ ($stateProvider) => {
         ),
       openBill: /* @ngInject */ ($window) => (billUrl) =>
         $window.open(billUrl, '_blank'),
-      orderApiSchema: /* @ngInject */ (WucOrderCartService) =>
-        WucOrderCartService.getOrderApiSchema(),
       pricings: /* @ngInject */ (catalog, PrivateDatabaseOrderCloudDb) =>
         PrivateDatabaseOrderCloudDb.constructor.getPricings(catalog.plans),
-      ramSizes: /* @ngInject */ (orderApiSchema, PrivateDatabaseOrderCloudDb) =>
-        PrivateDatabaseOrderCloudDb.constructor.getOrderableRamSizes(
-          orderApiSchema,
-        ),
-
+      ramSizes: /* @ngInject */ (catalog, PrivateDatabaseOrderCloudDb) =>
+        PrivateDatabaseOrderCloudDb.getOrderedRamSizes(catalog.plans),
       displayErrorMessage: /* @ngInject */ ($timeout, Alerter) => (
         errorMessage,
       ) =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | no
| New feature?     | no
| Breaking change? |no
| Tickets          | Feat MANAGER-12619
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Use new API to retrieve ram sizes for web cloud database order

## Related

<!-- Link dependencies of this PR -->
