### PR TITLE
feat(dedicated.nutanix): remove public bandwidth from cluster node

### DIFF
--- a/packages/manager/modules/bm-server-components/src/network-tile/component.js
+++ b/packages/manager/modules/bm-server-components/src/network-tile/component.js
@@ -19,6 +19,7 @@ export default {
     goToUpdateReverseDns: '<?',
     goToDeleteReverseDns: '<?',
     statePrefix: '<?',
+    hidePublicBandwidth: '<?',
   },
   controller,
   template,

--- a/packages/manager/modules/bm-server-components/src/network-tile/controller.js
+++ b/packages/manager/modules/bm-server-components/src/network-tile/controller.js
@@ -11,6 +11,7 @@ export default class BmServerComponentsNetworkTileController {
 
   $onInit() {
     this.statePrefix = this.statePrefix || 'app.dedicated-server.server';
+    this.hidePublicBandwidth = this.hidePublicBandwidth || false;
     this.manageIpUrl = this.coreURLBuilder.buildURL(
       'dedicated',
       '#/ip?serviceName=:serviceName',

--- a/packages/manager/modules/bm-server-components/src/network-tile/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-tile/template.html
@@ -96,7 +96,7 @@
         </oui-tile-definition>
         <server-bandwidth-dashboard
             data-ng-if="!!$ctrl.vrackInfos && $ctrl.specifications.vrack.bandwidth && $ctrl.specifications.vrack.bandwidth.value !== 0"
-            data-display-public-bandwidth="false"
+            data-display-public-bandwidth="!$ctrl.hidePublicBandwidth"
             data-bandwidth-vrack-option="$ctrl.bandwidthInformations.bandwidthVrackOptions"
             data-bandwidth-vrack-order-option="$ctrl.bandwidthInformations.bandwidthVrackOrderOptions"
             data-order-private-link="$ctrl.orderPrivateBandwidthLink"

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/component.js
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/component.js
@@ -18,6 +18,7 @@ export default {
     goToReboot: '<',
     isOldCluster: '<',
     orderPrivateBandwidthLink: '<',
+    hidePublicBandwidth: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/routing.js
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/routing.js
@@ -16,6 +16,7 @@ export default /* @ngInject */ ($stateProvider) => {
           },
         ),
       server: /* @ngInject */ (node) => node,
+      hidePublicBandwidth: () => true,
       trackingPrefix: /* @ngInject */ () =>
         'hpc::nutanix::cluster::node::dashboard',
       goToNodeNameEdit: /* @ngInject */ ($state) => () =>

--- a/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
+++ b/packages/manager/modules/nutanix/src/dashboard/nodes/node/general-info/template.html
@@ -152,6 +152,7 @@
                 data-order-private-bandwidth-link="$ctrl.orderPrivateBandwidthLink"
                 data-is-old-cluster="$ctrl.isOldCluster"
                 data-service-infos="$ctrl.serviceInfos"
+                data-hide-public-bandwidth="$ctrl.hidePublicBandwidth"
             >
             </server-network>
         </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | feat/nutanix-package-v2
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Feat MANAGER-14346
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

since the component is used in several places, set conditionnal display of bandwidth based on stateprefix to avoid regression in baremetal sections

## Related

<!-- Link dependencies of this PR -->
