### PR TITLE
feat(dedicated.account): refacto file extension checking in kyc upload

### DIFF
--- a/packages/components/ng-ovh-mondial-relay/package.json
+++ b/packages/components/ng-ovh-mondial-relay/package.json
@@ -41,7 +41,7 @@
     "set-value": "^2.0.1"
   },
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "~3.4.1",
     "lodash": "^4.17.15",
     "ovh-ui-kit-bs": "^4.2.0"

--- a/packages/manager/apps/carbon-calculator/package.json
+++ b/packages/manager/apps/carbon-calculator/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/carrier-sip/package.json
+++ b/packages/manager/apps/carrier-sip/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/ng-ovh-telecom-universe-components": "^7.24.0",
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.22",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.8",

--- a/packages/manager/apps/cda/package.json
+++ b/packages/manager/apps/cda/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/cloud-connect/package.json
+++ b/packages/manager/apps/cloud-connect/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/container/package.json
+++ b/packages/manager/apps/container/package.json
@@ -34,7 +34,7 @@
     "@ovh-ux/ovh-reket": "^2.1.1",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@ovhcloud/ods-core": "^14.0.1",
     "@ovhcloud/ods-stencil": "^14.0.1",
     "@ovhcloud/ods-theme-blue-jeans": "^14.0.1",

--- a/packages/manager/apps/dbaas-logs/package.json
+++ b/packages/manager/apps/dbaas-logs/package.json
@@ -43,7 +43,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_de_DE.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "GST-Zertifikat (optional)",
   "user_account_identity_documents_description": "Die Dokumente werden nach Vertragsende noch 5 Jahre aufbewahrt.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. Die maximale Dateigröße für jedes Dokument beträgt 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Nicht unterstütztes Dateiformat. Bitte verwenden Sie eines der zulässigen Formate: jpg, jpeg, pdf und png",
+  "user_account_identity_documents_selection_file_format_invalid": "Das Format {{values}} der hochgeladenen Dokumente wird nicht akzeptiert. Verwenden Sie bitte eines der unterstützten Formate: .jpg, .jpeg, .pdf oder .png.",
   "user_account_identity_documents_submit": "Meine Dokumente senden",
   "user_account_identity_documents_submit_success_message_title": "Wir haben Ihre Dokumente erhalten.",
   "user_account_identity_documents_submit_success_message_description": "Wir haben alle Ihre Dokumente erhalten. Sie werden unseren Teams zur Validierung vorgelegt. Sie werden per E-Mail über die Validierung informiert oder kontaktiert, wenn wir weitere Informationen benötigen.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_en_GB.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "GST certificate (optional)",
   "user_account_identity_documents_description": "The documents will be retained for 5 years after the end of the contract.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. The file size limit for each document is 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "File format not supported. Please use one of the accepted formats: jpg, jpeg, pdf and png",
+  "user_account_identity_documents_selection_file_format_invalid": "The {{values}} format of the downloaded document(s) is not supported. Please respect the format requirements: jpg, jpeg, pdf, and png.",
   "user_account_identity_documents_submit": "Send my documents",
   "user_account_identity_documents_submit_success_message_title": "Thank you, we have received your documents!",
   "user_account_identity_documents_submit_success_message_description": "We have received all of your documents. They will be submitted to our teams for validation. You will be notified of their validation by email, or you will be contacted if we need further information.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_es_ES.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificado GST (opcional)",
   "user_account_identity_documents_description": "Los documentos se conservarán durante 5 años una vez finalizado el contrato.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf y png. El tamaño máximo del archivo para cada documento es de 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato de archivo no compatible. Por favor, utilice cualquiera de los formatos aceptados: jpg, jpeg, pdf y png.",
+  "user_account_identity_documents_selection_file_format_invalid": "El formato {{values}} del (los) documento(s) adjunto(s) no es válido. Por favor, utilice cualquiera de los formatos indicados: jpg, jpeg, pdf y png.",
   "user_account_identity_documents_submit": "Enviar mis documentos",
   "user_account_identity_documents_submit_success_message_title": "Gracias, ¡hemos recibido sus documentos!",
   "user_account_identity_documents_submit_success_message_description": "Le confirmamos que hemos recibido todos sus documentos. A continuación, deberán ser validados por nuestro equipo. Le enviaremos un mensaje de correo electrónico una vez que hayan sido validados. Si es necesaria alguna información adicional, nos pondremos en contacto con usted.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_CA.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificat GST (optionnel)",
   "user_account_identity_documents_description": "Les documents seront conservés durant 5 ans après la fin du contrat.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. La taille maximale du fichier pour chaque document est de 10 Mo.",
-  "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
+  "user_account_identity_documents_selection_file_format_invalid": "Le format {{values}} du ou des documents téléchargés n'est pas accepté. Veuillez respecter le format requis : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
   "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_fr_FR.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificat GST (optionnel)",
   "user_account_identity_documents_description": "Les documents seront conservés durant 5 ans après la fin du contrat.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. La taille maximale du fichier pour chaque document est de 10 Mo.",
-  "user_account_identity_documents_selection_file_format_invalid": "Format de fichier non pris en charge. Veuillez utiliser l'un des formats acceptés : jpg, jpeg, pdf et png",
+  "user_account_identity_documents_selection_file_format_invalid": "Le format {{values}} du ou des documents téléchargés n'est pas accepté. Veuillez respecter le format requis : jpg, jpeg, pdf et png",
   "user_account_identity_documents_submit": "Envoyer mes documents",
   "user_account_identity_documents_submit_success_message_title": "Merci, nous avons bien reçu vos documents!",
   "user_account_identity_documents_submit_success_message_description": "Nous avons bien reçu l’ensemble de vos documents. Ils seront soumis à validation auprès de nos équipes. Vous serez informé par email de leur validation ou vous serez contacté si nous avons besoin d’informations complémentaires.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_it_IT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificato GST (facoltativo)",
   "user_account_identity_documents_description": "I documenti saranno conservati per cinque anni dalla fine del contratto.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png. La dimensione massima del file per ogni documento è 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato di file non supportato. Utilizza uno dei formati accettati: jpg, jpeg, pdf e png",
+  "user_account_identity_documents_selection_file_format_invalid": "Il formato {{values}} dei documenti caricati non è accettato. Ti chiediamo di rispettare il formato richiesto: jpg, jpeg, pdf e png",
   "user_account_identity_documents_submit": "Invia i documenti",
   "user_account_identity_documents_submit_success_message_title": "Grazie, abbiamo ricevuto i tuoi documenti!",
   "user_account_identity_documents_submit_success_message_description": "Abbiamo ricevuto tutti i documenti, che verranno verificati dai nostri team. Riceverai un'email di conferma di validazione oppure verrai contattato se avremo bisogno di maggiori informazioni.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pl_PL.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certyfikat GST (opcjonalnie)",
   "user_account_identity_documents_description": "Dokumenty będą przechowywane przez okres 5 lat od zakończenia umowy.",
   "user_account_identity_documents_selection_file_format": "Format: jpg, jpeg, pdf, png. Maksymalny rozmiar pliku dla każdego dokumentu to 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Nieobsługiwany format pliku. Użyj jednego z akceptowanych formatów: jpg, jpeg, pdf i png",
+  "user_account_identity_documents_selection_file_format_invalid": "Format {{values}} pobranego/pobranych dokumentów nie jest akceptowany. Zachowaj wymagany format: jpg, jpeg, pdf i png",
   "user_account_identity_documents_submit": "Wyślij dokumenty",
   "user_account_identity_documents_submit_success_message_title": "Dziękujemy, potwierdzamy, że otrzymaliśmy Twoje dokumenty!",
   "user_account_identity_documents_submit_success_message_description": "Otrzymaliśmy wszystkie Twoje dokumenty. Przekażemy je naszym zespołom do zatwierdzenia. Wyślemy do Ciebie e-mail z informacją o ich zatwierdzeniu lub skontaktujemy się z Tobą, jeśli będziemy potrzebować dodatkowych informacji.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/translations/Messages_pt_PT.json
@@ -15,7 +15,7 @@
   "user_account_identity_documents_list_doc3_optional": "Certificado GST (facultativo)",
   "user_account_identity_documents_description": "Os documentos serão conservados durante cinco anos após o termo do contrato.",
   "user_account_identity_documents_selection_file_format": "Formato: jpg, jpeg, pdf, png. O tamanho máximo do ficheiro para cada documento é de 10 MB.",
-  "user_account_identity_documents_selection_file_format_invalid": "Formato de ficheiro não suportado. Utilize um dos formatos possíveis: jpg, jpeg, pdf e png",
+  "user_account_identity_documents_selection_file_format_invalid": "O formato {{values}} dos documentos descarregados não é aceite. Respeite por favor o formato exigido : jpg, jpeg, pdf e png",
   "user_account_identity_documents_submit": "Enviar os meus documentos",
   "user_account_identity_documents_submit_success_message_title": "Obrigado. Recebemos com êxito os seus documentos!",
   "user_account_identity_documents_submit_success_message_description": "Recebemos com êxito todos os seus documentos. Serão sujeitos a validação por parte das nossas equipas. Receberá por e-mail a confirmação da validação, ou será contactado caso seja necessário fornecer mais informações.",

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
@@ -11,9 +11,10 @@ import {
 
 export default class AccountUserIdentityDocumentsController {
   /* @ngInject */
-  constructor($q, $http, coreConfig, coreURLBuilder, atInternet) {
+  constructor($q, $http, $scope, coreConfig, coreURLBuilder, atInternet) {
     this.$q = $q;
     this.$http = $http;
+    this.$scope = $scope;
     this.coreConfig = coreConfig;
     this.coreURLBuilder = coreURLBuilder;
     this.maximum_size = MAX_SIZE;
@@ -39,6 +40,10 @@ export default class AccountUserIdentityDocumentsController {
     this.user_type = USER_TYPE[this.currentUser]
       ? USER_TYPE[this.currentUser]
       : USER_TYPE.default;
+
+    this.$scope.$watchCollection('$ctrl.files', () => {
+      this.isFileExtensionsValid();
+    });
   }
 
   uploadIdentityDocuments() {
@@ -99,10 +104,19 @@ export default class AccountUserIdentityDocumentsController {
   }
 
   isFileExtensionsValid() {
-    this.fileExtensionsValid = !this.files.find(
-      ({ infos: { extension } }) =>
-        !KYC_ALLOWED_FILE_EXTENSIONS.includes(extension.toLowerCase()),
+    const badFileExtensionsList = [];
+    this.fileExtensionsValid = this.files.reduce(
+      (acc, { infos: { extension } }) => {
+        const formatedExtension = extension.toLowerCase();
+        const isExtensionIncluded = KYC_ALLOWED_FILE_EXTENSIONS.includes(
+          formatedExtension,
+        );
+        if (!isExtensionIncluded) badFileExtensionsList.push(formatedExtension);
+        return isExtensionIncluded && acc;
+      },
+      true,
     );
+    this.badFileExtensionsFormatedList = badFileExtensionsList.join(', ');
     return this.fileExtensionsValid;
   }
 

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
@@ -40,10 +40,6 @@ export default class AccountUserIdentityDocumentsController {
     this.user_type = USER_TYPE[this.currentUser]
       ? USER_TYPE[this.currentUser]
       : USER_TYPE.default;
-
-    this.$scope.$watchCollection('$ctrl.files', () => {
-      this.isFileExtensionsValid();
-    });
   }
 
   uploadIdentityDocuments() {

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
@@ -94,6 +94,9 @@
         <oui-message class="my-1" data-type="error">
             <span
                 data-translate="user_account_identity_documents_selection_file_format_invalid"
+                data-translate-values="{
+                  values: $ctrl.badFileExtensionsFormatedList
+                }"
             ></span>
         </oui-message>
     </div>
@@ -114,7 +117,7 @@
 
         <oui-form-actions
             class="mt-5"
-            data-disabled="$ctrl.form.$invalid || !$ctrl.files || $ctrl.files.length === 0 || $ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN"
+            data-disabled="$ctrl.form.$invalid || !$ctrl.files || $ctrl.files.length === 0 || $ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN || !$ctrl.fileExtensionsValid"
             data-on-submit="$ctrl.handleUploadConfirmModal(true)"
             data-submit-text="{{:: 'user_account_identity_documents_submit' | translate}}"
         ></oui-form-actions>

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
@@ -113,6 +113,8 @@
             data-maxsize="$ctrl.maximum_size"
             data-name="files"
             data-disabled="$ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN"
+            data-on-select="$ctrl.isFileExtensionsValid()"
+            data-on-remove="$ctrl.isFileExtensionsValid()"
         ></oui-file>
 
         <oui-form-actions

--- a/packages/manager/apps/dedicated/package.json
+++ b/packages/manager/apps/dedicated/package.json
@@ -86,7 +86,7 @@
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
     "@ovh-ux/sign-up": "^2.15.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "1.7.x",
     "angular-aria": "1.7.x",

--- a/packages/manager/apps/email-domain/package.json
+++ b/packages/manager/apps/email-domain/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/email-pro/package.json
+++ b/packages/manager/apps/email-pro/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/exchange/package.json
+++ b/packages/manager/apps/exchange/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/hub/package.json
+++ b/packages/manager/apps/hub/package.json
@@ -49,7 +49,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@ovh-ux/url-builder": "^1.1.1",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",

--- a/packages/manager/apps/iam/package.json
+++ b/packages/manager/apps/iam/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-translate": "^2.18.1",

--- a/packages/manager/apps/iplb/package.json
+++ b/packages/manager/apps/iplb/package.json
@@ -41,7 +41,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/metrics/package.json
+++ b/packages/manager/apps/metrics/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/nasha/package.json
+++ b/packages/manager/apps/nasha/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/netapp/package.json
+++ b/packages/manager/apps/netapp/package.json
@@ -44,7 +44,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/nutanix/package.json
+++ b/packages/manager/apps/nutanix/package.json
@@ -39,7 +39,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/octavia-load-balancer/package.json
+++ b/packages/manager/apps/octavia-load-balancer/package.json
@@ -40,7 +40,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/office/package.json
+++ b/packages/manager/apps/office/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/order-tracking/package.json
+++ b/packages/manager/apps/order-tracking/package.json
@@ -27,7 +27,7 @@
     "@ovh-ux/ng-ovh-swimming-poll": "^5.1.1",
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.22",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/apps/overthebox/package.json
+++ b/packages/manager/apps/overthebox/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-title": "^3.1.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "~1.7.5",
     "angular-aria": "^1.7.5",

--- a/packages/manager/apps/pci/package.json
+++ b/packages/manager/apps/pci/package.json
@@ -53,7 +53,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/public-cloud/package.json
+++ b/packages/manager/apps/public-cloud/package.json
@@ -59,7 +59,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-animate": "^1.7.5",

--- a/packages/manager/apps/restricted/package.json
+++ b/packages/manager/apps/restricted/package.json
@@ -23,7 +23,7 @@
     "@ovh-ux/manager-config": "^7.3.1",
     "@ovh-ux/manager-vite-config": "^0.5.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "4.6.0",
     "font-awesome": "^4.7.0",
     "i18next": "^20.4.0",

--- a/packages/manager/apps/sharepoint/package.json
+++ b/packages/manager/apps/sharepoint/package.json
@@ -37,7 +37,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/sign-up/package.json
+++ b/packages/manager/apps/sign-up/package.json
@@ -33,7 +33,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/sign-up": "^2.15.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.8",
     "angular-cookies": "^1.7.8",

--- a/packages/manager/apps/support/package.json
+++ b/packages/manager/apps/support/package.json
@@ -30,7 +30,7 @@
     "@ovh-ux/ng-ovh-user-pref": "^2.1.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.8",
     "angular-sanitize": "^1.7.8",

--- a/packages/manager/apps/telecom-dashboard/package.json
+++ b/packages/manager/apps/telecom-dashboard/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-title": "^3.1.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/telecom-task/package.json
+++ b/packages/manager/apps/telecom-task/package.json
@@ -32,7 +32,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-title": "^3.1.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.2.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/telecom/package.json
+++ b/packages/manager/apps/telecom/package.json
@@ -70,7 +70,7 @@
     "@ovh-ux/ng-ui-router-title": "^3.1.1",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "CSV-JS": "^1.0.0",
     "angular": "^1.7.5",

--- a/packages/manager/apps/veeam-cloud-connect/package.json
+++ b/packages/manager/apps/veeam-cloud-connect/package.json
@@ -36,7 +36,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/veeam-enterprise/package.json
+++ b/packages/manager/apps/veeam-enterprise/package.json
@@ -35,7 +35,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/vps/package.json
+++ b/packages/manager/apps/vps/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/vrack/package.json
+++ b/packages/manager/apps/vrack/package.json
@@ -38,7 +38,7 @@
     "@ovh-ux/ng-translate-async-loader": "^2.2.1",
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-cookies": "^1.7.8",

--- a/packages/manager/apps/web-paas/package.json
+++ b/packages/manager/apps/web-paas/package.json
@@ -42,7 +42,7 @@
     "@ovh-ux/ng-ui-router-breadcrumb": "^1.3.1",
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "angular": "^1.7.5",
     "angular-aria": "^1.7.8",

--- a/packages/manager/apps/web/package.json
+++ b/packages/manager/apps/web/package.json
@@ -66,7 +66,7 @@
     "@ovh-ux/ng-ui-router-layout": "^4.3.0",
     "@ovh-ux/request-tagger": "^0.2.0",
     "@ovh-ux/shell": "^3.5.0",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "@uirouter/angularjs": "^1.0.23",
     "URIjs": "^1.14.0",
     "angular": "^1.6.10",

--- a/packages/manager/modules/billing/package.json
+++ b/packages/manager/modules/billing/package.json
@@ -15,7 +15,7 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "^4.4.1",
     "lodash-es": "^4.17.15"
   },

--- a/packages/manager/modules/cloud-styles/package.json
+++ b/packages/manager/modules/cloud-styles/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^13.0.1",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "~3.3.7",
     "font-awesome": "^4.0.0",
     "ovh-common-style": "^3.2.2",

--- a/packages/manager/modules/cloud-universe-components/package.json
+++ b/packages/manager/modules/cloud-universe-components/package.json
@@ -34,7 +34,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/ng-ovh-cloud-universe-components' --include-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "~3.3.0",
     "jsurl": "^0.1.5",
     "lodash": "^4.17.15",

--- a/packages/manager/modules/hub/package.json
+++ b/packages/manager/modules/hub/package.json
@@ -15,7 +15,7 @@
     "@ovh-ux/manager-models": "^1.14.11"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "^4.4.1",
     "lodash-es": "^4.17.15"
   },

--- a/packages/manager/modules/sms/package.json
+++ b/packages/manager/modules/sms/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@ovh-ux/component-rollup-config": "^13.0.1",
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "~3.3.7"
   },
   "peerDependencies": {

--- a/packages/manager/modules/telecom-styles/package.json
+++ b/packages/manager/modules/telecom-styles/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "~3.3.7",
     "ovh-ui-kit-bs": "^4.2.0"
   },

--- a/packages/manager/modules/telecom-universe-components/package.json
+++ b/packages/manager/modules/telecom-universe-components/package.json
@@ -12,7 +12,7 @@
   "author": "OVH SAS",
   "main": "./src/index.js",
   "dependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "^3.4.1",
     "bootstrap4": "twbs/bootstrap#v4.6.2",
     "lodash": "^4.17.15"

--- a/packages/manager/modules/web-universe-components/package.json
+++ b/packages/manager/modules/web-universe-components/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@ovh-ux/ui-kit": "^6.7.7",
+    "@ovh-ux/ui-kit": "^6.10.0",
     "bootstrap": "^3.3.7"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4446,11 +4446,6 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.10.0.tgz#7299819d2150da5c1946b2199d1ecadd2013df51"
   integrity sha512-ijZTINZPeeCfC/Zahpc8c7QPbmsRgLQ8VUl2TY/WVJQhFR13P+oPL1f7qeYDKHGd0XoKPs3Lkb40j2rECw85PQ==
 
-"@ovh-ux/ui-kit@^6.7.7":
-  version "6.7.8"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.7.8.tgz#ec783cab3ddd9254087127793ca856780e48731b"
-  integrity sha512-am96JNK/XOKQkr9mixc1rNt63A1CxHKvjuKxBYgAEl6WQ9Jdlesytcts+Xn8c24kL1lkec4sJfeuDMG/5lhBIw==
-
 "@ovhcloud/ods-cdk@^14.1.1":
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/@ovhcloud/ods-cdk/-/ods-cdk-14.1.1.tgz#341ed0bfed7f599b253c2d087ba2f15a8915c436"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4441,6 +4441,11 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
   integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
 
+"@ovh-ux/ui-kit@^6.10.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.10.0.tgz#7299819d2150da5c1946b2199d1ecadd2013df51"
+  integrity sha512-ijZTINZPeeCfC/Zahpc8c7QPbmsRgLQ8VUl2TY/WVJQhFR13P+oPL1f7qeYDKHGd0XoKPs3Lkb40j2rECw85PQ==
+
 "@ovh-ux/ui-kit@^6.7.7":
   version "6.7.8"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ui-kit/-/ui-kit-6.7.8.tgz#ec783cab3ddd9254087127793ca856780e48731b"


### PR DESCRIPTION
Use the new ui-kit onRemove callback to check file extensions

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-13109`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-14157
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

I update UI-KIT to use the new onRemove callback of file component to avoid using watchCollection to trigger extension checking on file removal.

## Related

<!-- Link dependencies of this PR -->
