### PR TITLE
feat(pci.k8s): keep subnet UX the same

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.controller.js
@@ -97,15 +97,15 @@ export default class NetworkFormController {
       this.region.name,
     )
       .then(({ subnets, subnetsByRegion }) => {
-        this.subnets = subnets;
-        this.subnetsByRegion = subnetsByRegion;
+        this.subnets = this.augmentSubnets(subnets, { none: true });
+        this.subnetsByRegion = this.augmentSubnets(subnetsByRegion);
         this.subnetError = null;
         this.subnet = selectSubnet
           ? selectSubnet(this.subnetsByRegion)
-          : subnetsByRegion[0];
+          : this.subnetsByRegion[0];
         this.loadBalancersSubnet = selectLoadBalancersSubnet
           ? selectLoadBalancersSubnet(this.subnets)
-          : null;
+          : this.subnets[0];
         this.onSubnetChanged(this.subnet);
       })
       .catch((error) => {
@@ -141,5 +141,23 @@ export default class NetworkFormController {
     if (!this.gateway.enabled) {
       this.gateway.ip = '';
     }
+  }
+
+  augmentSubnets(subnets, { none = false } = {}) {
+    const noneItem = none
+      ? {
+          id: null,
+          displayedLabel: this.$translate.instant(
+            'kubernetes_network_form_subnet_none',
+          ),
+        }
+      : null;
+    return [
+      ...((noneItem && [noneItem]) || []),
+      ...subnets.map((subnet) => ({
+        ...subnet,
+        displayedLabel: `${subnet.id} - ${subnet.cidr}`,
+      })),
+    ];
   }
 }

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.template.html
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/network-form.template.html
@@ -65,11 +65,9 @@
                 data-name="subnet"
                 data-model="$ctrl.subnet"
                 data-items="$ctrl.subnetsByRegion"
-                data-match="id"
+                data-match="displayedLabel"
                 data-on-change="$ctrl.onSubnetChanged(modelValue)"
             >
-                <span data-ng-bind="$item.id"></span> -
-                <span data-ng-bind="$item.cidr"></span>
             </oui-select>
         </oui-field>
     </div>
@@ -193,28 +191,13 @@
             <oui-field
                 data-ng-attr-label="{{ $ctrl.dense ? ('kubernetes_network_form_load_balancers_subnet'|translate) : null }}"
             >
-                <label class="oui-select">
-                    <select
-                        id="loadBalancersSubnet"
-                        name="loadBalancersSubnet"
-                        class="oui-select__input"
-                        data-ng-model="$ctrl.loadBalancersSubnet"
-                    >
-                        <option
-                            data-ng-value="null"
-                            data-translate="kubernetes_network_form_load_balancers_subnet_none"
-                        ></option>
-                        <option
-                            data-ng-repeat="subnet in $ctrl.subnets"
-                            data-ng-value="subnet"
-                            data-ng-bind="subnet.id + ' - ' + subnet.cidr"
-                        ></option>
-                    </select>
-                    <span
-                        class="oui-icon oui-icon-chevron-down"
-                        aria-hidden="true"
-                    ></span>
-                </label>
+                <oui-select
+                    data-name="loadBalancersSubnet"
+                    data-model="$ctrl.loadBalancersSubnet"
+                    data-items="$ctrl.subnets"
+                    data-match="displayedLabel"
+                >
+                </oui-select>
             </oui-field>
         </div>
     </div>

--- a/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/kubernetes/components/network-form/translations/Messages_fr_FR.json
@@ -17,10 +17,10 @@
   "kubernetes_network_form_subnet": "Choisissez un sous-réseau pour votre cluster",
   "kubernetes_network_form_subnet_description": "Sélectionnez le sous-réseau à utiliser pour votre cluster Managed Kubernetes Service. Veuillez vous assurer que celui-ci respecte les prérequis réseau du service managé Managed Kubernetes Service.",
   "kubernetes_network_form_subnet_link": "Lire la documentation",
+  "kubernetes_network_form_subnet_none": "Aucun",
   "kubernetes_network_form_subnet_error_no_gateway_ip": "Le sous-réseau sélectionné n'a pas de passerelle définie. Cela est nécessaire si vous souhaitez utiliser un Load Balancer avec une adresse IP publique. Nous vous invitons à créer ou selectionner un autre sous-réseau pour votre cluster respectant les prérequis ou définir un sous-réseau dédié à vos Load Balancer dans les paramètres avancés.",
   "kubernetes_network_form_subnet_error_default": "Une erreur est survenue lors du chargement des sous-réseaux pour ce réseau privé : {{ error }}.",
   "kubernetes_network_form_load_balancers_subnet": "Choisissez un sous-réseau dédié pour vos Load Balancers",
   "kubernetes_network_form_load_balancers_subnet_description": "Il vous est possible de définir un sous-réseau spécifique pour vos Load Balancers. Cela est notamment nécessaire si le sous-réseau choisi pour votre cluster ne respecte pas les prérequis nécessaires à la création de Load Balancers managés OVHcloud.",
-  "kubernetes_network_form_load_balancers_subnet_none": "Aucun",
   "kubernetes_network_form_load_balancers_subnet_toggler": "Paramètres avancés"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-k8s_subnet-support`
| Bug fix?         | yes/no
| New feature?     | yes/no
| Breaking change? | yes/no
| Tickets          | Fix #TAPC-145
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [X] Only FR translations have been updated
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [X] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits