### PR TITLE
feat(dedicated.netapp): add efs dashboard polling when dissociating vrs

### DIFF
--- a/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
+++ b/packages/manager/modules/billing-components/src/components/services-actions/services-actions.controller.js
@@ -18,23 +18,24 @@ export default class ServicesActionsCtrl {
   }
 
   $onInit() {
-    let fetchAutoRenewLink = this.$q.when();
+    const fetchAutoRenewLink = this.$q.defer();
     if (!this.billingManagementAvailability) {
-      this.autorenewLink = null;
+      fetchAutoRenewLink.resolve(null);
     } else if (this.$injector.has('shellClient')) {
-      fetchAutoRenewLink = this.$injector
+      this.$injector
         .get('shellClient')
         .navigation.getURL('dedicated', '#/billing/autorenew')
         .then((url) => {
-          this.autorenewLink = url;
-        });
+          fetchAutoRenewLink.resolve(url);
+        })
+        .catch((error) => fetchAutoRenewLink.reject(error));
     } else {
-      this.autorenewLink = this.coreURLBuilder.buildURL(
-        'dedicated',
-        '#/billing/autorenew',
+      fetchAutoRenewLink.resolve(
+        this.coreURLBuilder.buildURL('dedicated', '#/billing/autorenew'),
       );
     }
-    return fetchAutoRenewLink.finally(() => {
+    return fetchAutoRenewLink.promise.then((link) => {
+      this.autorenewLink = link;
       this.isLoading = false;
       this.initLinks();
     });

--- a/packages/manager/modules/netapp/src/dashboard/constants.js
+++ b/packages/manager/modules/netapp/src/dashboard/constants.js
@@ -26,6 +26,11 @@ export const NETWORK_STATUS = {
   DISSOCIATING: 'dissociating',
 };
 
+export const POLLING_TYPE = {
+  ASSOCIATING: 'associating',
+  DISSOCIATING: 'dissociating',
+};
+
 export const FETCH_INTERVAL = 5000;
 
 export default {
@@ -34,4 +39,5 @@ export default {
   RECOMMIT_IMPRESSION_TRACKING_DATA,
   NETWORK_STATUS,
   FETCH_INTERVAL,
+  POLLING_TYPE,
 };

--- a/packages/manager/modules/netapp/src/dashboard/delete-network/controller.js
+++ b/packages/manager/modules/netapp/src/dashboard/delete-network/controller.js
@@ -14,7 +14,7 @@ export default class OvhManagerNetAppNetworkDeleteCtrl {
 
   cancel() {
     this.trackClick('cancel');
-    this.goBack();
+    this.goBack({ isDissociating: false });
   }
 
   validateField() {
@@ -30,7 +30,7 @@ export default class OvhManagerNetAppNetworkDeleteCtrl {
     )
       .then(() => {
         this.trackPage('success');
-        this.goBack().then(() => {
+        this.goBack({ isDissociating: true }).then(() => {
           this.Alerter.success(
             this.$translate.instant('netapp_network_delete_success_message'),
           );
@@ -38,7 +38,7 @@ export default class OvhManagerNetAppNetworkDeleteCtrl {
       })
       .catch((error) => {
         this.trackPage('error');
-        this.goBack().then(() => {
+        this.goBack({ isDissociating: false }).then(() => {
           this.Alerter.error(
             this.$translate.instant('netapp_dashboard_global_error', {
               message: error?.data?.message || error.message,

--- a/packages/manager/modules/netapp/src/dashboard/delete-network/routing.js
+++ b/packages/manager/modules/netapp/src/dashboard/delete-network/routing.js
@@ -20,7 +20,8 @@ export default /* @ngInject */ ($stateProvider) => {
         atInternet.trackPage({
           name: `${TRACKING_BASE}-${tracker}`,
         }),
-      goBack: /* @ngInject */ ($state) => () => $state.go('^'),
+      goBack: /* @ngInject */ ($state) => (params) =>
+        $state.go('^', params, { reload: params.isDissociating }),
     },
     atInternet: {
       rename: TRACKING_BASE,

--- a/packages/manager/modules/netapp/src/dashboard/delete-network/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/netapp/src/dashboard/delete-network/translations/Messages_fr_FR.json
@@ -4,5 +4,5 @@
   "netapp_network_delete_terminate": "Veuillez écrire le mot « Terminate » pour supprimer votre endpoint.",
   "netapp_network_delete_cancel": "Annuler",
   "netapp_network_delete_confirm": "Supprimer",
-  "netapp_network_delete_success_message": "Votre Endpoint a bien été supprimé."
+  "netapp_network_delete_success_message": "Votre Endpoint est en cours de suppression."
 }

--- a/packages/manager/modules/netapp/src/dashboard/index/component.js
+++ b/packages/manager/modules/netapp/src/dashboard/index/component.js
@@ -8,6 +8,7 @@ export default {
     goToNetworkConfiguration: '<',
     goToDeleteNetworkConfiguration: '<',
     networkInformations: '<',
+    pollDissociatingVrackServices: '<',
     goToCreateVolume: '<',
     isCommitmentAvailable: '<',
     isCreateVolumeAvailable: '<',

--- a/packages/manager/modules/netapp/src/dashboard/index/routing.js
+++ b/packages/manager/modules/netapp/src/dashboard/index/routing.js
@@ -5,6 +5,9 @@ export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('netapp.dashboard.index', {
     url: '',
     component: 'ovhManagerNetAppDashboardIndex',
+    params: {
+      isDissociating: null,
+    },
     resolve: {
       trackClick: /* @ngInject */ (atInternet) => (tracker) =>
         atInternet.trackClick({
@@ -57,8 +60,14 @@ export default /* @ngInject */ ($stateProvider) => {
         trackClick,
       ) => () => {
         trackClick('delete-endpoint');
-        return $state.go('netapp.dashboard.index.delete-network');
+        return $state.go(
+          'netapp.dashboard.index.delete-network',
+          {},
+          { reload: true },
+        );
       },
+      pollDissociatingVrackServices: /* @ngInject */ ($transition$) =>
+        !!$transition$.params().isDissociating,
     },
   });
 };

--- a/packages/manager/modules/netapp/src/dashboard/index/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/netapp/src/dashboard/index/translations/Messages_fr_FR.json
@@ -10,7 +10,7 @@
   "netapp_dashboard_network_configuration_status": "Statut",
   "netapp_dashboard_network_configuration_status_to_configure": "Prêt à configurer",
   "netapp_dashboard_network_configuration_status_associating": "En cours de déploiement",
-  "netapp_dashboard_network_configuration_status_dissociating": "TODO",
+  "netapp_dashboard_network_configuration_status_dissociating": "Dissociation en cours",
   "netapp_dashboard_network_configuration_status_associated": "Déployé",
   "netapp_dashboard_network_configuration_vrack_id": "Nom ou ID du vRack",
   "netapp_dashboard_network_configuration_vrack_services": "vRack Services",


### PR DESCRIPTION
ref: MANAGER-12540

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/efs-vrack-services`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-12540
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

- fix service-actions prod issue where the ellipsis menu us not appearing because the $scope isn't updated after the autorenew link is retrieve.
- add polling for vrack services - EFS dissociation
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
