### PR TITLE
fix(ip.gamefirewall): use same label for protocol display

### DIFF
--- a/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.controller.js
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.controller.js
@@ -79,7 +79,7 @@ export default /* @ngInject */ function IpGameFirewallCtrl(
 
   self.loading = false;
 
-  self.getProtocoleText = function getProtocoleText(protocol) {
+  self.getProtocolText = function getProtocolText(protocol) {
     return startCase(protocol);
   };
 

--- a/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.html
+++ b/packages/manager/apps/dedicated/client/app/ip/components/list/firewall/game/ip-ip-firewall-game.html
@@ -135,7 +135,7 @@
                             name="protocol"
                             class="form-control"
                             data-ng-model="IpGameFirewallCtrl.rule.protocol"
-                            data-ng-options="IpGameFirewallCtrl.getProtocoleText(protocol) for protocol in IpGameFirewallCtrl.enums.protocols"
+                            data-ng-options="IpGameFirewallCtrl.getProtocolText(protocol) for protocol in IpGameFirewallCtrl.enums.protocols"
                             data-ng-change="IpGameFirewallCtrl.selectProtocolDefaultPort()"
                         >
                         </select>
@@ -213,7 +213,7 @@
                     <th
                         scope="row"
                         data-ng-if="!rule.errorMessage"
-                        data-ng-bind="rule.protocol"
+                        data-ng-bind="IpGameFirewallCtrl.getProtocolText(rule.protocol)"
                     ></th>
                     <td
                         data-ng-if="!rule.errorMessage"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-528
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Use same label for protocol display between the protocol select and the table.

## Related

<!-- Link dependencies of this PR -->
