### PR TITLE
fix: logs data platform archive url payload

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/streams/archives/streams-archives.service.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/streams/archives/streams-archives.service.js
@@ -77,9 +77,6 @@ export default class LogsStreamsArchivesService {
     return this.$http
       .post(
         `/dbaas/logs/${serviceName}/output/graylog/stream/${streamId}/archive/${archiveId}/url`,
-        {
-          expirationInSeconds: this.LogsConstants.expirationInSeconds,
-        },
       )
       .then(({ data }) => data);
   }

--- a/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
@@ -55,7 +55,6 @@ export default {
   GRACE_PERIOD_MAX_IN_MINUTES: 60,
   BACKLOG_MIN: 1,
   BACKLOG_MAX: 20,
-  expirationInSeconds: 86400,
   indexStorage: {
     success: 'success',
     error: 'error',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |`master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Ticket | OB-5345
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

In Logs Data Platform, when downloading an archive, this API is called:

https://eu.api.ovh.com/console/#/dbaas/logs/%7BserviceName%7D/output/graylog/stream/%7BstreamId%7D/archive/%7BarchiveId%7D/url~POST

In the current code, a payload is given while no payload is expected. This PR removes the payload