### PR TITLE
feat(hosting): attachedDomain actions done through apiv6

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.controller.js
@@ -81,7 +81,6 @@ angular
           : null,
         domainWww: null,
         domainWwwNeeded: true,
-        ipv6Needed: true,
         mode: $scope.model.mode.OVH,
         path: '',
         pathFinal: null,
@@ -340,7 +339,6 @@ angular
             : null,
           $scope.selected.pathFinal,
           $scope.needWwwDomain(),
-          $scope.selected.ipv6Needed,
           $scope.selected.autoconfigure &&
             $scope.selected.mode === $scope.model.mode.OVH,
           $scope.selected.activeCDN,

--- a/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.html
+++ b/packages/manager/apps/web/client/app/hosting/multisite/add/hosting-multisite-add.html
@@ -310,26 +310,15 @@
                         data-ng-bind-html="'hosting_tab_DOMAINS_configuration_add_step3_common_action' | translate: { t0: 'A', t1: getSelectedDomainToDisplay(), t2: getHostingIp(hosting, selected.activeCDN, false) }"
                     ></li>
                     <li
-                        data-ng-if="!selected.autoconfigure && !selected.ipv6Needed"
-                        data-translate="hosting_tab_DOMAINS_configuration_add_step3_delete_4a_records"
-                        data-translate-values="{ domain: getSelectedDomainToDisplay() }"
-                    ></li>
-                    <li
-                        data-ng-if="!selected.autoconfigure && !selected.ipv6Needed && needWwwDomain()"
-                        data-translate="hosting_tab_DOMAINS_configuration_add_step3_delete_4a_records"
-                        data-translate-values="{ domain: getSelectedDomainToDisplay(needWwwDomain()) }"
-                    ></li>
-                    <li
                         data-ng-bind-html="'hosting_tab_DOMAINS_configuration_add_step3_common_action' | translate: { t0: 'A', t1: getSelectedDomainToDisplay(true), t2: getHostingIp(hosting, selected.activeCDN, false) }"
                         data-ng-if="needWwwDomain()"
                     ></li>
                     <li
                         data-ng-bind-html="'hosting_tab_DOMAINS_configuration_add_step3_common_action' | translate: { t0: 'AAAA', t1: getSelectedDomainToDisplay(), t2: getHostingIp(hosting, selected.activeCDN, true) }"
-                        data-ng-if="selected.ipv6Needed"
                     ></li>
                     <li
                         data-ng-bind-html="'hosting_tab_DOMAINS_configuration_add_step3_common_action' | translate: { t0: 'AAAA', t1: getSelectedDomainToDisplay(true), t2: getHostingIp(hosting, selected.activeCDN, true) }"
-                        data-ng-if="selected.ipv6Needed && needWwwDomain()"
+                        data-ng-if="needWwwDomain()"
                     ></li>
                 </ul>
 

--- a/packages/manager/apps/web/client/app/hosting/multisite/add/ovh/hosting-multisite-add-ovh.html
+++ b/packages/manager/apps/web/client/app/hosting/multisite/add/ovh/hosting-multisite-add-ovh.html
@@ -95,7 +95,6 @@
         firewall="selected.firewall"
         hosting="hosting"
         ip-location="selectedOptions.ipLocation"
-        ipv6="selected.ipv6Needed"
         own-log="selected.ownLog"
         own-log-domain="selected.ownLogDomain"
         path="selected.path"

--- a/packages/manager/apps/web/client/app/hosting/multisite/update/hosting-multisite-update.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/update/hosting-multisite-update.controller.js
@@ -337,7 +337,6 @@ angular
           $scope.selected.domain.name,
           $scope.selected.pathFinal,
           $scope.selected.domainWwwNeeded,
-          $scope.selected.domain.ipV6Enabled,
           $scope.selected.domain.cdn,
           $scope.selected.domain.ipLocation,
           $scope.selected.domain.firewall,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | yes
| Breaking change? | no
| Tickets          | WEB-18579
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description
Currently, when customer creates/updates/deletes a multisite, the DNS zone update is handled by 2api (repo hosting-web-domains).
It creates issues (WSD-10765) because 2api updates DNS zone too often, even when it is not needed (ex: customer updates multisite to remove SSL => the DNS zone is updated). 
The issue impacts mainly customers who set up manually the DNS zone : we revert it to OVH's ip whenever customers update a multisite.
We took the occasion of this issue to handle DNS zone update through webhosting's backend instead of 2api.

The content of the PR is : 
- call apiv6 directly instead of 2api in case of multisite creation/update/deletion
- remove code related to ipv6Needed parameter : it is always set to true

## Related

<!-- Link dependencies of this PR -->
