### PR TITLE
feat(octavia): adding info regarding health monitor creation

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/create/template.html
@@ -292,6 +292,9 @@
                         data-translate="octavia_load_balancer_create_instance_banner_text_bold"
                     ></b>
                 </p>
+                <p
+                    data-translate="octavia_load_balancer_create_instance_banner_health_monitor_text"
+                ></p>
             </oui-message>
             <octavia-load-balancer-instances-table
                 data-project-id="$ctrl.projectId"

--- a/packages/manager/modules/octavia-load-balancer/src/create/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/create/translations/Messages_fr_FR.json
@@ -33,6 +33,7 @@
   "octavia_load_balancer_create_instance_intro": "Pour configurer votre Load Balancer, définissez vos listeners (front ends) avec un port et un protocole. Attribuez-le ensuite à un pool d'instances (back ends) joignables sur un port et un protocole spécifiques. Si vous disposez de plusieurs protocoles et/ou ports par instance, vous pouvez configurer plusieurs pools par listener <a href=\"{{ linkUrl }}\" target=\"_blank\" data-track-name=\"{{ trackLabel }}\" data-track-on=\"click\" data-track-type=\"action\">en consultant la documentation</a>",
   "octavia_load_balancer_create_instance_banner_text": "Vous pouvez ajouter jusqu'à {{maxListeners}} listeners avec {{maxInstances}} instances au maximum dans cet assistant. Pour plus d'options ou pour éditer des fonctionnalités plus avancées (comme les protocoles proxy, le health check ou les politiques L7), passez en mode édition.",
   "octavia_load_balancer_create_instance_banner_text_bold": "Vous pourrez saisir des membres via IP après la création de votre Load Balancer dans la section membres de la vue Pool",
+  "octavia_load_balancer_create_instance_banner_health_monitor_text": "Dans cette première intégration du Load Balancer dans votre espace client, les Health Monitors ne sont configurables qu'à la création du LoadBalancer.",
   "octavia_load_balancer_create_name_title": "Informations",
   "octavia_load_balancer_create_name_field_label": "Nom du Load Balancer",
   "octavia_load_balancer_create_submit": "Créer un Load Balancer",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12903
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Adding some info regarding health monitor creation in the banner above instances table in the load balancer creation page

## Related

<!-- Link dependencies of this PR -->
