### PR TITLE
feat(pci): allow vlan id 0 when creating private network

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/add.constants.js
@@ -2,12 +2,12 @@ export const DEFAULT_CIDR = 16;
 
 export const DEFAULT_IP = '10.{vlanId}.0.0';
 
-export const DEFAULT_VLAN_ID = 0;
+export const DEFAULT_VLAN_ID = 1;
 
 export const NETWORK_ACTIVE_STATUS = 'ACTIVE';
 
 export const VLAN_ID = {
-  MIN: 2,
+  MIN: 0,
   MAX: 4000,
 };
 

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/add.controller.js
@@ -140,7 +140,7 @@ export default class PrivateNetworksAddCtrl {
   onSetVlanIdChange(modelValue) {
     this.trackCheckBoxClick(modelValue, 'set-vlan-id');
     if (modelValue) {
-      this.configuration.vlanId = this.VLAN_ID.MIN;
+      this.configuration.vlanId = DEFAULT_VLAN_ID;
     } else {
       this.configuration.vlanId = this.VLAN_ID.NEXT_AVAILABLE;
     }
@@ -194,7 +194,7 @@ export default class PrivateNetworksAddCtrl {
         vlanId !== DEFAULT_VLAN_ID &&
         !this.networks.some(({ vlanId: nextId }) => nextId === vlanId + 1),
     );
-    return network ? network.vlanId + 1 : VLAN_ID.MIN;
+    return network ? network.vlanId + 1 : DEFAULT_VLAN_ID;
   }
 
   regenerateNetworkAddress(vlanId) {

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/add.html
@@ -106,6 +106,14 @@
                     <p
                         data-translate="pci_projects_project_network_private_create_vlan_tip"
                     ></p>
+                    <oui-message
+                        data-ng-if="$ctrl.configureVlanId && $ctrl.configuration.vlanId === 0"
+                        data-type="warning"
+                    >
+                        <p
+                            data-translate="pci_projects_project_network_private_create_vlan_id_warning"
+                        ></p>
+                    </oui-message>
                     <oui-field
                         data-ng-if="$ctrl.configureVlanId"
                         aria-describedby="vlanTakenError"

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_de_DE.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Maske",
   "pci_projects_project_network_private_create_configure_choose_vlan": "VLAN-ID festlegen",
   "pci_projects_project_network_private_create_configure_vlan": "VLAN-ID",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Zwischen 2 und 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Zwischen 0 und 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Dieses VLAN ist bereits vergeben.",
   "pci_projects_project_network_private_create_configure_api": "Sie können Ihre IP-Bereiche über die API anpassen.",
   "pci_projects_project_network_private_create_localisation": "Standort",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Weiter",
   "pci_projects_project_network_private_create_loading": "Das private Netzwerk wird erstellt. Dies kann einige Minuten dauern",
   "pci_projects_project_network_private_create_success": "Das private Netzwerk wurde erstellt",
-  "pci_projects_project_network_private_create_error": "Bei der Erstellung des privaten Netzwerks ist ein Fehler aufgetreten: {{ message }}"
+  "pci_projects_project_network_private_create_error": "Bei der Erstellung des privaten Netzwerks ist ein Fehler aufgetreten: {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "Die VLAN-ID 0 wird standardmäßig für andere Produkte verwendet, auch außerhalb des Public-Cloud-Universums. Private IPs müssen mit Bedacht verwaltet werden."
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_en_GB.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Mask",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Set a VLAN ID",
   "pci_projects_project_network_private_create_configure_vlan": "VLAN ID",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Between 2 and 4,000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Between 0 and 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "This VLAN is already taken.",
   "pci_projects_project_network_private_create_configure_api": "You can customise your ranges via the API.",
   "pci_projects_project_network_private_create_localisation": "Region",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Next",
   "pci_projects_project_network_private_create_loading": "Your private network is being created. This may take a few minutes.",
   "pci_projects_project_network_private_create_success": "Private network created.",
-  "pci_projects_project_network_private_create_error": "An error has occurred modifying the private network: {{ message }}"
+  "pci_projects_project_network_private_create_error": "An error has occurred modifying the private network: {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "VLAN id 0 is used by default for other products, including non-Public Cloud products and solutions. Private IPs must be carefully managed"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_es_ES.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Máscara",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Indicar un ID de VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID de VLAN",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 2 y 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 0 y 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Esta VLAN ya está en uso.",
   "pci_projects_project_network_private_create_configure_api": "Puede personalizar los rangos desde la API.",
   "pci_projects_project_network_private_create_localisation": "Localización",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Siguiente",
   "pci_projects_project_network_private_create_loading": "Creando la red privada... La operación podría tardar unos minutos.",
   "pci_projects_project_network_private_create_success": "Se ha creado la red privada.",
-  "pci_projects_project_network_private_create_error": "Se ha producido un error al crear la red privada: {{ message }}."
+  "pci_projects_project_network_private_create_error": "Se ha producido un error al crear la red privada: {{ message }}.",
+  "pci_projects_project_network_private_create_vlan_id_warning": "La VLAN ID 0 se utiliza por defecto en otros productos, inclusive fuera del universo Public Cloud. Por favor, preste atención al gestionar sus IP privadas."
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_fr_CA.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Masque",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Définir un ID de VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID de VLAN",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 2 et 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 0 et 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Ce VLAN est déjà pris.",
   "pci_projects_project_network_private_create_configure_api": "Vous pouvez personnaliser vos plages via l'API.",
   "pci_projects_project_network_private_create_localisation": "Localisation",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Suivant",
   "pci_projects_project_network_private_create_loading": "La création du réseau privé est en cours. Cela peut prendre quelques minutes",
   "pci_projects_project_network_private_create_success": "Le réseau privé a bien été créé",
-  "pci_projects_project_network_private_create_error": "Une erreur est survenue lors de la création du réseau privé : {{ message }}"
+  "pci_projects_project_network_private_create_error": "Une erreur est survenue lors de la création du réseau privé : {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "Le VLAN id 0 est utilisé par défaut sur d'autres produits y compris en dehors de l'univers Public Cloud. Les IP privées doivent être gérées avec attention"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_fr_FR.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Masque",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Définir un ID de VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID de VLAN",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 2 et 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 0 et 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Ce VLAN est déjà pris.",
   "pci_projects_project_network_private_create_configure_api": "Vous pouvez personnaliser vos plages via l'API.",
   "pci_projects_project_network_private_create_localisation": "Localisation",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Suivant",
   "pci_projects_project_network_private_create_loading": "La création du réseau privé est en cours. Cela peut prendre quelques minutes",
   "pci_projects_project_network_private_create_success": "Le réseau privé a bien été créé",
-  "pci_projects_project_network_private_create_error": "Une erreur est survenue lors de la création du réseau privé : {{ message }}"
+  "pci_projects_project_network_private_create_error": "Une erreur est survenue lors de la création du réseau privé : {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "Le VLAN id 0 est utilisé par défaut sur d'autres produits y compris en dehors de l'univers Public Cloud. Les IP privées doivent être gérées avec attention"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_it_IT.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Maschera",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Definisci l’ID della VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID VLAN",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Tra 2 e 4.000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Tra 0 e 4.000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Questa VLAN risulta già in uso.",
   "pci_projects_project_network_private_create_configure_api": "È possibile personalizzare le classi via API.",
   "pci_projects_project_network_private_create_localisation": "Localizzazione",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Continua",
   "pci_projects_project_network_private_create_loading": "La creazione della rete privata è in corso. L’operazione potrebbe richiedere alcuni minuti.",
   "pci_projects_project_network_private_create_success": "La rete privata è stata creata correttamente.",
-  "pci_projects_project_network_private_create_error": "Si è verificato un errore durante la modifica della rete privata: {{ message }}"
+  "pci_projects_project_network_private_create_error": "Si è verificato un errore durante la modifica della rete privata: {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "Il VLAN id 0 è utilizzato di default su altri prodotti, anche al di fuori dell'universo Public Cloud. Gli IP privati devono essere gestiti con attenzione"
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_pl_PL.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Maska:",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Wybierz ID sieci VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID sieci VLAN:",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Wartość między 2 a 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Wartość między 0 a 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Ta sieć VLAN jest już zajęta.",
   "pci_projects_project_network_private_create_configure_api": "Możesz dostosować Twoje zakresy adresów za pomocą API.",
   "pci_projects_project_network_private_create_localisation": "Lokalizacja",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Dalej",
   "pci_projects_project_network_private_create_loading": "Trwa tworzenie prywatnej sieci. Może to zająć kilka minut.",
   "pci_projects_project_network_private_create_success": "Prywatna sieć została utworzona.",
-  "pci_projects_project_network_private_create_error": "Wystąpił błąd podczas tworzenia sieci prywatnej: {{ message }}"
+  "pci_projects_project_network_private_create_error": "Wystąpił błąd podczas tworzenia sieci prywatnej: {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "Identyfikator VLAN 0 jest domyślnie używany w innych produktach, w tym także tych spoza środowiska Public Cloud. Prywatnymi adresami IP należy zarządzać ostrożnie."
 }

--- a/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/private-networks/add/translations/Messages_pt_PT.json
@@ -6,7 +6,7 @@
   "pci_projects_project_network_private_create_configure_mask": "Máscara",
   "pci_projects_project_network_private_create_configure_choose_vlan": "Definir um ID de VLAN",
   "pci_projects_project_network_private_create_configure_vlan": "ID de VLAN",
-  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 2 e 4000",
+  "pci_projects_project_network_private_create_configure_vlan_limits": "Entre 0 e 4000",
   "pci_projects_project_network_private_create_configure_vlan_taken": "Esta VLAN já está a ser utilizada.",
   "pci_projects_project_network_private_create_configure_api": "Pode personalizar os seus intervalos através da API.",
   "pci_projects_project_network_private_create_localisation": "Localização",
@@ -35,5 +35,6 @@
   "pci_projects_project_network_private_create_next": "Seguinte",
   "pci_projects_project_network_private_create_loading": "A criação da rede privada está em curso. Esta operação poderá demorar alguns minutos",
   "pci_projects_project_network_private_create_success": "A rede privada foi criada com êxito",
-  "pci_projects_project_network_private_create_error": "Ocorreu um erro ao criar a rede privada: {{ message }}"
+  "pci_projects_project_network_private_create_error": "Ocorreu um erro ao criar a rede privada: {{ message }}",
+  "pci_projects_project_network_private_create_vlan_id_warning": "O VLAN id 0 é utilizado por predefinição noutros produtos, mesmo fora do universo Public Cloud. Os IP privados devem ser geridos com atenção"
 }


### PR DESCRIPTION
ref: MANAGER-12195

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-12195
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

allow vlan id 0 when creating private network

## Related

- [ ] CMT-6337
