### PR TITLE
feat(dedicated): update kvm plancode based on server location

### DIFF
--- a/packages/manager/modules/bm-server-components/src/ipmi/constants.js
+++ b/packages/manager/modules/bm-server-components/src/ipmi/constants.js
@@ -21,7 +21,13 @@ export const getIpmiGuideUrl = (subsidiary) => {
   return IPMI_GUIGES[subsidiary] || IPMI_GUIGES.DEFAULT;
 };
 
-export const KVM_PLAN_CODE = 'usb-kvm-ip';
+export const KVM_PLAN_CODE = {
+  US: {
+    EU: 'usb-kvm-ip-eu',
+    CA: 'usb-kvm-ip-ca',
+  },
+  OTHERS: 'usb-kvm-ip',
+};
 
 export const getKvmOrderTrackingPrefix = (serverType) => {
   return `dedicated::dedicated-server::${serverType}::ipmi::order-kvm`;

--- a/packages/manager/modules/bm-server-components/src/ipmi/service.js
+++ b/packages/manager/modules/bm-server-components/src/ipmi/service.js
@@ -1,5 +1,3 @@
-import { KVM_PLAN_CODE } from './constants';
-
 export default class BmServerComponentsIpmiService {
   /* @ngInject */
   constructor($http, $q, coreConfig) {
@@ -110,11 +108,11 @@ export default class BmServerComponentsIpmiService {
       );
   }
 
-  addKvmOptionToCart(cartId, duration, pricingMode, quantity) {
+  addKvmOptionToCart(cartId, duration, pricingMode, quantity, kvmPlancode) {
     return this.$http
       .post(`/order/cart/${cartId}/eco`, {
         duration,
-        planCode: KVM_PLAN_CODE,
+        planCode: kvmPlancode,
         pricingMode,
         quantity,
       })
@@ -151,13 +149,19 @@ export default class BmServerComponentsIpmiService {
       }));
   }
 
-  prepareKvmCart(serviceName, datacenter) {
+  prepareKvmCart(serviceName, datacenter, kvmPlancode) {
     let cartId = '';
 
     return this.createAndAssignNewCart()
       .then((data) => {
         cartId = data.cartId;
-        return this.addKvmOptionToCart(cartId, 'P1M', 'default', 1);
+        return this.addKvmOptionToCart(
+          cartId,
+          'P1M',
+          'default',
+          1,
+          kvmPlancode,
+        );
       })
       .then(({ itemId }) =>
         this.addKvmConfigurationToCart(itemId, cartId, serviceName, datacenter),


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-14435
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

The Manager is supplying the wrong plan code, it is supplying a plan code which does not exist in the catalog, however the Catalog is right. It should supply the correct plan code when it being called.

If the server is located in EU IS, the plan usb-kvm-ip-eu should be ordered.
If the server is located in CA IS, the plan usb-kvm-ip-ca should be ordered.

## Related

<!-- Link dependencies of this PR -->
