### PR TITLE
feat(dedicated.vmware): add tile related to edge size

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dashboard/dedicatedCloud-datacenter-dashboard.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dashboard/dedicatedCloud-datacenter-dashboard.html
@@ -36,22 +36,6 @@
                     </oui-action-menu>
                 </oui-tile-definition>
                 <oui-tile-definition
-                    data-term="{{:: 'dedicatedCloud_datacenter_description' | translate }}"
-                    data-description="{{ $ctrl.datacenter.model.description }}"
-                >
-                    <oui-action-menu
-                        aria-label="{{:: 'menu_action_label' | translate:{ t0: ('dedicatedCloud_description' | translate) } }}"
-                        data-compact
-                        data-placement="end"
-                    >
-                        <oui-action-menu-item
-                            aria-label="{{:: 'common_change' | translate }}"
-                            data-ng-click="$ctrl.editDescription($ctrl.datacenter.model.description, 'dedicatedCloud_datacenter_description')"
-                            ><span data-translate="common_change"></span>
-                        </oui-action-menu-item>
-                    </oui-action-menu>
-                </oui-tile-definition>
-                <oui-tile-definition
                     data-term="{{:: 'dedicatedCloud_datacenter_commercial_name' | translate }}"
                     data-description="{{:: ('dedicatedCloud_datacenter_commercial_name_' + $ctrl.datacenter.model.commercialName) | translate }}"
                 ></oui-tile-definition>
@@ -126,6 +110,7 @@
             <oui-tile
                 data-heading="{{:: 'dedicatedCloud_options_title' | translate }}"
                 data-loading="$ctrl.loading"
+                class="mb-3"
             >
                 <oui-tile-definition
                     data-ng-if="$ctrl.drpAvailability"
@@ -180,6 +165,22 @@
                             ></span>
                         </oui-action-menu-item>
                     </oui-action-menu>
+                </oui-tile-definition>
+            </oui-tile>
+            <oui-tile
+                data-heading="{{:: 'dedicatedCloud_nsx_edge_title' | translate }}"
+                data-loading="$ctrl.loading"
+            >
+                <oui-tile-definition
+                    data-term="{{:: 'dedicatedCloud_nsx_edge_level' | translate }}"
+                    data-description="{{:: $ctrl.datacenter.model.edgesLevel }}"
+                >
+                </oui-tile-definition>
+
+                <oui-tile-definition
+                    data-term="{{:: 'dedicatedCloud_nsx_edge_quantity' | translate }}"
+                    data-description="{{:: $ctrl.datacenter.model.edgesCount }}"
+                >
                 </oui-tile-definition>
             </oui-tile>
         </div>

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/dashboard/translations/Messages_fr_FR.json
@@ -1,6 +1,9 @@
 {
   "dedicatedCloud_information_title": "Informations générales",
   "dedicatedCloud_options_title": "Options",
+  "dedicatedCloud_nsx_edge_title": "NSX Edges",
+  "dedicatedCloud_nsx_edge_level": "Taille Edge NSX",
+  "dedicatedCloud_nsx_edge_quantity": "Nombre de Edge NSX",
   "dedicatedCloud_description": "Nom",
   "dedicatedCloud_datacenter_delete": "Supprimer le datacentre",
   "dedicatedCloud_datacenter_description": "Description",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/custom-nsx-edges-sizing
| Bug fix?         |  no
| New feature?     | no
| Breaking change? | no
| Tickets          | Feat MANAGER-12803
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Add of a new tile in the DC dashboard relates to Edge size for Vmware customer
Remove description tile definition in general tile

## Related

<!-- Link dependencies of this PR -->
