### PR TITLE
feat: make it easy to target LABEU instead of PROD api

### DIFF
--- a/packages/manager/core/vite-config/package.json
+++ b/packages/manager/core/vite-config/package.json
@@ -12,6 +12,7 @@
   "author": "OVH SAS",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "dependencies": {
     "@ovh-ux/manager-dev-server-config": "^6.0.0",
     "@vitejs/plugin-legacy": "^1.3.2",

--- a/packages/manager/core/vite-config/src/config.js
+++ b/packages/manager/core/vite-config/src/config.js
@@ -11,6 +11,9 @@ const isContainerApp = process.cwd().endsWith('container');
 
 const getBaseConfig = (config) => {
   const envConfig = config || {};
+  if (envConfig.isLABEU) {
+    envConfig.host = 'www.build-ovh.com';
+  }
 
   return {
     base: isContainerApp ? './' : '/app/',
@@ -30,7 +33,7 @@ const getBaseConfig = (config) => {
       legacy({
         targets: ['defaults'],
       }),
-      viteOvhDevServerPlugin({ isContainerApp, config: envConfig }),
+      viteOvhDevServerPlugin({ isContainerApp, envConfig }),
       IframeHmrPlugin(),
       svgr(),
     ],

--- a/packages/manager/core/vite-config/src/index.d.ts
+++ b/packages/manager/core/vite-config/src/index.d.ts
@@ -1,0 +1,10 @@
+export declare const getBaseConfig: (config: {
+  isLABEU?: boolean;
+  host?: string;
+  devLoginUrl?: string;
+  baseUrl?: string;
+  authURL?: string;
+  proxy?: {
+    host: string;
+  };
+}) => any;

--- a/packages/manager/core/vite-config/src/index.d.ts
+++ b/packages/manager/core/vite-config/src/index.d.ts
@@ -1,4 +1,5 @@
 export declare const getBaseConfig: (config: {
+  local2API?: boolean;
   isLABEU?: boolean;
   host?: string;
   devLoginUrl?: string;

--- a/packages/manager/core/vite-config/src/plugin/dev-server.js
+++ b/packages/manager/core/vite-config/src/plugin/dev-server.js
@@ -5,10 +5,7 @@ import { env, cwd } from 'process';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { proxy, sso as Sso } from '@ovh-ux/manager-dev-server-config';
 
-export default function viteOvhDevServerPlugin({
-  isContainerApp,
-  config: envConfig,
-}) {
+export default function viteOvhDevServerPlugin({ isContainerApp, envConfig }) {
   const region = process.env.REGION || 'EU';
   return {
     name: 'vite-ovh-dev-server',
@@ -75,6 +72,11 @@ export default function viteOvhDevServerPlugin({
 
       const v6Proxy = proxy.v6(region, envConfig);
       app.use(createProxyMiddleware(v6Proxy.context, v6Proxy));
+
+      if (envConfig.isLABEU) {
+        app.use(createProxyMiddleware(proxy.lab.v2.context, proxy.lab.v2));
+        app.use(createProxyMiddleware(proxy.lab.v6.context, proxy.lab.v6));
+      }
 
       server.middlewares.use(app);
     },

--- a/packages/manager/core/vite-config/src/plugin/dev-server.js
+++ b/packages/manager/core/vite-config/src/plugin/dev-server.js
@@ -66,7 +66,7 @@ export default function viteOvhDevServerPlugin({ isContainerApp, envConfig }) {
         // No dev proxy config
       }
 
-      if (env.local2API) {
+      if (env.local2API || envConfig.local2API) {
         app.use(proxy.aapi.context, createProxyMiddleware(proxy.aapi));
       }
 

--- a/packages/manager/tools/dev-server-config/src/proxy/index.js
+++ b/packages/manager/tools/dev-server-config/src/proxy/index.js
@@ -1,9 +1,11 @@
 const aapi = require('./aapi');
 const dev = require('./dev');
 const v6 = require('./v6');
+const lab = require('./lab');
 
 module.exports = {
   aapi,
   dev,
   v6,
+  lab,
 };

--- a/packages/manager/tools/dev-server-config/src/proxy/lab/index.js
+++ b/packages/manager/tools/dev-server-config/src/proxy/lab/index.js
@@ -1,0 +1,16 @@
+const LABEU_API_TARGET = 'https://eu.api.build-ovh.com';
+
+module.exports = {
+  v2: {
+    target: `${LABEU_API_TARGET}/v2`,
+    context: ['/engine/api/v2'],
+    changeOrigin: true,
+    logLevel: 'silent',
+  },
+  v6: {
+    target: `${LABEU_API_TARGET}/v1`,
+    context: ['/engine/apiv6'],
+    changeOrigin: true,
+    logLevel: 'silent',
+  },
+};


### PR DESCRIPTION
ref: MANAGER-13605

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-13605
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Make it easy to target LABEU instead of PROD api :
Just edit the vite.config.mjs of the container and your app :

`export default defineConfig(getBaseConfig({ isLABEU: true }));`
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
