### PR TITLE
fix(pci-ssh-key): allow search on publicKey

### DIFF
--- a/packages/manager/apps/pci-ssh-keys/src/data/ssh.ts
+++ b/packages/manager/apps/pci-ssh-keys/src/data/ssh.ts
@@ -52,11 +52,13 @@ export const filterSshKeys = (
   }
 
   if (searchQueries?.length) {
-    return (data || []).filter(({ name }) => {
+    return (data || []).filter(({ name, publicKey }) => {
       let matchAll = true;
       searchQueries.forEach((query) => {
         matchAll =
-          matchAll && `${name}`.toLowerCase().includes(query.toLowerCase());
+          matchAll &&
+          (name.toLowerCase().includes(query.toLowerCase()) ||
+            publicKey.toLowerCase().includes(query.toLowerCase()));
       });
       return matchAll;
     });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-1988
| License          | BSD 3-Clause

## Description

Allows ssh key search on publicKey