### PR TITLE
feat(web): 2api response is 200 when detach domain fails

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/hosting-multisite.service.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/hosting-multisite.service.js
@@ -59,7 +59,10 @@ angular.module('services').service(
               });
             },
           );
+        } else {
+          throw new Error(response.messages[0]?.message);
         }
+
         this.Hosting.resetDomains();
         this.getTaskIds({ fn: 'attachedDomain/delete' }, serviceName).then(
           (taskIds) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |  master
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Feat MANAGER-14246
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

2api response is 200 when detach domain fails : add a test on state and throw an exception if state is error 

## Related

<!-- Link dependencies of this PR -->
