### PR TITLE
fix(pack): set previous title to correct value for meetings

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/meeting/move-meeting.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/meeting/move-meeting.controller.js
@@ -54,6 +54,7 @@ export default class MoveMeetingCtrl {
                 slots,
               });
               slots = [];
+              prevTitle = title;
             }
             slots.push({
               id: index,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-591
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

set previous title to correct value for meetings

## Related

<!-- Link dependencies of this PR -->
