### PR TITLE
fix(pci-ssh-keys): use correct translations for modal add ssh key

### DIFF
--- a/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/AddSshModal.tsx
+++ b/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/AddSshModal.tsx
@@ -123,7 +123,7 @@ export default function AddSshModal({
           variant={ODS_BUTTON_VARIANT.ghost}
           onClick={onClose}
         >
-          {t('common_cancel')}
+          {t('pci_projects_project_sshKeys_add_cancel_label')}
         </OsdsButton>
         <OsdsButton
           slot="actions"
@@ -132,7 +132,7 @@ export default function AddSshModal({
           data-testid="submitButton"
           {...(isPending || !name || !publicKey ? { disabled: true } : {})}
         >
-          {t('common_confirm')}
+          {t('pci_projects_project_sshKeys_add_submit_label')}
         </OsdsButton>
       </OsdsModal>
     </>


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-ssh-keys`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-1980
| License          | BSD 3-Clause

## Description

Use correct translations for action buttons for add ssh modal
