### PR TITLE
feat(2fa):  add see page messages

### DIFF
--- a/packages/manager/apps/account-disable-2fa/src/i18n.ts
+++ b/packages/manager/apps/account-disable-2fa/src/i18n.ts
@@ -5,6 +5,7 @@ import { initReactI18next } from 'react-i18next';
 export default function initI18n(
   locale = 'fr_FR',
   availablesLocales = ['fr_FR'],
+  sub: string,
 ) {
   i18n
     .use(initReactI18next)
@@ -19,12 +20,19 @@ export default function initI18n(
       lng: locale,
       fallbackLng: 'fr_FR',
       supportedLngs: availablesLocales,
-      ns: ['account-disable-2fa'], // namespaces to load by default
+      ns: ['account-disable-2fa', 'account-disable-2fa-sub'], // namespaces to load by default
       backend: {
-        loadPath: (lngs: string[], namespaces: string[]) =>
-          `${import.meta.env.BASE_URL}translations/${namespaces[0]}/Messages_${
-            lngs[0]
-          }.json`,
+        loadPath: (lngs: string[], namespaces: string[], ...d: []) => {
+          const namespace: string = namespaces[0];
+          if (namespace.endsWith('sub')) {
+            return `${import.meta.env.BASE_URL}translations/${
+              namespaces[0]
+            }/${sub}/Messages_${lngs[0]}.json`;
+          }
+          return `${import.meta.env.BASE_URL}translations/${
+            namespaces[0]
+          }/Messages_${lngs[0]}.json`;
+        },
       },
       postProcess: 'normalize',
     });

--- a/packages/manager/apps/account-disable-2fa/src/index.tsx
+++ b/packages/manager/apps/account-disable-2fa/src/index.tsx
@@ -16,7 +16,7 @@ const user = {
 };
 const locale = user.language;
 
-initI18n(locale, [locale]);
+initI18n(locale, [locale], user.subsidiary);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/manager/apps/account-disable-2fa/src/pages/Home.page.tsx
+++ b/packages/manager/apps/account-disable-2fa/src/pages/Home.page.tsx
@@ -4,13 +4,13 @@ import ovhCloudLogo from '@/assets/logo-ovhcloud.png';
 
 export default function Home() {
   return (
-    <div className="container mx-auto px-5">
-      <div className="m-10">
+    <div className="sm:container mx-auto px-5">
+      <div className="md:m-10 m-4">
         <div className="p-3 md:py-5">
           <div className="inline-block pb-3 md:pb-5">
             <img src={ovhCloudLogo} alt="ovh-cloud-logo" className="app-logo" />
           </div>
-          <div className="flex justify-center app-content lg:w-8/12 mx-auto min-h-[500px] shadow shadow-[0_0_6px_0_rgba(40,89,192,0.2)]">
+          <div className="flex justify-center app-content lg:w-8/12 mx-auto min-h-[500px] sm:shadow sm:shadow-[0_0_6px_0_rgba(40,89,192,0.2)] sm:border-none border-t-[1px] border-gray-300">
             <Outlet />
           </div>
         </div>

--- a/packages/manager/apps/account-disable-2fa/src/pages/see/See.page.tsx
+++ b/packages/manager/apps/account-disable-2fa/src/pages/see/See.page.tsx
@@ -1,5 +1,85 @@
+import { OsdsIcon, OsdsLink, OsdsText } from '@ovhcloud/ods-components/react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ODS_THEME_COLOR_INTENT,
+  ODS_THEME_TYPOGRAPHY_LEVEL,
+} from '@ovhcloud/ods-common-theming';
+import {
+  ODS_ICON_NAME,
+  ODS_ICON_SIZE,
+  ODS_TEXT_SIZE,
+} from '@ovhcloud/ods-components';
 
 export default function SeeRequest() {
-  return <h1>See request</h1>;
+  const { t } = useTranslation('account-disable-2fa');
+  const { t: tsub } = useTranslation('account-disable-2fa-sub');
+
+  return (
+    <div className="lg:px-20 sm:px-6 lg:py-10 sm:py-6 flex flex-col gap-4 justify-between">
+      <OsdsText
+        color={ODS_THEME_COLOR_INTENT.info}
+        level={ODS_THEME_TYPOGRAPHY_LEVEL.heading}
+        className="block mb-6"
+        size={ODS_TEXT_SIZE._500}
+      >
+        {t('account-disable-2fa-see-title')}
+      </OsdsText>
+
+      <OsdsText
+        color={ODS_THEME_COLOR_INTENT.text}
+        level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
+        className="block"
+        size={ODS_TEXT_SIZE._400}
+      >
+        {t('account-disable-2fa-see-description1')}
+      </OsdsText>
+
+      <OsdsText
+        color={ODS_THEME_COLOR_INTENT.text}
+        level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
+        className="block"
+        size={ODS_TEXT_SIZE._400}
+      >
+        {t('account-disable-2fa-see-description2')}
+      </OsdsText>
+
+      <OsdsText
+        color={ODS_THEME_COLOR_INTENT.text}
+        level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
+        className="block"
+        size={ODS_TEXT_SIZE._400}
+      >
+        {tsub('account-disable-2fa-contact-availability')}
+      </OsdsText>
+
+      <OsdsText
+        color={ODS_THEME_COLOR_INTENT.text}
+        level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
+        className="block"
+        size={ODS_TEXT_SIZE._400}
+      >
+        <span
+          dangerouslySetInnerHTML={{
+            __html: tsub('account-disable-2fa-contact-phone'),
+          }}
+        ></span>
+      </OsdsText>
+
+      <OsdsLink
+        color={ODS_THEME_COLOR_INTENT.primary}
+        className="mt-auto"
+        href="https://ovhcloud.com"
+      >
+        {t('account-disable-2fa-back-home')}
+        <span slot="end">
+          <OsdsIcon
+            name={ODS_ICON_NAME.ARROW_RIGHT}
+            size={ODS_ICON_SIZE.xs}
+            hoverable
+          ></OsdsIcon>
+        </span>
+      </OsdsLink>
+    </div>
+  );
 }

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/ASIA/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/ASIA/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 7am - 5pm (GMT+8)",
+  "account-disable-2fa-contact-phone": "+65 6962 8978"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/AU/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/AU/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 5pm (AEST)",
+  "account-disable-2fa-contact-phone": "1300 OVH AUS (684 287)<br/>Vous appelez de l'étranger ?<br/>+61 3 83 758 172"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/CA/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/CA/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "",
+  "account-disable-2fa-contact-phone": "1-855-684-5463"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/CZ/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/CZ/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/DE/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/DE/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "+49 681 906730"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/ES/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/ES/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "91 758 34 77"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/FI/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/FI/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/FR/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/FR/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "1007 / +33 9 72 10 10 07"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/GB/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/GB/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "0333 370 0425"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IE/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IE/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IN/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IN/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9AM - 5PM (GMT +5:30)",
+  "account-disable-2fa-contact-phone": "Numéro gratuit : 000 800 040 4567"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IT/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/IT/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "+39 02 5560 0423"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/LT/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/LT/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/LTE/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/LTE/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/MA/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/MA/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 09h - 18h",
+  "account-disable-2fa-contact-phone": "+212 5 22 26 00 86"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/NL/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/NL/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 9am - 6pm",
+  "account-disable-2fa-contact-phone": "+353 (0) 1 691 72 83"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/PL/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/PL/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "71 750 02 00"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/PT/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/PT/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 09h - 18h",
+  "account-disable-2fa-contact-phone": "+351 213 155 642"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/QC/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/QC/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "",
+  "account-disable-2fa-contact-phone": "1-855-684-5463"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/SG/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/SG/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 7am - 5pm (GMT+8)",
+  "account-disable-2fa-contact-phone": "+65 6962 8979"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/SN/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/SN/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "1007 / +33 9 72 10 10 07"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/TN/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/TN/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "Lundi au vendredi : 08:00 - 18:00",
+  "account-disable-2fa-contact-phone": "+216 71 966 044"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/WE/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/WE/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "",
+  "account-disable-2fa-contact-phone": "1-855-684-5463"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/WS/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa-sub/WS/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "account-disable-2fa-contact-availability": "",
+  "account-disable-2fa-contact-phone": "1-855-684-5463"
+}

--- a/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa/Messages_fr_FR.json
+++ b/packages/manager/apps/account-disable-2fa/src/public/translations/account-disable-2fa/Messages_fr_FR.json
@@ -1,1 +1,6 @@
-{}
+{
+  "account-disable-2fa-see-title": "Vous avez déjà demandé la désactivation de la double authentification.",
+  "account-disable-2fa-see-description1": "Veuillez répondre sur l'échange e-mail initial ou attendre sa clôture avant de soumettre une nouvelle demande.",
+  "account-disable-2fa-see-description2": "Vous n'avez reçu aucun e-mail ? Veuillez nous contacter à l'aide des informations ci-dessous :",
+  "account-disable-2fa-back-home": "Retour à la page d'accueil"
+}


### PR DESCRIPTION
ref: MANAGER-14145

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/acquisition-storage-2fa`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix 14145
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Adding messages from different sub to the 'see' page. the see page is displayed when the 2FA deactivation status is 'open'

## Related

<!-- Link dependencies of this PR -->
