### PR TITLE
feat(dedicated.netapp): use vrs display name if possible

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/index/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/index/template.html
@@ -86,8 +86,11 @@
                     <oui-tile-description>
                         <a
                             data-ng-href="{{ $ctrl.vrackServicesLink($ctrl.networkInformations.vrackServices.id)}}"
-                            data-ng-bind=":: $ctrl.networkInformations.vrackServices.id"
-                        ></a>
+                        >
+                            <span
+                                data-ng-bind=":: $ctrl.networkInformations.vrackServices.currentState.displayName || $ctrl.networkInformations.vrackServices.id"
+                            ></span>
+                        </a>
                     </oui-tile-description>
                 </oui-tile-definition>
                 <oui-tile-definition


### PR DESCRIPTION
ref: MANAGER-13784

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/efs-vrack-services`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-13784
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

If the EFS have a vrack services linked we display his displayName. If the vrack services has no displayName, we display his ID

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
