### PR TITLE
feat(octavia): updated submit label for listener edition

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/template.html
@@ -66,7 +66,7 @@
     </oui-field>
     <oui-form-actions
         data-disabled="!listener.$valid"
-        data-submit-text="{{:: 'octavia_load_balancer_listeners_create_submit' | translate }}"
+        data-submit-text="{{:: 'octavia_load_balancer_listeners_create_submit' + ($ctrl.isEditing ? '_edition' : '') | translate }}"
         data-cancel-text="{{:: 'octavia_load_balancer_listeners_create_cancel' | translate }}"
         data-on-submit="$ctrl.onSubmit()"
         data-on-cancel="$ctrl.onCancel()"

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/translations/Messages_en_GB.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/translations/Messages_en_GB.json
@@ -7,5 +7,6 @@
   "octavia_load_balancer_listeners_create_pool": "Default pool (optional)",
   "octavia_load_balancer_listeners_create_pool_default": "Select a pool",
   "octavia_load_balancer_listeners_create_cancel": "Cancel",
-  "octavia_load_balancer_listeners_create_submit": "Add"
+  "octavia_load_balancer_listeners_create_submit": "Add",
+  "octavia_load_balancer_listeners_create_submit_edition": "Edit"
 }

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/components/listener-form/translations/Messages_fr_FR.json
@@ -7,5 +7,6 @@
   "octavia_load_balancer_listeners_create_pool": "Pool par défaut (facultatif)",
   "octavia_load_balancer_listeners_create_pool_default": "Sélectionner un pool",
   "octavia_load_balancer_listeners_create_cancel": "Annuler",
-  "octavia_load_balancer_listeners_create_submit": "Ajouter"
+  "octavia_load_balancer_listeners_create_submit": "Ajouter",
+  "octavia_load_balancer_listeners_create_submit_edition": "Editer"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12719
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Changed the label of the listener form's submit button when in edit mode

## Related

<!-- Link dependencies of this PR -->
