### PR TITLE
fix(dedicated.account): disable access to kyc fraud without menu

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.routes.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.routes.js
@@ -26,6 +26,8 @@ export default /* @ngInject */ ($stateProvider) => {
       transition
         .injector()
         .getAsync('needkyc')
-        .then((needkyc) => (needkyc ? false : { state: 'app.account' })),
+        .then((needkyc) =>
+          needkyc ? false : { state: 'app.account.user.dashboard' },
+        ),
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-14566
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Made the KYC Fraud route not accessible if FF return false or KYC Fraud procedure status is not Required nor Open

## Related

<!-- Link dependencies of this PR -->
