### PR TITLE
feat(dedicated.order): filter orders to remove null values

### DIFF
--- a/packages/manager/modules/billing/src/orders/orders/orders.routing.js
+++ b/packages/manager/modules/billing/src/orders/orders/orders.routing.js
@@ -21,7 +21,7 @@ export default /* @ngInject */ ($stateProvider) => {
           .sort('date', 'DESC')
           .limit(5000)
           .execute(null, true)
-          .$promise.then(({ data }) => data),
+          .$promise.then(({ data }) => data.filter((value) => value !== null)),
       /* @ngInject */
       timeNow: ($http) =>
         $http


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Feat MANAGER-14221
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~~Only FR translations have been~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Sometimes when Iceberg expand does not manage to fetch all elements it returns some items as "null" which ends up in a blank datagrid. Datagrid should probably omit those values in order to display successful partial result.

## Related

<!-- Link dependencies of this PR -->
