### PR TITLE
feat(dedicated): add button to buy domain in vps dashboard

### DIFF
--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.constants.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.constants.js
@@ -8,6 +8,9 @@ export const DASHBOARD_FEATURES = {
 };
 export const SERVICE_TYPE = 'vps';
 
+export const ADD_DOMAIN_LINK =
+  'https://www.ovh.com/fr/order/webcloud/#/webCloud/domain/select?selection=~()';
+
 export const NEW_RANGE_VERSION = '2019v1';
 
 export const VPS_STATES = {

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.controller.js
@@ -7,6 +7,7 @@ import map from 'lodash/map';
 import 'moment';
 import { RANGES } from '../upscale/upscale.constants';
 import {
+  ADD_DOMAIN_LINK,
   VPS_RANGE_COMPARE_LINKS,
   COMMIT_IMPRESSION_TRACKING_DATA,
   DASHBOARD_FEATURES,
@@ -47,6 +48,7 @@ export default class {
     this.VpsService = VpsService;
     this.VpsHelperService = VpsHelperService;
     this.VpsUpgradeService = VpsUpgradeService;
+    this.ADD_DOMAIN_LINK = ADD_DOMAIN_LINK;
     this.DASHBOARD_FEATURES = DASHBOARD_FEATURES;
     this.SERVICE_TYPE = SERVICE_TYPE;
 

--- a/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
+++ b/packages/manager/modules/vps/src/dashboard/vps-dashboard.html
@@ -345,8 +345,31 @@
                     </oui-tile-definition>
                     <oui-tile-definition
                         data-term="{{ ::'vps_dashboard_secondary_dns' | translate }}"
-                        data-description="{{ ::$ctrl.vps.secondaryDns }}"
                     >
+                        <oui-tile-description>
+                            <p>
+                                {{ $ctrl.vps.secondaryDns }}
+                            </p>
+                            <div
+                                ng-if="$ctrl.vps.secondaryDns === ('vps_dashboard_secondary_dns_count_0' | translate)"
+                            >
+                                <p>
+                                    {{ ::'vps_dashboard_domain_link_message' |
+                                    translate}}
+                                </p>
+                                <a
+                                    class="oui-button oui-button_secondary"
+                                    data-ng-href="{{ $ctrl.ADD_DOMAIN_LINK }}"
+                                    data-track-on="click"
+                                    data-track-name="{{:: $ctrl.trackingPrefix + '::migrate-my-vps' }}"
+                                    target="_top"
+                                >
+                                    <span
+                                        data-translate="vps_dashboard_domain_link"
+                                    ></span>
+                                </a>
+                            </div>
+                        </oui-tile-description>
                     </oui-tile-definition>
                 </div>
             </oui-tile>

--- a/packages/manager/modules/vps/src/vps/translations/Messages_de_DE.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_de_DE.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Bitte kopieren Sie den CURL-Befehl und führen Sie ihn auf Ihrer Maschine aus. Mehr Informationen zu CURL finden <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">Sie hier</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Download-Link erstellen",
   "vps_configuration_download_snapshot_title_button": "Snapshot herunterladen",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Der Snapshot wird gerade erstellt. Versuchen Sie es erneut, wenn der Vorgang abgeschlossen ist."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Der Snapshot wird gerade erstellt. Versuchen Sie es erneut, wenn der Vorgang abgeschlossen ist.",
+  "vps_dashboard_domain_link": "Eine Domain hinzufügen",
+  "vps_dashboard_domain_link_message": "Fügen Sie Ihrem VPS eine Domain hinzu, um Ihr Projekt mit der ganzen Welt zu teilen"
 }

--- a/packages/manager/modules/vps/src/vps/translations/Messages_en_GB.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_en_GB.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Please copy the CURL command above, and run it on your terminal. To learn more about CURL, <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">click here</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Generate download link",
   "vps_configuration_download_snapshot_title_button": "Download Snapshot",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "The snapshot is being created. Please try again later when this process is complete."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "The snapshot is being created. Please try again later when this process is complete.",
+  "vps_dashboard_domain_link": "Add a domain name",
+  "vps_dashboard_domain_link_message": "Add a domain name to your VPS to easily share your project with the world"
 }

--- a/packages/manager/modules/vps/src/vps/translations/Messages_es_ES.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_es_ES.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Copie el comando CURL anterior y ejecútelo en su terminal. Para más información sobre CURL, haga clic <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">aquí</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Generar el enlace de descarga",
   "vps_configuration_download_snapshot_title_button": "Descargar el snapshot",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "El snapshot se está creando. Vuelva a intentarlo más tarde una vez completado el proceso."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "El snapshot se está creando. Vuelva a intentarlo más tarde una vez completado el proceso.",
+  "vps_dashboard_domain_link": "Añadir un dominio",
+  "vps_dashboard_domain_link_message": "Añada un dominio a su VPS para compartir fácilmente su proyecto con el mundo entero"
 }

--- a/packages/manager/modules/vps/src/vps/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_fr_CA.json
@@ -93,6 +93,8 @@
   "vps_dashboard_reverse_dns": "Reverse DNS",
   "vps_dashboard_reverse_dns_none": "Non configuré",
   "vps_dashboard_secondary_dns": "DNS secondaire",
+  "vps_dashboard_domain_link": "Ajouter un nom de domaine",
+  "vps_dashboard_domain_link_message": "Ajoutez un nom de domaine à votre VPS pour partager facilement votre projet avec le monde entier",
   "vps_dashboard_secondary_dns_count_0": "Aucun domaine configuré",
   "vps_dashboard_secondary_dns_count_x": "{{ count }} domaine(s) configuré(s)",
   "vps_dashboard_state_services": "Statut",

--- a/packages/manager/modules/vps/src/vps/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_fr_FR.json
@@ -93,6 +93,8 @@
   "vps_dashboard_reverse_dns": "Reverse DNS",
   "vps_dashboard_reverse_dns_none": "Non configuré",
   "vps_dashboard_secondary_dns": "DNS secondaire",
+  "vps_dashboard_domain_link": "Ajouter un nom de domaine",
+  "vps_dashboard_domain_link_message": "Ajoutez un nom de domaine à votre VPS pour partager facilement votre projet avec le monde entier",
   "vps_dashboard_secondary_dns_count_0": "Aucun domaine configuré",
   "vps_dashboard_secondary_dns_count_x": "{{ count }} domaine(s) configuré(s)",
   "vps_dashboard_state_services": "Statut",

--- a/packages/manager/modules/vps/src/vps/translations/Messages_it_IT.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_it_IT.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Copia il comando CURL qui sotto ed eseguilo sul tuo terminale. Per maggiori informazioni su CURL, <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">clicca qui</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Generare il link di download",
   "vps_configuration_download_snapshot_title_button": "Scaricare lo Snapshot",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Lo Snapshot è in fase di creazione, ti preghiamo di riprovare più tardi al termine del processo."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Lo Snapshot è in fase di creazione, ti preghiamo di riprovare più tardi al termine del processo.",
+  "vps_dashboard_domain_link": "Aggiungi un dominio",
+  "vps_dashboard_domain_link_message": "Aggiungi un dominio al tuo VPS per condividere facilmente il tuo progetto con tutto il mondo"
 }

--- a/packages/manager/modules/vps/src/vps/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_pl_PL.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Skopiuj powyższe polecenie CURL i uruchom je na Twoim urządzeniu. Aby uzyskać więcej informacji na temat CURL, <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">kliknij tutaj</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Wygeneruj link do pobrania",
   "vps_configuration_download_snapshot_title_button": "Pobierz snapshot",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Trwa tworzenie snapshota. Spróbuj ponownie później, kiedy ten proces zostanie zakończony."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "Trwa tworzenie snapshota. Spróbuj ponownie później, kiedy ten proces zostanie zakończony.",
+  "vps_dashboard_domain_link": "Dodaj domenę",
+  "vps_dashboard_domain_link_message": "Dodaj domenę do serwera VPS, aby łatwo udostępniać swój projekt innym"
 }

--- a/packages/manager/modules/vps/src/vps/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/vps/src/vps/translations/Messages_pt_PT.json
@@ -541,5 +541,7 @@
   "vps_dashboard_snapshot_download_modal_snapshot_curl_info": "Copie o comando CURL acima e execute-o no seu terminal. Para saber mais sobre o CURL, <a href=\"{{curlDocumentationLink}}\" target=\"_blank\">clique aqui</a>.",
   "vps_dashboard_snapshot_download_modal_snapshot_button_label": "Gerar o link de download",
   "vps_configuration_download_snapshot_title_button": "Fazer download do Snapshot",
-  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "A criação da snapshot está em curso. Tente mais tarde, quando o processo estiver concluído."
+  "vps_dashboard_snapshot_download_modal_snapshot_error_download_not_ready": "A criação da snapshot está em curso. Tente mais tarde, quando o processo estiver concluído.",
+  "vps_dashboard_domain_link": "Adicionar um domínio",
+  "vps_dashboard_domain_link_message": "Adicione um domínio ao seu VPS para poder partilhar facilmente o seu projeto com o mundo inteiro"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Feat #14196
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [X] Only FR translations have been updated
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Today we are missing opportunities => % attachment VPS & domains 42.7%, web hosting 16.6%, BM 15.5% 
In the block ‘Secondary DNS’, add a sentence to promote domain and a CTA with that link to https://www.ovh.com/fr/order/webcloud/#/webCloud/domain/select?selection=~()
See screenshot for example
Page: https://www.ovh.com/manager/#/dedicated/vps/vps-....vps.ovh.net