### PR TITLE
feat(octavia): changed listener edit button label

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_en_GB.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_en_GB.json
@@ -19,7 +19,7 @@
   "octavia_load_balancer_listeners_provisioning_status_deleting": "deleting",
   "octavia_load_balancer_listeners_provisioning_status_error": "error",
   "octavia_load_balancer_listeners_provisioning_status_updating": "updating",
-  "octavia_load_balancer_listeners_actions_detail": "Edit/See",
+  "octavia_load_balancer_listeners_actions_detail": "Edit",
   "octavia_load_balancer_listeners_actions_delete": "Delete",
   "octavia_load_balancer_listeners_create_success": "The new {{ listener }} listener has been created!",
   "octavia_load_balancer_listeners_edit_success": "The {{ listener }} listener has been updated!",

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/listeners/translations/Messages_fr_FR.json
@@ -19,7 +19,7 @@
   "octavia_load_balancer_listeners_provisioning_status_deleting": "en cours de suppression",
   "octavia_load_balancer_listeners_provisioning_status_error": "erreur",
   "octavia_load_balancer_listeners_provisioning_status_updating": "en cours de mise à jour",
-  "octavia_load_balancer_listeners_actions_detail": "Editer/Voir",
+  "octavia_load_balancer_listeners_actions_detail": "Editer",
   "octavia_load_balancer_listeners_actions_delete": "Supprimer",
   "octavia_load_balancer_listeners_create_success": "Le nouveau listener {{ listener }} a été créé avec succès !",
   "octavia_load_balancer_listeners_edit_success": "Le listener {{ listener }} a été mis à jour avec succès !",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12721
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Changed the label of the listener edit button

## Related

<!-- Link dependencies of this PR -->
