### PR TITLE
feat(vpn): set private network on creation by default

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.constants.js
@@ -4,8 +4,8 @@ export const PRIVATE_MODE = 'private_mode';
 export const PUBLIC_MODE = 'public_mode';
 export const LOCAL_PRIVATE_MODE = 'local_private_mode';
 export const INSTANCE_MODES_ENUM = [
-  { mode: PUBLIC_MODE },
   { mode: PRIVATE_MODE },
+  { mode: PUBLIC_MODE },
   { mode: LOCAL_PRIVATE_MODE },
 ];
 

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.constants.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.constants.js
@@ -1,10 +1,12 @@
 export const BANDWIDTH_OUT = 'bandwidth_instance_out.consumption';
 export const FILTER_PRIVATE_NETWORK_BAREMETAL = 'ovh.baremetal';
-
+export const PRIVATE_MODE = 'private_mode';
+export const PUBLIC_MODE = 'public_mode';
+export const LOCAL_PRIVATE_MODE = 'local_private_mode';
 export const INSTANCE_MODES_ENUM = [
-  { mode: 'public_mode' },
-  { mode: 'private_mode' },
-  { mode: 'local_private_mode' },
+  { mode: PUBLIC_MODE },
+  { mode: PRIVATE_MODE },
+  { mode: LOCAL_PRIVATE_MODE },
 ];
 
 export const AVAILABLE_SUBNET = [

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -66,6 +66,7 @@ export default class PciInstancesAddController {
       WINDOWS_PRIVATE_MODE_LICENSE_GUIDE.DEFAULT;
     this.instanceModeEnum = INSTANCE_MODES_ENUM;
     this.PUBLIC_MODE = PUBLIC_MODE;
+    this.PRIVATE_MODE = PRIVATE_MODE;
     this.currency = coreConfig.getUser().currency.symbol;
     this.PciProjectAdditionalIpService = PciProjectAdditionalIpService;
     this.FLOATING_IP_AVAILABILITY_INFO_LINK = FLOATING_IP_AVAILABILITY_INFO_LINK;

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -143,7 +143,7 @@ export default class PciInstancesAddController {
 
     this.selectedFloatingIP = null;
     this.loadMessages();
-    [, this.selectedMode] = this.modes;
+    [this.selectedMode] = this.modes;
     this.showAddPrivateNetworkModalForm = false;
     this.isAttachFloatingIP = false;
     this.isAttachPublicNetwork = false;

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -27,6 +27,9 @@ import {
   PUBLIC_NETWORK,
   PUBLIC_NETWORK_BAREMETAL,
   LOCAL_ZONE_REGION,
+  LOCAL_PRIVATE_MODE,
+  PUBLIC_MODE,
+  PRIVATE_MODE,
 } from './add.constants';
 
 export default class PciInstancesAddController {
@@ -62,6 +65,7 @@ export default class PciInstancesAddController {
       WINDOWS_PRIVATE_MODE_LICENSE_GUIDE[this.user.ovhSubsidiary] ||
       WINDOWS_PRIVATE_MODE_LICENSE_GUIDE.DEFAULT;
     this.instanceModeEnum = INSTANCE_MODES_ENUM;
+    this.PUBLIC_MODE = PUBLIC_MODE;
     this.currency = coreConfig.getUser().currency.symbol;
     this.PciProjectAdditionalIpService = PciProjectAdditionalIpService;
     this.FLOATING_IP_AVAILABILITY_INFO_LINK = FLOATING_IP_AVAILABILITY_INFO_LINK;
@@ -139,7 +143,7 @@ export default class PciInstancesAddController {
 
     this.selectedFloatingIP = null;
     this.loadMessages();
-    [this.selectedMode] = this.modes;
+    [, this.selectedMode] = this.modes;
     this.showAddPrivateNetworkModalForm = false;
     this.isAttachFloatingIP = false;
     this.isAttachPublicNetwork = false;
@@ -629,11 +633,11 @@ export default class PciInstancesAddController {
   }
 
   isPrivateMode() {
-    return this.selectedMode.name === this.instanceModeEnum[1].mode;
+    return this.selectedMode.name === PRIVATE_MODE;
   }
 
   isLocalPrivateMode() {
-    return this.selectedMode.name === this.instanceModeEnum[2].mode;
+    return this.selectedMode.name === LOCAL_PRIVATE_MODE;
   }
 
   isLocalZone() {
@@ -680,7 +684,7 @@ export default class PciInstancesAddController {
     if (
       modelValue &&
       modelValue.subnet &&
-      this.selectedMode.name !== this.instanceModeEnum[1].mode &&
+      !this.isPrivateMode() &&
       !this.isLocalZone()
     ) {
       this.getSubnetGateways(modelValue.subnet[0].id)
@@ -1078,8 +1082,8 @@ export default class PciInstancesAddController {
   }
 
   displayNetwork(mode, type) {
-    if (type === this.LOCAL_ZONE_REGION) return mode !== 'public_mode';
-    if (type !== this.LOCAL_ZONE_REGION) return mode !== 'local_private_mode';
-    return true;
+    return type === this.LOCAL_ZONE_REGION
+      ? mode !== PUBLIC_MODE
+      : !this.isLocalPrivateMode();
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -560,7 +560,7 @@
 
         <oui-message
             data-type="warning"
-            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== $ctrl.PUBLIC_MODE"
+            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== $ctrl.PRIVATE_MODE"
         >
             <p
                 data-translate="pci_projects_project_instances_add_privateNetwork_gateway_detectected_banner_info1"

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -42,7 +42,7 @@
                 ? 'pci_projects_project_instances_add_region_selected_title'
                 : 'pci_projects_project_instances_add_region_title') | translate: {
                     location: $ctrl.model.location
-                }
+                })
             }}"
         data-valid="$ctrl.model.datacenter && $ctrl.isRegionAvailable($ctrl.model.datacenter)"
         data-prevent-next="true"
@@ -564,7 +564,7 @@
 
         <oui-message
             data-type="warning"
-            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== MODE_PUBLIC"
+            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== $ctrl.PUBLIC_MODE"
         >
             <p
                 data-translate="pci_projects_project_instances_add_privateNetwork_gateway_detectected_banner_info1"

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -564,7 +564,7 @@
 
         <oui-message
             data-type="warning"
-            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== $ctrl.instanceModeEnum[1].mode"
+            data-ng-if="$ctrl.subnetGateways.length > 0 && !$ctrl.isGatewayLoading && $ctrl.selectedMode.name !== MODE_PUBLIC"
         >
             <p
                 data-translate="pci_projects_project_instances_add_privateNetwork_gateway_detectected_banner_info1"

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -493,7 +493,7 @@
                 data-variant="light"
                 data-on-change="$ctrl.onSelectedModeChange(mode)"
                 data-required
-                data-disabled="$ctrl.disableNetwork && (mode.name === 'private_mode' || mode.name === 'public_mode')"
+                data-disabled="$ctrl.disableNetwork && (mode.name === $ctrl.PRIVATE_MODE || mode.name === $ctrl.PUBLIC_MODE)"
             >
                 <oui-select-picker-section>
                     <p data-translate="{{:: mode.description1}}"></p>

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -42,7 +42,7 @@
                 ? 'pci_projects_project_instances_add_region_selected_title'
                 : 'pci_projects_project_instances_add_region_title') | translate: {
                     location: $ctrl.model.location
-                })
+                }
             }}"
         data-valid="$ctrl.model.datacenter && $ctrl.isRegionAvailable($ctrl.model.datacenter)"
         data-prevent-next="true"
@@ -476,10 +476,6 @@
             data-ng-if="!$ctrl.isLocalZone()"
             class="font-weight-bold"
             data-translate="pci_projects_project_instances_add_privateNetwork_sub_title"
-        ></p>
-        <p
-            data-ng-if="!$ctrl.isLocalZone()"
-            data-translate="pci_projects_project_instances_add_privateNetwork_info1"
         ></p>
         <p
             data-ng-if="$ctrl.isLocalZone()"

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Hinzufügen",
   "pci_projects_project_instances_add_privateNetwork_title": "Konfigurieren Sie Ihr Netzwerk",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Bitte wählen Sie den Typ der Netzwerkverbindung Ihrer neuen Public Cloud-Instanz aus.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "Der öffentliche Modus wird standardmäßig ausgewählt: Dies ist das klassische Netzwerkmodell. Möglicherweise ist es nicht mit allen Produkten kompatibel oder in allen Regionen verfügbar.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Öffentlicher Modus",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "Dies ist das klassische Netzwerkmodell von Public Cloud-Instanzen. Die Instanzen bekommen einen öffentlichen Netzwerk-Port zugewiesen.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Bitte beachten Sie, dass dieser Modus mit neuen Netzwerkdiensten wie Loadbalancer oder Floating IPs nicht kompatibel ist.",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Add",
   "pci_projects_project_instances_add_privateNetwork_title": "Configure your network",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Please select the network connection type for your new Public Cloud instance.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "Public mode is selected by default: this is the standard network model. This may not be compatible with all products, or available in all regions.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Public mode",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "This is the standard network model for Public Cloud instances. Instances will have a public network port attached.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Please note that this mode is not compatible for new network services (Load Balancer or Floating IPs).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Añadir",
   "pci_projects_project_instances_add_privateNetwork_title": "Configure su red",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Seleccione el tipo de conexión de red de su nueva instancia Public Cloud.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "El modo público se selecciona por defecto: es el modelo de red convencional. Es posible que no sea compatible con todos los productos o que no esté disponible en todas las regiones.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Modo público",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "Es el modelo de red clásico de las instancias Public Cloud. Las instancias tendrán un puerto de red público asociado.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Tenga en cuenta que este modo no es compatible con los nuevos servicios de red (Load Balancer o Floating IP).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
@@ -47,7 +47,6 @@
   "pci_projects_project_instances_add_privateNetwork_local_private_mode_description2": "Le 'Local Private Mode' prend en charge le DHCP pour fournir automatiquement un adressage IP à vos instances.",
   "pci_projects_project_instances_add_privateNetwork_title": "Configurez votre réseau",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Merci de sélectionner le type de connexion réseau de votre nouvelle Instance du Cloud Public.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "Le mode Public est sélectionné par défaut : il s'agit du modèle de réseau classique. Il est possible que ce ne soit pas compatible avec tous les produits ni disponible dans toutes les régions.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Mode Public",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "C'est le modèle de réseau classique des instances Public Cloud. Les instances auront un port réseau public rattaché.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Veuillez noter que ce mode n'est pas compatible pour les nouveaux services de réseau (Load Balancer ou Floating IP).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_FR.json
@@ -47,7 +47,6 @@
   "pci_projects_project_instances_add_privateNetwork_local_private_mode_description2": "Le 'Local Private Mode' prend en charge le DHCP pour fournir automatiquement un adressage IP à vos instances.",
   "pci_projects_project_instances_add_privateNetwork_title": "Configurez votre réseau",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Merci de sélectionner le type de connexion réseau de votre nouvelle Instance du Cloud Public.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "Le mode Public est sélectionné par défaut : il s'agit du modèle de réseau classique. Il est possible que ce ne soit pas compatible avec tous les produits ni disponible dans toutes les régions.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Mode Public",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "C'est le modèle de réseau classique des instances Public Cloud. Les instances auront un port réseau public rattaché.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Veuillez noter que ce mode n'est pas compatible pour les nouveaux services de réseau (Load Balancer ou Floating IP).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Aggiungi",
   "pci_projects_project_instances_add_privateNetwork_title": "Configura la tua rete",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Seleziona il tipo di connessione di rete della nuova istanza Public Cloud.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "La modalità “Public” è selezionata di default e corrisponde al modello di rete classico. Potrebbe non essere compatibile con tutti i servizi e non essere disponibile in tutte le Region.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Modalità Public",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "È il modello di rete classico delle istanze Public Cloud. Le istanze avranno una porta di rete pubblica collegata.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Ricordiamo che questa modalità non è compatibile con i nuovi servizi di rete (Load Balancer o Floating IP).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Dodaj",
   "pci_projects_project_instances_add_privateNetwork_title": "Skonfiguruj sieć",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Wybierz rodzaj połączenia sieciowego dla Twojej nowej instancji Public Cloud.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "Tryb publiczny jest ustawiony domyślnie: jest to klasyczny model sieci. Możliwe, że nie jest kompatybilny ze wszystkimi produktami lub dostępny we wszystkich regionach.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Tryb publiczny",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "To klasyczny model sieci instancji Public Cloud. Instancje będą miały przypisany publiczny port sieciowy.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Tryb ten nie jest kompatybilny z nowymi usługami sieciowymi (Load Balancer lub Floating IP).",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
@@ -31,7 +31,6 @@
   "pci_projects_project_instances_add_script_add_label": "Adicionar",
   "pci_projects_project_instances_add_privateNetwork_title": "Configure a sua rede",
   "pci_projects_project_instances_add_privateNetwork_sub_title": "Escolha o tipo de ligação de rede da sua nova instância Public Cloud.",
-  "pci_projects_project_instances_add_privateNetwork_info1": "O modo Público é selecionado por predefinição: este é o modelo de rede clássico. É possível que não seja compatível com todos os produtos nem esteja disponível em todas as regiões.",
   "pci_projects_project_instances_add_privateNetwork_public_mode": "Modo Público",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description1": "É o modelo de rede clássico das instâncias Public Cloud. As instâncias terão uma porta de rede pública associada.",
   "pci_projects_project_instances_add_privateNetwork_public_mode_description2": "Tenha em conta que este modo não é compatível para os novos serviços de rede (Load Balancer ou Floating IP).",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #10454 
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
When we create a network service, set it as private by default instead of public
## Related

<!-- Link dependencies of this PR -->
