### PR TITLE
feat(dedicated.network-security): traffic chart updates

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
@@ -158,7 +158,7 @@
   "ip_table_manage_mac": "Modifier votre adresse MAC virtuelle",
   "ip_table_manage_mitigation_DEFAULT_to_PERMANENT": "Centre de Scrubbing: mode permanent",
   "ip_table_manage_mitigation_PERMANENT_to_AUTO": "Centre de scrubbing: mode automatique",
-  "ip_table_manage_mitigation_stats": "Tableau de bord Anti-DDoS",
+  "ip_table_manage_mitigation_stats": "Network Security Dashboard",
   "ip_table_manage_firewall_enable": "Activer le Edge Network Firewall",
   "ip_table_manage_firewall_disable": "Désactiver le Edge Network Firewall",
   "ip_table_manage_firewall_disable_tooltip": "La mitigation est actuellement activée, le firewall ne peut être désactivé.",

--- a/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.constant.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.constant.js
@@ -1,6 +1,7 @@
 export const PAGE_SIZE = 300;
 
 export const TRAFFIC_PERIODS = [
+  { key: 'last6h', value: 'network_security_dashboard_filter_last_6h' },
   { key: 'last24h', value: 'network_security_dashboard_filter_last_24h' },
   { key: 'lastWeek', value: 'network_security_dashboard_filter_last_week' },
   {
@@ -10,6 +11,7 @@ export const TRAFFIC_PERIODS = [
 ];
 
 export const TRAFFIC_PERIOD_LIST = {
+  last6h: 'last6h',
   last24h: 'last24h',
   lastWeek: 'lastWeek',
   last2weeks: 'last2weeks',

--- a/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.controller.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.controller.js
@@ -100,6 +100,9 @@ export default class TrafficController {
     const after = new Date();
     const before = currentDate.toISOString();
     switch (this.period.name) {
+      case this.TRAFFIC_PERIOD_LIST.last6h:
+        after.setTime(after.getTime() - 6 * 60 * 60 * 1000);
+        break;
       case this.TRAFFIC_PERIOD_LIST.lastWeek:
         after.setDate(after.getDate() - 7);
         break;

--- a/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.html
+++ b/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.html
@@ -131,7 +131,16 @@
                 ></p>
             </div>
         </div>
-        <div class="d-flex justify-content-end">
+        <div class="d-flex justify-content-end mt-2">
+            <oui-button
+                variant="secondary"
+                icon-left="oui-icon-refresh"
+                data-on-click="$ctrl.getTraffic()"
+                data-oui-tooltip="{{:: 'network_security_dashboard_refresh' | translate }}"
+                data-oui-tooltip-placement="top"
+                class="mr-4"
+            >
+            </oui-button>
             <oui-checkbox
                 data-model="$ctrl.isStackable"
                 data-on-change="$ctrl.updateStackable(modelValue)"

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_FR.json
@@ -13,6 +13,7 @@
   "network_security_dashboard_col_end": "Heure de fin",
   "network_security_dashboard_col_ip": "IP de destination",
   "network_security_dashboard_col_vector": "Vecteurs d'attaque",
+  "network_security_dashboard_filter_last_6h": "Dernières 6h",
   "network_security_dashboard_filter_last_24h": "Dernières 24h",
   "network_security_dashboard_filter_last_week": "La semaine dernière",
   "network_security_dashboard_filter_last_2_weeks": "2 semaines avant",
@@ -57,5 +58,6 @@
   "network_security_dashboard_empty_table": "Le service sélectionné n'a pas d'adresse IP associée, veuillez en sélectionner un autre.",
   "network_security_dashboard_invalid_ip": "La valeur saisie pour l'IP est incorrecte.",
   "network_security_dashboard_like_this": "Vous aimez ?",
-  "network_security_dashboard_like_this_tooltip": "Vous aimez cette page ? Faites nous part de vos remarques !"
+  "network_security_dashboard_like_this_tooltip": "Vous aimez cette page ? Faites nous part de vos remarques !",
+  "network_security_dashboard_refresh": "Raffraîchir les données"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-514
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

- add a 6 hours period to retrieve traffic chart
- add a refresh button on traffic chart
- reword label to access to network security dashboard from IPs table

## Related

<!-- Link dependencies of this PR -->
