### PR TITLE
fix(dedicated.netapp): limit manual snapshot to 50

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/constants.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/constants.js
@@ -1,5 +1,11 @@
 export const MAXIMUM_SNAPSHOT_ALLOWED = 50;
 
+export const SNAPSHOT_TYPE = {
+  AUTOMATIC: 'automatic',
+  MANUAL: 'manual',
+  SYSTEM: 'system',
+};
+
 export const STATUS = {
   ACTIVE: [
     'available',
@@ -14,5 +20,6 @@ export const STATUS = {
 
 export default {
   MAXIMUM_SNAPSHOT_ALLOWED,
+  SNAPSHOT_TYPE,
   STATUS,
 };

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/constants.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/constants.js
@@ -1,18 +1,11 @@
-export const SNAPSHOT_TYPE = {
-  AUTOMATIC: 'automatic',
-  MANUAL: 'manual',
-  SYSTEM: 'system'
-}
-
 export const SNAPSHOT_STATUS = {
   AVAILABLE: 'available',
-  MANAGE_ERROR: 'manage_error'
-}
+  MANAGE_ERROR: 'manage_error',
+};
 
 export const FETCH_INTERVAL = 1000;
 
 export default {
-  SNAPSHOT_TYPE,
   SNAPSHOT_STATUS,
-  FETCH_INTERVAL
-}
+  FETCH_INTERVAL,
+};

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/controller.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/controller.js
@@ -1,4 +1,5 @@
-import { SNAPSHOT_STATUS, SNAPSHOT_TYPE } from "./constants";
+import { SNAPSHOT_TYPE } from '../constants';
+import { SNAPSHOT_STATUS } from './constants';
 
 export default class NetAppVolumesDashboardSnapshotsRestoreController {
   /* @ngInject */
@@ -12,7 +13,9 @@ export default class NetAppVolumesDashboardSnapshotsRestoreController {
     if (!this.hasOnlySystemSnapshot) {
       this.snapshotToRevertTo = this.snapshots
         .filter((snapshot) => snapshot.type !== SNAPSHOT_TYPE.SYSTEM)
-        .reduce((current, mostRecent) => current.createdAt > mostRecent.createdAt ? current : mostRecent);
+        .reduce((current, mostRecent) =>
+          current.createdAt > mostRecent.createdAt ? current : mostRecent,
+        );
     }
     this.isLoading = false;
   }
@@ -24,32 +27,37 @@ export default class NetAppVolumesDashboardSnapshotsRestoreController {
 
   validateVolumeName() {
     this.volumeNameValidated =
-      (this.volumeName === this.volume.name) || (this.volumeName === this.volumeId);
+      this.volumeName === this.volume.name || this.volumeName === this.volumeId;
   }
 
   restoreVolume() {
     this.isLoading = true;
     this.trackClick('restore::confirm');
-    this.NetAppRestoreVolumeService.restoreVolume(this.serviceName, this.volumeId, this.snapshotToRevertTo)
-    .then(() =>
-      this.goToSnapshots(
-        this.$translate.instant('netapp_volumes_snapshots_restore_success'),
-      ),
+    this.NetAppRestoreVolumeService.restoreVolume(
+      this.serviceName,
+      this.volumeId,
+      this.snapshotToRevertTo,
     )
-    .catch((error) => {
-      const message = error.status === SNAPSHOT_STATUS.MANAGE_ERROR
-        ? this.$translate.instant('netapp_volumes_snapshots_hold_error')
-        : error.data?.message;
-      return this.goToSnapshots(
-        this.$translate.instant('netapp_volumes_snapshots_restore_error', {
-          message,
-          requestId: error.headers?.('X-Ovh-Queryid') || null
-        }),
-        'error',
-      );
-    })
-    .finally(() => {
-      this.isLoading = false;
-    });
+      .then(() =>
+        this.goToSnapshots(
+          this.$translate.instant('netapp_volumes_snapshots_restore_success'),
+        ),
+      )
+      .catch((error) => {
+        const message =
+          error.status === SNAPSHOT_STATUS.MANAGE_ERROR
+            ? this.$translate.instant('netapp_volumes_snapshots_hold_error')
+            : error.data?.message;
+        return this.goToSnapshots(
+          this.$translate.instant('netapp_volumes_snapshots_restore_error', {
+            message,
+            requestId: error.headers?.('X-Ovh-Queryid') || null,
+          }),
+          'error',
+        );
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
   }
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/service.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/service.js
@@ -1,4 +1,5 @@
-import { FETCH_INTERVAL, SNAPSHOT_STATUS, SNAPSHOT_TYPE } from "./constants";
+import { SNAPSHOT_TYPE } from '../constants';
+import { FETCH_INTERVAL, SNAPSHOT_STATUS } from './constants';
 
 export default class NetAppRestoreVolumeService {
   /* @ngInject */
@@ -13,24 +14,30 @@ export default class NetAppRestoreVolumeService {
     if (snapshot.type === SNAPSHOT_TYPE.MANUAL) {
       return this.revertVolume(serviceName, volumeId, snapshot.id);
     }
-    return this.holdSnapshot(serviceName, volumeId, snapshot.id)
-      .then(({data}) => {
-        return this.startSnapshotPolling(serviceName, volumeId, data.id)
-          .then((pollingData) => {
+    return this.holdSnapshot(serviceName, volumeId, snapshot.id).then(
+      ({ data }) => {
+        return this.startSnapshotPolling(serviceName, volumeId, data.id).then(
+          (pollingData) => {
             return this.revertVolume(serviceName, volumeId, pollingData.id);
-          });
-      })
-
+          },
+        );
+      },
+    );
   }
 
   holdSnapshot(serviceName, volumeId, snapshotId) {
-    return this.$http.post(`/storage/netapp/${serviceName}/share/${volumeId}/snapshot/${snapshotId}/hold`);
+    return this.$http.post(
+      `/storage/netapp/${serviceName}/share/${volumeId}/snapshot/${snapshotId}/hold`,
+    );
   }
 
   revertVolume(serviceName, volumeId, snapshotID) {
-    return this.$http.post(`/storage/netapp/${serviceName}/share/${volumeId}/revert`, {
-      snapshotID
-    });
+    return this.$http.post(
+      `/storage/netapp/${serviceName}/share/${volumeId}/revert`,
+      {
+        snapshotID,
+      },
+    );
   }
 
   // POLLING MANAGEMENT FUNCTIONS
@@ -51,16 +58,16 @@ export default class NetAppRestoreVolumeService {
         interval: FETCH_INTERVAL,
         retryMaxAttempts: 0,
         method: 'get',
-        successRule: (data) =>
-          data.status === SNAPSHOT_STATUS.AVAILABLE,
-        errorRule: (data) =>
-          data.status === SNAPSHOT_STATUS.MANAGE_ERROR
+        successRule: (data) => data.status === SNAPSHOT_STATUS.AVAILABLE,
+        errorRule: (data) => data.status === SNAPSHOT_STATUS.MANAGE_ERROR,
       },
     );
   }
 
   stopSnapshotPolling(serviceName, volumeId, snapshotId) {
-    this.Poller.kill({ namespace: `snapshot_${serviceName}_${volumeId}_${snapshotId}` });
+    this.Poller.kill({
+      namespace: `snapshot_${serviceName}_${volumeId}_${snapshotId}`,
+    });
   }
   // END POLLING MANAGEMENT FUNCTIONS
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/routing.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/routing.js
@@ -1,5 +1,5 @@
 import Snapshot from './Snapshot.class';
-import { SNAPSHOT_TYPE } from './restore/constants';
+import { SNAPSHOT_TYPE } from './constants';
 
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('netapp.dashboard.volumes.dashboard.snapshots', {
@@ -75,11 +75,12 @@ export default /* @ngInject */ ($stateProvider) => {
           .then((snapshots) =>
             snapshots.map((snapshot) => new Snapshot(snapshot)),
           ),
-      hasOnlySystemSnapshot: /* @ngInject */ (snapshots) => !snapshots.find(
-            (snapshot) =>
-              snapshot.type === SNAPSHOT_TYPE.AUTOMATIC
-              || snapshot.type === SNAPSHOT_TYPE.MANUAL
-          ),
+      hasOnlySystemSnapshot: /* @ngInject */ (snapshots) =>
+        !snapshots.find(
+          (snapshot) =>
+            snapshot.type === SNAPSHOT_TYPE.AUTOMATIC ||
+            snapshot.type === SNAPSHOT_TYPE.MANUAL,
+        ),
       totalSnapshots: /* @ngInject */ ($http, $q, serviceName) =>
         $http
           .get(`/storage/netapp/${serviceName}/share`)
@@ -89,14 +90,18 @@ export default /* @ngInject */ ($stateProvider) => {
                 shares.map(({ id: shareId }) =>
                   $http
                     .get(
-                      `/storage/netapp/${serviceName}/share/${shareId}/snapshot`,
+                      `/storage/netapp/${serviceName}/share/${shareId}/snapshot?detail=true`,
                     )
-                    .then(({ data: snapshot }) => snapshot.length),
+                    .then(
+                      ({ data: snapshots }) =>
+                        snapshots.filter(
+                          (snapshot) => snapshot.type === SNAPSHOT_TYPE.MANUAL,
+                        ).length,
+                    ),
                 ),
               )
               .then((snapshots) => snapshots.reduce((a, b) => a + b, 0)),
           ),
-
       snapshotPolicies: /* @ngInject */ (getSnapshotPolicies) =>
         getSnapshotPolicies().catch(() => []),
       currentPolicy: /* @ngInject */ ($http, serviceName, volumeId) =>


### PR DESCRIPTION
ref: MANAGER-14075


| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` (after merge of https://github.com/ovh/manager/pull/12021)
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes
| Tickets          | Fix #MANAGER-14075
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Breaking changes : move SNAPSHOT_TYPE constant from manager/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/restore/constants.js to manager/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/constants.js

## Related

- [ ] https://github.com/ovh/manager/pull/12021
<!-- Link dependencies of this PR -->
