### PR TITLE
fix(telecom): fix modem wifi no qrcode text display

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/xdsl/modem/wifi/config/modal/wifi-config-modal.controller.js
@@ -23,7 +23,7 @@ export default class XdslModemWifiConfigModalCtrl {
         this.qrcode = qrcode ? `data:image/png;base64, ${qrcode}` : '';
       })
       .catch((error) => {
-        if (error.status === 403 && error.statusText === 'Forbidden') {
+        if (error.status === 403) {
           // Display modal with message to inform the customer where to find QR code on modem side
           this.message = this.$translate.instant(
             'xdsl_modem_wifi_config_modal_modem_qrcode',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #INC0019671
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

fix the modal display when the modem wifi code has not been changed yet

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
