### PR TITLE
feat(dedicated.ips): improve IPs grid performance by splitting API calls

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.constant.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.constant.js
@@ -71,7 +71,7 @@ export const IP_COMPONENTS_LIST_TRACKING_HIT = {
   ORGANISATION: 'manage-organisation',
 };
 export const PAGE_SIZE_MIN = 10;
-export const PAGE_SIZE_MAX = 50;
+export const PAGE_SIZE_MAX = 100;
 
 export default {
   BADGES,

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
@@ -102,6 +102,7 @@ export default class IpListController {
     $scope.advancedModeFilter = true;
     $scope.version = null;
     $scope.selected_option = FILTER_OPTIONS.ALL_IPS;
+    $scope.PAGE_SIZE_MAX = PAGE_SIZE_MAX;
 
     this.securityUrl =
       SECURITY_URL[coreConfig.getUser().ovhSubsidiary] || SECURITY_URL.DEFAULT;

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.controller.js
@@ -262,6 +262,7 @@ export default class IpListController {
         pageSize: $scope.pageSize,
         version: $scope.version,
         isAdditionalIp: $scope.isAdditionalIp,
+        simpleMode: true,
       });
       cancelFetch = cancel;
       request
@@ -271,10 +272,20 @@ export default class IpListController {
             return {
               ...ip,
               collapsed: !ip.isUniq,
+              fetchingData: true,
             };
           });
           $scope.loading.table = false;
-          $scope.ipsList.forEach(checkIps);
+          $scope.ipsList.forEach((ip) => {
+            refreshIp(ip.ipBlock)
+              .then((refreshedIp) => {
+                Object.assign(ip, refreshedIp);
+                checkIps(ip);
+              })
+              .finally(() => {
+                set(ip, 'fetchingData', false);
+              });
+          });
         })
         .catch((error) => {
           if (error?.xhrStatus === 'abort') {

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.html
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.html
@@ -365,30 +365,38 @@
 
                 <!-- Reverse -->
                 <td>
-                    <span
-                        class="label label-info"
-                        title="{{ 'ip_table_manage_delegation_ipv6block_delegation_reverse_dns' | translate }}"
-                        data-ng-if="ipBlock.delegation && ipBlock.delegation.length > 0"
-                        >NS</span
-                    >
-                    <ul class="list-unstyled" data-ng-show="ipBlock.delegation">
-                        <li data-ng-repeat="reverse in ipBlock.delegation">
-                            <span data-ng-bind="reverse"></span>
-                            <button
-                                class="btn btn-link"
-                                type="button"
-                                data-ng-click="setAction('ip/reverse/delete/ip-ip-reverse-delete', {ipBlock: ipBlock, reverse:reverse})"
-                                title="{{:: 'common_delete' | translate }}"
-                            >
-                                <span
-                                    class="fa fa-trash"
-                                    aria-label="{{:: 'common_delete' | translate }}"
-                                    aria-hidden="true"
+                    <div data-ng-if="ipBlock.fetchingData" class="text-center">
+                        <oui-skeleton size="m"></oui-skeleton>
+                    </div>
+                    <div data-ng-if="!ipBlock.fetchingData">
+                        <span
+                            class="label label-info"
+                            title="{{ 'ip_table_manage_delegation_ipv6block_delegation_reverse_dns' | translate }}"
+                            data-ng-if="ipBlock.delegation && ipBlock.delegation.length > 0"
+                            >NS</span
+                        >
+                        <ul
+                            class="list-unstyled"
+                            data-ng-show="ipBlock.delegation"
+                        >
+                            <li data-ng-repeat="reverse in ipBlock.delegation">
+                                <span data-ng-bind="reverse"></span>
+                                <button
+                                    class="btn btn-link"
+                                    type="button"
+                                    data-ng-click="setAction('ip/reverse/delete/ip-ip-reverse-delete', {ipBlock: ipBlock, reverse:reverse})"
+                                    title="{{:: 'common_delete' | translate }}"
                                 >
-                                </span>
-                            </button>
-                        </li>
-                    </ul>
+                                    <span
+                                        class="fa fa-trash"
+                                        aria-label="{{:: 'common_delete' | translate }}"
+                                        aria-hidden="true"
+                                    >
+                                    </span>
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
                 </td>
 
                 <!-- Virtual MAC -->
@@ -492,58 +500,63 @@
 
                 <!-- Reverse -->
                 <td>
-                    <span
-                        data-ng-if="!ip.reverseEdit"
-                        data-ng-bind="ip.reverse ? (ip.reverse | ipPunycode:true) : '-'"
-                    >
-                    </span>
-                    <button
-                        type="button"
-                        class="btn btn-link"
-                        title="{{:: 'common_change' | translate }}"
-                        data-ng-if="!ip.reverseEdit"
-                        data-ng-click="editReverseInline(ipBlock, ip)"
-                    >
+                    <div data-ng-if="ipBlock.fetchingData" class="text-center">
+                        <oui-skeleton size="m"></oui-skeleton>
+                    </div>
+                    <div data-ng-if="!ipBlock.fetchingData">
                         <span
-                            class="fa fa-edit"
-                            aria-hidden="true"
-                            aria-label="{{:: 'common_change' | translate }}"
+                            data-ng-if="!ip.reverseEdit"
+                            data-ng-bind="ip.reverse ? (ip.reverse | ipPunycode:true) : '-'"
                         >
                         </span>
-                    </button>
-                    <div class="input-group" data-ng-if="ip.reverseEdit">
-                        <input
-                            type="text"
-                            class="form-control"
-                            data-ng-model="ip.reverseEditValue"
-                        />
-                        <span class="input-group-btn">
-                            <button
-                                class="btn btn-primary"
-                                data-ng-click="editReverseInlineApply(ipBlock, ip, $event)"
-                                data-ng-disabled="!reverseIsValid(ip.reverseEditValue)"
-                                title="{{:: 'common_confirm' | translate }}"
+                        <button
+                            type="button"
+                            class="btn btn-link"
+                            title="{{:: 'common_change' | translate }}"
+                            data-ng-if="!ip.reverseEdit"
+                            data-ng-click="editReverseInline(ipBlock, ip)"
+                        >
+                            <span
+                                class="fa fa-edit"
+                                aria-hidden="true"
+                                aria-label="{{:: 'common_change' | translate }}"
                             >
-                                <span
-                                    class="fa fa-check"
-                                    aria-label="{{:: 'common_confirm' | translate }}"
-                                    aria-hidden="true"
+                            </span>
+                        </button>
+                        <div class="input-group" data-ng-if="ip.reverseEdit">
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-ng-model="ip.reverseEditValue"
+                            />
+                            <span class="input-group-btn">
+                                <button
+                                    class="btn btn-primary"
+                                    data-ng-click="editReverseInlineApply(ipBlock, ip, $event)"
+                                    data-ng-disabled="!reverseIsValid(ip.reverseEditValue)"
+                                    title="{{:: 'common_confirm' | translate }}"
                                 >
-                                </span>
-                            </button>
-                            <button
-                                class="btn btn-default"
-                                data-ng-click="editReverseInlineCancel(ipBlock, ip, $event)"
-                                title="{{:: 'common_cancel' | translate }}"
-                            >
-                                <span
-                                    class="fa fa-times"
-                                    aria-label="{{:: 'common_confirm' | translate }}"
-                                    aria-hidden="true"
+                                    <span
+                                        class="fa fa-check"
+                                        aria-label="{{:: 'common_confirm' | translate }}"
+                                        aria-hidden="true"
+                                    >
+                                    </span>
+                                </button>
+                                <button
+                                    class="btn btn-default"
+                                    data-ng-click="editReverseInlineCancel(ipBlock, ip, $event)"
+                                    title="{{:: 'common_cancel' | translate }}"
                                 >
-                                </span>
-                            </button>
-                        </span>
+                                    <span
+                                        class="fa fa-times"
+                                        aria-label="{{:: 'common_confirm' | translate }}"
+                                        aria-hidden="true"
+                                    >
+                                    </span>
+                                </button>
+                            </span>
+                        </div>
                     </div>
                 </td>
                 <!-- VMAC -->

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/list.html
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/list.html
@@ -698,6 +698,7 @@
         data-ng-if="!loading.table && ipsCount > 0"
         data-current-offset="paginationOffset"
         data-page-size="pageSize"
+        data-page-size-max="PAGE_SIZE_MAX"
         data-total-items="ipsCount"
         data-on-change="onPaginationChange($event)"
     >

--- a/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.service.js
+++ b/packages/manager/apps/dedicated/client/app/ip/ip/ip-ip.service.js
@@ -444,6 +444,7 @@ export default /* @ngInject */ function Ip(
     extras = true,
     version,
     isAdditionalIp,
+    simpleMode,
   }) => {
     const params = {
       ...otherParams,
@@ -453,6 +454,7 @@ export default /* @ngInject */ function Ip(
       pageSize,
       version,
       isAdditionalIp,
+      simpleMode,
     };
     const canceller = $q.defer();
     const cancel = () => {


### PR DESCRIPTION
ref: MANAGER-12778

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-12778
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~Breaking change is mentioned in relevant commits~

## Description

To improve performance, IPs datagrid loading has been split in two calls :

- Load IPs in simple mode (no additional data fetched)
- Each IP load its additional data asynchronously

## Related

<!-- Link dependencies of this PR -->
