### PR TITLE
fix(web.webhosting): allow to order hosting without dnsConfiguration or module

### DIFF
--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.controller.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.controller.js
@@ -17,7 +17,8 @@ export default class {
   }
 
   orderWebhosting() {
-    const { enableHosting, enableEmails } = this.cartOption.dnsConfiguration;
+    const enableHosting = this.cartOption.dnsConfiguration?.enableHosting;
+    const enableEmails = this.cartOption.dnsConfiguration?.enableEmails;
     let dnsZoneLabel = CONFIGURATION_OPTIONS.DNS_ZONE.VALUES.NO_CHANGE;
     if (enableHosting && enableEmails) {
       dnsZoneLabel = CONFIGURATION_OPTIONS.DNS_ZONE.VALUES.RESET_ALL;

--- a/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.controller.js
+++ b/packages/manager/apps/web/client/app/domain/webhosting/order/steps/domain-webhosting-order-steps.controller.js
@@ -32,7 +32,7 @@ export default class {
     const expressOrderJson = {
       planCode: this.cartOption.offer.planCode,
       duration: this.cartOption.offer.durations[0],
-      pricingMode: this.cartOption.module.pricingMode,
+      pricingMode: this.cartOption.offer.pricing.pricingMode,
       quantity: 1,
       configuration: [
         {
@@ -44,7 +44,11 @@ export default class {
           value: dnsZoneLabel,
         },
       ],
-      option: [
+      productId: WEBHOSTING_ORDER_PRODUCT,
+    };
+
+    if (this.cartOption.module) {
+      expressOrderJson.option = [
         {
           planCode: this.cartOption.module.planCode,
           duration: this.cartOption.module.duration,
@@ -57,9 +61,8 @@ export default class {
             },
           ],
         },
-      ],
-      productId: WEBHOSTING_ORDER_PRODUCT,
-    };
+      ];
+    }
 
     return this.$window.open(
       `${this.expressOrderUrl}?products=${JSURL.stringify([expressOrderJson])}`,


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | INC0032459
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits (n/a)

## Description

Change to avoid to read into an undefined variable when not dnsConfiguration not selected

## Related

