### PR TITLE
fix(dedicated): replace old windows rescue name by the new one

### DIFF
--- a/packages/manager/modules/bm-server-components/src/netboot/constants.js
+++ b/packages/manager/modules/bm-server-components/src/netboot/constants.js
@@ -28,7 +28,10 @@ export const NETBOOT_GUIDES = {
   DEFAULT: 'https://docs.ovh.com/us/en/dedicated/hardware-diagnostics',
 };
 
-export const UNSUPPORTED_SSH_KEY_RESCUES = ['WinRescue', 'WiRe'];
+export const UNSUPPORTED_SSH_KEY_RESCUES = [
+  'WinRescue',
+  'rescue-customer-windows',
+];
 export const SSH_KEY = {
   pattern: /^(ssh-rsa|ecdsa-sha\d+-nistp\d+|ssh-ed\d+)\s+(AAAA[a-zA-Z0-9/=+]+)(\s+(\S{1,128}))*$/,
   placeholder:


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-14395
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)

## Description

Renamed old ``WiRe`` rescue by the new ``rescue-customer-windows``