### PR TITLE
feat(web): save dashboard domain columns

### DIFF
--- a/packages/manager/apps/web/client/app/domain/list/list-domain-layout.controller.js
+++ b/packages/manager/apps/web/client/app/domain/list/list-domain-layout.controller.js
@@ -145,6 +145,27 @@ export default class ListDomainLayoutCtrl extends ListLayoutHelper.ListLayoutCtr
     this.$scope.$on('domain.csv.export.error', () => {
       this.loading.domainsExportCsv = false;
     });
+
+    this.loadColumnConfig();
+  }
+
+  onColumnChange(id, columns) {
+    this.columnsConfig = columns;
+    this.saveColumnConfig();
+  }
+
+  loadColumnConfig() {
+    const savedConfig = localStorage.getItem(`${this.datagridId}Config`);
+    if (savedConfig) {
+      this.columnsConfig = JSON.parse(savedConfig);
+    }
+  }
+
+  saveColumnConfig() {
+    localStorage.setItem(
+      `${this.datagridId}Config`,
+      JSON.stringify(this.columnsConfig),
+    );
   }
 
   goToContactManagementEdit(domain) {

--- a/packages/manager/apps/web/client/app/domain/list/template.html
+++ b/packages/manager/apps/web/client/app/domain/list/template.html
@@ -95,6 +95,8 @@
 
         <oui-datagrid-column
             data-title="::'domains_column_domains_tech_state' | translate"
+            data-property="dnssecState"
+            prevent-customization
         >
             <span
                 class="oui-icon oui-icon-success-circle"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Feat #14271
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] Only FR translations have been updated
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

As a customer, I would like the domain dashboard columns to be saved on my browser.

Local storage will be used to make a temporary backup of saved columns.