### PR TITLE
Rescue - Add buttons to choose between password and SSH key authentication

### DIFF
--- a/packages/manager/modules/bm-server-components/src/netboot/constants.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/constants.js
@@ -28,10 +28,20 @@ export const NETBOOT_GUIDES = {
   DEFAULT: 'https://docs.ovh.com/us/en/dedicated/hardware-diagnostics',
 };
 
+export const UNSUPPORTED_SSH_KEY_RESCUES = ['WinRescue', 'WiRe'];
+export const SSH_KEY = {
+  pattern: /^(ssh-rsa|ecdsa-sha\d+-nistp\d+|ssh-ed\d+)\s+(AAAA[a-zA-Z0-9/=+]+)(\s+(\S{1,128}))*$/,
+  placeholder:
+    'ssh-rsa AAAAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX== my-public-key',
+  rows: 15,
+};
+
 export const getNetbootGuideUrl = (subsidiary) => {
   return NETBOOT_GUIDES[subsidiary] || NETBOOT_GUIDES.DEFAULT;
 };
 
 export default {
   getNetbootGuideUrl,
+  UNSUPPORTED_SSH_KEY_RESCUES,
+  SSH_KEY,
 };

--- a/packages/manager/modules/bm-server-components/src/netboot/service.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/service.js
@@ -4,25 +4,30 @@ export default class BmServerComponentsNetbootService {
     this.$http = $http;
   }
 
-  setNetBoot(serviceName, bootId, rootDevice) {
+  setNetBoot(
+    serviceName,
+    bootId,
+    rootDevice = null,
+    rescueMail = null,
+    rescueSshKey = null,
+  ) {
     return this.$http
       .put(`/dedicated/server/${serviceName}`, {
         bootId,
         rootDevice,
-      })
-      .then(({ data }) => data);
-  }
-
-  updateRescueMail(serviceName, bootId, rescueMail) {
-    return this.$http
-      .put(`/dedicated/server/${serviceName}`, {
-        bootId,
         rescueMail,
+        rescueSshKey,
       })
       .then(({ data }) => data);
   }
 
   getRescueMail(serviceName) {
+    return this.$http
+      .get(`/dedicated/server/${serviceName}`)
+      .then(({ data }) => data);
+  }
+
+  getServerInfos(serviceName) {
     return this.$http
       .get(`/dedicated/server/${serviceName}`)
       .then(({ data }) => data);

--- a/packages/manager/modules/bm-server-components/src/netboot/template.html
+++ b/packages/manager/modules/bm-server-components/src/netboot/template.html
@@ -20,6 +20,7 @@
             data-submit-text="{{ ::'server_configuration_netboot_next' | translate }}"
             data-on-focus="$ctrl.isInConfigurationStep = true"
             data-on-submit="$ctrl.onConfigurationSubmit(form)"
+            prevent-next
         >
             <div class="row mb-1">
                 <div
@@ -78,6 +79,7 @@
                             name="rescue"
                             data-ng-options="rescue as rescue.kernel + ' - ' + rescue.description for rescue in $ctrl.netboots.rescue track by rescue.kernel"
                             data-ng-model="$ctrl.currentNetboot.rescue"
+                            data-ng-change="$ctrl.onRescueKernelChange()"
                             required
                         >
                             <option
@@ -87,6 +89,51 @@
                             </option>
                         </select>
                     </oui-field>
+
+                    <div class="row mb-2">
+                        <div
+                            class="col-md-4"
+                            data-ng-repeat="(key, data) in $ctrl.rescueAuthMethods"
+                        >
+                            <oui-select-picker
+                                data-name="{{:: data }}"
+                                data-model="$ctrl.currentAuthMethod"
+                                data-label="{{:: ('server_configuration_netboot_auth_method_'+ data) | translate }}"
+                                data-values="[data]"
+                            >
+                            </oui-select-picker>
+                        </div>
+                    </div>
+
+                    <div data-ng-if="$ctrl.currentAuthMethod === $ctrl.SSHKEY">
+                        <oui-field
+                            data-label="{{:: 'server_configuration_netboot_sshkey_input' | translate}}"
+                        >
+                            <div
+                                class="float-right sshkey-switch"
+                                data-ng-model="model.keyIsValid"
+                                data-sshkey-switch
+                                data-sshkey-switch-key="{{$ctrl.ssh.publicKey}}"
+                            ></div>
+
+                            <textarea
+                                class="oui-input form-control"
+                                name="rescueSshKey"
+                                id="rescueSshKey"
+                                placeholder="{{:: 'server_configuration_netboot_sshkey_input_placeholder' | translate:{t0: $ctrl.ssh.inputRules.placeholder} }}"
+                                data-ng-model="$ctrl.ssh.publicKey"
+                                data-ng-required="true"
+                                data-ng-pattern="$ctrl.ssh.inputRules.pattern"
+                                data-ng-trim="true"
+                                spellcheck="false"
+                                autocomplete="off"
+                                autocapitalize="off"
+                                autocorrect="off"
+                                rows="{{ $ctrl.ssh.inputRules.rows }}"
+                            >
+                            </textarea>
+                        </oui-field>
+                    </div>
 
                     <oui-field
                         label="{{:: 'server_configuration_netboot_rescue_mail' | translate}}"
@@ -196,9 +243,22 @@
                 </li>
                 <li data-ng-if="$ctrl.currentNetboot.type === $ctrl.RESCUE">
                     <strong
+                        data-ng-bind=":: 'server_configuration_netboot_auth_method' | translate"
+                    ></strong>
+                    <span data-ng-bind="$ctrl.currentAuthMethod"></span>
+                </li>
+                <li data-ng-if="$ctrl.currentNetboot.type === $ctrl.RESCUE">
+                    <strong
                         data-ng-bind=":: 'server_configuration_netboot_step2_rescue_mail' | translate"
                     ></strong>
-                    <span data-ng-bind="$ctrl.currentNetboot.rescueMail"></span>
+                    <span
+                        data-ng-if="$ctrl.currentNetboot.rescueMail !== '' && $ctrl.currentNetboot.rescueMail !== null"
+                        data-ng-bind="$ctrl.currentNetboot.rescueMail"
+                    ></span>
+                    <span
+                        data-ng-if="$ctrl.currentNetboot.rescueMail === '' || $ctrl.currentNetboot.rescueMail === null"
+                        data-ng-bind=":: 'server_configuration_netboot_rescue_mail_none' | translate"
+                    ></span>
                 </li>
                 <li data-ng-if="$ctrl.currentNetboot.type === $ctrl.NETWORK">
                     <strong

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_de_DE.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_de_DE.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Update wird durchgeführt...",
   "server_configuration_netboot_invalid": "Ungültig",
   "server_configuration_netboot_rescue_help": "Der Rescue-Modus kann nützlich sein, um auf einem Dedicated Server Hardwareprobleme zu diagnostizieren.",
-  "server_configuration_netboot_rescue_help_link": "Sehen Sie sich die Anleitung für die Hardware-Diagnose an."
+  "server_configuration_netboot_rescue_help_link": "Sehen Sie sich die Anleitung für die Hardware-Diagnose an.",
+  "server_configuration_netboot_rescue_mail_none": "Keine",
+  "server_configuration_netboot_auth_method": "Authentifizierungsmethode:",
+  "server_configuration_netboot_auth_method_sshkey": "Authentifizierung per SSH-Schlüssel",
+  "server_configuration_netboot_auth_method_password": "Authentifizierung per Kennwort",
+  "server_configuration_netboot_sshkey_input": "Ihr öffentlicher SSH-Schlüssel:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Fügen Sie einen Wert vom Typ sshPubKey ein. Beispiel: {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_en_GB.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_en_GB.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Updating...",
   "server_configuration_netboot_invalid": "Invalid",
   "server_configuration_netboot_rescue_help": "Rescue mode is useful for diagnosing hardware faults on a dedicated server.",
-  "server_configuration_netboot_rescue_help_link": "Access the hardware diagnostic guide."
+  "server_configuration_netboot_rescue_help_link": "Access the hardware diagnostic guide.",
+  "server_configuration_netboot_rescue_mail_none": "None",
+  "server_configuration_netboot_auth_method": "Authentication method:",
+  "server_configuration_netboot_auth_method_sshkey": "Authentication via SSH key",
+  "server_configuration_netboot_auth_method_password": "Password authentication",
+  "server_configuration_netboot_sshkey_input": "Your Public SSH key:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Enter an sshPubKey value. For example: {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_es_ES.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_es_ES.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Actualización",
   "server_configuration_netboot_invalid": "No válido",
   "server_configuration_netboot_rescue_help": "El modo «rescue» puede resultar útil a la hora de diagnosticar fallos de hardware en un servidor dedicado.",
-  "server_configuration_netboot_rescue_help_link": "Acceder a la guía de diagnóstico de hardware."
+  "server_configuration_netboot_rescue_help_link": "Acceder a la guía de diagnóstico de hardware.",
+  "server_configuration_netboot_rescue_mail_none": "Ninguno",
+  "server_configuration_netboot_auth_method": "Método de autenticación:",
+  "server_configuration_netboot_auth_method_sshkey": "Autenticación con clave SSH",
+  "server_configuration_netboot_auth_method_password": "Autenticación con contraseña",
+  "server_configuration_netboot_sshkey_input": "Su clave SSH pública:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Introduzca un valor de tipo «sshPubKey». Ejemplo: {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_CA.json
@@ -19,6 +19,7 @@
   "server_configuration_netboot_rescue_help_link": "Accéder au guide de diagnostic matériel.",
   "server_configuration_netboot_rescue_choice": "Rescue disponible :",
   "server_configuration_netboot_rescue_mail": "Recevoir les identifiants du mode sur l'adresse e-mail :",
+  "server_configuration_netboot_rescue_mail_none": "Aucune",
   "server_configuration_netboot_rescue_mail_invalid": "Invalide",
   "server_configuration_netboot_kernel_choice": "Kernel disponible :",
   "server_configuration_netboot_kernel_option": "Options prise en charges par ce kernel :",
@@ -38,5 +39,10 @@
   "server_configuration_netboot_confirm": "Valider",
   "server_configuration_netboot_review": "Résumé",
   "server_configuration_netboot_save_in_progress": "Mise à jour...",
-  "server_configuration_netboot_invalid": "Invalide"
+  "server_configuration_netboot_invalid": "Invalide",
+  "server_configuration_netboot_auth_method": "Méthode d'authentification :",
+  "server_configuration_netboot_auth_method_sshkey": "Authentification par clé SSH",
+  "server_configuration_netboot_auth_method_password": "Authentification par mot de passe",
+  "server_configuration_netboot_sshkey_input": "Votre clé SSH Publique :",
+  "server_configuration_netboot_sshkey_input_placeholder": "Insérez une valeur de type sshPubKey. Exemple : {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_fr_FR.json
@@ -19,6 +19,7 @@
   "server_configuration_netboot_rescue_help_link": "Accéder au guide de diagnostic matériel.",
   "server_configuration_netboot_rescue_choice": "Rescue disponible :",
   "server_configuration_netboot_rescue_mail": "Recevoir les identifiants du mode sur l'adresse e-mail :",
+  "server_configuration_netboot_rescue_mail_none": "Aucune",
   "server_configuration_netboot_rescue_mail_invalid": "Invalide",
   "server_configuration_netboot_kernel_choice": "Kernel disponible :",
   "server_configuration_netboot_kernel_option": "Options prise en charges par ce kernel :",
@@ -38,5 +39,10 @@
   "server_configuration_netboot_confirm": "Valider",
   "server_configuration_netboot_review": "Résumé",
   "server_configuration_netboot_save_in_progress": "Mise à jour...",
-  "server_configuration_netboot_invalid": "Invalide"
+  "server_configuration_netboot_invalid": "Invalide",
+  "server_configuration_netboot_auth_method": "Méthode d'authentification :",
+  "server_configuration_netboot_auth_method_sshkey": "Authentification par clé SSH",
+  "server_configuration_netboot_auth_method_password": "Authentification par mot de passe",
+  "server_configuration_netboot_sshkey_input": "Votre clé SSH Publique :",
+  "server_configuration_netboot_sshkey_input_placeholder": "Insérez une valeur de type sshPubKey. Exemple : {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_it_IT.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_it_IT.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Aggiornamento...",
   "server_configuration_netboot_invalid": "Non valido",
   "server_configuration_netboot_rescue_help": "La modalità Rescue può essere utile per diagnosticare malfunzionamenti hardware su un server dedicato.",
-  "server_configuration_netboot_rescue_help_link": "Accedi alla guida di diagnostica hardware."
+  "server_configuration_netboot_rescue_help_link": "Accedi alla guida di diagnostica hardware.",
+  "server_configuration_netboot_rescue_mail_none": "Nessuno",
+  "server_configuration_netboot_auth_method": "Metodo di autenticazione:",
+  "server_configuration_netboot_auth_method_sshkey": "Autenticazione tramite chiave SSH",
+  "server_configuration_netboot_auth_method_password": "Autenticazione tramite password",
+  "server_configuration_netboot_sshkey_input": "La tua chiave SSH pubblica:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Inserire un valore di tipo sshPubKey. Esempio: {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pl_PL.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Aktualizacja...",
   "server_configuration_netboot_invalid": "Nieprawidłowy",
   "server_configuration_netboot_rescue_help": "Tryb rescue może być przydatny podczas diagnozowania usterek sprzętowych na serwerze dedykowanym.",
-  "server_configuration_netboot_rescue_help_link": "Dostęp do przewodnika dotyczącego diagnostyki sprzętu."
+  "server_configuration_netboot_rescue_help_link": "Dostęp do przewodnika dotyczącego diagnostyki sprzętu.",
+  "server_configuration_netboot_rescue_mail_none": "Brak",
+  "server_configuration_netboot_auth_method": "Metoda uwierzytelnienia:",
+  "server_configuration_netboot_auth_method_sshkey": "Uwierzytelnienie za pomocą klucza SSH",
+  "server_configuration_netboot_auth_method_password": "Uwierzytelnienie za pomocą hasła",
+  "server_configuration_netboot_sshkey_input": "Publiczny klucz SSH:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Wprowadź wartość typu sshPubKey. <u>Przykład:</u> {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/bm-server-components/src/netboot/translations/Messages_pt_PT.json
@@ -38,5 +38,11 @@
   "server_configuration_netboot_save_in_progress": "Atualização...",
   "server_configuration_netboot_invalid": "Inválida",
   "server_configuration_netboot_rescue_help": "O rescue pode ser útil para diagnosticar avarias materiais num servidor dedicado.",
-  "server_configuration_netboot_rescue_help_link": "Aceda ao manual de diagnóstico de hardware"
+  "server_configuration_netboot_rescue_help_link": "Aceda ao manual de diagnóstico de hardware",
+  "server_configuration_netboot_rescue_mail_none": "Nenhuma",
+  "server_configuration_netboot_auth_method": "Método de autenticação:",
+  "server_configuration_netboot_auth_method_sshkey": "Autenticação com chave SSH",
+  "server_configuration_netboot_auth_method_password": "Autenticação com palavra-passe",
+  "server_configuration_netboot_sshkey_input": "A sua chave SSH pública:",
+  "server_configuration_netboot_sshkey_input_placeholder": "Introduza um valor do tipo sshPubKey. Exemplo: {{t0}}"
 }

--- a/packages/manager/modules/bm-server-components/src/server/server.service.js
+++ b/packages/manager/modules/bm-server-components/src/server/server.service.js
@@ -270,17 +270,6 @@ export default class Server {
     });
   }
 
-  updateRescueMail(productId, bootId, rescueMail) {
-    return this.put(productId, '', {
-      data: {
-        bootId,
-        rescueMail,
-      },
-      proxypass: true,
-      broadcast: 'dedicated.informations.reload',
-    });
-  }
-
   removeHack(productId) {
     return this.put(productId, '', {
       data: {


### PR DESCRIPTION
Ref : MANAGER-12571

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)

## Description

Added Password and SSH Key authentication choices in the dedicated servers netboot wizard
The available authentication methods depends on the selected rescue kernel.

## Related

MANAGER-12571

### Translations
- [x] CMT-9664