### PR TITLE
fix(public-cloud): renamed region list component used by octavia

### DIFF
--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -39,7 +39,6 @@
     "@ovh-ux/ng-ovh-feature-flipping": "^1.1.1",
     "@ovh-ux/ng-ovh-http": "^5.1.1",
     "@ovh-ux/ng-ovh-payment-method": "^9.12.0",
-    "@ovh-ux/ng-ovh-pci-universe-components": "^1.1.0",
     "@ovh-ux/ng-ovh-proxy-request": "^2.1.1",
     "@ovh-ux/ng-ovh-request-tagger": "^1.2.1",
     "@ovh-ux/ng-ovh-responsive-popover": "^6.1.1",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -43,7 +43,6 @@
     "@ovh-ux/ng-ovh-feature-flipping": "^1.1.1",
     "@ovh-ux/ng-ovh-http": "^5.1.1",
     "@ovh-ux/ng-ovh-payment-method": "^9.12.0",
-    "@ovh-ux/ng-ovh-pci-universe-components": "^1.1.0",
     "@ovh-ux/ng-ovh-proxy-request": "^2.1.1",
     "@ovh-ux/ng-ovh-request-tagger": "^1.2.1",
     "@ovh-ux/ng-ovh-responsive-popover": "^6.1.1",

--- a/packages/manager/modules/pci/package.json
+++ b/packages/manager/modules/pci/package.json
@@ -49,7 +49,6 @@
     "@ovh-ux/ng-ovh-contracts": "^4.2.1",
     "@ovh-ux/ng-ovh-feature-flipping": "^1.0.5",
     "@ovh-ux/ng-ovh-payment-method": "^9.3.1",
-    "@ovh-ux/ng-ovh-pci-universe-components": "^1.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^2.0.4",
     "@ovh-ux/ng-ovh-responsive-popover": "^6.0.0",
     "@ovh-ux/ng-ovh-swimming-poll": "^5.0.5",

--- a/packages/manager/modules/pci/src/components/project/index.js
+++ b/packages/manager/modules/pci/src/components/project/index.js
@@ -9,6 +9,7 @@ import flavorsList from './flavors-list';
 import guidesHeader from './guides-header';
 import imagesList from './images-list';
 import quotaRegionHeader from './quota-region-header';
+import regionList from './regions-list';
 import rights from './rights';
 import sshKeys from './instance/ssh-keys';
 import storages from './storages';
@@ -25,6 +26,7 @@ angular.module(moduleName, [
   imagesList,
   quotaRegionHeader,
   'ovh-api-services',
+  regionList,
   rights,
   sshKeys,
   storages,

--- a/packages/manager/modules/pci/src/index.js
+++ b/packages/manager/modules/pci/src/index.js
@@ -27,7 +27,6 @@ import 'font-awesome/css/font-awesome.css';
 import 'ovh-common-style/dist/ovh-common-style.css';
 
 import { region } from '@ovh-ux/manager-components';
-import pciUniverseComponents from '@ovh-ux/ng-ovh-pci-universe-components';
 import components from './components';
 import error from './error';
 import projects from './projects';
@@ -58,7 +57,6 @@ const moduleName = 'ovhManagerPci';
 angular
   .module(moduleName, [
     components,
-    pciUniverseComponents,
     error,
     projects,
     'ui.router',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes
| Tickets          | Fix MANAGER-13720
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Removed dependencies to "@ovh-ux/ng-ovh-pci-universe-components" in public-cloud projects where it does not belong

## Related

<!-- Link dependencies of this PR -->
