### PR TITLE
fix(public-cloud): use add private network link if no private network

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
@@ -60,11 +60,19 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href('pci.projects.project.privateNetwork', {
           projectId,
         }),
-      addLocalPrivateNetworksLink: /* @ngInject */ ($state, projectId) =>
-        $state.href('pci.projects.project.privateNetwork.localZone', {
-          projectId,
-        }),
-
+      addLocalPrivateNetworksLink: /* @ngInject */ (
+        $state,
+        projectId,
+        privateNetworks,
+      ) =>
+        $state.href(
+          `pci.projects.project.privateNetwork.${
+            !privateNetworks.length ? 'add' : 'localZone'
+          }`,
+          {
+            projectId,
+          },
+        ),
       goBack: /* @ngInject */ (goToInstances) => goToInstances,
 
       prices: /* @ngInject */ (

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.routing.js
@@ -60,19 +60,10 @@ export default /* @ngInject */ ($stateProvider) => {
         $state.href('pci.projects.project.privateNetwork', {
           projectId,
         }),
-      addLocalPrivateNetworksLink: /* @ngInject */ (
-        $state,
-        projectId,
-        privateNetworks,
-      ) =>
-        $state.href(
-          `pci.projects.project.privateNetwork.${
-            !privateNetworks.length ? 'add' : 'localZone'
-          }`,
-          {
-            projectId,
-          },
-        ),
+      addLocalPrivateNetworksLink: /* @ngInject */ ($state, projectId) =>
+        $state.href('pci.projects.project.privateNetwork.add', {
+          projectId,
+        }),
       goBack: /* @ngInject */ (goToInstances) => goToInstances,
 
       prices: /* @ngInject */ (


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13911
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

On instance creation page if the user choose a local zone region, and has no private network, a link is displaying which redirect to private network creation

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
