### PR TITLE
fix(container): not displayed when card is going to expire

### DIFF
--- a/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
+++ b/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
@@ -44,8 +44,8 @@ const computeAlert = (paymentMethods: IPaymentMethod[]): string => {
     if (creditCardExpirationDate.getTime() < Date.now()) {
       return PAYMENT_ALERTS.EXPIRED_CARD;
     }
-    const expirationDateMinus30Days = new Date();
-    expirationDateMinus30Days.setDate(expirationDateMinus30Days.getDate() - 30);
+    const expirationDateMinus30Days = new Date(creditCardExpirationDate);
+    expirationDateMinus30Days.setDate(creditCardExpirationDate.getDate() - 30);
     const isSoonToBeExpireCreditCard = expirationDateMinus30Days.getTime() < Date.now();
     if (isSoonToBeExpireCreditCard) {
       return PAYMENT_ALERTS.SOON_EXPIRED_CARD;

--- a/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
+++ b/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
@@ -38,14 +38,15 @@ const computeAlert = (paymentMethods: IPaymentMethod[]): string => {
     return PAYMENT_ALERTS.NO_DEFAULT;
   }
   const currentCreditCard: IPaymentMethod = paymentMethods?.find(currentPaymentMethod => currentPaymentMethod.paymentType === 'CREDIT_CARD');
+  
   if (currentCreditCard) {
     const creditCardExpirationDate = new Date(currentCreditCard.expirationDate);
     if (creditCardExpirationDate.getTime() < Date.now()) {
       return PAYMENT_ALERTS.EXPIRED_CARD;
     }
-    const currentDateMinus30Days = new Date();
-    currentDateMinus30Days.setDate(currentDateMinus30Days.getDate() - 30);
-    const isSoonToBeExpireCreditCard = currentDateMinus30Days.getTime() > Date.now() && creditCardExpirationDate.getTime() > Date.now();
+    const currentDatePlus30Days = new Date();
+    currentDatePlus30Days.setDate(currentDatePlus30Days.getDate() + 30);
+    const isSoonToBeExpireCreditCard = currentDatePlus30Days.getTime() > creditCardExpirationDate.getTime();
     if (isSoonToBeExpireCreditCard) {
       return PAYMENT_ALERTS.SOON_EXPIRED_CARD;
     }

--- a/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
+++ b/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
@@ -44,9 +44,9 @@ const computeAlert = (paymentMethods: IPaymentMethod[]): string => {
     if (creditCardExpirationDate.getTime() < Date.now()) {
       return PAYMENT_ALERTS.EXPIRED_CARD;
     }
-    const currentDatePlus30Days = new Date();
-    currentDatePlus30Days.setDate(currentDatePlus30Days.getDate() + 30);
-    const isSoonToBeExpireCreditCard = currentDatePlus30Days.getTime() > creditCardExpirationDate.getTime();
+    const expirationDateMinus30Days = new Date();
+    expirationDateMinus30Days.setDate(expirationDateMinus30Days.getDate() - 30);
+    const isSoonToBeExpireCreditCard = expirationDateMinus30Days.getTime() < Date.now();
     if (isSoonToBeExpireCreditCard) {
       return PAYMENT_ALERTS.SOON_EXPIRED_CARD;
     }


### PR DESCRIPTION
Fix time calculation plus 30 days
ref: MANAGER-13918

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/MANAGER-12494` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-13918
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [] Breaking change is mentioned in relevant commits (n/a)

## Description

I change how to check if the card expiry date is between now and now plus 30 days.

## Related

