### PR TITLE
feat(octavia): fix unable to select a region without network

### DIFF
--- a/packages/manager/modules/pci-universe-components/src/project/regions-list/regions-list.controller.js
+++ b/packages/manager/modules/pci-universe-components/src/project/regions-list/regions-list.controller.js
@@ -95,12 +95,12 @@ export default class RegionsListController {
     }
   }
 
-  static isRegionDisabled(region) {
-    return region.length === 1 && !region[0].hasEnoughQuota;
+  static isRegionDisabled(regions) {
+    return !regions.some((region) => region.hasEnoughQuota);
   }
 
   onMacroChange(macro, regions) {
-    [this.region] = regions;
+    this.region = regions.find((region) => region.hasEnoughQuota);
     this.onRegionChange(this.region);
   }
 

--- a/packages/manager/modules/pci-universe-components/src/project/regions-list/regions-list.html
+++ b/packages/manager/modules/pci-universe-components/src/project/regions-list/regions-list.html
@@ -33,7 +33,7 @@
                         data-required
                     >
                         <oui-select-picker-section
-                            data-ng-if="$ctrl.constructor.isRegionDisabled(regions) && $ctr.quotaUrl"
+                            data-ng-if="$ctrl.constructor.isRegionDisabled(regions) && $ctrl.quotaUrl"
                         >
                             <a
                                 class="oui-button oui-button_ghost"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12762
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Fixed regions-list component to have macro region disabled when no associated micro region hasEnoughQuota and when a macro region is selected it does not automaticaly select a disabled micro region

## Related

<!-- Link dependencies of this PR -->
