### PR TITLE
fix(procedures.2fa): added a fallback to i18n for unhandled language

### DIFF
--- a/packages/manager/apps/procedures/src/App.tsx
+++ b/packages/manager/apps/procedures/src/App.tsx
@@ -27,11 +27,7 @@ if (!user) {
   const redirectUrl = getRedirectLoginUrl(user);
   window.location.assign(redirectUrl);
 } else {
-  initI18n(
-    locale || 'en_GB',
-    [locale || 'en_GB'],
-    getSubsidiary(subsidiary, locale),
-  );
+  initI18n(locale || 'en_GB', getSubsidiary(subsidiary, locale));
   initAuthenticationInterceptor(token);
   initInterceptor();
 

--- a/packages/manager/apps/procedures/src/i18n.ts
+++ b/packages/manager/apps/procedures/src/i18n.ts
@@ -2,11 +2,19 @@ import i18n from 'i18next';
 import I18NextHttpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
-export default function initI18n(
-  locale = 'fr_FR',
-  availablesLocales = ['fr_FR'],
-  sub: string,
-) {
+const availableLocales: string[] = [
+  'fr_FR',
+  'fr_CA',
+  'en_GB',
+  'pt_PT',
+  'pl_PL',
+  'es_ES',
+  'it_IT',
+  'de_DE',
+];
+
+export default function initI18n(locale = 'fr_FR', sub: string) {
+  const validLocale = availableLocales.includes(locale) ? locale : 'en_GB';
   i18n
     .use(initReactI18next)
     .use(I18NextHttpBackend)
@@ -17,9 +25,9 @@ export default function initI18n(
         value ? value.replace(/&amp;/g, '&') : value,
     })
     .init({
-      lng: locale,
-      fallbackLng: 'fr_FR',
-      supportedLngs: availablesLocales,
+      lng: validLocale,
+      fallbackLng: 'en_GB',
+      supportedLngs: availableLocales,
       ns: [
         'account-disable-2fa',
         'account-disable-2fa/error',


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `release/procedures-2fa`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13716
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a fallback to en_GB when the user has an unsupported locale

## Related

<!-- Link dependencies of this PR -->
