### PR TITLE
feat(sign-up): add purpose of purchase field on signupform

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_de_DE.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Grund für den Kauf",
   "new_account_content_check_validation": "Bitte überprüfen Sie die eingegebenen Informationen (MwSt., Telefonnummer, Geburtsdatum usw.), um das Formular zu validieren.",
   "signup_enum_country_BV": "Norwegen  – Bouvetinsel",
-  "signup_enum_country_HM": "Vereinigtes Königreich – Heard und MacDonald-Inseln"
+  "signup_enum_country_HM": "Vereinigtes Königreich – Heard und MacDonald-Inseln",
+  "signup_enum_purposeOfPurchase_personal": "Persönliche Nutzung",
+  "signup_enum_purposeOfPurchase_commercial": "Nutzung im Rahmen einer Geschäftstätigkeit",
+  "signup_enum_purposeOfPurchase_non-commercial": "Nutzung für gemeinnützige, religiöse oder politische Aktivitäten",
+  "signup_enum_purposeOfPurchase_study": "Nutzung für Studien oder akademische Forschung",
+  "signup_enum_purposeOfPurchase_public-service": "Nutzung für die Erbringung öffentlicher Dienstleistungen"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_en_GB.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Reason for purchase",
   "new_account_content_check_validation": "Kindly check the information provided (VAT, phone number, date of birth, etc.) before confirming the form.",
   "signup_enum_country_BV": "Norway – Bouvet Island",
-  "signup_enum_country_HM": "United Kingdom – Heard and MacDonald Islands"
+  "signup_enum_country_HM": "United Kingdom – Heard and MacDonald Islands",
+  "signup_enum_purposeOfPurchase_personal": "Personal",
+  "signup_enum_purposeOfPurchase_commercial": "Business",
+  "signup_enum_purposeOfPurchase_non-commercial": "Non-profit, religious or political",
+  "signup_enum_purposeOfPurchase_study": "Academic study/research",
+  "signup_enum_purposeOfPurchase_public-service": "Government services"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_es_ES.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Motivo de la compra",
   "new_account_content_check_validation": "Por favor, compruebe los datos introducidos (IVA, número de teléfono, fecha de nacimiento, etc.) para proceder a la validación del formulario.",
   "signup_enum_country_BV": "Noruega - Isla Bouvet",
-  "signup_enum_country_HM": "Reino Unido - Islas Heard y McDonald"
+  "signup_enum_country_HM": "Reino Unido - Islas Heard y McDonald",
+  "signup_enum_purposeOfPurchase_personal": "Uso a título personal",
+  "signup_enum_purposeOfPurchase_commercial": "Uso en el marco de una actividad comercial",
+  "signup_enum_purposeOfPurchase_non-commercial": "Uso en actividades no lucrativas, religiosas o políticas",
+  "signup_enum_purposeOfPurchase_study": "Uso con fines académicos o de investigación",
+  "signup_enum_purposeOfPurchase_public-service": "Uso con fines de servicio público"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -769,5 +769,10 @@
   "signup_enum_phoneType_mobile": "Mobile",
   "signup_information_banner_for_indian_subsidiary": "Pour modifier des informations relatives à votre compte, veuillez contacter notre assistance client en ",
   "signup_information_banner_link_for_indian_subsidiary": "cliquant ici.",
-  "new_account_content_check_validation": "Veuillez vérifier les informations saisies (TVA, numéro de téléphone, date de naissance, etc.) pour procéder à la validation du formulaire."
+  "new_account_content_check_validation": "Veuillez vérifier les informations saisies (TVA, numéro de téléphone, date de naissance, etc.) pour procéder à la validation du formulaire.",
+  "signup_enum_purposeOfPurchase_personal": "Utilisation à titre personnel",
+  "signup_enum_purposeOfPurchase_commercial": "Utilisation dans le cadre d'une activité commerciale",
+  "signup_enum_purposeOfPurchase_non-commercial": "Utilisation dans le cadre d'une activité non lucrative, religieuse ou politique",
+  "signup_enum_purposeOfPurchase_study": "Utilisation à des fins d'étude ou de recherche universitaire",
+  "signup_enum_purposeOfPurchase_public-service": "Utilisation à des fins de service public"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -769,5 +769,10 @@
   "signup_enum_phoneType_mobile": "Mobile",
   "signup_information_banner_for_indian_subsidiary": "Pour modifier des informations relatives à votre compte, veuillez contacter notre assistance client en ",
   "signup_information_banner_link_for_indian_subsidiary": "cliquant ici.",
-  "new_account_content_check_validation": "Veuillez vérifier les informations saisies (TVA, numéro de téléphone, date de naissance, etc.) pour procéder à la validation du formulaire."
+  "new_account_content_check_validation": "Veuillez vérifier les informations saisies (TVA, numéro de téléphone, date de naissance, etc.) pour procéder à la validation du formulaire.",
+  "signup_enum_purposeOfPurchase_personal": "Utilisation à titre personnel",
+  "signup_enum_purposeOfPurchase_commercial": "Utilisation dans le cadre d'une activité commerciale",
+  "signup_enum_purposeOfPurchase_non-commercial": "Utilisation dans le cadre d'une activité non lucrative, religieuse ou politique",
+  "signup_enum_purposeOfPurchase_study": "Utilisation à des fins d'étude ou de recherche universitaire",
+  "signup_enum_purposeOfPurchase_public-service": "Utilisation à des fins de service public"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_it_IT.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Motivo dell'acquisto",
   "new_account_content_check_validation": "Verifica le informazioni inserite (P. IVA, numero di telefono, data di nascita, etc.) per procedere alla convalida del modulo.",
   "signup_enum_country_BV": "Norvegia - Isola Bouvet",
-  "signup_enum_country_HM": "Regno Unito - Isole Heard e McDonald"
+  "signup_enum_country_HM": "Regno Unito - Isole Heard e McDonald",
+  "signup_enum_purposeOfPurchase_personal": "Utilizzo a titolo personale",
+  "signup_enum_purposeOfPurchase_commercial": "Utilizzo nell'ambito di un'attività commerciale",
+  "signup_enum_purposeOfPurchase_non-commercial": "Utilizzo nell'ambito di un'attività non lucrativa, religiosa o politica",
+  "signup_enum_purposeOfPurchase_study": "Utilizzo a fini di studio o ricerca universitaria",
+  "signup_enum_purposeOfPurchase_public-service": "Utilizzo a fini di servizio pubblico"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pl_PL.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Przyczyna zakupu",
   "new_account_content_check_validation": "Prosimy o sprawdzenie podanych informacji (numer VAT, numer telefonu, data urodzenia, etc.) w celu zatwierdzenia formularza.",
   "signup_enum_country_BV": "Norwegia - Wyspa Bouveta",
-  "signup_enum_country_HM": "Zjednoczone Królestwo - Wyspy Heard i MacDonald"
+  "signup_enum_country_HM": "Zjednoczone Królestwo - Wyspy Heard i MacDonald",
+  "signup_enum_purposeOfPurchase_personal": "Do celów prywatnych",
+  "signup_enum_purposeOfPurchase_commercial": "Do celów związanych z działalnością gospodarczą",
+  "signup_enum_purposeOfPurchase_non-commercial": "Do celów związanych z działalnością non-profit, religijną lub polityczną",
+  "signup_enum_purposeOfPurchase_study": "Do celów naukowych lub badań akademickich",
+  "signup_enum_purposeOfPurchase_public-service": "Do celów użyteczności publicznej"
 }

--- a/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/account/user/components/newAccountForm/translations/Messages_pt_PT.json
@@ -769,5 +769,10 @@
   "signup_field_purposeOfPurchase": "Razão da compra",
   "new_account_content_check_validation": "Verifique as informações introduzidas (IVA, número de telefone, data de nascimento, etc.) para proceder à validação do formulário.",
   "signup_enum_country_BV": "Noruega - Ilha Bouvet",
-  "signup_enum_country_HM": "Reino Unido - Ilhas Heard e MacDonald"
+  "signup_enum_country_HM": "Reino Unido - Ilhas Heard e MacDonald",
+  "signup_enum_purposeOfPurchase_personal": "Utilização pessoal",
+  "signup_enum_purposeOfPurchase_commercial": "Utilização no âmbito de uma atividade comercial",
+  "signup_enum_purposeOfPurchase_non-commercial": "Utilização sem fins lucrativos, religiosa ou política",
+  "signup_enum_purposeOfPurchase_study": "Utilização para fins de estudo ou de investigação universitária",
+  "signup_enum_purposeOfPurchase_public-service": "Utilização para fins de serviço público"
 }

--- a/packages/manager/modules/sign-up/src/form/details/details.controller.js
+++ b/packages/manager/modules/sign-up/src/form/details/details.controller.js
@@ -260,7 +260,7 @@ export default class SignUpDetailsCtrl {
 
   onFieldBlur(field) {
     if (field.$invalid) {
-      this.onFieldError(startCase(field.$name));
+      this.onFieldError(startCase(field.$name).replaceAll(' ', ''));
     }
   }
 

--- a/packages/manager/modules/sign-up/src/form/details/details.html
+++ b/packages/manager/modules/sign-up/src/form/details/details.html
@@ -325,21 +325,24 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="row" data-ng-if="$ctrl.signUpFormCtrl.rules.purposeOfPurchase">
         <div class="col-lg">
             <!-- purchase purpose -->
             <oui-field
                 data-label="{{ 'sign_up_details_field_purpose_of_purchase' | translate }}"
             >
-                <input
-                    type="text"
-                    class="oui-input"
-                    name="purposeOfPurchase"
+                <oui-select
                     id="purposeOfPurchase"
-                    data-ng-model="$ctrl.signUpFormCtrl.model.purposeOfPurchase"
+                    name="purposeOfPurchase"
+                    placeholder="{{:: 'sign_up_details_field_purpose_of_purchase_placeholder' | translate }}"
+                    data-model="$ctrl.signUpFormCtrl.model.purposeOfPurchase"
+                    data-items="$ctrl.signUpFormCtrl.rules.purposeOfPurchase.in"
+                    data-value-property="value"
+                    data-match="label"
                     data-ng-required="$ctrl.signUpFormCtrl.rules.purposeOfPurchase.mandatory"
-                    data-ng-pattern="$ctrl.signUpFormCtrl.rules.purposeOfPurchase.regularExpression"
-                />
+                    data-ng-blur="$ctrl.onFieldBlur($ctrl.formCtrl.purposeOfPurchase)"
+                >
+                </oui-select>
             </oui-field>
             <!-- /input[name="purposeOfPurchase"] -->
         </div>

--- a/packages/manager/modules/sign-up/src/form/details/details.html
+++ b/packages/manager/modules/sign-up/src/form/details/details.html
@@ -324,4 +324,24 @@
             <!-- /input[name="birthDay"] -->
         </div>
     </div>
+
+    <div class="row">
+        <div class="col-lg">
+            <!-- purchase purpose -->
+            <oui-field
+                data-label="{{ 'sign_up_details_field_purpose_of_purchase' | translate }}"
+            >
+                <input
+                    type="text"
+                    class="oui-input"
+                    name="purposeOfPurchase"
+                    id="purposeOfPurchase"
+                    data-ng-model="$ctrl.signUpFormCtrl.model.purposeOfPurchase"
+                    data-ng-required="$ctrl.signUpFormCtrl.rules.purposeOfPurchase.mandatory"
+                    data-ng-pattern="$ctrl.signUpFormCtrl.rules.purposeOfPurchase.regularExpression"
+                />
+            </oui-field>
+            <!-- /input[name="purposeOfPurchase"] -->
+        </div>
+    </div>
 </div>

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_de_DE.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_de_DE.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "Ich bin damit einverstanden, SMS zu den Neuheiten und kommerziellen Angeboten von OVHcloud zu erhalten.",
   "sign_up_details_field_gender": "Geschlecht",
   "sign_up_details_field_birthday": "Geburtsdatum",
-  "sign_up_details_field_address_help_text": "Vergewissern Sie sich, dass die Adresse mit der Adresse auf Ihrem Nachweis übereinstimmt."
+  "sign_up_details_field_address_help_text": "Vergewissern Sie sich, dass die Adresse mit der Adresse auf Ihrem Nachweis übereinstimmt.",
+  "sign_up_details_field_purpose_of_purchase": "Grund für den Kauf",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Bitte geben Sie den Grund für Ihren Kauf an."
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_en_GB.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "I agree to receive SMS messages regarding OVHcloud news and commercial offers",
   "sign_up_details_field_gender": "Genre",
   "sign_up_details_field_birthday": "Date of birth",
-  "sign_up_details_field_address_help_text": "Check that the address matches the one listed in your supporting document."
+  "sign_up_details_field_address_help_text": "Check that the address matches the one listed in your supporting document.",
+  "sign_up_details_field_purpose_of_purchase": "Purpose of purchase",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Please state the purpose of your purchase"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_es_ES.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_es_ES.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "Acepto libremente recibir SMS sobre las novedades y ofertas comerciales de OVHcloud.",
   "sign_up_details_field_gender": "Género",
   "sign_up_details_field_birthday": "Fecha de nacimiento",
-  "sign_up_details_field_address_help_text": "Asegúrese de que la dirección coincide con la dirección que aparece en su justificante."
+  "sign_up_details_field_address_help_text": "Asegúrese de que la dirección coincide con la dirección que aparece en su justificante.",
+  "sign_up_details_field_purpose_of_purchase": "Motivo de la compra",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Por favor, indique el motivo de su compra"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_CA.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_landline_phone": "Fixe",
   "sign_up_details_field_sms_consent": "J'accepte librement de recevoir des SMS relatifs aux nouveautés et offres commerciales d'OVHcloud.",
   "sign_up_details_field_gender": "Genre",
-  "sign_up_details_field_birthday": "Date de naissance"
+  "sign_up_details_field_birthday": "Date de naissance",
+  "sign_up_details_field_purpose_of_purchase": "Raison de l'achat",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Veuillez indiquer la raison de votre achat"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_FR.json
@@ -15,5 +15,6 @@
   "sign_up_details_field_sms_consent": "J'accepte librement de recevoir des SMS relatifs aux nouveautés et offres commerciales d'OVHcloud.",
   "sign_up_details_field_gender": "Genre",
   "sign_up_details_field_birthday": "Date de naissance",
-  "sign_up_details_field_purpose_of_purchase": "Purchase purpose"
+  "sign_up_details_field_purpose_of_purchase": "Raison de l'achat",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Veuillez indiquer la raison de votre achat"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_fr_FR.json
@@ -14,5 +14,6 @@
   "sign_up_details_field_landline_phone": "Fixe",
   "sign_up_details_field_sms_consent": "J'accepte librement de recevoir des SMS relatifs aux nouveautés et offres commerciales d'OVHcloud.",
   "sign_up_details_field_gender": "Genre",
-  "sign_up_details_field_birthday": "Date de naissance"
+  "sign_up_details_field_birthday": "Date de naissance",
+  "sign_up_details_field_purpose_of_purchase": "Purchase purpose"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_it_IT.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_it_IT.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "Accetto liberamente di ricevere SMS relativi a novità e offerte commerciali di OVHcloud.",
   "sign_up_details_field_gender": "Genere",
   "sign_up_details_field_birthday": "Data di nascita",
-  "sign_up_details_field_address_help_text": "Assicurati che l’indirizzo corrisponda a quello indicato nel tuo documento giustificativo."
+  "sign_up_details_field_address_help_text": "Assicurati che l’indirizzo corrisponda a quello indicato nel tuo documento giustificativo.",
+  "sign_up_details_field_purpose_of_purchase": "Motivo dell'acquisto",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Indica il motivo del tuo acquisto"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_pl_PL.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "Zgadzam się na otrzymywanie wiadomości SMS dotyczących nowości i ofert handlowych OVHcloud.",
   "sign_up_details_field_gender": "Płeć",
   "sign_up_details_field_birthday": "Data urodzenia",
-  "sign_up_details_field_address_help_text": "Upewnij się, że adres zgadza się z adresem podanym w Twoim dokumencie tożsamości."
+  "sign_up_details_field_address_help_text": "Upewnij się, że adres zgadza się z adresem podanym w Twoim dokumencie tożsamości.",
+  "sign_up_details_field_purpose_of_purchase": "Przyczyna zakupu",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Podaj przyczynę zakupu"
 }

--- a/packages/manager/modules/sign-up/src/form/details/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/sign-up/src/form/details/translations/Messages_pt_PT.json
@@ -14,5 +14,7 @@
   "sign_up_details_field_sms_consent": "Aceito livremente receber SMS relativos às novidades e ofertas comerciais da OVHcloud.",
   "sign_up_details_field_gender": "Género",
   "sign_up_details_field_birthday": "Data de nascimento",
-  "sign_up_details_field_address_help_text": "Certifique-se de que o endereço corresponde ao que figura no seu comprovativo."
+  "sign_up_details_field_address_help_text": "Certifique-se de que o endereço corresponde ao que figura no seu comprovativo.",
+  "sign_up_details_field_purpose_of_purchase": "Razão da compra",
+  "sign_up_details_field_purpose_of_purchase_placeholder": "Indique o motivo da sua compra"
 }

--- a/packages/manager/modules/sign-up/src/form/form.constants.js
+++ b/packages/manager/modules/sign-up/src/form/form.constants.js
@@ -28,6 +28,9 @@ export const ENUM_TRANSLATION_RULES = [
     fieldName: 'sex',
     sort: true,
   },
+  {
+    fieldName: 'purposeOfPurchase',
+  },
 ];
 
 export const MODEL_DEBOUNCE_DELAY = 500;

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_de_DE.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_de_DE.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "Weiblich",
   "sign_up_form_enum_sex_male": "Männlich",
   "sign_up_form_enum_country_BV": "Norwegen  – Bouvetinsel",
-  "sign_up_form_enum_country_HM": "Vereinigtes Königreich – Heard und MacDonald-Inseln"
+  "sign_up_form_enum_country_HM": "Vereinigtes Königreich – Heard und MacDonald-Inseln",
+  "sign_up_form_enum_purposeofpurchase_personal": "Persönliche Nutzung",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Nutzung im Rahmen einer Geschäftstätigkeit",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Nutzung für gemeinnützige, religiöse oder politische Aktivitäten",
+  "sign_up_form_enum_purposeofpurchase_study": "Nutzung für Studien oder akademische Forschung",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Nutzung für die Erbringung öffentlicher Dienstleistungen"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_en_GB.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_en_GB.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "Female",
   "sign_up_form_enum_sex_male": "Male",
   "sign_up_form_enum_country_BV": "Norway – Bouvet Island",
-  "sign_up_form_enum_country_HM": "United Kingdom – Heard and MacDonald Islands"
+  "sign_up_form_enum_country_HM": "United Kingdom – Heard and MacDonald Islands",
+  "sign_up_form_enum_purposeofpurchase_personal": "Personal",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Business",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Non-profit, religious or political",
+  "sign_up_form_enum_purposeofpurchase_study": "Academic study/research",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Government services"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_es_ES.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_es_ES.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "Mujer",
   "sign_up_form_enum_sex_male": "Hombre",
   "sign_up_form_enum_country_BV": "Noruega - Isla Bouvet",
-  "sign_up_form_enum_country_HM": "Reino Unido - Islas Heard y McDonald"
+  "sign_up_form_enum_country_HM": "Reino Unido - Islas Heard y McDonald",
+  "sign_up_form_enum_purposeofpurchase_personal": "Uso a título personal",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Uso en el marco de una actividad comercial",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Uso en actividades no lucrativas, religiosas o políticas",
+  "sign_up_form_enum_purposeofpurchase_study": "Uso con fines académicos o de investigación",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Uso con fines de servicio público"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_fr_CA.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_IT_area_FM": "Fermo (Marche)",
   "sign_up_form_enum_IT_area_MB": "Monza E Brianza (Lombardia)",
   "sign_up_form_enum_sex_female": "Femme",
-  "sign_up_form_enum_sex_male": "Homme"
+  "sign_up_form_enum_sex_male": "Homme",
+  "sign_up_form_enum_purposeofpurchase_personal": "Utilisation à titre personnel",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Utilisation dans le cadre d'une activité commerciale",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Utilisation dans le cadre d'une activité non lucrative, religieuse ou politique",
+  "sign_up_form_enum_purposeofpurchase_study": "Utilisation à des fins d'étude ou de recherche universitaire",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Utilisation à des fins de service public"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_fr_FR.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_IT_area_FM": "Fermo (Marche)",
   "sign_up_form_enum_IT_area_MB": "Monza E Brianza (Lombardia)",
   "sign_up_form_enum_sex_female": "Femme",
-  "sign_up_form_enum_sex_male": "Homme"
+  "sign_up_form_enum_sex_male": "Homme",
+  "sign_up_form_enum_purposeofpurchase_personal": "Utilisation à titre personnel",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Utilisation dans le cadre d'une activité commerciale",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Utilisation dans le cadre d'une activité non lucrative, religieuse ou politique",
+  "sign_up_form_enum_purposeofpurchase_study": "Utilisation à des fins d'étude ou de recherche universitaire",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Utilisation à des fins de service public"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_it_IT.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_it_IT.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "F",
   "sign_up_form_enum_sex_male": "M",
   "sign_up_form_enum_country_BV": "Norvegia - Isola Bouvet",
-  "sign_up_form_enum_country_HM": "Regno Unito - Isole Heard e McDonald"
+  "sign_up_form_enum_country_HM": "Regno Unito - Isole Heard e McDonald",
+  "sign_up_form_enum_purposeofpurchase_personal": "Utilizzo a titolo personale",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Utilizzo nell'ambito di un'attività commerciale",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Utilizzo nell'ambito di un'attività non lucrativa, religiosa o politica",
+  "sign_up_form_enum_purposeofpurchase_study": "Utilizzo a fini di studio o ricerca universitaria",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Utilizzo a fini di servizio pubblico"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_pl_PL.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "Kobieta",
   "sign_up_form_enum_sex_male": "Mężczyzna",
   "sign_up_form_enum_country_BV": "Norwegia - Wyspa Bouveta",
-  "sign_up_form_enum_country_HM": "Zjednoczone Królestwo - Wyspy Heard i MacDonald"
+  "sign_up_form_enum_country_HM": "Zjednoczone Królestwo - Wyspy Heard i MacDonald",
+  "sign_up_form_enum_purposeofpurchase_personal": "Do celów prywatnych",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Do celów związanych z działalnością gospodarczą",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Do celów związanych z działalnością non-profit, religijną lub polityczną",
+  "sign_up_form_enum_purposeofpurchase_study": "Do celów naukowych lub badań akademickich",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Do celów użyteczności publicznej"
 }

--- a/packages/manager/modules/sign-up/src/form/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/sign-up/src/form/translations/Messages_pt_PT.json
@@ -679,5 +679,10 @@
   "sign_up_form_enum_sex_female": "Feminino",
   "sign_up_form_enum_sex_male": "Masculino",
   "sign_up_form_enum_country_BV": "Noruega - Ilha Bouvet",
-  "sign_up_form_enum_country_HM": "Reino Unido - Ilhas Heard e MacDonald"
+  "sign_up_form_enum_country_HM": "Reino Unido - Ilhas Heard e MacDonald",
+  "sign_up_form_enum_purposeofpurchase_personal": "Utilização pessoal",
+  "sign_up_form_enum_purposeofpurchase_commercial": "Utilização no âmbito de uma atividade comercial",
+  "sign_up_form_enum_purposeofpurchase_non-commercial": "Utilização sem fins lucrativos, religiosa ou política",
+  "sign_up_form_enum_purposeofpurchase_study": "Utilização para fins de estudo ou de investigação universitária",
+  "sign_up_form_enum_purposeofpurchase_public-service": "Utilização para fins de serviço público"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-11504
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added new field "purposeOfPurchase" on the sign up form for IN customer.
Added translations for the account update screen

## Related

- [x] CMT-13866
