### PR TITLE
feat(pci): handle deep links for new accounts

### DIFF
--- a/packages/manager/apps/public-cloud/src/index.links.js
+++ b/packages/manager/apps/public-cloud/src/index.links.js
@@ -21,7 +21,7 @@ export const useDeepLinks = ({ $stateProvider, ovhShell }) => ({
    * - An array of {@link Link} objects
    * - Each link object must contain a `public` description of the public URL, and a `redirect` description of the deep app link
    * - The `redirect.path` key can contain parameters, these parameters must be enclosed by `{}`
-   * @param {string} arg1.otherwise
+   * @param {(arg1: { stateName: string }) => any} arg1.otherwise
    * - Fallbacks to this state name if the router is unable to resolve the deep link. Default to `"app"`
    * @param {LinkParams} arg1.params
    * - Each key of this `params` object must be a state resolvable
@@ -32,7 +32,8 @@ export const useDeepLinks = ({ $stateProvider, ovhShell }) => ({
    */
   register: ({ links, otherwise, params, options }) => {
     links.forEach((link) => {
-      $stateProvider.state(options.stateName({ link }), {
+      const stateName = options.stateName({ link });
+      $stateProvider.state(stateName, {
         url: link.public.path,
         redirectTo: (transition) => {
           const injector = transition.injector();
@@ -49,7 +50,7 @@ export const useDeepLinks = ({ $stateProvider, ovhShell }) => ({
             .then((path) => {
               ovhShell.navigation.navigateTo(link.redirect.application, path);
             })
-            .catch(() => otherwise);
+            .catch(() => otherwise({ stateName }));
         },
         resolve: {
           ...params,

--- a/packages/manager/apps/public-cloud/src/index.routes.js
+++ b/packages/manager/apps/public-cloud/src/index.routes.js
@@ -42,7 +42,10 @@ export default /* @ngInject */ (
     options: {
       stateName: ({ link }) => kebabCase(`${LINK_PREFIX}-${link.public.path}`),
     },
-    otherwise: 'app.redirect',
+    otherwise: ({ stateName }) => ({
+      state: 'app.redirect',
+      params: { redirectState: stateName },
+    }),
   });
 
   /**
@@ -56,10 +59,10 @@ export default /* @ngInject */ (
    * This state shouldn't have sub states or you should override `redirect` resolve.
    */
   $stateProvider.state('app.redirect', {
-    url: '?onboarding',
+    url: '?onboarding&redirectState',
     resolve: {
-      redirect: /* @ngInject */ ($state) =>
-        $state.go('pci.projects.onboarding'),
+      redirect: /* @ngInject */ ($state, $stateParams) =>
+        $state.go('pci.projects.onboarding', $stateParams),
     },
   });
 

--- a/packages/manager/modules/pci/src/projects/creating/index.js
+++ b/packages/manager/modules/pci/src/projects/creating/index.js
@@ -7,7 +7,7 @@ const moduleName = 'ovhManagerPciProjectsCreatingLazyLoading';
 angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
   /* @ngInject */ ($stateProvider) => {
     $stateProvider.state('pci.projects.creating.**', {
-      url: '/creating',
+      url: '/creating?redirectState',
       lazyLoad: ($transition$) => {
         const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 

--- a/packages/manager/modules/pci/src/projects/creating/routing.js
+++ b/packages/manager/modules/pci/src/projects/creating/routing.js
@@ -7,7 +7,7 @@ import { DISCOVERY_PROJECT_PLANCODE } from '../project/project.constants';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('pci.projects.creating', {
-    url: '/creating/:orderId/:voucherCode',
+    url: '/creating/:orderId/:voucherCode?redirectState',
     views: {
       '@pci': component.name,
     },
@@ -43,6 +43,7 @@ export default /* @ngInject */ ($stateProvider) => {
         getTargetedState,
         goToState,
         isCreatingDiscoveryProject,
+        redirectState,
       ) => (projectId) => {
         atInternet.setPciProjectMode({
           isDiscoveryProject: isCreatingDiscoveryProject,
@@ -55,6 +56,10 @@ export default /* @ngInject */ ($stateProvider) => {
           ...(voucherCode ? { voucherCode } : {}),
           pciCreationNumProjects3: numProjects,
         });
+
+        if (redirectState) {
+          return goToState({ state: redirectState });
+        }
 
         // Used in redirection case to a specific page
         if (isRedirectRequired) {
@@ -106,6 +111,9 @@ export default /* @ngInject */ ($stateProvider) => {
             (item) => item.order?.plan.code === DISCOVERY_PROJECT_PLANCODE,
           ),
         ),
+
+      redirectState: /* @ngInject */ ($transition$) =>
+        $transition$.params().redirectState,
     },
   });
 };

--- a/packages/manager/modules/pci/src/projects/onboarding/index.js
+++ b/packages/manager/modules/pci/src/projects/onboarding/index.js
@@ -7,7 +7,7 @@ const moduleName = 'ovhManagerPciProjectsOnBoardingLazyLoading';
 angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
   /* @ngInject */ ($stateProvider) => {
     $stateProvider.state('pci.projects.onboarding.**', {
-      url: '/onboarding',
+      url: '/onboarding?redirectState',
       lazyLoad: ($transition$) => {
         const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
 

--- a/packages/manager/modules/pci/src/projects/onboarding/onboarding.routing.js
+++ b/packages/manager/modules/pci/src/projects/onboarding/onboarding.routing.js
@@ -6,7 +6,7 @@ import { PCI_HDS_ADDON } from '../project/project.constants';
 export default /* @ngInject */ ($stateProvider) => {
   const stateName = 'pci.projects.onboarding';
   $stateProvider.state(stateName, {
-    url: '/onboarding',
+    url: '/onboarding?redirectState',
     component: 'pciProjectsOnboarding',
     atInternet: {
       ignore: true, // this tell AtInternet to not track this state
@@ -41,7 +41,6 @@ export default /* @ngInject */ ($stateProvider) => {
             if (onBoardingStateName !== stateName) {
               return onBoardingStateName;
             }
-
             return false;
           },
         );
@@ -82,7 +81,7 @@ export default /* @ngInject */ ($stateProvider) => {
       setCartProjectItem: /* @ngInject */ (model, cart, pciProjectNew) => () =>
         pciProjectNew.setCartProjectItemDescription(cart, model.description),
 
-      onCartFinalized: /* @ngInject */ ($state, cart) => (
+      onCartFinalized: /* @ngInject */ ($state, cart, redirectState) => (
         { orderId },
         isDiscoveryProject,
       ) => {
@@ -90,6 +89,7 @@ export default /* @ngInject */ ($stateProvider) => {
           orderId,
           voucherCode: cart?.projectItem?.voucherConfiguration?.value || '',
           isDiscoveryProject,
+          redirectState,
         });
       },
 
@@ -121,6 +121,9 @@ export default /* @ngInject */ ($stateProvider) => {
               PCI_HDS_ADDON.planCode,
             )
           : null,
+
+      redirectState: /* @ngInject */ ($transition$) =>
+        $transition$.params().redirectState,
     },
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #TAPC-1083
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] Only FR translations have been updated
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

### Description

This PR does support deep links for PCI Discovery mode only

This PR does NOT support the following PCI scenarios 
- New Indian accounts
- PCI Discovery NON-eligible accounts : all association accounts and polish users
- Forwarding query string parameters (voucher, context, ...)
- Old PCI project creation funnel