### PR TITLE
feat(pci-rancher): Configuration page - Change banner content

### DIFF
--- a/packages/manager/apps/pci-rancher/src/public/translations/pci-rancher/dashboard/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-rancher/src/public/translations/pci-rancher/dashboard/Messages_fr_CA.json
@@ -27,7 +27,7 @@
   "createRancherDiscoveryMode": "Vous êtes actuellement en mode « Découverte ». <strong>Pour finaliser la création de votre ressource</strong>, vous devez activer votre projet.",
   "createRancherDiscoveryModeActive": "Activez votre projet",
   "createRancherTitle": "Managed Rancher Service",
-  "createRancherInfoMessage": "Profitez de notre service gratuitement pendant la phase Beta. Veuillez noter qu'une fois la phase Beta terminée, vous serez facturé à l'heure, en fonction du nombre total de vCPU des nœuds de travail (Worker Nodes) de vos « downstream clusters » Rancher, en considérant <strong>un minimum de 20 vCPU facturés</strong>.",
+  "createRancherInfoMessage": "Votre utilisation sera facturée à l’heure, en fonction du nombre total de vCPU de chacun des nœuds de travail de vos « downstream clusters » Rancher, en considérant <strong>un minimum de 20 vCPU facturés</strong>.",
   "createRancherName": "Nom",
   "createRancherDescription": "Vous pourrez gérer plusieurs « downstream clusters » au sein de ce service.",
   "createRancherPlaceholder": "mon_rancher",

--- a/packages/manager/apps/pci-rancher/src/public/translations/pci-rancher/dashboard/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-rancher/src/public/translations/pci-rancher/dashboard/Messages_fr_FR.json
@@ -27,7 +27,7 @@
   "createRancherDiscoveryMode": "Vous êtes actuellement en mode « Découverte ». <strong>Pour finaliser la création de votre ressource</strong>, vous devez activer votre projet.",
   "createRancherDiscoveryModeActive": "Activez votre projet",
   "createRancherTitle": "Managed Rancher Service",
-  "createRancherInfoMessage": "Profitez de notre service gratuitement pendant la phase Beta. Veuillez noter qu'une fois la phase Beta terminée, vous serez facturé à l'heure, en fonction du nombre total de vCPU des nœuds de travail (Worker Nodes) de vos « downstream clusters » Rancher, en considérant <strong>un minimum de 20 vCPU facturés</strong>.",
+  "createRancherInfoMessage": "Votre utilisation sera facturée à l’heure, en fonction du nombre total de vCPU de chacun des nœuds de travail de vos « downstream clusters » Rancher, en considérant <strong>un minimum de 20 vCPU facturés</strong>.",
   "createRancherName": "Nom",
   "createRancherDescription": "Vous pourrez gérer plusieurs « downstream clusters » au sein de ce service.",
   "createRancherPlaceholder": "mon_rancher",


### PR DESCRIPTION
ref: TAPC-987

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | #TAPC-980
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Currently the blue banner in the Rancher Configuration page mention that the service is free. Update the content to billed mode
