### PR TITLE
fix(pci-private-network): query invalidation after creation

### DIFF
--- a/packages/manager/apps/pci-private-network/src/pages/new/store.ts
+++ b/packages/manager/apps/pci-private-network/src/pages/new/store.ts
@@ -246,6 +246,14 @@ export const useNewNetworkStore = create<TStore>()((set, get) => ({
     }
 
     await queryClient.invalidateQueries({
+      queryKey: ['project', get().project?.id, 'gateway'],
+    });
+
+    await queryClient.invalidateQueries({
+      queryKey: ['subnet', get().project?.id],
+    });
+
+    await queryClient.invalidateQueries({
       queryKey: ['aggregated-network', get().project?.id],
     });
   },


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | pci-private-network
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2308
| License          | BSD 3-Clause

## Description

invalidate gateway & subnet after creation