### PR TITLE
fix(pci-ssh-keys): display correct translations for remove ssh modal

### DIFF
--- a/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/RemoveSshModal.tsx
+++ b/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/RemoveSshModal.tsx
@@ -70,7 +70,7 @@ export default function RemoveSshModal({
           variant={ODS_BUTTON_VARIANT.ghost}
           onClick={onClose}
         >
-          {t('common_cancel')}
+          {t('pci_projects_project_sshKeys_remove_cancel_label')}
         </OsdsButton>
         <OsdsButton
           slot="actions"
@@ -79,7 +79,7 @@ export default function RemoveSshModal({
           {...(isPending || isPendingRemoveSsh ? { disabled: true } : {})}
           data-testid="submitButton"
         >
-          {t('common_confirm')}
+          {t('pci_projects_project_sshKeys_remove_submit_label')}
         </OsdsButton>
       </OsdsModal>
     </>


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-+ssh-keys`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          |
| License          | BSD 3-Clause


- [ ] Try to keep pull requests small so they can be easily reviewed.
- [ ] Commits are signed-off
- [ ] Only FR translations have been updated
- [ ] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Use correct translations for action button remove ssh modal
