### PR TITLE
feat(octavia): allow for empty load balancer name while creating

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/create/template.html
@@ -328,7 +328,6 @@
                         data-ng-model="$ctrl.model.loadBalancerName"
                         data-ng-maxlength="70"
                         data-ng-pattern="$ctrl.loadBalancerNameRegex"
-                        required
                     />
                 </oui-field>
             </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-10833
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Removed the necessity of setting a name while creating a load balancer

## Related

<!-- Link dependencies of this PR -->
