### PR TITLE
feat(octavia): fixed typo on no floating ip banner

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/create/translations/Messages_fr_FR.json
@@ -20,7 +20,7 @@
   "octavia_load_balancer_create_floating_ip_new_information": "La création de votre Floating IP se fera à la fin du processus de configuration.",
   "octavia_load_balancer_create_floating_ip_new_price": "La nouvelle Floating IP sera facturée {{price}}",
   "octavia_load_balancer_create_floating_ip_new_price_interval": " / heure",
-  "octavia_load_balancer_create_floating_ip_no_floating_ip_information": "En choississant de n'attacher aucune IP Publique, votre Load balancer ne sera accesible que depuis un réseau privé.",
+  "octavia_load_balancer_create_floating_ip_no_floating_ip_information": "En choississant de n'attacher aucune IP Publique, votre Load balancer ne sera accessible que depuis un réseau privé.",
   "octavia_load_balancer_create_private_network_title": "Sélectionnez un réseau privé",
   "octavia_load_balancer_create_private_network_intro": "Configurer le réseau privé dans lequel sera hébergé votre load balancer : si vous souhaitez qu'une floating IP soit associé à votre load balancer, le subnet doit avoir une gateway ip",
   "octavia_load_balancer_create_private_network_field": "Choisissez un réseau privé",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12715
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Fixed a typo in the banner displayed when "No Public IP" is selected

## Related

<!-- Link dependencies of this PR -->
