### PR TITLE
Revert "feat(dedicated.server): hide backup tab if not orderable"

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/server/server.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/server/server.routing.js
@@ -60,10 +60,6 @@ export default /* @ngInject */ ($stateProvider) => {
           ...serviceInfo,
           serviceType: SERVICE_TYPE,
         })),
-      backupIsOrderable: /* @ngInject */ (Server, serverName) =>
-        Server.getOrderables(serverName, 'backupStorage').then(
-          ({ orderable }) => orderable,
-        ),
       specifications: /* @ngInject */ (serverName, Server) =>
         Server.getBandwidth(serverName),
       user: /* @ngInject */ (currentUser) => currentUser,

--- a/packages/manager/modules/bm-server-components/src/server/server.component.js
+++ b/packages/manager/modules/bm-server-components/src/server/server.component.js
@@ -13,7 +13,6 @@ export default {
     user: '<',
     worldPart: '<',
     nutanixCluster: '<',
-    backupIsOrderable: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/bm-server-components/src/server/server.html
+++ b/packages/manager/modules/bm-server-components/src/server/server.html
@@ -65,7 +65,7 @@
             data-href="{{:: $ctrl.getTabItemUrl('ftpBackup') }}"
             active="$ctrl.getTabItemUrl('ftpBackup') === $ctrl.currentActiveLink()"
             data-disabled="server.isExpired"
-            data-ng-if="$ctrl.features.isFeatureAvailable('dedicated-server:backup') && $ctrl.backupIsOrderable"
+            data-ng-if="$ctrl.features.isFeatureAvailable('dedicated-server:backup')"
             ><span data-translate="server_tab_ftp_backup"></span
         ></oui-header-tabs-item>
         <oui-header-tabs-item


### PR DESCRIPTION
This reverts commit 7eee615b336e7a470c963ed320660c845d5257fa.

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #INC0056700
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Revert the hide of backup storage tab because it not only hide for incompatible server but also for server with maximum capacity of storage
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
