### PR TITLE
fix(web.domain): display the domain after also redirect

### DIFF
--- a/packages/manager/apps/web/client/app/domain/redirection/add/domain-redirection-add.html
+++ b/packages/manager/apps/web/client/app/domain/redirection/add/domain-redirection-add.html
@@ -54,6 +54,9 @@
                     ><span
                         data-translate="domain_tab_REDIRECTION_add_step1_www"
                     ></span>
+                    <span
+                        data-ng-bind="'www.' + (ctrl.newRedirection.subdomain ? ctrl.newRedirection.subdomain + '.' : '') + ctrl.newRedirection.domain.displayName"
+                    ></span>
                 </oui-checkbox>
             </form>
         </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTRSD-126319 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I display the domain after "also redirect" example for `MySubDomain.MyDomain`: 
- [ ] redirect also `www.MySubDomain.MyDomain`
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
