### PR TITLE
ci: fix manager-components issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/manager_components_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/manager_components_bug_report.yml
@@ -1,4 +1,4 @@
-name: [Internal]Bug Report on  Manager Components
+name: Bug Report on  Manager Components (Internal)
 description: File a bug report on Manager components
 title: '[manager-components]: <TITLE>'
 labels: ['manager-components', 'bug']

--- a/.github/ISSUE_TEMPLATE/manager_components_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/manager_components_feature_request.yml
@@ -1,4 +1,4 @@
-name: [Internal]New Feature Request for Manager Components
+name: New Feature Request for Manager Components (Internal)
 description: Request for new component/hook/util
 title: '[manager-components]: <TITLE>'
 labels: ['manager-components', 'feature']


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-14530
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fixes the error to display issue template for manager-components.
