### PR TITLE
feat(pack.move): translation missing on migration/move pack

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/building-details/migration-building-details.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/building-details/migration-building-details.constant.js
@@ -6,6 +6,7 @@ export const FIBER_PTO = {
 
 export const STAIR_FLOOR = {
   unknown: '_NA_',
+  buildingUnknown: '_NA_^_NA_',
 };
 
 export default { FIBER_PTO, STAIR_FLOOR };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/building-details/migration-building-details.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/building-details/migration-building-details.controller.js
@@ -125,7 +125,10 @@ export default class TelecomPackMigrationBuildingDetailsCtrl {
 
   convertStairs(stair) {
     const stairsModel = {};
-    if (stair.stair === STAIR_FLOOR.unknown) {
+    if (
+      stair.stair === STAIR_FLOOR.unknown ||
+      stair.stair === STAIR_FLOOR.buildingUnknown
+    ) {
       stairsModel.stair = {
         label: this.$translate.instant(
           'telecom_pack_migration_building_details_none',

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.constant.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.constant.js
@@ -6,6 +6,7 @@ export const FIBER_PTO = {
 
 export const STAIR_FLOOR = {
   unknown: '_NA_',
+  buildingUnknown: '_NA_^_NA_',
 };
 
 export default { FIBER_PTO, STAIR_FLOOR };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/building-details/move-building-details.controller.js
@@ -97,7 +97,10 @@ export default class MoveBuildingDetailsCtrl {
 
   convertStairs(stair) {
     const stairsModel = {};
-    if (stair.stair === STAIR_FLOOR.unknown) {
+    if (
+      stair.stair === STAIR_FLOOR.unknown ||
+      stair.stair === STAIR_FLOOR.buildingUnknown
+    ) {
       stairsModel.stair = {
         label: this.$translate.instant('pack_move_building_details_none'),
         value: stair.stair,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-519
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

add translation for '_NA_^_NA_' label for stair on migration and move packs.

## Related

<!-- Link dependencies of this PR -->
