### PR TITLE
fix(dedicated): fix backup storage order modal closing

### DIFF
--- a/packages/manager/modules/bm-server-components/src/ftp-backup-storage/order/dedicated-server-ftp-backup-order.controller.js
+++ b/packages/manager/modules/bm-server-components/src/ftp-backup-storage/order/dedicated-server-ftp-backup-order.controller.js
@@ -47,14 +47,14 @@ export default class FtpBackupOrdercontroller {
       this.$stateParams.productId,
       this.order.model[this.order.choiceIndex].capacity,
     )
-      .then(
-        (data) => {
-          this.order.bc = data;
-          this.order.bc.details[0].explanation = {
-            price: this.order.model[this.order.choiceIndex].price,
-          };
-        },
-        (reason) => {
+      .then((data) => {
+        this.order.bc = data;
+        this.order.bc.details[0].explanation = {
+          price: this.order.model[this.order.choiceIndex].price,
+        };
+      })
+      .catch((reason) => {
+        this.goBack().then(() =>
           this.Alerter.alertFromSWS(
             this.$translate.instant(
               'server_configuration_ftpbackup_order_load_detail_failure',
@@ -62,11 +62,10 @@ export default class FtpBackupOrdercontroller {
             ),
             reason,
             FTP_BACKUP_STORAGE_ALERT,
-          );
-        },
-      )
+          ),
+        );
+      })
       .finally(() => {
-        this.goBack();
         this.loading = false;
       });
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix DTRSD-124793
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Removed the call to goBack in the finally of the getDetail method as to not close the modal when the offer details have been loaded and allow the customer to continue with his order

## Related

<!-- Link dependencies of this PR -->
