### PR TITLE
fix(iam): wrong label on policy form in en

### DIFF
--- a/packages/manager/modules/iam/src/components/createPolicy/translations/Messages_en_GB.json
+++ b/packages/manager/modules/iam/src/components/createPolicy/translations/Messages_en_GB.json
@@ -30,5 +30,5 @@
   "iam_create_policy_success_create": "The policy {{ name }} has been created",
   "iam_create_policy_success_edit": "The policy {{ name }} has been modified",
   "iam_create_policy_form_description_error_pattern": "The policy name may only contain alphanumeric characters, spaces and \"-\", \"/\", \"_\", \"+\"",
-  "iam_create_policy_form_description_heading": "Policy"
+  "iam_create_policy_form_description_heading": "Policy description"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-14685
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

wrong label on policy form in en : just asked for a new translation on EN translation file

## Related

<!-- Link dependencies of this PR -->
