### PR TITLE
fix(dedicated): also display mrtg graph for scale and hgr

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.component.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.component.js
@@ -20,7 +20,6 @@ export default {
     resiliatePublicBandwidthLink: '<',
     resiliatePrivateBandwidthLink: '<',
     trafficInformation: '<',
-    technicalDetails: '<',
     urls: '<',
     user: '<',
     serverService: '<',

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
@@ -69,7 +69,7 @@
 <!-- MRTG -->
 <div
     class="mb-5"
-    data-ng-if="!$ctrl.server.isExpired && !['hgr', 'scale'].includes($ctrl.technicalDetails.server.range)"
+    data-ng-if="!$ctrl.server.isExpired"
 >
     <server-mrtg-tile
         data-server-service="$ctrl.serverService"

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.routing.js
@@ -71,15 +71,6 @@ export default /* @ngInject */ ($stateProvider) => {
               'app.dedicated-server.server.interfaces.bandwidth-public-order',
               { productId: serverName },
             ),
-      technicalDetails: /* @ngInject */ ($http, serverName) =>
-        $http
-          .get(`/dedicated/technical-details/${serverName}`, {
-            serviceType: 'aapi',
-          })
-          .then(({ data }) =>
-            data?.baremetalServers?.storage ? data?.baremetalServers : null,
-          )
-          .catch(() => null),
       trafficInformation: /* @ngInject */ (
         $q,
         $stateParams,

--- a/packages/manager/modules/bm-server-components/src/mrtg-tile/controller.js
+++ b/packages/manager/modules/bm-server-components/src/mrtg-tile/controller.js
@@ -107,12 +107,12 @@ export default class BmServerComponentsMrtgTileController {
           return {
             id: mac,
             linkType,
-            displayName: this.$translate.instant(
-              `server_mrtg_network_${linkType}`,
-              {
-                t0: mac,
-              },
-            ),
+            displayName:
+              linkType === 'no_vrack'
+                ? this.$translate.instant(`server_mrtg_network_${linkType}`, {
+                    t0: mac,
+                  })
+                : mac,
             disabled,
           };
         });

--- a/packages/manager/modules/bm-server-components/src/mrtg-tile/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/mrtg-tile/translations/Messages_fr_FR.json
@@ -1,8 +1,6 @@
 {
   "server_mrtg_loading_fail": "Une erreur est survenue lors du chargement des statistiques",
   "server_mrtg_network": "Réseau :",
-  "server_mrtg_network_public": "Interface réseau publique ({{t0}})",
-  "server_mrtg_network_private": "vRack ({{t0}})",
   "server_mrtg_network_no_vrack": "vRack (non configuré sur ce serveur)",
   "server_mrtg_type": "Type :",
   "server_mrtg_type_ERRORS": "Erreurs",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

MRTG data from API is now relevant for servers with link aggregations. Chart legend translation "public interfaces" or "vrack" is now confuse for server with link aggregations: replaced by mac address for all servers so that customer understands the link with the data above in the same page.

## Related

ref: MANAGER-14000
