### PR TITLE
fix(pci.kube): fix disappearing version step next button

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/add/add.controller.js
@@ -193,6 +193,7 @@ export default class {
     const { region } = this.cluster;
     const { name, enabled } = region;
     this.displaySelectedRegion = true;
+    this.displaySelectedVersion = false;
 
     if (!enabled) {
       this.isAddingNewRegion = true;


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PRB0040048
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Resetted the boolean to only display selected version on kubernetes version step (creation form) when arriving on the version step, since the "Next" button disappeared when clicking on the already selected version (not clear it is selected)

## Related

<!-- Link dependencies of this PR -->
