### PR TITLE
feat(project.activate): prefill voucher in activation page if available

### DIFF
--- a/packages/manager/modules/pci/src/projects/new/components/voucher/component.js
+++ b/packages/manager/modules/pci/src/projects/new/components/voucher/component.js
@@ -17,5 +17,6 @@ export default {
     defaultPaymentMethod: '<',
     trackClick: '<',
     viewOptions: '<',
+    discoveryPromotionVoucherAmount: '@',
   },
 };

--- a/packages/manager/modules/pci/src/projects/new/components/voucher/controller.js
+++ b/packages/manager/modules/pci/src/projects/new/components/voucher/controller.js
@@ -1,4 +1,5 @@
 import PciEligibility from '../../classes/eligibility.class';
+import { DISCOVERY_PROMOTION_VOUCHER } from '../../../project/project.constants';
 
 export default class PciProjectNewVoucherCtrl {
   /* @ngInject */
@@ -213,8 +214,8 @@ export default class PciProjectNewVoucherCtrl {
   ============================= */
 
   $onInit() {
+    this.initVoucherForProjectActivation();
     this.formVisible = !this.viewOptions.foldVoucher;
-
     const { value, valid } = this.model.voucher;
 
     if (value) {
@@ -224,6 +225,13 @@ export default class PciProjectNewVoucherCtrl {
 
       this.formVisible = true;
       this.$timeout(() => this.setVoucherFormState());
+    }
+  }
+
+  initVoucherForProjectActivation() {
+    if (this.discoveryPromotionVoucherAmount) {
+      this.model.voucher.setValue(DISCOVERY_PROMOTION_VOUCHER);
+      this.setVoucherFormState();
     }
   }
 

--- a/packages/manager/modules/pci/src/projects/project/activate/activate.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/activate/activate.routing.js
@@ -112,6 +112,9 @@ export default /* @ngInject */ ($stateProvider) => {
   registerPCINewPaymentState($stateProvider, {
     stateName: paymentStateName,
     configStep: false,
+    bindings: {
+      discoveryPromotionVoucherAmount: '@',
+    },
     views: {
       default: `@${paymentStateName}`,
       progress: `progress@${paymentStateName}`,


### PR DESCRIPTION
ref: TAPC-497

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-discovery-add-payment-to-activation-page` <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-497 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
