### PR TITLE
feat(2fa): set up invisible challenge

### DIFF
--- a/packages/manager/apps/account-disable-2fa/package.json
+++ b/packages/manager/apps/account-disable-2fa/package.json
@@ -51,6 +51,9 @@
     "vite": "^4.5.0",
     "vitest": "^1.2.0"
   },
+  "peerDependencies": {
+    "axios": "^1.1.2"
+  },
   "regions": [
     "CA",
     "EU"

--- a/packages/manager/apps/account-disable-2fa/src/data/invisible-challenge.interceptor.ts
+++ b/packages/manager/apps/account-disable-2fa/src/data/invisible-challenge.interceptor.ts
@@ -1,0 +1,56 @@
+import { v6 } from '@ovh-ux/manager-core-api';
+import {
+  ChallengeApiInterceptor,
+  ChallengeApiInterceptorChallengeResponse,
+  INVISIBLE_CHALLENGE_ERROR_CLASS,
+} from '@/utils/invisible-challenge';
+
+export const initInterceptor = () => {
+  const challengeApiInterceptor = new ChallengeApiInterceptor(v6);
+  challengeApiInterceptor.attachMessageListener();
+
+  type ResponseWithChallenge = {
+    class?: string;
+    body?: {
+      type: 'image' | 'url';
+      payload: string;
+    };
+  };
+
+  v6.interceptors.response.use(undefined, (error) => {
+    const { response } = error;
+    const { status, data } = response;
+
+    if (status === 400 && data.class === INVISIBLE_CHALLENGE_ERROR_CLASS) {
+      const {
+        body: { payload },
+      } = data as ResponseWithChallenge;
+      if (!payload) {
+        // This should not happen. (API bug)
+        console.warn(
+          '[ChallengeApiInterceptor] missing payload in the challenge response body.',
+        );
+        return Promise.reject(data);
+      }
+
+      return challengeApiInterceptor
+        .loadChallenge(payload)
+        .then((challenge: ChallengeApiInterceptorChallengeResponse) =>
+          challengeApiInterceptor.resendFirstRequestWithHeaders(
+            error.config,
+            challenge,
+          ),
+        )
+        .catch((challengeError) => {
+          console.warn(
+            '[ChallengeApiInterceptor] Unable to get the API challenge.',
+          );
+          return Promise.reject(challengeError);
+        });
+    }
+
+    return Promise.reject(error);
+  });
+};
+
+export default initInterceptor;

--- a/packages/manager/apps/account-disable-2fa/src/data/invisible-challenge.interceptor.ts
+++ b/packages/manager/apps/account-disable-2fa/src/data/invisible-challenge.interceptor.ts
@@ -2,8 +2,8 @@ import { v6 } from '@ovh-ux/manager-core-api';
 import {
   ChallengeApiInterceptor,
   ChallengeApiInterceptorChallengeResponse,
-  INVISIBLE_CHALLENGE_ERROR_CLASS,
-} from '@/utils/invisible-challenge';
+} from '@/utils/invisible-challenge.class';
+import { INVISIBLE_CHALLENGE_ERROR_CLASS } from '@/utils/invisible-challenge.constants';
 
 export const initInterceptor = () => {
   const challengeApiInterceptor = new ChallengeApiInterceptor(v6);

--- a/packages/manager/apps/account-disable-2fa/src/index.tsx
+++ b/packages/manager/apps/account-disable-2fa/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import initI18n from './i18n';
+import initInterceptor from './data/invisible-challenge.interceptor';
 
 import './global.css';
 import './index.scss';
@@ -17,6 +18,7 @@ const user = {
 const locale = user.language;
 
 initI18n(locale, [locale], user.subsidiary);
+initInterceptor();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/manager/apps/account-disable-2fa/src/utils/iframe.ts
+++ b/packages/manager/apps/account-disable-2fa/src/utils/iframe.ts
@@ -1,0 +1,53 @@
+export type IframeLoaderPayload = {
+  src: string;
+  id?: string;
+  title?: string;
+  style?: string;
+  width?: string;
+};
+
+const getNewIframeElement = (
+  payload: IframeLoaderPayload,
+): HTMLIFrameElement => {
+  if (!payload || !payload.src) {
+    throw new Error('[IframeLoader][getNewIframeElement()] missing payload.');
+  }
+
+  const iframe = document.createElement('iframe');
+  iframe.src = payload.src;
+
+  if (payload.title) {
+    iframe.title = payload.title;
+  }
+  if (payload.width) {
+    iframe.width = payload.width;
+  }
+  if (payload.id) {
+    iframe.id = payload.id;
+  }
+  if (payload.style) {
+    iframe.style.cssText = payload.style;
+  }
+
+  return iframe;
+};
+
+export const loadIframe = (payload: IframeLoaderPayload): Promise<unknown> => {
+  if (!payload || !payload.src) {
+    throw new Error('[IframeLoader][load()] missing payload.');
+  }
+
+  const iframe = getNewIframeElement(payload);
+  const promise = new Promise((resolve, reject) => {
+    iframe.onload = resolve;
+    // The following code is never called
+    // see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#error_and_load_event_behavior
+    iframe.onerror = reject;
+  });
+
+  document.body.appendChild(iframe);
+  return promise;
+};
+
+export const removeIframe = (iframe: HTMLIFrameElement): HTMLIFrameElement =>
+  document.body.removeChild(iframe);

--- a/packages/manager/apps/account-disable-2fa/src/utils/iframe.ts
+++ b/packages/manager/apps/account-disable-2fa/src/utils/iframe.ts
@@ -33,10 +33,6 @@ const getNewIframeElement = (
 };
 
 export const loadIframe = (payload: IframeLoaderPayload): Promise<unknown> => {
-  if (!payload || !payload.src) {
-    throw new Error('[IframeLoader][load()] missing payload.');
-  }
-
   const iframe = getNewIframeElement(payload);
   const promise = new Promise((resolve, reject) => {
     iframe.onload = resolve;

--- a/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.class.ts
+++ b/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.class.ts
@@ -1,5 +1,10 @@
 import { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { IframeLoaderPayload, loadIframe, removeIframe } from '@/utils/iframe';
+import {
+  CHALLENGE_IFRAME_ID,
+  IFRAME_STYLE,
+  TTL_TO_WAIT_IFRAME_RESPONSE,
+} from '@/utils/invisible-challenge.constants';
 
 export type ChallengeApiInterceptorChallengeResponse = {
   challenge_response: string;
@@ -15,12 +20,6 @@ export enum ChallengeFailureReasons {
   NoIframe,
   Timeout,
 }
-
-export const CHALLENGE_IFRAME_ID = 'ovh_security_challenge';
-export const TTL_TO_WAIT_IFRAME_RESPONSE = 1000;
-export const INVISIBLE_CHALLENGE_ERROR_CLASS =
-  'Client::BadRequest::ChallengeRequired';
-export const IFRAME_STYLE = 'position: absolute; width:0; height:0; border:0;';
 
 export class ChallengeApiInterceptor {
   private apiClient: AxiosInstance;
@@ -39,10 +38,8 @@ export class ChallengeApiInterceptor {
   }
 
   public attachMessageListener() {
-    window.addEventListener(
-      'message',
-      (message: MessageEvent) => this.onIframeMessage(message),
-      false,
+    window.addEventListener('message', (message: MessageEvent) =>
+      this.onIframeMessage(message),
     );
   }
 

--- a/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.constants.ts
+++ b/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.constants.ts
@@ -1,0 +1,5 @@
+export const CHALLENGE_IFRAME_ID = 'ovh_security_challenge';
+export const TTL_TO_WAIT_IFRAME_RESPONSE = 1000;
+export const INVISIBLE_CHALLENGE_ERROR_CLASS =
+  'Client::BadRequest::ChallengeRequired';
+export const IFRAME_STYLE = 'position: absolute; width:0; height:0; border:0;';

--- a/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.ts
+++ b/packages/manager/apps/account-disable-2fa/src/utils/invisible-challenge.ts
@@ -1,0 +1,165 @@
+import { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { IframeLoaderPayload, loadIframe, removeIframe } from '@/utils/iframe';
+
+export type ChallengeApiInterceptorChallengeResponse = {
+  challenge_response: string;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve?: (value: T) => void;
+  reject?: (reason?: ChallengeFailureReasons) => void;
+};
+
+export enum ChallengeFailureReasons {
+  NoIframe,
+  Timeout,
+}
+
+export const CHALLENGE_IFRAME_ID = 'ovh_security_challenge';
+export const TTL_TO_WAIT_IFRAME_RESPONSE = 1000;
+export const INVISIBLE_CHALLENGE_ERROR_CLASS =
+  'Client::BadRequest::ChallengeRequired';
+export const IFRAME_STYLE = 'position: absolute; width:0; height:0; border:0;';
+
+export class ChallengeApiInterceptor {
+  private apiClient: AxiosInstance;
+
+  private iframe: HTMLIFrameElement | null;
+
+  private deferWaitingChallenge: Deferred<unknown> | null;
+
+  private abortTimeout: number;
+
+  constructor(apiClient: AxiosInstance) {
+    this.apiClient = apiClient;
+    this.iframe = null;
+    this.deferWaitingChallenge = null;
+    this.abortTimeout = null;
+  }
+
+  public attachMessageListener() {
+    window.addEventListener(
+      'message',
+      (message: MessageEvent) => this.onIframeMessage(message),
+      false,
+    );
+  }
+
+  public loadChallenge(url: string): Promise<unknown> {
+    if (this.deferWaitingChallenge) {
+      return this.deferWaitingChallenge.promise;
+    }
+
+    // alternative to Promise.withResolvers()
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
+    this.deferWaitingChallenge = {
+      promise: null,
+      resolve: () => null,
+      reject: () => null,
+    };
+    this.deferWaitingChallenge.promise = new Promise((resolve, reject) => {
+      this.deferWaitingChallenge.resolve = resolve;
+      this.deferWaitingChallenge.reject = reject;
+    });
+
+    // If the iframe is already loaded
+    if (this.iframe) {
+      // And the payload has not changed, we can re-use it.
+      if (this.iframe.src === url) {
+        // This iframe is already loaded, go forward to talk with it
+        this.onIframeLoaded();
+        return this.deferWaitingChallenge.promise;
+      }
+      // Otherwise we remove the previous one to use a new one
+      removeIframe(this.iframe);
+      this.iframe = null;
+    }
+    const payload: IframeLoaderPayload = {
+      src: url,
+      id: CHALLENGE_IFRAME_ID,
+      style: IFRAME_STYLE,
+      title: 'Security Challenge - API - Interceptor',
+    };
+
+    loadIframe(payload).then((loadEvent: Event) => {
+      this.iframe = loadEvent.target as HTMLIFrameElement;
+
+      if (!this.iframe) {
+        this.iframe = document.getElementById(
+          CHALLENGE_IFRAME_ID,
+        ) as HTMLIFrameElement;
+      }
+
+      this.onIframeLoaded();
+    });
+
+    return this.deferWaitingChallenge.promise;
+  }
+
+  private onIframeLoaded() {
+    if (!this.iframe) {
+      this.abortChallenge(ChallengeFailureReasons.NoIframe);
+      return;
+    }
+
+    const iframeContentWindow = this.iframe.contentWindow;
+    iframeContentWindow.postMessage(
+      { type: 'challengeRequest' },
+      this.iframe.src,
+    );
+
+    // If something went wrong with the iframe communication, schedule a safety aborting
+    // process to avoid infinitely wait for an iframe message.
+    this.abortTimeout = window.setTimeout(() => {
+      this.abortChallenge(ChallengeFailureReasons.Timeout);
+    }, TTL_TO_WAIT_IFRAME_RESPONSE);
+  }
+
+  private abortChallenge(reason: ChallengeFailureReasons): void {
+    console.debug('[ChallengeApiInterceptor] Aborting.');
+    this.deferWaitingChallenge.reject(reason);
+    this.deferWaitingChallenge = null;
+
+    this.clearAbortTimeoutIfNeeded();
+  }
+
+  private clearAbortTimeoutIfNeeded() {
+    if (this.abortTimeout) {
+      clearTimeout(this.abortTimeout);
+      this.abortTimeout = null;
+    }
+  }
+
+  private resolveWaitingChallenge(
+    challenge: ChallengeApiInterceptorChallengeResponse,
+  ): void {
+    this.deferWaitingChallenge.resolve(challenge);
+    this.deferWaitingChallenge = null;
+
+    this.clearAbortTimeoutIfNeeded();
+  }
+
+  private onIframeMessage(message: MessageEvent): void {
+    if (
+      !this.iframe?.src.startsWith(message.origin) ||
+      !message.data?.challenge_response
+    ) {
+      return;
+    }
+
+    this.resolveWaitingChallenge(message.data);
+  }
+
+  public resendFirstRequestWithHeaders(
+    originalConfig: InternalAxiosRequestConfig,
+    challenge: ChallengeApiInterceptorChallengeResponse,
+  ): Promise<unknown> {
+    // Recreate the request config, and adding to its headers the challenge information (source & response)
+    const config: InternalAxiosRequestConfig = { ...originalConfig };
+    config.headers.set('X-Challenge-Payload', this.iframe.src);
+    config.headers.set('X-Challenge-Response', challenge.challenge_response);
+    // Resend the request with the challenge information
+    return this.apiClient.request(config);
+  }
+}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/acquisition-storage-2fa`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-14063
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Setup of an "invisible challenge" to ensure no bot is requesting the non authenticated API methods.

## Related

<!-- Link dependencies of this PR -->
