### PR TITLE
feat(modem.config): display qr code to config modem

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.controller.js
@@ -243,4 +243,11 @@ export default /* @ngInject */ function XdslModemWifiConfigCtrl(
         },
       );
   };
+
+  self.showQRcode = function showQRcode(row) {
+    $state.go('telecom.packs.pack.xdsl.line.modem.wifi.config', {
+      wifiName: row.wifiName,
+      ssid: row.SSID,
+    });
+  };
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/config.html
@@ -94,9 +94,16 @@
 
                     <oui-action-menu data-compact data-placement="end">
                         <oui-action-menu-item
-                            on-click="ConfigWifiCtrl.setSelectedWifi($row)"
+                            data-on-click="ConfigWifiCtrl.setSelectedWifi($row)"
                         >
                             <span data-translate="edit"></span>
+                        </oui-action-menu-item>
+                        <oui-action-menu-item
+                            data-on-click="ConfigWifiCtrl.showQRcode($row)"
+                        >
+                            <span
+                                data-translate="xdsl_modem_wifi_config_show"
+                            ></span>
                         </oui-action-menu-item>
                     </oui-action-menu>
                 </oui-datagrid>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/index.js
@@ -4,6 +4,7 @@ import '@uirouter/angularjs';
 import '@ovh-ux/ng-translate-async-loader';
 import 'angular-translate';
 import 'ovh-api-services';
+import wifiConfigModal from './modal';
 
 import routing from './config.routing';
 
@@ -16,6 +17,7 @@ angular
     'pascalprecht.translate',
     'ovh-api-services',
     'ui.router',
+    wifiConfigModal,
   ])
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/index.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerTelecomPackConfigWifiModalLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    $stateProvider.state('telecom.packs.pack.xdsl.line.modem.wifi.config.**', {
+      url: '/config?wifiName&ssid',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+
+        return import('./wifi-config-modal.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      },
+    });
+  },
+);
+
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.component.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.component.js
@@ -1,0 +1,13 @@
+import controller from './wifi-config-modal.controller';
+import template from './wifi-config-modal.html';
+
+export default {
+  bindings: {
+    serviceName: '<',
+    wifiName: '<',
+    ssid: '<',
+    goBack: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.controller.js
@@ -1,0 +1,39 @@
+export default class XdslModemWifiConfigModalCtrl {
+  /* @ngInject */
+  constructor($http, $translate, $stateParams, TucToast) {
+    this.$http = $http;
+    this.$translate = $translate;
+    this.$stateParams = $stateParams;
+    this.TucToast = TucToast;
+  }
+
+  $onInit() {
+    this.getQRcode();
+  }
+
+  getQRcode() {
+    // Retrieve QR code from APIv6
+    this.$http
+      .get(
+        `apiv6/xdsl/${this.$stateParams.serviceName}/modem/wifi/${this.wifiName}/qrCode`,
+      )
+      .then((response) => {
+        // Display modal with the QR code retrieved from APIv6
+        const qrcode = response.data;
+        this.qrcode = qrcode ? `data:image/png;base64, ${qrcode}` : '';
+      })
+      .catch((error) => {
+        if (error.status === 403 && error.statusText === 'Forbidden') {
+          // Display modal with message to inform the customer where to find QR code on modem side
+          this.message = this.$translate.instant(
+            'xdsl_modem_wifi_config_modal_modem_qrcode',
+          );
+        } else {
+          // Display error
+          this.TucToast.error(
+            this.$translate.instant('xdsl_modem_wifi_read_error'),
+          );
+        }
+      });
+  }
+}

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.html
@@ -1,0 +1,32 @@
+<oui-modal
+    data-heading="{{:: 'xdsl_modem_wifi_config_modal_title' | translate }}"
+    data-on-dismiss="$ctrl.goBack()"
+>
+    <div data-ng-if="$ctrl.qrcode" class="d-flex flex-column">
+        <p data-translate="xdsl_modem_wifi_config_modal_description"></p>
+        <div class="d-flex flex-row">
+            <div class="d-flex justify-content-center">
+                <img
+                    src="{{$ctrl.qrcode}}"
+                    alt="{{'xdsl_modem_wifi_config_modal_qrcode' | translate}}"
+                />
+            </div>
+            <div class="d-flex flex-column justify-content-center ml-5">
+                <span>
+                    <label
+                        data-translate="xdsl_modem_wifi_config_modal_ssid"
+                    ></label>
+                    <span data-ng-bind="$ctrl.ssid"></span>
+                </span>
+                <span>
+                    <label
+                        data-translate="xdsl_modem_wifi_config_modal_wifi_name"
+                    ></label>
+                    <span data-ng-bind="$ctrl.wifiName"></span>
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <p data-ng-if="$ctrl.message" data-ng-bind=":: $ctrl.message"></p>
+</oui-modal>

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.module.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.module.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+import '@ovh-ux/manager-core';
+import '@ovh-ux/ng-ui-router-layout';
+import '@uirouter/angularjs';
+import 'angular-translate';
+
+import routing from './wifi-config-modal.routing';
+import component from './wifi-config-modal.component';
+
+const moduleName = 'ovhManagerTelecomPackConfigWifiModal';
+
+angular
+  .module(moduleName, [
+    'ovhManagerCore',
+    'pascalprecht.translate',
+    'ui.router',
+    'ngUiRouterLayout',
+  ])
+  .config(routing)
+  .component('configWifiModal', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.routing.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.routing.js
@@ -1,0 +1,18 @@
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('telecom.packs.pack.xdsl.line.modem.wifi.config', {
+    url: '/config?wifiName&ssid',
+    views: {
+      modal: {
+        component: 'configWifiModal',
+      },
+    },
+    layout: 'modal',
+    resolve: {
+      wifiName: /* @ngInject */ ($transition$) =>
+        $transition$.params().wifiName,
+      ssid: /* @ngInject */ ($transition$) => $transition$.params().ssid,
+      goBack: /* @ngInject */ ($state) => () => $state.go('^'),
+      breadcrumb: () => null,
+    },
+  });
+};

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_de_DE.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_de_DE.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 und WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "QR-Code anzeigen",
+  "xdsl_modem_wifi_config_modal_title": "WiFi Zugang",
+  "xdsl_modem_wifi_config_modal_description": "Den QR-Code mit Ihrem Smartphone scannen, um sich einzuloggen",
+  "xdsl_modem_wifi_config_modal_qrcode": "QR-Code für den Zugriff auf Ihr WLAN",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID",
+  "xdsl_modem_wifi_config_modal_wifi_name": "WLAN-Name:",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "Der Hauptschlüssel wurde noch nicht geändert, Sie können den QR-Code Ihres Modems direkt verwenden."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_en_GB.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "Oops! We were unable to update your WiFi.",
   "xdsl_modem_wifi_config_info": "A WiFi network configuration change is already in progress. The changes you make will be applied once this change is complete.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 and WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Show QR code",
+  "xdsl_modem_wifi_config_modal_title": "WiFi access",
+  "xdsl_modem_wifi_config_modal_description": "Scan the QR code using your smartphone to connect",
+  "xdsl_modem_wifi_config_modal_qrcode": "QR code to access your WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID:",
+  "xdsl_modem_wifi_config_modal_wifi_name": "WiFi name",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "The security key has not yet been modified. You can use your modem’s QR code directly."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_es_ES.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_es_ES.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "¡Vaya! No hemos podido actualizar su wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 y WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Mostrar el código QR",
+  "xdsl_modem_wifi_config_modal_title": "Acceso WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Escanear el código QR con su smartphone para conectarse",
+  "xdsl_modem_wifi_config_modal_qrcode": "Código QR para acceder a su WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID:",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nombre del WiFi:",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "La clave de seguridad aún no ha sido modificada. Puede utilizar directamente el código QR de su módem."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_CA.json
@@ -42,5 +42,12 @@
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 et WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Afficher le QR code",
+  "xdsl_modem_wifi_config_modal_title": "Accès WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Scanner le QR code à l'aide de votre smartphone pour vous connecter",
+  "xdsl_modem_wifi_config_modal_qrcode": "QR code pour accèder à votre WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID :",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nom du WiFi :",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "La clé de sécurité n'a pas encore été modifiée, vous pouvez utiliser directement le QR code de votre modem."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_fr_FR.json
@@ -42,5 +42,12 @@
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 et WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Afficher le QR code",
+  "xdsl_modem_wifi_config_modal_title": "Accès WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Scanner le QR code à l'aide de votre smartphone pour vous connecter",
+  "xdsl_modem_wifi_config_modal_qrcode": "QR code pour accèder à votre WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID :",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nom du WiFi :",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "La clé de sécurité n'a pas encore été modifiée, vous pouvez utiliser directement le QR code de votre modem."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_it_IT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_it_IT.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "Ops! Impossibile aggiornare il tuo Wi-Fi. ",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 e WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Visualizza codice QR",
+  "xdsl_modem_wifi_config_modal_title": "Accesso WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Scansionare il codice QR utilizzando il vostro smartphone per collegarvi",
+  "xdsl_modem_wifi_config_modal_qrcode": "QR code per accedere al WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID:",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nome WiFi:",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "La chiave di sicurezza non è stata ancora modificata, puoi utilizzare direttamente il QR code del tuo modem."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pl_PL.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 i WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Wyświetl kod QR",
+  "xdsl_modem_wifi_config_modal_title": "Dostęp WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Zeskanuj kod QR za pomocą smartphone'a, aby się zalogować",
+  "xdsl_modem_wifi_config_modal_qrcode": "Kod QR umożliwiający dostęp do sieci WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID:",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nazwa WiFi:",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "Klucz bezpieczeństwa nie został jeszcze zmodyfikowany. Możesz użyć kodu QR bezpośrednio z modemu."
 }

--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/translations/Messages_pt_PT.json
@@ -45,5 +45,12 @@
   "xdsl_modem_wifi_write_error": "Oups ! Nous n'avons pas pu mettre à jour votre wifi.",
   "xdsl_modem_wifi_config_info": "Une modification de configuration d'un réseau Wi-Fi est déjà en cours. Les modifications que vous allez apporter seront appliquées une fois cette modification terminée.",
   "xdsl_modem_wifi_WPA2andWPA3": "WPA2 e WPA3",
-  "xdsl_modem_wifi_WPA3": "WPA3"
+  "xdsl_modem_wifi_WPA3": "WPA3",
+  "xdsl_modem_wifi_config_show": "Mostrar o código QR",
+  "xdsl_modem_wifi_config_modal_title": "Acesso WiFi",
+  "xdsl_modem_wifi_config_modal_description": "Digitalizar o código QR usando seu smartphone para se conectar",
+  "xdsl_modem_wifi_config_modal_qrcode": "Código QR para aceder ao seu WiFi",
+  "xdsl_modem_wifi_config_modal_ssid": "SSID:",
+  "xdsl_modem_wifi_config_modal_wifi_name": "Nome do WiFi:",
+  "xdsl_modem_wifi_config_modal_modem_qrcode": "A chave de segurança ainda não foi modificada, pode utilizar diretamente o código QR do seu modem."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-518
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Display QR code for WiFi configuration

## Related

<!-- Link dependencies of this PR -->
