### PR TITLE
fix: set alignement of osds-pagination to right

### DIFF
--- a/packages/manager-components/src/components/paginated-datagrid/paginated-datagrid.component.tsx
+++ b/packages/manager-components/src/components/paginated-datagrid/paginated-datagrid.component.tsx
@@ -205,6 +205,7 @@ export const PaginatedDatagrid = <T extends unknown>({
       {pagination && (
         <OsdsPagination
           current={pagination.pageIndex + 1}
+          className={'flex justify-end'}
           total-items={totalItems}
           total-pages={pageCount}
           default-items-per-page={pagination.pageSize}


### PR DESCRIPTION
ref:DTCORE-1910

Align to right the pagination datagrid