### PR TITLE
feat(dedicated): remove vrack form network tile if no bandwidth

### DIFF
--- a/packages/manager/modules/bm-server-components/src/network-tile/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-tile/template.html
@@ -211,7 +211,7 @@
 
         <!-- vRack -->
         <oui-tile-definition
-            data-ng-if="!!$ctrl.vrackInfos"
+            data-ng-if="!!$ctrl.vrackInfos && $ctrl.specifications.vrack.bandwidth && $ctrl.specifications.vrack.bandwidth.value !== 0"
             data-term="{{:: 'server_network_vrack' | translate}}"
         >
             <oui-tile-description>

--- a/packages/manager/modules/bm-server-components/src/network-tile/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-tile/template.html
@@ -96,6 +96,7 @@
         </oui-tile-definition>
 
         <server-bandwidth-dashboard
+            data-ng-if="!!$ctrl.vrackInfos && $ctrl.specifications.vrack.bandwidth && $ctrl.specifications.vrack.bandwidth.value !== 0"
             data-bandwidth-option="$ctrl.bandwidthInformations.bandwidthOption"
             data-bandwidth-vrack-option="$ctrl.bandwidthInformations.bandwidthVrackOptions"
             data-bandwidth-vrack-order-option="$ctrl.bandwidthInformations.bandwidthVrackOrderOptions"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-12915
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Because Rise and Sys servers can't be used with vrack, we should remove the vrack line on the network tile of server dashboard.

## Related

<!-- Link dependencies of this PR -->
