### PR TITLE
fix(pci-public-ip): redirect after order ip

### DIFF
--- a/packages/manager/apps/pci-public-ip/src/pages/order/hooks/useActions.ts
+++ b/packages/manager/apps/pci-public-ip/src/pages/order/hooks/useActions.ts
@@ -111,6 +111,7 @@ export const useActions = (projectId: string) => {
           break;
         case StepIdsEnum.FAILOVER_INSTANCE:
           doOrderFailoverIp();
+          navigate('../additional-ips');
           break;
         case StepIdsEnum.FLOATING_REGION:
           openStep(StepIdsEnum.FLOATING_INSTANCE);


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | fix/pci-public-ip
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2164
| License          | BSD 3-Clause

## Description

navigate back after ordering addtional ip