### PR TITLE
fix(iam): add identity to policy was removing managed permissions

### DIFF
--- a/packages/manager/modules/iam/src/iam.service.js
+++ b/packages/manager/modules/iam/src/iam.service.js
@@ -223,21 +223,33 @@ export default class IAMService {
 
   /**
    * Modify a policie's identities given its id
-   * @param {string} id The policy's id
+   * @param {string} policyId The policy's id
    * @param {string[]} identities The policy's identities
    * @returns {Promise}
    */
-  setPolicyIdentities(id, identities) {
-    return this.getPolicy(id)
-      .then((policy) => {
-        const { name, resources, permissions } = policy;
+  setPolicyIdentities(policyId, identities) {
+    return this.getPolicy(policyId)
+      .then((policyResponse) => {
+        // remove fields from GET response which cannot be used in PUT query.
+        // equivalent to delete policy.createdAt, delete policy.id ...
+        const {
+          createdAt,
+          updatedAt,
+          id,
+          owner,
+          readOnly,
+          ...policy
+        } = policyResponse;
+        policy.identities = identities;
         return this.Apiv2Service.httpApiv2({
           method: 'put',
-          url: `${URL.POLICY}/${id}`,
-          data: { name, resources, permissions, identities },
+          url: `${URL.POLICY}/${policyId}`,
+          data: policy,
         });
       })
-      .then(({ data: policy }) => IAMService.transformPolicy(policy));
+      .then(({ data: policy }) => {
+        IAMService.transformPolicy(policy);
+      });
   }
 
   /**


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` / `release/**` / `develop` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes
| Tickets          | MANAGER-12875
| License          | BSD 3-Clause


- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Adding an identity to a policy with managed permissions was breaking the policy. Describe in IAM manager Webex channel.

This comes from how identities were added to policy. With this fix, i prevent any future field to be removed if it isn't listed in `setPolicyIdentities`