### PR TITLE
fix(octavia): fix the helping text for delay on Health Monitor

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/pools/detail/health-monitor/components/health-monitor-form/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/octavia-load-balancer/src/load-balancers/load-balancer/pools/detail/health-monitor/components/health-monitor-form/translations/Messages_fr_FR.json
@@ -10,7 +10,7 @@
   "octavia_load_balancer_health_monitor_form_expected_code_help": "Le code HTTP considéré comme un succès",
   "octavia_load_balancer_health_monitor_form_expected_code_tooltip": "Les codes d'état HTTP attendus en cas de réussite du health check. Il doit s'agir d'un seul chiffre, d'une liste de chiffres séparés par des virgules ou d'un intervalle (deux chiffres séparés par un trait d'union).",
   "octavia_load_balancer_health_monitor_form_max_retries_down_tooltip": "Le nombre d'échecs de connexion autorisé avant de marquer le membre comme erreur. Doit être un nombre compris entre 1 et 10. La valeur par défaut est 3. ",
-  "octavia_load_balancer_health_monitor_form_delay_tooltip": "Intervalle entre 2 tests du Health Monitor. Doit être supérieur ou égal au timeout.",
+  "octavia_load_balancer_health_monitor_form_delay_tooltip": "Intervalle entre 2 tests du Health Monitor. Doit être supérieur au timeout.",
   "octavia_load_balancer_health_monitor_form_max_retries_tooltip": "Le nombre d'échecs de connexion autorisés avant de marquer le membre comme inactif. Doit être un nombre compris entre 1 et 10.",
   "octavia_load_balancer_health_monitor_form_timeout_tooltip": "Le temps après lequel un health check s'arrête. Doit être un nombre supérieur ou égal à 0 et inférieur à la périodicité",
   "octavia_load_balancer_health_monitor_form_cancel": "Annuler",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/octavia-health-monitor`
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-13841
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

## Related

