### PR TITLE
fix(dedicated): wrong server region displayed

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_de_DE.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_de_DE.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Klicken Sie hier, um dieses Schlüssel-Wert-Paar zu löschen.",
   "dedicated_server_dashboard_region_unknown": "Information nicht verfügbar",
   "dedicated_server_dashboard_zone_unknown": "Information nicht verfügbar",
-  "server_configuration_installation_inputs_bad_hostname": "Der Hostname darf nur aus Ziffern, Buchstaben, Bindestrichen und Punkten entsprechend dem in RFC 1035 definierten Format bestehen."
+  "server_configuration_installation_inputs_bad_hostname": "Der Hostname darf nur aus Ziffern, Buchstaben, Bindestrichen und Punkten entsprechend dem in RFC 1035 definierten Format bestehen.",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europa (Frankreich – HDF) (Backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_en_GB.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_en_GB.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Click here to delete this key-value pair",
   "dedicated_server_dashboard_region_unknown": "Information unavailable",
   "dedicated_server_dashboard_zone_unknown": "Information unavailable",
-  "server_configuration_installation_inputs_bad_hostname": "The host name must contain numbers, letters, hyphens and full stops, according to the format defined in RFC 1035"
+  "server_configuration_installation_inputs_bad_hostname": "The host name must contain numbers, letters, hyphens and full stops, according to the format defined in RFC 1035",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europe (France - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_es_ES.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_es_ES.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Haga clic aquí para eliminar este par clave-valor",
   "dedicated_server_dashboard_region_unknown": "Información no disponible",
   "dedicated_server_dashboard_zone_unknown": "Información no disponible",
-  "server_configuration_installation_inputs_bad_hostname": "El «hostname» solo debe estar compuesto por números, letras, guiones y puntos según el formato establecido en la RFC 1035"
+  "server_configuration_installation_inputs_bad_hostname": "El «hostname» solo debe estar compuesto por números, letras, guiones y puntos según el formato establecido en la RFC 1035",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europa (Francia - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_CA.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_number_increase_tooltip": "Cliquez ici pour incrémenter cette valeur",
   "server_configuration_installation_inputs_item_number_decrease_tooltip": "Cliquez ici pour décrémenter cette valeur",
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Cliquez ici pour ajouter un couple clé-valeur",
-  "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Cliquez ici pour supprimer ce couple clé-valeur"
+  "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Cliquez ici pour supprimer ce couple clé-valeur",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europe (France - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_FR.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_number_increase_tooltip": "Cliquez ici pour incrémenter cette valeur",
   "server_configuration_installation_inputs_item_number_decrease_tooltip": "Cliquez ici pour décrémenter cette valeur",
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Cliquez ici pour ajouter un couple clé-valeur",
-  "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Cliquez ici pour supprimer ce couple clé-valeur"
+  "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Cliquez ici pour supprimer ce couple clé-valeur",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europe (France - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_it_IT.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_it_IT.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Clicca qui per eliminare questa coppia chiave-valore",
   "dedicated_server_dashboard_region_unknown": "Informazione non disponibile",
   "dedicated_server_dashboard_zone_unknown": "Informazione non disponibile",
-  "server_configuration_installation_inputs_bad_hostname": "L'hostname deve essere composto esclusivamente da cifre, lettere, trattini e punti nel formato definito nella RFC 1035"
+  "server_configuration_installation_inputs_bad_hostname": "L'hostname deve essere composto esclusivamente da cifre, lettere, trattini e punti nel formato definito nella RFC 1035",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europa (Francia - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pl_PL.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Kliknij tutaj, aby usunąć parę klucz-wartość",
   "dedicated_server_dashboard_region_unknown": "Informacja niedostępna",
   "dedicated_server_dashboard_zone_unknown": "Informacja niedostępna",
-  "server_configuration_installation_inputs_bad_hostname": "Nazwa hosta może zawierać wyłącznie cyfry, litery, łączniki i punkty w formacie określonym w RFC 1035."
+  "server_configuration_installation_inputs_bad_hostname": "Nazwa hosta może zawierać wyłącznie cyfry, litery, łączniki i punkty w formacie określonym w RFC 1035.",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europa (Francja - HDF) (backup)"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pt_PT.json
@@ -56,5 +56,6 @@
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Clique aqui para eliminar este par chave-valor",
   "dedicated_server_dashboard_region_unknown": "Informação indisponível",
   "dedicated_server_dashboard_zone_unknown": "Informação indisponível",
-  "server_configuration_installation_inputs_bad_hostname": "O hostname deve ser composto unicamente por números, letras, hífenes e pontos conforme o formato definido na RFC 1035"
+  "server_configuration_installation_inputs_bad_hostname": "O hostname deve ser composto unicamente por números, letras, hífenes e pontos conforme o formato definido na RFC 1035",
+  "dedicated_server_dashboard_region_eu-west-hdf-backup": "Europa (França - HDF) (backup)"
 }


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-14536
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

wrong server region displayed for "eu-west-hdf-backup"

## Related

<!-- Link dependencies of this PR -->
