### PR TITLE
feat(octavia): added provisionning status on load balancers list

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancers.component.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancers.component.js
@@ -8,6 +8,7 @@ export default {
     goToDeleteLoadBalancer: '<',
     dashboardPageLink: '<',
     dashboardPageTracking: '<',
+    provisioningStatusBadges: '<',
     operatingStatusBadges: '<',
   },
   template,

--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancers.html
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancers.html
@@ -65,11 +65,22 @@
                 ></span>
             </oui-datagrid-column>
             <oui-datagrid-column
+                data-title=":: 'octavia_load_balancer_provisioning_status' | translate"
+                data-property="provisioningStatus"
+                data-sortable
+                data-type="options"
+            >
+                <span
+                    class="oui-badge"
+                    data-ng-class="$ctrl.provisioningStatusBadges[$value]"
+                    data-translate="{{:: 'octavia_load_balancer_provisioning_status_' + $value }}"
+                ></span>
+            </oui-datagrid-column>
+            <oui-datagrid-column
                 data-title=":: 'octavia_load_balancer_operating_status' | translate"
                 data-property="operatingStatus"
                 data-sortable
                 data-type="options"
-                data-type-options="$ctrl.stateEnumFilter"
             >
                 <span
                     class="oui-badge"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12802
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a column on load balancers datagrid to display the provisionning status

## Related

<!-- Link dependencies of this PR -->
