### PR TITLE
fix(container): visual bug on vmware sidebar item

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/index.module.scss
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/index.module.scss
@@ -53,6 +53,10 @@
   }
 }
 
+.sticky {
+  overflow: auto;
+}
+
 .orderButton ~ .sticky {
   top: 4rem;
 }


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-14343
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Visual bug on sidebar : when an item becomes sticky it overflows the container. Fix by forcing the overflow to auto for sticky class. 

## Related

<!-- Link dependencies of this PR -->
