### PR TITLE
feat(dedicated.account): error messages to be reviewed

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "GST-Zertifikat (optional)",
   "user_account_identity_documents_description": "Die Dokumente werden nach Vertragsende noch 5 Jahre aufbewahrt.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. Die maximale Dateigröße für jedes Dokument beträgt 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Nicht unterstütztes Dateiformat. Bitte verwenden Sie eines der zulässigen Formate: jpg, jpeg, pdf und png",
+  "user_account_identity_documents_selection_file_format_invalid": "Das Format {{values}} der hochgeladenen Dokumente wird nicht akzeptiert. Verwenden Sie bitte eines der unterstützten Formate: .jpg, .jpeg, .pdf oder .png.",
   "user_account_identity_documents_submit": "Meine Dokumente senden",
   "user_account_identity_documents_submit_success_message_title": "Wir haben Ihre Dokumente erhalten.",
   "user_account_identity_documents_submit_success_message_description": "Wir haben alle Ihre Dokumente erhalten. Sie werden unseren Teams zur Validierung vorgelegt. Sie werden per E-Mail über die Validierung informiert oder kontaktiert, wenn wir weitere Informationen benötigen.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "GST certificate (optional)",
   "user_account_identity_documents_description": "The documents will be retained for 5 years after the end of the contract.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. The file size limit for each document is 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "File format not supported. Please use one of the accepted formats: jpg, jpeg, pdf and png",
+  "user_account_identity_documents_selection_file_format_invalid": "The {{values}} format of the downloaded document(s) is not supported. Please respect the format requirements: jpg, jpeg, pdf, and png.",
   "user_account_identity_documents_submit": "Send my documents",
   "user_account_identity_documents_submit_success_message_title": "Thank you, we have received your documents!",
   "user_account_identity_documents_submit_success_message_description": "We have received all of your documents. They will be submitted to our teams for validation. You will be notified of their validation by email, or you will be contacted if we need further information.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificado GST (opcional)",
   "user_account_identity_documents_description": "Los documentos se conservarán durante 5 años una vez finalizado el contrato.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf y png. El tamaño máximo del archivo para cada documento es de 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato de archivo no compatible. Por favor, utilice cualquiera de los formatos aceptados: jpg, jpeg, pdf y png.",
+  "user_account_identity_documents_selection_file_format_invalid": "El formato {{values}} del (los) documento(s) adjunto(s) no es válido. Por favor, utilice cualquiera de los formatos indicados: jpg, jpeg, pdf y png.",
   "user_account_identity_documents_submit": "Enviar mis documentos",
   "user_account_identity_documents_submit_success_message_title": "Gracias, ¡hemos recibido sus documentos!",
   "user_account_identity_documents_submit_success_message_description": "Le confirmamos que hemos recibido todos sus documentos. A continuación, deberán ser validados por nuestro equipo. Le enviaremos un mensaje de correo electrónico una vez que hayan sido validados. Si es necesaria alguna información adicional, nos pondremos en contacto con usted.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificat GST (optionnel)",
   "user_account_identity_documents_description": "Les documents seront conservés durant 5 ans après la fin du contrat.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. La taille maximale du fichier pour chaque document est de 10 Mo.",
-  "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
+  "user_account_identity_documents_selection_file_format_invalid": "Le format {{values}} du ou des documents téléchargés n'est pas accepté. Veuillez respecter le format requis : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
   "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificat GST (optionnel)",
   "user_account_identity_documents_description": "Les documents seront conservés durant 5 ans après la fin du contrat.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. La taille maximale du fichier pour chaque document est de 10 Mo.",
-  "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
+  "user_account_identity_documents_selection_file_format_invalid": "Le format {{values}} du ou des documents téléchargés n'est pas accepté. Veuillez respecter le format requis : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
   "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificato GST (facoltativo)",
   "user_account_identity_documents_description": "I documenti saranno conservati per cinque anni dalla fine del contratto.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png. La dimensione massima del file per ogni documento è 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato di file non supportato. Utilizza uno dei formati accettati: jpg, jpeg, pdf e png",
+  "user_account_identity_documents_selection_file_format_invalid": "Il formato {{values}} dei documenti caricati non è accettato. Ti chiediamo di rispettare il formato richiesto: jpg, jpeg, pdf e png",
   "user_account_identity_documents_submit": "Invia i documenti",
   "user_account_identity_documents_submit_success_message_title": "Grazie, abbiamo ricevuto i tuoi documenti!",
   "user_account_identity_documents_submit_success_message_description": "Abbiamo ricevuto tutti i documenti, che verranno verificati dai nostri team. Riceverai un'email di conferma di validazione oppure verrai contattato se avremo bisogno di maggiori informazioni.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certyfikat GST (opcjonalnie)",
   "user_account_identity_documents_description": "Dokumenty będą przechowywane przez okres 5 lat od zakończenia umowy.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. Maksymalny rozmiar pliku dla każdego dokumentu to 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Nieobsługiwany format pliku. Użyj jednego z akceptowanych formatów: jpg, jpeg, pdf i png",
+  "user_account_identity_documents_selection_file_format_invalid": "Format {{values}} pobranego/pobranych dokumentów nie jest akceptowany. Zachowaj wymagany format: jpg, jpeg, pdf i png",
   "user_account_identity_documents_submit": "Wyślij dokumenty",
   "user_account_identity_documents_submit_success_message_title": "Dziękujemy, potwierdzamy, że otrzymaliśmy Twoje dokumenty!",
   "user_account_identity_documents_submit_success_message_description": "Otrzymaliśmy wszystkie Twoje dokumenty. Przekażemy je naszym zespołom do zatwierdzenia. Wyślemy do Ciebie e-mail z informacją o ich zatwierdzeniu lub skontaktujemy się z Tobą, jeśli będziemy potrzebować dodatkowych informacji.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificado GST (facultativo)",
   "user_account_identity_documents_description": "Os documentos serão conservados durante cinco anos após o termo do contrato.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png. O tamanho máximo do ficheiro para cada documento é de 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato de ficheiro não suportado. Utilize um dos formatos possíveis: jpg, jpeg, pdf e png",
+  "user_account_identity_documents_selection_file_format_invalid": "O formato {{values}} dos documentos descarregados não é aceite. Respeite por favor o formato exigido : jpg, jpeg, pdf e png",
   "user_account_identity_documents_submit": "Enviar os meus documentos",
   "user_account_identity_documents_submit_success_message_title": "Obrigado. Recebemos com êxito os seus documentos!",
   "user_account_identity_documents_submit_success_message_description": "Recebemos com êxito todos os seus documentos. Serão sujeitos a validação por parte das nossas equipas. Receberá por e-mail a confirmação da validação, ou será contactado caso seja necessário fornecer mais informações.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
@@ -11,9 +11,10 @@ import {
 
 export default class AccountUserIdentityDocumentsController {
   /* @ngInject */
-  constructor($q, $http, coreConfig, coreURLBuilder, atInternet) {
+  constructor($q, $http, $scope, coreConfig, coreURLBuilder, atInternet) {
     this.$q = $q;
     this.$http = $http;
+    this.$scope = $scope;
     this.coreConfig = coreConfig;
     this.coreURLBuilder = coreURLBuilder;
     this.maximum_size = MAX_SIZE;
@@ -39,6 +40,10 @@ export default class AccountUserIdentityDocumentsController {
     this.user_type = USER_TYPE[this.currentUser]
       ? USER_TYPE[this.currentUser]
       : USER_TYPE.default;
+
+    this.$scope.$watchCollection('$ctrl.files', () => {
+      this.isFileExtensionsValid();
+    });
   }
 
   uploadIdentityDocuments() {
@@ -99,10 +104,19 @@ export default class AccountUserIdentityDocumentsController {
   }
 
   isFileExtensionsValid() {
-    this.fileExtensionsValid = !this.files.find(
-      ({ infos: { extension } }) =>
-        !KYC_ALLOWED_FILE_EXTENSIONS.includes(extension.toLowerCase()),
+    const badFileExtensionsList = [];
+    this.fileExtensionsValid = this.files.reduce(
+      (acc, { infos: { extension } }) => {
+        const formatedExtension = extension.toLowerCase();
+        const isExtensionIncluded = KYC_ALLOWED_FILE_EXTENSIONS.includes(
+          formatedExtension,
+        );
+        if (!isExtensionIncluded) badFileExtensionsList.push(formatedExtension);
+        return isExtensionIncluded && acc;
+      },
+      true,
     );
+    this.badFileExtensionsFormatedList = badFileExtensionsList.join(', ');
     return this.fileExtensionsValid;
   }
 

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
@@ -94,6 +94,9 @@
         <oui-message class="my-1" data-type="error">
             <span
                 data-translate="user_account_identity_documents_selection_file_format_invalid"
+                data-translate-values="{
+                  values: $ctrl.badFileExtensionsFormatedList
+                }"
             ></span>
         </oui-message>
     </div>
@@ -114,7 +117,7 @@
 
         <oui-form-actions
             class="mt-5"
-            data-disabled="$ctrl.form.$invalid || !$ctrl.files || $ctrl.files.length === 0 || $ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN"
+            data-disabled="$ctrl.form.$invalid || !$ctrl.files || $ctrl.files.length === 0 || $ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN || !$ctrl.fileExtensionsValid"
             data-on-submit="$ctrl.handleUploadConfirmModal(true)"
             data-submit-text="{{:: 'user_account_identity_documents_submit' | translate}}"
         ></oui-form-actions>


### PR DESCRIPTION
Change error's text and trigger when upload file
ref: MANAGER-13109

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-13109
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

I change the error message when a user select a file to upload and add a watch to trigger the check files extension when the user select the file and when he remove it (to remove the error message)

## Related

Translations:
- [x] CMT-10583