### PR TITLE
fix(dedicated): hardware raid configuration not taken into account

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -2164,7 +2164,8 @@ export default class ServerInstallationOvhCtrl {
       this.$scope.installation.hardwareRaid.arrays;
     if (this.$scope.installation.hardwareRaid.arrays === 1) {
       return this.$scope.installation.hardwareRaid.controller.disks[0].names.slice(
-        this.$scope.installation.hardwareRaid.disks - 1,
+        0,
+        this.$scope.installation.hardwareRaid.disks,
       );
     }
 
@@ -2177,7 +2178,8 @@ export default class ServerInstallationOvhCtrl {
     // ]
     return chunk(
       this.$scope.installation.hardwareRaid.controller.disks[0].names.slice(
-        this.$scope.installation.hardwareRaid.disks - 1,
+        0,
+        this.$scope.installation.hardwareRaid.disks,
       ),
       disksPerArray,
     ).map((elem) => `[${elem.toString()}]`);

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
@@ -443,10 +443,9 @@
                                         && ( !installation.hardwareRaid.raid
                                             || !installation.hardwareRaid.disks
                                             || !installation.hardwareRaid.arrays)"
-                        data-ng-bind="informations.nbPhysicalDisk"
-                    ></strong
-                    >&nbsp;
-                    <strong data-ng-bind="informations.typeDisk"></strong>&nbsp;
+                        data-ng-bind="installation.hardwareRaid.disks ? installation.hardwareRaid.disks : 1"
+                    ></strong>
+                    <strong data-ng-bind="informations.typeDisk"></strong>
                     <strong
                         data-ng-show="informations.raidController"
                         data-translate="server_configuration_installation_ovh_step2_raid_hard"

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
@@ -429,14 +429,20 @@
                     </span>
                     <select
                         class="form-control"
-                        data-ng-show="informations.nbDisk > 1"
+                        data-ng-show="informations.nbDisk > 1
+                                        && ( !installation.hardwareRaid.raid
+                                            || !installation.hardwareRaid.disks
+                                            || !installation.hardwareRaid.arrays)"
                         data-ng-options="nbdisk as nbdisk for nbdisk in $ctrl.getNbDisqueList(informations.nbDisk)"
                         data-ng-model="installation.nbDiskUse"
                         data-ng-disabled="setPartition.indexSet != -1 || newPartition.display"
                     >
                     </select>
                     <strong
-                        data-ng-hide="informations.nbDisk > 1"
+                        data-ng-hide="informations.nbDisk > 1
+                                        && ( !installation.hardwareRaid.raid
+                                            || !installation.hardwareRaid.disks
+                                            || !installation.hardwareRaid.arrays)"
                         data-ng-bind="informations.nbPhysicalDisk"
                     ></strong
                     >&nbsp;
@@ -1831,10 +1837,11 @@
                         </div>
 
                         <!-- nbDisk -->
-                        <div
-                            class="form-inline"
-                            data-ng-show="informations.nbDisk > 1 && !installation.customInstall"
-                        >
+                        <div class="form-inline" data-ng-show="informations.nbDisk > 1
+                                                                  && !installation.customInstall
+                                                                  && ( !installation.hardwareRaid.raid
+                                                                     || !installation.hardwareRaid.disks
+                                                                     || !installation.hardwareRaid.arrays)">
                             <label
                                 for="nbDiskUse"
                                 class="control-label"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
~Breaking change is mentioned in relevant commits~

## Description

- hardware raid configuration not taken into account during OS installation
- OS installation wizard: do not display number of disks dropdown at step 4/4 when already set at previous steps (HW raid configuration at step 2/4 or custom partitioning at step 3/4)
- OS installation wizard: do not display number of disks dropdown at step 3/4 when already set at previous step (HW raid configuration at step 2/4)


## Related

ref: MANAGER-12911
