### PR TITLE
fix(pci-ssh-keys): add error message in add ssh-key modal

### DIFF
--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_de_DE.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_de_DE.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "von",
   "common_pagination_results": "Ergebnisse",
-  "common_pagination_no_results": "Keine Ergebnisse"
+  "common_pagination_no_results": "Keine Ergebnisse",
+
+  "common_field_error_required": "Bitte füllen Sie dieses Feld aus."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_en_GB.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_en_GB.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "on",
   "common_pagination_results": "results",
-  "common_pagination_no_results": "No result"
+  "common_pagination_no_results": "No result",
+
+  "common_field_error_required": "Please fill in this field."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_es_ES.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_es_ES.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "de",
   "common_pagination_results": "resultados",
-  "common_pagination_no_results": "No hay resultados"
+  "common_pagination_no_results": "No hay resultados",
+
+  "common_field_error_required": "Complete este campo."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_fr_CA.json
@@ -28,5 +28,7 @@
 
   "common_pagination_of": "sur",
   "common_pagination_results": "résultats",
-  "common_pagination_no_results": "Aucun résultat"
+  "common_pagination_no_results": "Aucun résultat",
+
+  "common_field_error_required": "Veuillez compléter ce champ."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_fr_FR.json
@@ -28,5 +28,7 @@
 
   "common_pagination_of": "sur",
   "common_pagination_results": "résultats",
-  "common_pagination_no_results": "Aucun résultat"
+  "common_pagination_no_results": "Aucun résultat",
+
+  "common_field_error_required": "Veuillez compléter ce champ."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_it_IT.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_it_IT.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "su",
   "common_pagination_results": "risultati",
-  "common_pagination_no_results": "Nessun risultato"
+  "common_pagination_no_results": "Nessun risultato",
+
+  "common_field_error_required": "Completa questo campo"
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_pl_PL.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "z",
   "common_pagination_results": "wyniki",
-  "common_pagination_no_results": "Brak wyników"
+  "common_pagination_no_results": "Brak wyników",
+
+  "common_field_error_required": "Wypełnij to pole."
 }

--- a/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-ssh-keys/public/translations/common/Messages_pt_PT.json
@@ -25,5 +25,7 @@
 
   "common_pagination_of": "em",
   "common_pagination_results": "resultados",
-  "common_pagination_no_results": "Nenhum resultado encontrado"
+  "common_pagination_no_results": "Nenhum resultado encontrado",
+
+  "common_field_error_required": "Preencha o campo."
 }

--- a/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/AddSshModal.tsx
+++ b/packages/manager/apps/pci-ssh-keys/src/components/ssh-keys/AddSshModal.tsx
@@ -50,16 +50,28 @@ export default function AddSshModal({
   });
   const [name, setName] = useState('');
   const [publicKey, setPublicKey] = useState('');
+  const [formErrors, setFormErrors] = useState({
+    missingName: false,
+    missingKey: false,
+  });
 
   const handleInputNameChange = useCallback(
     (event: OdsInputValueChangeEvent) => {
       setName(`${event.detail.value}`);
+      setFormErrors((errors) => ({
+        ...errors,
+        missingName: !event.detail.value,
+      }));
     },
     [setName],
   );
   const handleInputPublicKeyChange = useCallback(
     (event: OsdsTextareaCustomEvent<OdsTextAreaValueChangeEvent>) => {
       setPublicKey(`${event.detail.value}`);
+      setFormErrors((errors) => ({
+        ...errors,
+        missingKey: !event.detail.value,
+      }));
     },
     [setPublicKey],
   );
@@ -73,7 +85,17 @@ export default function AddSshModal({
         <slot name="content">
           {!isPending && (
             <>
-              <OsdsFormField className={'mb-8'}>
+              <OsdsFormField
+                className={'mb-8'}
+                color={
+                  formErrors.missingName
+                    ? ODS_THEME_COLOR_INTENT.error
+                    : ODS_THEME_COLOR_INTENT.primary
+                }
+                error={
+                  formErrors.missingName ? t('common_field_error_required') : ''
+                }
+              >
                 <OsdsText
                   slot="label"
                   level={ODS_THEME_TYPOGRAPHY_LEVEL.heading}
@@ -84,13 +106,45 @@ export default function AddSshModal({
                 <OsdsInput
                   type={ODS_INPUT_TYPE.text}
                   className={'border'}
+                  color={
+                    formErrors.missingName
+                      ? ODS_THEME_COLOR_INTENT.error
+                      : ODS_THEME_COLOR_INTENT.primary
+                  }
+                  {...{ error: formErrors.missingName ? true : undefined }}
+                  style={
+                    formErrors.missingName
+                      ? {
+                          borderColor: 'var(--ods-color-error-200)',
+                        }
+                      : {}
+                  }
                   required={true}
                   onOdsValueChange={handleInputNameChange}
+                  onOdsInputBlur={() =>
+                    setFormErrors((errors) => ({
+                      ...errors,
+                      missingName: !name,
+                    }))
+                  }
                   ariaLabel={t('pci_projects_project_sshKeys_add_name')}
                   data-testid="sshKeyName"
                 />
               </OsdsFormField>
-              <OsdsFormField>
+              <OsdsFormField
+                color={
+                  formErrors.missingKey
+                    ? ODS_THEME_COLOR_INTENT.error
+                    : ODS_THEME_COLOR_INTENT.primary
+                }
+                error={
+                  formErrors.missingKey
+                    ? `${t('common_field_error_required')} ${t(
+                        'pci_projects_project_sshKeys_add_infos',
+                      )}`
+                    : ''
+                }
+              >
                 <OsdsText
                   slot="label"
                   level={ODS_THEME_TYPOGRAPHY_LEVEL.heading}
@@ -99,9 +153,20 @@ export default function AddSshModal({
                   {t('pci_projects_project_sshKeys_add_key')}
                 </OsdsText>
                 <OsdsTextarea
-                  className={'border'}
+                  color={
+                    formErrors.missingKey
+                      ? ODS_THEME_COLOR_INTENT.error
+                      : ODS_THEME_COLOR_INTENT.primary
+                  }
+                  {...{ error: formErrors.missingKey ? true : undefined }}
                   required={true}
                   onOdsValueChange={handleInputPublicKeyChange}
+                  onOdsBlur={() =>
+                    setFormErrors((errors) => ({
+                      ...errors,
+                      missingKey: !publicKey,
+                    }))
+                  }
                   ariaLabel={t('pci_projects_project_sshKeys_add_key')}
                   data-testid="sshPublicKey"
                   rows={5}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-ssh-keys
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-1983
| License          | BSD 3-Clause

## Description

Add error message to ssh key add modal