### PR TITLE
fix(dedicated.cdn): fix typo

### DIFF
--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_de_DE.json
@@ -46,7 +46,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Möchten Sie die Cache-Regel {{t0}} ändern?",
   "cdn_configuration_cacherule_update_step1_current": "Derzeitige TTL:",
   "cdn_configuration_cacherule_update_step1_new": "Neue TTL:",
-  "cdn_configuration_cacherule_update_step1_info": "Hinweis: Hinweis: die Änderung einer deaktivierten Regel reaktiviert diese.",
+  "cdn_configuration_cacherule_update_step1_info": "Hinweis: Das Bearbeiten einer deaktivierten Regel führt dazu, dass diese wieder aktiviert wird.",
   "cdn_configuration_cacherule_update_step2_summary": "Zusammenfassung",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Alte TTL:",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Neue TTL:",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_en_GB.json
@@ -46,7 +46,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Do you want to modify the cache rule {{t0}}?",
   "cdn_configuration_cacherule_update_step1_current": "Current TTL:",
   "cdn_configuration_cacherule_update_step1_new": "New TTL:",
-  "cdn_configuration_cacherule_update_step1_info": "Note: NB: modifying a disabled rule will re-enable it.",
+  "cdn_configuration_cacherule_update_step1_info": "Note: Editing a disabled rule re-enables it.",
   "cdn_configuration_cacherule_update_step2_summary": "Summary:",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Old TTL:",
   "cdn_configuration_cacherule_update_step2_new_ttl": "New TTL:",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_es_ES.json
@@ -46,7 +46,7 @@
   "cdn_configuration_cacherule_update_step1_question": "¿Quiere editar la regla de caché {{t0}}?",
   "cdn_configuration_cacherule_update_step1_current": "TTL actual:",
   "cdn_configuration_cacherule_update_step1_new": "Nuevo TTL:",
-  "cdn_configuration_cacherule_update_step1_info": "Nota: La modificación de una regla desactivada la ha reactivado.",
+  "cdn_configuration_cacherule_update_step1_info": "Importante: Editar una regla desactivada hará que esta se reactive.",
   "cdn_configuration_cacherule_update_step2_summary": "Resumen:",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Antiguo TTL:",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Nuevo TTL:",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_fr_CA.json
@@ -49,7 +49,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Vous souhaitez modifier la règle de cache {{t0}} ?",
   "cdn_configuration_cacherule_update_step1_current": "TTL actuel :",
   "cdn_configuration_cacherule_update_step1_new": "Nouveau TTL :",
-  "cdn_configuration_cacherule_update_step1_info": "Note : La modification d'une règle désactivée l'a réactive.",
+  "cdn_configuration_cacherule_update_step1_info": "Note : La modification d'une règle désactivée la réactive.",
   "cdn_configuration_cacherule_update_step2_summary": "Résumé :",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Ancien ttl :",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Nouveau ttl :",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_fr_FR.json
@@ -49,7 +49,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Vous souhaitez modifier la règle de cache {{t0}} ?",
   "cdn_configuration_cacherule_update_step1_current": "TTL actuel :",
   "cdn_configuration_cacherule_update_step1_new": "Nouveau TTL :",
-  "cdn_configuration_cacherule_update_step1_info": "Note : La modification d'une règle désactivée l'a réactive.",
+  "cdn_configuration_cacherule_update_step1_info": "Note : La modification d'une règle désactivée la réactive.",
   "cdn_configuration_cacherule_update_step2_summary": "Résumé :",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Ancien ttl :",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Nouveau ttl :",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_pl_PL.json
@@ -46,7 +46,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Czy chcesz zmienić regułę cache {{t0}}?",
   "cdn_configuration_cacherule_update_step1_current": "Aktualny TTL:",
   "cdn_configuration_cacherule_update_step1_new": "Nowy TTL:",
-  "cdn_configuration_cacherule_update_step1_info": "Notatka Uwaga: Modyfikacja wyłączonej reguły uaktywnia tą regułę.",
+  "cdn_configuration_cacherule_update_step1_info": "Uwaga: modyfikacja dezaktywowanej reguły powoduje jej ponowną aktywację.",
   "cdn_configuration_cacherule_update_step2_summary": "Podsumowanie:",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Aktualny TTL:",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Nowy TTL:",

--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/translations/Messages_pt_PT.json
@@ -46,7 +46,7 @@
   "cdn_configuration_cacherule_update_step1_question": "Deseja modificar a regra de cache {{t0}}?",
   "cdn_configuration_cacherule_update_step1_current": "Atual TTL:",
   "cdn_configuration_cacherule_update_step1_new": "Novo TTL :",
-  "cdn_configuration_cacherule_update_step1_info": "Nota Nota: a modificação de uma regra que foi previamente desativada ativa novamente essa regra.",
+  "cdn_configuration_cacherule_update_step1_info": "Nota: A modificação de uma regra desativa-a reativa.",
   "cdn_configuration_cacherule_update_step2_summary": "Resumo:",
   "cdn_configuration_cacherule_update_step2_old_ttl": "Antigo ttl:",
   "cdn_configuration_cacherule_update_step2_new_ttl": "Novo ttl:",


### PR DESCRIPTION
OPTIONAL DESCRIPTION: Fix typo in cdn_configuration_cacherule_update_step1_info message
ref: CDN-1158


| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? |no
| Tickets          | CDN-1158
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix typo in cdn_configuration_cacherule_update_step1_info message

## Related