### PR TITLE
feat(public-cloud): consider new localzone plancodes

### DIFF
--- a/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
+++ b/packages/manager/modules/pci/src/components/project/flavors-list/flavors-list.service.js
@@ -112,8 +112,8 @@ export default class FlavorsList {
               'legacy',
             ),
             locationCompatibility: this.getlocationCompatibility(
-              productAvailability.plans.find(
-                (plan) => plan.code === resource.planCodes.hourly,
+              productAvailability.plans?.filter((plan) =>
+                plan.code?.startsWith(resource.planCodes.hourly),
               ),
             ),
           });
@@ -122,11 +122,18 @@ export default class FlavorsList {
   }
 
   getlocationCompatibility(productAvailability) {
+    // New plancodes has been introduced for localzones which will have region names after plan codes names like ***.consumption.EU-WEST-LZ-BRU-A
+    // So we need to consider all the plancodes which starts with "**flavorName**.consumption"
+    // After fetching all the productCapabilities we need to combine all the regions of possible plans
+    // of "b38.consumption" "b38.consumption.EU-WEST-LZ-BRU-A" "b38.consumption.EU-SOUTH-LZ-MAD-A" into regionsAllowed
+    const regionsAllowed = productAvailability?.flatMap(
+      ({ regions }) => regions,
+    );
     return {
-      isLocalZone: productAvailability?.regions.some(
+      isLocalZone: regionsAllowed?.some(
         (region) => region.type === this.LOCAL_ZONE,
       ),
-      isGlobalZone: productAvailability?.regions.some(
+      isGlobalZone: regionsAllowed?.some(
         (region) => region.type !== this.LOCAL_ZONE,
       ),
     };

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.controller.js
@@ -183,10 +183,18 @@ export default class PciInstancesAddController {
 
     return this.PciProjectsProjectInstanceService.getProductAvailability(
       this.projectId,
-      planCode,
       this.coreConfig.getUser().ovhSubsidiary,
-    ).then((productCapability) => {
-      const productRegionsAllowed = productCapability?.plans[0]?.regions;
+    ).then((productCapabilities) => {
+      // New plancodes has been introduced for localzones which will have region names after plan codes names like ***.consumption.EU-WEST-LZ-BRU-A
+      // So we need to consider all the plancodes which starts with "**flavorName**.consumption"
+      const productCapability = productCapabilities.plans?.filter((plan) =>
+        plan.code?.startsWith(planCode),
+      );
+      // After fetching all the productCapabilities we need to combine all the regions of possible plans
+      // of "b38.consumption" "b38.consumption.EU-WEST-LZ-BRU-A" "b38.consumption.EU-SOUTH-LZ-MAD-A" into regionsAllowed
+      const productRegionsAllowed = productCapability?.flatMap(
+        ({ regions }) => regions,
+      );
       Object.entries(this.regions).forEach(([continent, locationsMap]) => {
         // Create datacenters continent groups
         this.availableRegions[continent] = {};

--- a/packages/manager/modules/pci/src/projects/project/instances/instances.service.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.service.js
@@ -541,12 +541,11 @@ export default class PciProjectInstanceService {
       });
   }
 
-  getProductAvailability(projectId, planCode, ovhSubsidiary) {
+  getProductAvailability(projectId, ovhSubsidiary) {
     return this.$http
       .get(`/cloud/project/${projectId}/capabilities/productAvailability`, {
         params: {
           ovhSubsidiary,
-          planCode,
         },
       })
       .then(({ data }) => data);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-13994
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
Instance creation wizard takes only "b3-8.consumption" into account to get the list of regions, it should get all plans starting with "b3-8.consumption" like "b3-8.consumption.EU-SOUTH-LZ-MAD-A" and "b3-8.consumption.EU-WEST-LZ-BRU-A" to correctly get localzone regions.

