### PR TITLE
fix(web.domain): updated dns records management restriction

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dnssec/domain-dnssec.controller.js
+++ b/packages/manager/apps/web/client/app/domain/dnssec/domain-dnssec.controller.js
@@ -31,7 +31,7 @@ angular.module('controllers').controller(
     $onInit() {
       this.const = {
         ALGORITHM_OPTIONS: this.constants.algorithm_options,
-        ALTERABLE_DNSSEC_SERVER_TYPE: 'EXTERNAL',
+        ALTERABLE_DNSSEC_SERVER_TYPE: ['EXTERNAL', 'MIXED'],
         FLAGS_OPTIONS: this.constants.flags_options,
         MAX_AMOUNT_DNSSEC: 4,
         PUBLIC_KEY_REGEX: null,
@@ -54,8 +54,9 @@ angular.module('controllers').controller(
         return false;
       }
       return (
-        this.product.nameServerType ===
-          this.const.ALTERABLE_DNSSEC_SERVER_TYPE &&
+        this.const.ALTERABLE_DNSSEC_SERVER_TYPE.includes(
+          this.product.nameServerType,
+        ) &&
         !this.product.managedByOvh &&
         !this.hasActiveTask
       );
@@ -66,8 +67,9 @@ angular.module('controllers').controller(
         return false;
       }
       return (
-        this.product.nameServerType ===
-          this.const.ALTERABLE_DNSSEC_SERVER_TYPE &&
+        this.const.ALTERABLE_DNSSEC_SERVER_TYPE.includes(
+          this.product.nameServerType,
+        ) &&
         !this.product.managedByOvh &&
         this.hasActiveTask &&
         this.product.dnssecSupported


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #INC0050998
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Changed the DS Records management restriction to authorized it for "MIXED" domains

## Related

<!-- Link dependencies of this PR -->
