### PR TITLE
fix(ip.gamefirewall): check ports are not already used

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.service.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.service.js
@@ -166,4 +166,80 @@ export default /* @ngInject */ function IpGameFirewallService(
       (http) => $q.reject(http.data),
     );
   };
+
+  // Check if the new rule is not into other rules
+  // for example:
+  // newRule = {from: 4320, to: 4330},
+  // rule = {from: 4300, to: 4400}
+  this.hasNewRuleIntoRule = function hasNewRuleIntoRule(newRule, rule) {
+    return (
+      newRule.ports.from < rule.ports.from && newRule.ports.to < rule.ports.to
+    );
+  };
+
+  // Check if the new rule port to is not into other rules
+  // for example:
+  // newRule = {from: 4200, to: 4330},
+  // rule = {from: 4300, to: 4400}
+  this.hasNewRulePortToIntoRule = function hasNewRulePortToIntoRule(
+    newRule,
+    rule,
+  ) {
+    return (
+      newRule.ports.from < rule.ports.to &&
+      newRule.ports.to > rule.ports.from &&
+      newRule.ports.to < rule.ports.to
+    );
+  };
+
+  // Check if the new rule port from is not into other rules
+  // for example:
+  // newRule = {from: 4300, to: 4500},
+  // rule = {from: 4200, to: 4400}
+  this.hasNewRulePortFromIntoRule = function hasNewRulePortFromIntoRule(
+    newRule,
+    rule,
+  ) {
+    return (
+      newRule.ports.from > rule.ports.from &&
+      newRule.ports.from < rule.ports.to &&
+      newRule.ports.to > rule.ports.to
+    );
+  };
+
+  // Check if the rule is not into new rule
+  // for example:
+  // newRule = {from: 4100, to: 4500},
+  // rule = {from: 4200, to: 4300}
+  this.hasRuleIntoNewRule = function hasRuleIntoNewRule(newRule, rule) {
+    return (
+      newRule.ports.from < rule.ports.from && newRule.ports.to > rule.ports.to
+    );
+  };
+
+  // Check if other rule is not included into new rule
+  // for example:
+  // newRule = {from: 4100 , to: 4300},
+  // rule = {from: 4200 , to: 4200}
+  this.hasRuleIncludedInNewRule = function hasRuleIncludedInNewRule(
+    newRule,
+    rule,
+  ) {
+    return (
+      newRule.ports.from < newRule.ports.to &&
+      rule.ports.from > newRule.ports.from
+    );
+  };
+
+  // Check if new rule is not included into other rule
+  // newRule = {from: 4200 , to: 4200}
+  // rule = {from: 4100 , to: 4300},
+  this.hasNewRuleIncludedInRule = function hasNewRuleIncludedInRule(
+    newRule,
+    rule,
+  ) {
+    return (
+      newRule.ports.from < rule.ports.to && newRule.ports.from > rule.ports.from
+    );
+  };
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_de_DE.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "Der Quell-Port muss leer sein, wenn „Fragmente“ ausgewählt ist.",
   "ip_firewall_destination_port_not_empty_tooltip": "Der Ziel-Port muss leer sein, wenn „Fragmente“ ausgewählt ist.",
   "ip_firewall_check_errors": "Die eingegebenen Daten enthalten Fehler. Bitte überprüfen Sie die rot markierten Felder.",
-  "ip_firewall_rule_status_inactif": "Inaktiv"
+  "ip_firewall_rule_status_inactif": "Inaktiv",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "Der Port (oder Portbereich) steht mit einer anderen Regel in Konflikt."
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_en_GB.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "The source port must be empty when “Fragments” is selected.",
   "ip_firewall_destination_port_not_empty_tooltip": "The destination port must be empty when “Fragments” is selected.",
   "ip_firewall_check_errors": "There are errors in the data entered, please check the fields in red.",
-  "ip_firewall_rule_status_inactif": "Disabled"
+  "ip_firewall_rule_status_inactif": "Disabled",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "The port (or port range) conflicts with another rule."
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_es_ES.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "El puerto de origen debe estar vacío cuando se selecciona la opción «Fragmentos».",
   "ip_firewall_destination_port_not_empty_tooltip": "El puerto de destino debe estar vacío cuando se selecciona la opción «Fragmentos».",
   "ip_firewall_check_errors": "Hay errores en los datos introducidos. Por favor, compruebe los campos marcados en rojo.",
-  "ip_firewall_rule_status_inactif": "Inactivo"
+  "ip_firewall_rule_status_inactif": "Inactivo",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "El puerto (o el rango de puertos) entra(n) en conflicto con otra regla."
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_CA.json
@@ -351,6 +351,7 @@
   "ip_game_mitigation_firewall_enable_success_true": "La politique par défaut de protection DDoS du GAME va être désactivée dans quelques instants.",
   "ip_game_mitigation_firewall_enable_error_true": "Une erreur est survenue lors de la désactivation du mode restriction GAME.",
   "ip_game_mitigation_firewall_rule_add_invalid_parameters": "La saisie des ports est obligatoire.",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "Le port (ou la plage de ports) est en conflit avec une autre règle.",
   "ip_game_mitigation_back_link_title": "Gérer les IPs",
   "ip_game_mitigation_guide": "Guides",
   "ip_game_mitigation_rule_apply": "Valider",

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_fr_FR.json
@@ -351,6 +351,7 @@
   "ip_game_mitigation_firewall_enable_success_true": "La politique par défaut de protection DDoS du GAME va être désactivée dans quelques instants.",
   "ip_game_mitigation_firewall_enable_error_true": "Une erreur est survenue lors de la désactivation du mode restriction GAME.",
   "ip_game_mitigation_firewall_rule_add_invalid_parameters": "La saisie des ports est obligatoire.",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "Le port (ou la plage de ports) est en conflit avec une autre règle.",
   "ip_game_mitigation_back_link_title": "Gérer les IPs",
   "ip_game_mitigation_guide": "Guides",
   "ip_game_mitigation_rule_apply": "Valider",

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_it_IT.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "La porta sorgente deve essere vuota quando è selezionato \"Frammenti\".",
   "ip_firewall_destination_port_not_empty_tooltip": "La porta di destinazione deve essere vuota quando è selezionato \"Frammenti\".",
   "ip_firewall_check_errors": "Sono presenti errori nei dati inseriti, controlla i campi evidenziati in rosso.",
-  "ip_firewall_rule_status_inactif": "Disattivo"
+  "ip_firewall_rule_status_inactif": "Disattivo",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "La porta (o intervallo di porte) è in conflitto con un'altra regola."
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_pl_PL.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "Dla zaznaczonej opcji fragmentacji nie podajemy adresów portów źródłowych.",
   "ip_firewall_destination_port_not_empty_tooltip": "Dla zaznaczonej opcji fragmentacji nie podajemy adresów portów docelowych.",
   "ip_firewall_check_errors": "Wprowadzone dane zawierają błędy. Sprawdź pola zaznaczone na czerwono.",
-  "ip_firewall_rule_status_inactif": "Nieaktywna"
+  "ip_firewall_rule_status_inactif": "Nieaktywna",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "Port (lub zakres portów) jest w konflikcie z inną regułą."
 }

--- a/packages/manager/apps/dedicated/client/app/ip/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/ip/translations/Messages_pt_PT.json
@@ -779,5 +779,6 @@
   "ip_firewall_source_port_not_empty_tooltip": "A porta de origem deve estar vazia quando selecionar « Fragmentos ».",
   "ip_firewall_destination_port_not_empty_tooltip": "A porta de destino deve estar vazia quando selecionar « Fragmentos ».",
   "ip_firewall_check_errors": "Existem erros nos dados introduzidos, queira verificar os campos assinalados a vermelho.",
-  "ip_firewall_rule_status_inactif": "Inativo"
+  "ip_firewall_rule_status_inactif": "Inativo",
+  "ip_game_mitigation_firewall_rule_add_ports_already_used": "A porta (ou intervalo de portas) está em conflito com outra regra."
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-526
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

When adding new GAME firewall rule, check that the ports are not already used by other rules or are not into other rules ranges.

## Related

<!-- Link dependencies of this PR -->
