### PR TITLE
fix(container): hide preloader when mfa enrollment is displayed

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/index.tsx
+++ b/packages/manager/apps/container/src/container/legacy/index.tsx
@@ -87,20 +87,22 @@ function LegacyContainer(): JSX.Element {
                   />
                 </Suspense>
               )}
-              <Preloader visible={preloaderVisible}>
-                <>
-                  <IFrameAppRouter
-                    iframeRef={iframeRef}
-                    configuration={applications}
-                  />
-                  <iframe
-                    title="app"
-                    role="document"
-                    src="about:blank"
-                    ref={iframeRef}
-                  ></iframe>
-                </>
-              </Preloader>
+              {!isMfaEnrollmentVisible && (
+                <Preloader visible={preloaderVisible}>
+                  <>
+                    <IFrameAppRouter
+                      iframeRef={iframeRef}
+                      configuration={applications}
+                    />
+                    <iframe
+                      title="app"
+                      role="document"
+                      src="about:blank"
+                      ref={iframeRef}
+                    ></iframe>
+                  </>
+                </Preloader>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PRB0041138
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] j~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a condition to display Preloader only when MfaEnrollment is not visible

## Related

<!-- Link dependencies of this PR -->
