### PR TITLE
feat(dedicated.account): validation message clarification in the manager

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png Maximale Größe: 10 MB",
   "user_account_identity_documents_submit": "Meine Dokumente senden",
   "user_account_identity_documents_submit_success_message_title": "Wir haben Ihre Dokumente erhalten.",
-  "user_account_identity_documents_submit_success_message_description": "Wir haben alle Ihre Dokumente erhalten. Sie werden unseren Teams zur Validierung vorgelegt. Sie werden per E-Mail über die Validierung informiert oder kontaktiert, wenn wir weitere Informationen benötigen.",
+  "user_account_identity_documents_submit_success_message_description": "Sie werden unseren Teams zur Validierung vorgelegt. Sie werden per E-Mail über die Validierung informiert oder kontaktiert, wenn wir weitere Informationen benötigen.",
   "user_account_identity_documents_submit_error_message_description": "Ihre Dokumente wurden nicht richtig gesendet. Bitte wiederholen Sie den Upload und die Übermittlung Ihrer Dokumente.",
   "user_account_identity_documents_go_back_to_dashboard": "Mein Dashboard anzeigen",
   "user_account_identity_documents_legal_info1": "OVH S.A.S ist für die Verarbeitung Ihrer personenbezogenen Daten verantwortlich. Die über dieses Formular erhobenen Daten werden verarbeitet, um den <a href=\"{{ link1 }}\" target=\"_blank\">Richtlinien zur Cybersicherheit vom 28.04.2022</a> Rechnung zu tragen, die das CERT-IN gemäß den Bestimmungen des Unterabschnitts (6) von <a href=\"{{ link2 }}\" target=\"_blank\">Artikel 70B</a> des Information Technology (IT) Act von 2000 veröffentlicht hat.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png\nMaximum size: 10 MB.",
   "user_account_identity_documents_submit": "Send my documents",
   "user_account_identity_documents_submit_success_message_title": "Thank you, we have received your documents!",
-  "user_account_identity_documents_submit_success_message_description": "We have received all of your documents. They will be submitted to our teams for validation. You will be notified of their validation by email, or you will be contacted if we need further information.",
+  "user_account_identity_documents_submit_success_message_description": "They will be submitted to our teams for validation. You will be notified of their validation by email, or you will be contacted if we need further information.",
   "user_account_identity_documents_submit_error_message_description": "Your documents were not sent correctly. Please re-upload your documents.",
   "user_account_identity_documents_go_back_to_dashboard": "View my dashboard",
   "user_account_identity_documents_legal_info1": "OVH S.A.S is responsible for processing your personal data. The data collected via this form is processed in order to comply with the <a href=\"{{ link1 }}\" target=\"_blank\">Cybersecurity Guidelines of 28.04.2022</a> published by CERT-IN under the provisions of subsection (6) of <a href=\"{{ link2 }}\" target=\"_blank\">section 70B</a> of The Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png Tamaño máximo: 10 MB.",
   "user_account_identity_documents_submit": "Enviar mis documentos",
   "user_account_identity_documents_submit_success_message_title": "Gracias, ¡hemos recibido sus documentos!",
-  "user_account_identity_documents_submit_success_message_description": "Le confirmamos que hemos recibido todos sus documentos. A continuación, deberán ser validados por nuestro equipo. Le enviaremos un mensaje de correo electrónico una vez que hayan sido validados. Si es necesaria alguna información adicional, nos pondremos en contacto con usted.",
+  "user_account_identity_documents_submit_success_message_description": "A continuación, deberán ser validados por nuestro equipo. Le enviaremos un mensaje de correo electrónico una vez que hayan sido validados. Si es necesaria alguna información adicional, nos pondremos en contacto con usted.",
   "user_account_identity_documents_submit_error_message_description": "Sus documentos no se han enviado correctamente. Por favor, vuelva a cargarlos y a enviar sus documentos.",
   "user_account_identity_documents_go_back_to_dashboard": "Ver mi panel de control",
   "user_account_identity_documents_legal_info1": "OVH SAS es el responsable del tratamiento de sus datos personales. Los datos recopilados a través de este formulario son tratados en cumplimiento de las <a href=\"{{ link1 }}\" target=\"_blank\">Directrices de Ciberseguridad del 28/04/2022</a> publicadas por el CERT-In en virtud de las disposiciones de la subsección (6) del <a href=\"{{ link2 }}\" target=\"_blank\">artículo 70-B</a> de la Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
@@ -16,12 +16,12 @@
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png Taille maximale: 10 mo.",
   "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
-  "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
-  "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",
-  "user_account_identity_documents_submit_error_message_description": "Vos documents n’ont pas été correctement envoyés. Veuillez refaire l’upload et l’envoi de vos documents",
+  "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents !",
+  "user_account_identity_documents_submit_success_message_description": "Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d'informations complémentaires.",
+  "user_account_identity_documents_submit_error_message_description": "Vos documents n'ont pas été correctement envoyés. Veuillez refaire l'upload et l'envoi de vos documents",
   "user_account_identity_documents_go_back_to_dashboard": "Voir mon tableau de bord",
-  "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l’Information Technology (IT) Act, 2000.",
-  "user_account_identity_documents_legal_info2": "Pour en savoir plus sur le traitement de vos données personnelles et connaître vos droits, vous pouvez consulter notre <a href=\"{{ link }}\" target=\"_blank\">Politique d’utilisation des données à caractère personnel.</a>",
+  "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l'Information Technology (IT) Act, 2000.",
+  "user_account_identity_documents_legal_info2": "Pour en savoir plus sur le traitement de vos données personnelles et connaître vos droits, vous pouvez consulter notre <a href=\"{{ link }}\" target=\"_blank\">Politique d'utilisation des données à caractère personnel.</a>",
   "user_account_identity_documents_verification_in_progress_info": "Le traitement de vos documents est actuellement en cours d'analyse par notre équipe.",
   "user_account_identity_documents_verification_waiting_info": "Votre demande a été analysée mais nécessite des documents complémentaires. Veuillez consulter votre ticket de support."
 }

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
@@ -16,12 +16,12 @@
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png Taille maximale: 10 mo.",
   "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
-  "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
+  "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents !",
   "user_account_identity_documents_submit_success_message_description": "Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d'informations complémentaires.",
-  "user_account_identity_documents_submit_error_message_description": "Vos documents n’ont pas été correctement envoyés. Veuillez refaire l’upload et l’envoi de vos documents",
+  "user_account_identity_documents_submit_error_message_description": "Vos documents n'ont pas été correctement envoyés. Veuillez refaire l'upload et l'envoi de vos documents",
   "user_account_identity_documents_go_back_to_dashboard": "Voir mon tableau de bord",
-  "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l’Information Technology (IT) Act, 2000.",
-  "user_account_identity_documents_legal_info2": "Pour en savoir plus sur le traitement de vos données personnelles et connaître vos droits, vous pouvez consulter notre <a href=\"{{ link }}\" target=\"_blank\">Politique d’utilisation des données à caractère personnel.</a>",
+  "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l'Information Technology (IT) Act, 2000.",
+  "user_account_identity_documents_legal_info2": "Pour en savoir plus sur le traitement de vos données personnelles et connaître vos droits, vous pouvez consulter notre <a href=\"{{ link }}\" target=\"_blank\">Politique d'utilisation des données à caractère personnel.</a>",
   "user_account_identity_documents_verification_in_progress_info": "Le traitement de vos documents est actuellement en cours d'analyse par notre équipe.",
   "user_account_identity_documents_verification_waiting_info": "Votre demande a été analysée mais nécessite des documents complémentaires. Veuillez consulter votre ticket de support."
 }

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
@@ -17,7 +17,7 @@
   "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
-  "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",
+  "user_account_identity_documents_submit_success_message_description": "Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",
   "user_account_identity_documents_submit_error_message_description": "Vos documents n’ont pas été correctement envoyés. Veuillez refaire l’upload et l’envoi de vos documents",
   "user_account_identity_documents_go_back_to_dashboard": "Voir mon tableau de bord",
   "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l’Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
@@ -17,7 +17,7 @@
   "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
-  "user_account_identity_documents_submit_success_message_description": "Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",
+  "user_account_identity_documents_submit_success_message_description": "Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d'informations complémentaires.",
   "user_account_identity_documents_submit_error_message_description": "Vos documents n’ont pas été correctement envoyés. Veuillez refaire l’upload et l’envoi de vos documents",
   "user_account_identity_documents_go_back_to_dashboard": "Voir mon tableau de bord",
   "user_account_identity_documents_legal_info1": "OVH S.A.S est le responsable du traitement de vos données personnelles. Les données collectées via ce formulaire sont traitées afin de se conformer aux <a href=\"{{ link1 }}\" target=\"_blank\">Directives de cybersécurité du 28.04.2022</a> publiées par le CERT-IN en vertu des dispositions de la sous-section (6) de <a href=\"{{ link2 }}\" target=\"_blank\">l'article 70B</a> de l’Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png Dimensione massima: 10 MB.",
   "user_account_identity_documents_submit": "Invia i documenti",
   "user_account_identity_documents_submit_success_message_title": "Grazie, abbiamo ricevuto i tuoi documenti!",
-  "user_account_identity_documents_submit_success_message_description": "Abbiamo ricevuto tutti i documenti, che verranno verificati dai nostri team. Riceverai un'email di conferma di validazione oppure verrai contattato se avremo bisogno di maggiori informazioni.",
+  "user_account_identity_documents_submit_success_message_description": "che verranno verificati dai nostri team. Riceverai un'email di conferma della validazione o verrai contattato se avremo bisogno di maggiori informazioni.",
   "user_account_identity_documents_submit_error_message_description": "I documenti non sono stati inviati correttamente. Ti preghiamo di procedere nuovamente all’upload e all’invio dei documenti.",
   "user_account_identity_documents_go_back_to_dashboard": "Visualizza il pannello di controllo",
   "user_account_identity_documents_legal_info1": "OVH S.A.S è il responsabile del trattamento dei tuoi dati personali. I dati raccolti tramite questo modulo sono trattati in conformità con le <a href=\"{{ link1 }}\" target=\"_blank\">Direttive sulla cybersicurezza del 28.04.2022</a> pubblicate dal CERT-IN ai sensi delle disposizioni della sottosezione (6) dell'<a href=\"{{ link2 }}\" target=\"_blank\">articolo 70B</a> dell’Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png Maksymalny rozmiar: 10 MB.",
   "user_account_identity_documents_submit": "Wyślij dokumenty",
   "user_account_identity_documents_submit_success_message_title": "Dziękujemy, potwierdzamy, że otrzymaliśmy Twoje dokumenty!",
-  "user_account_identity_documents_submit_success_message_description": "Otrzymaliśmy wszystkie Twoje dokumenty. Przekażemy je naszym zespołom do zatwierdzenia. Wyślemy do Ciebie e-mail z informacją o ich zatwierdzeniu lub skontaktujemy się z Tobą, jeśli będziemy potrzebować dodatkowych informacji.",
+  "user_account_identity_documents_submit_success_message_description": "Przekażemy je naszym zespołom do zatwierdzenia. O ich zatwierdzeniu zostaniesz poinformowany e-mailem. Jeśli będziemy potrzebować dodatkowych informacji, skontaktujemy się z Tobą.",
   "user_account_identity_documents_submit_error_message_description": "Twoje dokumenty nie zostały poprawnie wysłane. Prosimy o ponowne ich załadowanie i przesłanie.",
   "user_account_identity_documents_go_back_to_dashboard": "Wyświetl mój dashboard",
   "user_account_identity_documents_legal_info1": "Grupa OVH S.A.S jest odpowiedzialna za przetwarzanie  Twoich danych osobowych. Dane gromadzone za pomocą tego formularza są przetwarzane w celu zapewnienia zgodności z <a href=\"{{ link1 }}\" target=\"_blank\">Wytycznymi dotyczącymi cyberbezpieczeństwa z dnia 28.04.2022</a> opublikowanymi przez CERT-IN na podstawie przepisów zawartych w podsekcji 6 <a href=\"{{ link2 }}\" target=\"_blank\">art. 70B</a> ustawy o technologii informacyjnej (IT) z 2000 r.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png. Tamanho máximo: 10 MB.",
   "user_account_identity_documents_submit": "Enviar os meus documentos",
   "user_account_identity_documents_submit_success_message_title": "Obrigado. Recebemos com êxito os seus documentos!",
-  "user_account_identity_documents_submit_success_message_description": "Recebemos com êxito todos os seus documentos. Serão sujeitos a validação por parte das nossas equipas. Receberá por e-mail a confirmação da validação, ou será contactado caso seja necessário fornecer mais informações.",
+  "user_account_identity_documents_submit_success_message_description": "Serão sujeitos a validação por parte das nossas equipas. Receberá por e-mail a confirmação da validação, ou será contactado caso seja necessário fornecer mais informações.",
   "user_account_identity_documents_submit_error_message_description": "Os seus documentos não foram corretamente enviados. Repita o upload e o envio dos seus documentos",
   "user_account_identity_documents_go_back_to_dashboard": "Ver o painel de controlo",
   "user_account_identity_documents_legal_info1": "A OVH S.A.S é a responsável pelo tratamento dos seus dados pessoais. Os dados recolhidos através deste formulário são tratados de modo a cumprir as <a href=\"{{ link1 }}\" target=\"_blank\">Diretrizes de Cibersegurança de 28/04/2022</a>, publicadas pelo CERT-IN, em conformidade com o disposto na subsecção (6) <a href=\"{{ link2 }}\" target=\"_blank\">do artigo 70B</a> do Information Technology (IT) Act, 2000.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
@@ -7,7 +7,7 @@
     <!-- information banner for open status -->
     <oui-message
         data-type="info"
-        data-ng-if="$ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN && !$ctrl.displayError"
+        data-ng-if="$ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN && !$ctrl.displayError && $ctrl.showUploadOption"
     >
         <span
             data-translate="user_account_identity_documents_verification_in_progress_info"


### PR DESCRIPTION
Avoid to have an info and a success banner at the same time when an indian user try to upload documents Ref: MANAGER-13110

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-13110
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

I add a condition to avoid the info banner appear at the same time of the success banner when the user upload a document.

## Related

Translations:
- [x] CMT-10584
