### PR TITLE
fix(pci-vouchers): wrong text for buy credit modal

### DIFF
--- a/packages/manager/apps/pci-vouchers/src/components/vouchers/BuyCreditModal.tsx
+++ b/packages/manager/apps/pci-vouchers/src/components/vouchers/BuyCreditModal.tsx
@@ -117,7 +117,7 @@ export default function BuyCreditModal({
           onClick={() => buy(amount)}
           data-testid="submitButton"
         >
-          {t('common_confirm')}
+          {t('cpb_vouchers_add_credit_valid')}
         </OsdsButton>
       </OsdsModal>
     </>


### PR DESCRIPTION
ref: DTCORE-1913

display the right text for buy credit modal
