### PR TITLE
fix(telecom.sidebar): set label to service name if empty

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/TelecomSidebar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/TelecomSidebar.tsx
@@ -97,8 +97,9 @@ export default function TelecomSidebar() {
                       const services = await loadServices(
                         `/pack/xdsl/${xdsl.serviceName}/xdslAccess/services`,
                       );
-                      return services.map((service) => ({
+                      const servicesLoaded = services.map((service) => ({
                         ...service,
+                        label: service.label || service.serviceName,
                         keywords: service.extraParams?.length
                           ? service.extraParams[0]
                           : '',
@@ -108,6 +109,7 @@ export default function TelecomSidebar() {
                           </span>
                         ),
                       }));
+                      return servicesLoaded;
                     },
                   })),
                   ...xdslStandalone.map((sdsl) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-533
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Set label to service name if is empty, into left menu

## Related

<!-- Link dependencies of this PR -->
