### PR TITLE
fix(pci.k8s): keep lb subnet selected

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.controller.js
@@ -135,9 +135,6 @@ export default class NetworkFormController {
 
   toggleLoadBalancersSubnet() {
     this.isLoadBalancersSubnetShown = !this.isLoadBalancersSubnetShown;
-    if (!this.isLoadBalancersSubnetShown) {
-      this.loadBalancersSubnet = null;
-    }
   }
 
   onGatewayChanged() {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-k8s_subnet-support`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-1288
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~