### PR TITLE
fix(pci-ssh-keys): fix clickable disable button

### DIFF
--- a/packages/manager/apps/pci-ssh-keys/src/pages/ListingPage.tsx
+++ b/packages/manager/apps/pci-ssh-keys/src/pages/ListingPage.tsx
@@ -157,12 +157,14 @@ export default function ListingPage() {
           color={ODS_THEME_COLOR_INTENT.primary}
           disabled={isDiscoveryProject(project) ? true : undefined}
           onClick={() => {
-            navigate('./add');
-            trackClick({
-              name: 'PCI_PROJECTS_SSH_KEYS_ADD',
-              type: 'action',
-              level2: PCI_LEVEL2,
-            });
+            if (!isDiscoveryProject(project)) {
+              navigate('./add');
+              trackClick({
+                name: 'PCI_PROJECTS_SSH_KEYS_ADD',
+                type: 'action',
+                level2: PCI_LEVEL2,
+              });
+            }
           }}
         >
           <OsdsIcon


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-ssh-keys
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-1990
| License          | BSD 3-Clause

## Description

fix clickable disabled ods button