### PR TITLE
fix(dedicated.account): update core config user after account update

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/new-account-form-controller.js
@@ -344,6 +344,7 @@ export default class NewAccountFormController {
         if (result !== null) {
           return this.$q.reject(result);
         }
+        this.coreConfig.updateUser(model);
         return result;
       })
       .catch((error) => {

--- a/packages/manager/modules/core/src/config/config.provider.js
+++ b/packages/manager/modules/core/src/config/config.provider.js
@@ -16,6 +16,11 @@ export default class CoreConfig {
     return this.environment.getUser();
   }
 
+  updateUser(userUpdate) {
+    const user = this.environment.getUser();
+    this.environment.setUser({ ...user, ...userUpdate });
+  }
+
   getUserLocale() {
     return this.environment.getUserLocale();
   }
@@ -91,6 +96,7 @@ export default class CoreConfig {
       isRegion: (region) => this.isRegion(region),
 
       getUser: () => this.getUser(),
+      updateUser: (userUpdate) => this.updateUser(userUpdate),
 
       getUserLocale: () => this.getUserLocale(),
       setUserLocale: (locale) => this.setUserLocale(locale),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13917
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a function in coreConfig's provider to be able to update user's information.
Called this new function after the account update is successful

## Related

<!-- Link dependencies of this PR -->
