### PR TITLE
feat(octavia): sending correct value to deactivate session persistence

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/pools/edit/controller.js
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/pools/edit/controller.js
@@ -26,7 +26,7 @@ export default class OctaviaLoadBalancerPoolsEditCtrl {
           type: this.model.persistentSession.value,
           cookieName: this.model.cookieName,
         }
-      : undefined;
+      : { type: 'disabled' };
     this.OctaviaLoadBalancerPoolsService.editPool(
       this.projectId,
       this.region,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-12302
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Fixed the disabling of session persistence on pool update

## Related

<!-- Link dependencies of this PR -->
