### PR TITLE
fix(pci.storages.databases): DTRSD-126388 - Display redis users information

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/storages/databases/database/users/informations/informations.routing.js
@@ -5,7 +5,6 @@ export default /* @ngInject */ ($stateProvider) => {
       url: '/informations',
       params: {
         user: null,
-        type: null,
       },
       views: {
         modal: {


### PR DESCRIPTION
dtrsd-126388

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #DTRSD-126388
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
Fix the display of user information for Redis engine. 

## Related

<!-- Link dependencies of this PR -->
