### PR TITLE
feat(octavia): uniformise flavor picker sizes

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/index.js
+++ b/packages/manager/modules/octavia-load-balancer/src/create/index.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import '@uirouter/angularjs';
 import 'oclazyload';
 
+import './style.scss';
+
 const moduleName = 'ovhManagerOctaviaLoadBalancerCreateLazyLoading';
 
 angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(

--- a/packages/manager/modules/octavia-load-balancer/src/create/style.scss
+++ b/packages/manager/modules/octavia-load-balancer/src/create/style.scss
@@ -1,0 +1,5 @@
+oui-select-picker {
+  .oui-select-picker__label-container {
+    flex-grow: 1;
+  }
+}

--- a/packages/manager/modules/octavia-load-balancer/src/create/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/create/template.html
@@ -31,9 +31,9 @@
                         </span>
                     </a>
                 </p>
-                <div class="container-fluid">
+                <div class="container-fluid d-flex flex-wrap">
                     <oui-select-picker
-                        class="d-inline-block col-md-6 col-xl-3 my-3"
+                        class="d-flex col-sm-12 col-md-6 col-xl-3 my-3"
                         data-ng-repeat="size in $ctrl.sizeFlavour | orderBy:'price' track by $index"
                         data-label="{{:: 'octavia_load_balancer_create_size_flavour_title' | translate:{sizeCode: size.label} }}"
                         data-description="{{:: 'octavia_load_balancer_create_size_flavour_description_' + size.code | translate}}"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12716
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Standardized flavor selectors size

## Related

<!-- Link dependencies of this PR -->
