### PR TITLE
fix(rancher): allow uppercase in rancher name but not at start and end MANAGER-13627

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "yarn run build:turbo",
-    "build:turbo": "turbo run build",
+    "build:turbo": "turbo run build --concurrency=75%",
     "dev": "turbo run dev",
     "clean": "lerna clean -y && yarn run clean:dist && rimraf node_modules",
     "clean:dist": "rimraf \"packages/**/dist\"",

--- a/packages/manager/apps/pci-rancher/src/utils/rancher.test.ts
+++ b/packages/manager/apps/pci-rancher/src/utils/rancher.test.ts
@@ -4,7 +4,7 @@ describe('Should validate rancher name', () => {
   it('When i add a valid rancher name', () => {
     expect(isValidRancherName('rancher1234')).toBe(true);
     expect(isValidRancherName('rancher1234-_.r')).toBe(true);
-    expect(isValidRancherName('rancher')).toBe(true);
+    expect(isValidRancherName('rANcher')).toBe(true);
     expect(
       isValidRancherName(
         '012345678901234567890123456789012345678901234567890123456789123',
@@ -16,7 +16,7 @@ describe('Should validate rancher name', () => {
     it('When i add invalid character in rancher name', () => {
       expect(isValidRancherName('ranche(r1xs23___4((')).toBe(false);
       expect(isValidRancherName('rancher1234-_.@')).toBe(false);
-      expect(isValidRancherName('rAncher')).toBe(false);
+      expect(isValidRancherName('RancheR')).toBe(false);
     });
 
     it('When length is not valid', () => {

--- a/packages/manager/apps/pci-rancher/src/utils/rancher.ts
+++ b/packages/manager/apps/pci-rancher/src/utils/rancher.ts
@@ -1,3 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const isValidRancherName = (name: string) =>
-  /^[a-z0-9][-_.a-z0-9]{1,61}[a-z0-9]$/.test(name);
+  /^[a-z0-9][-_.A-Za-z0-9]{1,61}[a-z0-9]$/.test(name);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13627
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [ ] Commits are signed-off
- [ ] Only FR translations have been updated
- [ ] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Allow uppercase in rancher name but not at start and end
## Related

MANAGER-13627
<!-- Link dependencies of this PR -->
