### PR TITLE
[manager-components] DTCORE-2475

### DIFF
--- a/packages/manager-react-components/src/components/datagrid/text-cell.component.tsx
+++ b/packages/manager-react-components/src/components/datagrid/text-cell.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { OsdsText } from '@ovhcloud/ods-components/react';
 import {
   ODS_THEME_COLOR_INTENT,
@@ -10,7 +10,11 @@ import { useTranslation } from 'react-i18next';
 /** Simple datagrid cell text formatter applying ODS style */
 export function DataGridTextCell({
   children,
-}: React.PropsWithChildren<unknown>) {
+  className,
+}: {
+  children?: ReactNode;
+  className?: string;
+}) {
   const { t } = useTranslation('datagrid');
   return (
     <OsdsText
@@ -21,6 +25,7 @@ export function DataGridTextCell({
           : ODS_THEME_TYPOGRAPHY_SIZE._300
       }
       color={ODS_THEME_COLOR_INTENT.text}
+      className={className}
     >
       {children ?? t('common_empty_text_cell')}
     </OsdsText>

--- a/packages/manager-react-components/src/hooks/index.ts
+++ b/packages/manager-react-components/src/hooks/index.ts
@@ -13,6 +13,7 @@ export * from './services';
 export * from './tasks';
 export { useProductMaintenance } from './pci/useMaintenance';
 export {
+  isLocalZone,
   getMacroRegion,
   useTranslatedMicroRegions,
 } from './region/useTranslatedMicroRegions';


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | DTCORE-2475
| License          | BSD 3-Clause

## Description

- add optional className to DataGridTextCell
- export isLocalZone from useTranslatedMicroRegions hook

# Notes

the pci related hook useTranslatedMicroRegions will be moved in the near future in manager-pci-common package in a separate PR