### PR TITLE
feat(dedicated.account): fixed issues with disabling field for kyc

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/account.routing.js
+++ b/packages/manager/apps/dedicated/client/app/account/account.routing.js
@@ -14,12 +14,17 @@ export default /* @ngInject */ ($stateProvider) => {
                 featureAvailability['identity-documents'],
             );
         },
-        kycStatus: /* @ngInject */ ($http, isKycFeatureAvailable) => {
+        getKycStatus: /* @ngInject */ (
+          $http,
+          $q,
+          isKycFeatureAvailable,
+        ) => () => {
           if (isKycFeatureAvailable) {
             return $http.get(`/me/procedure/identity`).then(({ data }) => data);
           }
-          return false;
+          return $q.resolve(false);
         },
+        kycStatus: /* @ngInject */ (getKycStatus) => getKycStatus(),
       },
     },
     {

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.constant.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.constant.js
@@ -35,6 +35,7 @@ export const TRACKING_TASK_TAG = {
 export const KYC_STATUS = {
   OPEN: 'open',
   REQUIRED: 'required',
+  OK: 'ok',
 };
 
 export const KYC_ALLOWED_FILE_EXTENSIONS = ['jpg', 'jpeg', 'pdf', 'png'];

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -178,6 +178,17 @@ export default class NewAccountFormFieldController {
     };
   }
 
+  $onChanges({ isEditionDisabledByKyc }) {
+    if (
+      isEditionDisabledByKyc &&
+      typeof isEditionDisabledByKyc.currentValue !== 'undefined'
+    ) {
+      // Indian subsidiary changes
+      this.disableInputField = this.canInputFieldDisabled();
+      this.disableDropDownSelection = this.canDropDownDisabled();
+    }
+  }
+
   // if rule has a default value, use it
   setDefaultValue() {
     if (this.rule.defaultValue && !this.rule.initialValue) {
@@ -463,8 +474,9 @@ export default class NewAccountFormFieldController {
       this.isIndianSubsidiary &&
       this.isEditionDisabledByKyc &&
       !(
-        this.rule.fieldName === this.FIELD_NAME_LIST.vat &&
-        this.user.legalform !== USER_TYPE_ENTERPRISE
+        (this.rule.fieldName === this.FIELD_NAME_LIST.vat &&
+          this.user.legalform !== USER_TYPE_ENTERPRISE) ||
+        this.rule.fieldName === this.FIELD_NAME_LIST.purposeOfPurchase
       )
     );
   }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.constants.js
@@ -125,6 +125,7 @@ export const FIELD_NAME_LIST = {
   vat: 'vat',
   gst: 'gst',
   iceNumber: 'iceNumber',
+  purposeOfPurchase: 'purposeOfPurchase',
 };
 
 export const SUBSIDIARIES_VAT_FIELD_OVERRIDE = {

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-component.js
@@ -10,6 +10,7 @@ export default {
     userAccountServiceInfos: '<',
     fieldToFocus: '<',
     kycStatus: '<',
+    getKycStatus: '<',
   },
   template,
   controller,

--- a/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.component.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.component.js
@@ -5,6 +5,7 @@ export default {
   bindings: {
     fieldToFocus: '<',
     kycStatus: '<',
+    getKycStatus: '<',
   },
   template,
   controller,

--- a/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.html
+++ b/packages/manager/apps/dedicated/client/app/account/user/infos/user-infos.html
@@ -144,6 +144,7 @@
                     data-user-account-service-infos="$ctrl.userAccountServiceInfos"
                     data-field-to-focus="$ctrl.fieldToFocus"
                     data-kyc-status="$ctrl.kycStatus"
+                    data-get-kyc-status="$ctrl.getKycStatus"
                 >
                 </new-account-form>
             </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-13832
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Fixed issue where fields were not disabled when user go directly from identity document page to profile page
Fixed issue where the field Purpose of Purchase was disabled when it should not
Set up a call to refresh the KYC request status when the profile's update is failling (in the event the failure was due to an KYC request status disabling profile edition)

## Related

<!-- Link dependencies of this PR -->
