### PR TITLE
fix(dedicated): prevent os installation on diskgroup (cache controller)

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -492,9 +492,9 @@ export default class ServerInstallationOvhCtrl {
       this.$stateParams.productId,
     ).then((spec) => {
       this.$scope.informations.diskGroups =
-        spec.diskGroups?.sort((a, b) =>
-          a.description.localeCompare(b.description),
-        ) || [];
+        spec.diskGroups
+          ?.filter((diskGroup) => diskGroup.raidController !== 'cache')
+          ?.sort((a, b) => a.description.localeCompare(b.description)) || [];
       this.resetDiskGroup();
     });
   }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

Hide diskgroup that has the cache controller to prevent OS reinstallation on that diskgroup

## Related

ref: MANAGER-13061