### PR TITLE
fix(dedicated.server): unblocking server banner

### DIFF
--- a/packages/manager/modules/bm-server-components/src/service-status/service-status.controller.js
+++ b/packages/manager/modules/bm-server-components/src/service-status/service-status.controller.js
@@ -52,6 +52,7 @@ export default class BmServerComponentsGeneralInformationController {
           this.$translate.instant(
             'dedicated_server_dashboard_remove_hack_success',
           ),
+          true,
         );
       })
       .catch((data) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?      /no
| Breaking change?  /no
| Tickets          | Fix DTRSD-124907
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Unblocking server success banner isn't displayed correctly

## Related

<!-- Link dependencies of this PR -->
