### PR TITLE
feat(octavia): add new tracking on load balancer creation page

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/constants.js
+++ b/packages/manager/modules/octavia-load-balancer/src/create/constants.js
@@ -81,27 +81,29 @@ export const GETTING_STARTED_LINK = {
     'https://help.ovhcloud.com/csm/en-ie-public-cloud-network-getting-started-load-balancer?id=kb_article_view&sysparm_article=KB0050193',
 };
 
-export const TRACKING_CHAPTER_1 = 'PublicCloud';
-
 export const TRACKING_NAME =
   'pci::projects::project::octavia-loadbalancer::add';
 
-export const TRACKING_PRODUCT_PAGE = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::goto-product-page`;
+const TRACKING_ROOT = `PublicCloud::${TRACKING_NAME}`;
 
-export const TRACKING_REGION_AVAILABILITY = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::goto-region-availability`;
-
-export const TRACKING_PRIVATE_NETWORK_CREATION = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::create-private-network`;
-
-export const TRACKING_INSTANCE_DOCUMENTATION = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::goto-documentation`;
-
-export const TRACKING_LOAD_BALANCER_CREATION_CANCEL = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::cancel`;
-
-export const TRACKING_LOAD_BALANCER_CREATION_SUBMIT = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}::confirm`;
-
-export const TRACKING_LOAD_BALANCER_CREATION_SUBMIT_DETAIL = `octavia-loadbalancer::confirm-creation`;
-
-export const TRACKING_LOAD_BALANCER_CREATION_SUBMIT_ERROR = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}-error`;
-export const TRACKING_LOAD_BALANCER_CREATION_SUBMIT_SUCCESS = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}-success`;
+export const LOAD_BALANCER_CREATION_TRACKING = {
+  ROOT: TRACKING_ROOT,
+  GO_TO_PRODUCT_PAGE: `${TRACKING_ROOT}::goto-product-page`,
+  GO_TO_REGION_AVAILABILITY: `${TRACKING_ROOT}::goto-region-availability`,
+  CREATE_PRIVATE_NETWORK: `${TRACKING_ROOT}::create-private-network`,
+  GO_TO_INSTANCE_DOCUMENTATION: `${TRACKING_ROOT}::goto-documentation`,
+  CANCEL: `${TRACKING_ROOT}::cancel`,
+  SUBMIT: `${TRACKING_ROOT}::confirm`,
+  CONFIRM: `octavia-loadbalancer::confirm-creation`,
+  ERROR: `${TRACKING_ROOT}-error`,
+  SUCCESS: `${TRACKING_ROOT}-success`,
+  FINISH_STEP_1: 'loadbalancer_octavia_add_size',
+  FINISH_STEP_2: 'loadbalancer_octavia_add_region',
+  FINISH_STEP_3: 'loadbalancer_octavia_add_ip',
+  FINISH_STEP_4: 'loadbalancer_octavia_add_network',
+  FINISH_STEP_5: 'loadbalancer_octavia_add_instances',
+  SKIP_STEP_5: 'loadbalancer_octavia_add_instances_skip',
+};
 
 export const AGORA_ADDON_FAMILY = 'octavia-loadbalancer';
 
@@ -129,16 +131,7 @@ export default {
   PRODUCT_LINK,
   REGION_AVAILABILITY_LINK,
   GETTING_STARTED_LINK,
-  TRACKING_CHAPTER_1,
-  TRACKING_PRODUCT_PAGE,
-  TRACKING_REGION_AVAILABILITY,
-  TRACKING_PRIVATE_NETWORK_CREATION,
-  TRACKING_INSTANCE_DOCUMENTATION,
-  TRACKING_LOAD_BALANCER_CREATION_CANCEL,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_DETAIL,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_ERROR,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_SUCCESS,
+  LOAD_BALANCER_CREATION_TRACKING,
   AGORA_ADDON_FAMILY,
   TRACKING_NAME,
   SIZE_FLAVOUR_REGEX,

--- a/packages/manager/modules/octavia-load-balancer/src/create/controller.js
+++ b/packages/manager/modules/octavia-load-balancer/src/create/controller.js
@@ -6,17 +6,7 @@ import {
   MAX_LISTENER,
   PRODUCT_LINK,
   REGION_AVAILABILITY_LINK,
-  TRACKING_CHAPTER_1,
-  TRACKING_NAME,
-  TRACKING_INSTANCE_DOCUMENTATION,
-  TRACKING_LOAD_BALANCER_CREATION_CANCEL,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_DETAIL,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_ERROR,
-  TRACKING_LOAD_BALANCER_CREATION_SUBMIT_SUCCESS,
-  TRACKING_PRIVATE_NETWORK_CREATION,
-  TRACKING_PRODUCT_PAGE,
-  TRACKING_REGION_AVAILABILITY,
+  LOAD_BALANCER_CREATION_TRACKING,
 } from './constants';
 
 export default class OctaviaLoadBalancerCreateCtrl {
@@ -43,11 +33,15 @@ export default class OctaviaLoadBalancerCreateCtrl {
   }
 
   $onInit() {
-    this.trackingProductPage = TRACKING_PRODUCT_PAGE;
-    this.trackingRegionAvailability = TRACKING_REGION_AVAILABILITY;
-    this.trackingPrivateNetworkCreation = TRACKING_PRIVATE_NETWORK_CREATION;
-    this.trackingInstanceDocumentation = TRACKING_INSTANCE_DOCUMENTATION;
-    this.trackingInstanceTablePrefix = `${TRACKING_CHAPTER_1}::${TRACKING_NAME}`;
+    this.trackingProductPage =
+      LOAD_BALANCER_CREATION_TRACKING.GO_TO_PRODUCT_PAGE;
+    this.trackingRegionAvailability =
+      LOAD_BALANCER_CREATION_TRACKING.GO_TO_REGION_AVAILABILITY;
+    this.trackingPrivateNetworkCreation =
+      LOAD_BALANCER_CREATION_TRACKING.CREATE_PRIVATE_NETWORK;
+    this.trackingInstanceDocumentation =
+      LOAD_BALANCER_CREATION_TRACKING.GO_TO_INSTANCE_DOCUMENTATION;
+    this.trackingInstanceTablePrefix = LOAD_BALANCER_CREATION_TRACKING.ROOT;
 
     this.productPageLink =
       PRODUCT_LINK[this.user.ovhSubsidiary] || PRODUCT_LINK.DEFAULT;
@@ -219,27 +213,39 @@ export default class OctaviaLoadBalancerCreateCtrl {
       });
   }
 
+  trackFinishStep(step) {
+    this.atInternet.trackClick({
+      name: LOAD_BALANCER_CREATION_TRACKING[`FINISH_STEP_${step}`],
+      type: 'action',
+    });
+  }
+
   skipListeners() {
     this.model.listeners = [];
     this.currentStep += 1;
+    this.atInternet.trackClick({
+      name: LOAD_BALANCER_CREATION_TRACKING.SKIP_STEP_5,
+      type: 'action',
+    });
+    return true;
   }
 
   onCancel() {
     this.resetCurrentStep();
     this.atInternet.trackClick({
-      name: TRACKING_LOAD_BALANCER_CREATION_CANCEL,
+      name: LOAD_BALANCER_CREATION_TRACKING.CANCEL,
       type: 'action',
     });
   }
 
   createLoadBalancer() {
     this.atInternet.trackClick({
-      name: TRACKING_LOAD_BALANCER_CREATION_SUBMIT,
+      name: LOAD_BALANCER_CREATION_TRACKING.SUBMIT,
       type: 'action',
     });
 
     this.atInternet.trackClick({
-      name: `${TRACKING_LOAD_BALANCER_CREATION_SUBMIT_DETAIL}::${this.model.size.code}::${this.model.region.name}`,
+      name: `${LOAD_BALANCER_CREATION_TRACKING.CONFIRM}::${this.model.size.code}::${this.model.region.name}`,
       type: 'action',
     });
 
@@ -263,7 +269,7 @@ export default class OctaviaLoadBalancerCreateCtrl {
         );
 
         this.atInternet.trackPage({
-          name: TRACKING_LOAD_BALANCER_CREATION_SUBMIT_SUCCESS,
+          name: LOAD_BALANCER_CREATION_TRACKING.SUCCESS,
         });
 
         this.goToListingPage();
@@ -280,7 +286,7 @@ export default class OctaviaLoadBalancerCreateCtrl {
         this.$anchorScroll();
 
         this.atInternet.trackPage({
-          name: TRACKING_LOAD_BALANCER_CREATION_SUBMIT_ERROR,
+          name: LOAD_BALANCER_CREATION_TRACKING.ERROR,
         });
       });
   }

--- a/packages/manager/modules/octavia-load-balancer/src/create/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/create/template.html
@@ -15,6 +15,7 @@
             data-prevent-next="true"
             data-valid="$ctrl.model.size"
             data-on-focus="$ctrl.resetCurrentStep()"
+            data-on-submit="$ctrl.trackFinishStep('1')"
         >
             <div class="mb-4">
                 <p>
@@ -66,6 +67,7 @@
             data-header="{{:: 'octavia_load_balancer_create_region_title' | translate }}"
             data-prevent-next="true"
             data-on-focus="$ctrl.regionStepFocus()"
+            data-on-submit="$ctrl.trackFinishStep('2')"
         >
             <div class="mb-4">
                 <p>
@@ -96,6 +98,7 @@
             data-name="{{:: stepFloatingIp.name}}"
             data-header="{{:: 'octavia_load_balancer_create_floating_ip_title' | translate }}"
             data-prevent-next="true"
+            data-on-submit="$ctrl.trackFinishStep('3')"
         >
             <p
                 class="mb-4"
@@ -169,6 +172,7 @@
             data-prevent-next="true"
             data-valid="$ctrl.isPrivateNetworkStepValid()"
             data-on-focus="$ctrl.privateNetworkStepFocus()"
+            data-on-submit="$ctrl.trackFinishStep('4')"
         >
             <div class="mb-4">
                 <p
@@ -273,6 +277,7 @@
             data-prevent-next="true"
             data-skippable="true"
             data-on-skip="$ctrl.skipListeners()"
+            data-on-submit="$ctrl.trackFinishStep('5')"
         >
             <p
                 data-translate="octavia_load_balancer_create_instance_intro"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-batch-1-feedbacks`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-13535
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added new tracking when switching step and refacto the load balancer creation page tracking

## Related

<!-- Link dependencies of this PR -->
