### PR TITLE
feat(dedicated): move billing status and action in commitment section

### DIFF
--- a/packages/manager/modules/billing-components/src/components/subscription-tile/subscription-tile.html
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/subscription-tile.html
@@ -10,6 +10,7 @@
             ></span>
         </oui-tile-description>
     </oui-tile-definition>
+    <!-- If there is no Engagement for the product, we display the billing status / actions within this section -->
     <oui-tile-definition
         term="{{:: 'manager_billing_subscription_next_due_date' | translate }}"
     >
@@ -17,10 +18,15 @@
             <oui-skeleton size="s" data-ng-if="$ctrl.isLoading"></oui-skeleton>
             <div data-ng-if="!$ctrl.isLoading">
                 <p data-ng-bind="$ctrl.service.nextBillingDate"></p>
-                <billing-status service="$ctrl.serviceInfos"></billing-status>
+                <billing-status
+                    data-ng-if="!$ctrl.withEngagement"
+                    service="$ctrl.serviceInfos"
+                ></billing-status>
             </div>
         </oui-tile-description>
-        <oui-tile-actions data-ng-if="!$ctrl.isLoading">
+        <oui-tile-actions
+            data-ng-if="!$ctrl.isLoading && !$ctrl.withEngagement"
+        >
             <billing-services-actions
                 service="$ctrl.serviceInfos"
                 tracking-prefix="{{ $ctrl.trackingPrefix }}"
@@ -34,9 +40,10 @@
             </billing-services-actions>
         </oui-tile-actions>
     </oui-tile-definition>
+    <!-- If there is Engagement for the product, we display the billing status / actions within this section -->
     <oui-tile-definition
         term="{{:: 'manager_billing_subscription_engagement' | translate }}"
-        ng-if="$ctrl.withEngagement"
+        data-ng-if="$ctrl.withEngagement"
     >
         <oui-tile-description>
             <oui-skeleton size="s" data-ng-if="$ctrl.isLoading"></oui-skeleton>
@@ -66,6 +73,7 @@
                     data-translate="manager_billing_subscription_engagement_status_commitement_pending"
                     data-translate-values="{ nextBillingDate: $ctrl.service.nextBillingDate }"
                 ></span>
+                <billing-status service="$ctrl.serviceInfos"></billing-status>
             </p>
             <a
                 data-ng-if="!$ctrl.isLoading && $ctrl.constructor.showCommit($ctrl.serviceInfos, $ctrl.service.isEngaged(), $ctrl.highlightEngagement)"
@@ -90,6 +98,19 @@
                 </p>
             </a>
         </oui-tile-description>
+        <oui-tile-actions data-ng-if="!$ctrl.isLoading">
+            <billing-services-actions
+                service="$ctrl.serviceInfos"
+                tracking-prefix="{{ $ctrl.trackingPrefix }}"
+                user="$ctrl.user"
+                get-commitment-link="$ctrl.goToCommit()"
+                get-cancel-commitment-link="$ctrl.goToCancelCommit()"
+                get-cancel-resiliation-link="$ctrl.goToCancelResiliation()"
+                get-resiliation-link="$ctrl.goToResiliation()"
+                billing-management-availability="$ctrl.featuresAvailability.isFeatureAvailable('billing:management')"
+            >
+            </billing-services-actions>
+        </oui-tile-actions>
     </oui-tile-definition>
     <oui-tile-definition
         ng-if="$ctrl.featuresAvailability.isFeatureAvailable('contact') && $ctrl.withContactManagement"


### PR DESCRIPTION
ref: MANAGER-13277

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-13277
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

If the product allow commitment, we move the billing status / actions within the commitment section:
![image](https://github.com/user-attachments/assets/d81ffdf9-38cb-44a4-a17b-1778f6765d95)

Concerned products : Dedicated server, NasHa, EFS
<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
