### PR TITLE
fix(migration.confirm): display success after migrate return ok

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.controller.js
@@ -204,7 +204,7 @@ export default class TelecomPackMigrationConfirmCtrl {
     return this.TucPackMigrationProcess.startMigration()
       .then((migrationTask) => {
         this.process.migrationTaskId = migrationTask.id;
-        this.process.currentStep = 'migration';
+        this.isMigrationOK = true;
       })
       .catch((error) => {
         this.TucToast.error(

--- a/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/migration/confirm/pack-migration-confirm.html
@@ -4,7 +4,18 @@
         <h3 data-translate="telecom_pack_migration_doing"></h3>
     </div>
 
-    <form name="resumeForm" data-ng-submit="$ctrl.startMigration()">
+    <div
+        class="alert alert-success"
+        role="alert"
+        data-ng-if="$ctrl.isMigrationOK"
+        data-translate="telecom_pack_migration_success_title"
+    ></div>
+
+    <form
+        name="resumeForm"
+        data-ng-submit="$ctrl.startMigration()"
+        data-ng-if="!$ctrl.isMigrationOK"
+    >
         <div class="widget-presentation" data-ng-if="!$ctrl.loading.migrate">
             <h2
                 class="widget-presentation-title"
@@ -256,7 +267,9 @@
             ></p>
         </div>
 
-        <div data-ng-if="$ctrl.process.selectedOffer.needMeeting">
+        <div
+            data-ng-if="$ctrl.process.selectedOffer.needMeeting && !$ctrl.loading.migrate"
+        >
             <p
                 class="mb-3 font-weight-bold"
                 data-translate="telecom_pack_migration_contract_action_create"
@@ -291,7 +304,7 @@
             </div>
         </div>
 
-        <div class="widget-presentation">
+        <div class="widget-presentation" data-ng-if="!$ctrl.loading.migrate">
             <h2
                 class="widget-presentation-title"
                 data-translate="telecom_pack_migration_confirm_resume_contact_owner"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-520
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Display success after migrate return OK instead of polling task which could take several days before status changed.

## Related

<!-- Link dependencies of this PR -->
