### PR TITLE
feat(dedicate): remove fail over ip label form network iface

### DIFF
--- a/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/bandwidth-dashboard/translations/Messages_fr_FR.json
@@ -16,7 +16,6 @@
   "dedicated_server_interfaces_bandwidth_incoming_label": "Bande passante entrante",
   "dedicated_server_interfaces_bandwidth_outgoing_label": "Bande passante sortante",
   "dedicated_server_interfaces_ip_label": "IP",
-  "dedicated_server_interfaces_failover_ip_label": "IP Fail Over",
   "dedicated_server_interfaces_vrack_label": "Réseau privé",
   "dedicated_server_interfaces_vrack_select_label": "Choisissez un réseau privé",
   "server_consumption_throttled": "Service ralenti",

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/component.js
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/component.js
@@ -1,4 +1,5 @@
 import template from './template.html';
+import controller from './controller';
 
 export default {
   bindings: {
@@ -9,5 +10,6 @@ export default {
     urls: '<',
     failoverIps: '<',
   },
+  controller,
   template,
 };

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/controller.js
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/controller.js
@@ -1,0 +1,8 @@
+import { LABELS } from './interfaces.constants';
+
+export default class BMNetworkInterfaceController {
+  /* @ngInject */
+  constructor() {
+    this.LABELS = LABELS;
+  }
+}

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/interfaces.constants.js
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/interfaces.constants.js
@@ -32,6 +32,11 @@ export const VIRTUAL_TYPE = {
   publicAggregation: 'public_aggregation',
 };
 
+export const LABELS = {
+  ADDITIONAL_IP: 'Additional IP',
+};
+
 export default {
+  LABELS,
   GUIDES,
 };

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/template.html
@@ -104,9 +104,7 @@
             </oui-clipboard>
             <span data-ng-if="!$row.isPublic()">-</span>
         </oui-datagrid-column>
-        <oui-datagrid-column
-            data-title="::'dedicated_server_interfaces_failover_ip_label' | translate"
-        >
+        <oui-datagrid-column data-title="::$ctrl.LABELS.ADDITIONAL_IP">
             <span
                 data-ng-if="$row.isPublic()"
                 data-ng-bind="$ctrl.failoverIps.length"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-12711
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Remove translation for fail over Ip and replace it by a constant label "Additional IP"

## Related

<!-- Link dependencies of this PR -->
