### PR TITLE
fix(i18n): add missing translations [CDS 3038]

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -243,7 +243,7 @@
   "logs_streams_col_retention": "Retention",
   "logs_streams_col_storage": "Space used",
   "logs_streams_enabled": "Active",
-  "logs_streams_disabled": "On break",
+  "logs_streams_disabled": "Paused",
   "logs_streams_no_streams": "No data streams",
   "logs_streams_col_shared": "Shared data stream",
   "logs_streams_manage_alerts": "Manage alerts",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop` 
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #OB-5372
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

This change allows users to have a better understanding of the status of a logs stream in Logs Data Platform by changing the translation of a paused stream from "On break" to "Paused".

## Related

This replace https://github.com/ovh/manager/pull/11719
