### PR TITLE
fix(octavia): load of network if no public ip selection

### DIFF
--- a/packages/manager/modules/octavia-load-balancer/src/create/controller.js
+++ b/packages/manager/modules/octavia-load-balancer/src/create/controller.js
@@ -140,10 +140,6 @@ export default class OctaviaLoadBalancerCreateCtrl {
       });
   }
 
-  onFloatingIpChange() {
-    this.getPrivateNetworks();
-  }
-
   isPrivateNetworkStepValid() {
     return (
       !this.gatewayLoading &&

--- a/packages/manager/modules/octavia-load-balancer/src/create/template.html
+++ b/packages/manager/modules/octavia-load-balancer/src/create/template.html
@@ -98,6 +98,7 @@
             data-name="{{:: stepFloatingIp.name}}"
             data-header="{{:: 'octavia_load_balancer_create_floating_ip_title' | translate }}"
             data-prevent-next="true"
+            data-on-focus="$ctrl.getPrivateNetworks()"
             data-on-submit="$ctrl.trackFinishStep('3')"
         >
             <p
@@ -121,7 +122,6 @@
                         data-title="{{:: 'octavia_load_balancer_create_floating_ip_field' | translate }}"
                         data-placeholder="{{:: 'octavia_load_balancer_create_floating_ip_field' | translate }}"
                         data-name="{{:: stepPrivateNetwork.name + '_select_floatingip'}}"
-                        on-change="$ctrl.onFloatingIpChange()"
                         searchable
                     >
                     </oui-select>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13157
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

When the user don't touch the public IP selection box, the networks are not loaded as it is done on public IP change event.
This PR move the network loading to the focus of the public IP step. As private network, subnet and gateway check are quite long to load, doing it on the previous step is faster for the user


## Related

<!-- Link dependencies of this PR -->
