### PR TITLE
fix(dedicated.orders): fix the display when an order is null

### DIFF
--- a/packages/manager/modules/billing/src/orders/orders/orders.routing.js
+++ b/packages/manager/modules/billing/src/orders/orders/orders.routing.js
@@ -21,7 +21,7 @@ export default /* @ngInject */ ($stateProvider) => {
           .sort('date', 'DESC')
           .limit(5000)
           .execute(null, true)
-          .$promise.then(({ data }) => data),
+          .$promise.then(({ data }) => data.filter((order) => order)),
       /* @ngInject */
       timeNow: ($http) =>
         $http


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-125942
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Set up a filter on null (/falsy) value when retrieving orders to avoid having an empty list displayed

## Related

<!-- Link dependencies of this PR -->
