### PR TITLE
fix(container): safari not rendering svg icons

### DIFF
--- a/packages/manager/core/ovh-product-icons/utils/SvgIconWrapper.tsx
+++ b/packages/manager/core/ovh-product-icons/utils/SvgIconWrapper.tsx
@@ -25,11 +25,13 @@ const iconComponents: IconComponents = {
   ...telecomIcons,
 };
 
+const DEFAULT_SIZE = 32;
+
 const SvgIconWrapper: React.FC<SvgIconProps> = ({
   name,
   className,
-  width,
-  height,
+  width = DEFAULT_SIZE,
+  height = DEFAULT_SIZE,
 }) => {
   const IconComponent = iconComponents[name];
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | INC0021526 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Issue on svgIconWrapper class, safari browser not rendering SVGs without height and width attribute.
