### PR TITLE
feat(dedicated-cloud): add region in HPC & some display fixes

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/general-information.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/general-information.html
@@ -1,6 +1,7 @@
 <oui-tile
     class="h-100"
     data-heading="{{:: 'ovhManagerPccDashboardGeneralInformation_heading' | translate }}"
+    data-loading="$ctrl.isLoading"
 >
     <div class="oui-tile__item">
         <dl class="oui-tile__definition">
@@ -102,13 +103,18 @@
     </oui-tile-definition>
 
     <oui-tile-definition
-        data-term="{{:: 'ovhManagerPccDashboardGeneralInformation_location_term' | translate }}"
+        data-term="{{:: 'ovhManagerPccDashboardGeneralInformation_location_zone' | translate }}"
         data-description="{{:: $ctrl.bindings.location }}"
     ></oui-tile-definition>
 
     <oui-tile-definition
-        data-term="{{:: 'ovhManagerPccDashboardGeneralInformation_accessPolicy_term' | translate }}"
-        data-description="{{:: $ctrl.bindings.accessPolicy }}"
+        data-term="{{:: 'ovhManagerPccDashboardGeneralInformation_location_region_location' | translate }}"
+        data-description="{{:: $ctrl.locationInfo.regionLocation }}"
+    ></oui-tile-definition>
+
+    <oui-tile-definition
+        data-term="{{:: 'ovhManagerPccDashboardGeneralInformation_location_region' | translate }}"
+        data-description="{{:: $ctrl.locationInfo.region }}"
     ></oui-tile-definition>
 
     <oui-tile-definition

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_de_DE.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Die kleine Aktualisierung installieren ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Datum der Aktualisierung ändern",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "IP-Blöcke mit einem anderen Dienst verbinden",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Kommerzieller Name"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Kaufmännische Reihe",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Beim Abrufen der Daten, die zum Anzeigen der Standortinformationen erforderlich sind, ist ein Fehler aufgetreten.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Private-Cloud-Zone",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Standort",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Region"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_en_GB.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Install minor update ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modify the update date",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "Link IP blocks to another service",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Commercial name"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Commercial range",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "An error has occurred retrieving the data required to display location information.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Private Cloud Area",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Location",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Region"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_es_ES.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Instalar la actualización menor ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modificar la fecha de actualización",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "Asociar bloques de IP a otro servicio",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nombre comercial"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gama comercial",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Se ha producido un error al cargar la información necesaria para mostrar los datos de localización.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Zona Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Localización",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Región"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_fr_CA.json
@@ -17,13 +17,12 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Installer la mise à jour mineure ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modifier la date de mise à jour",
 
-  "ovhManagerPccDashboardGeneralInformation_location_term": "Localisation",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nom commercial",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Une erreur est survenue lors de la récupération des données nécessaires à l'affichage des informations de localisation.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Zone Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Localisation",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Région",
 
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_term": "Politique d'accès",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_FILTERED": "Restreinte",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_OPEN": "Ouverte",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_NOT_CONFIGURED": "Pas encore configurée",
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gamme commerciale",
 
   "ovhManagerPccDashboardGeneralInformation_numberOfDatacenters_term": "Nombre de datacenters",
 

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_fr_FR.json
@@ -17,13 +17,12 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Installer la mise à jour mineure ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modifier la date de mise à jour",
 
-  "ovhManagerPccDashboardGeneralInformation_location_term": "Localisation",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nom commercial",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Une erreur est survenue lors de la récupération des données nécessaires à l'affichage des informations de localisation.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Zone Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Localisation",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Région",
 
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_term": "Politique d'accès",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_FILTERED": "Restreinte",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_OPEN": "Ouverte",
-  "ovhManagerPccDashboardGeneralInformation_accessPolicy_definition_NOT_CONFIGURED": "Pas encore configurée",
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gamme commerciale",
 
   "ovhManagerPccDashboardGeneralInformation_numberOfDatacenters_term": "Nombre de datacenters",
 

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_it_IT.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Installa l'aggiornamento minore ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modifica la data di aggiornamento",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "Associare blocchi IP a un altro servizio",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nome commerciale"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gamma commerciale",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Si è verificato un errore durante il recupero dei dati necessari alla visualizzazione delle informazioni di localizzazione.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Zona Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Localizzazione",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Region"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_pl_PL.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Zainstaluj aktualizację pomocniczą ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Zmień datę aktualizacji",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "Przypisz bloki IP do innej usługi",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nazwa oferty"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gama",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Wystąpił błąd podczas pobierania danych niezbędnych do wyświetlenia informacji o lokalizacji.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Strefa Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Lokalizacja",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Region"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dashboard/tiles/general-information/translations/Messages_pt_PT.json
@@ -29,5 +29,9 @@
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_update_minor": "Instalar a atualização menor ({{version}} - build {{build}})",
   "ovhManagerPccDashboardGeneralInformation_softwareSolution_reschedule_update": "Modificar a data de atualização",
   "ovhManagerPccDashboardGeneralInformation_numberOfIPBlocks_actionMenu_move": "Associar blocos de IP a outro serviço",
-  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Nome comercial"
+  "ovhManagerPccDashboardGeneralInformation_commercial_range": "Gama comercial",
+  "ovhManagerPccDashboardGeneralInformation_loadLocation_error": "Ocorreu um erro aquando da recuperação dos dados necessários à apresentação das informações de localização.",
+  "ovhManagerPccDashboardGeneralInformation_location_zone": "Zona Private Cloud",
+  "ovhManagerPccDashboardGeneralInformation_location_region_location": "Localização",
+  "ovhManagerPccDashboardGeneralInformation_location_region": "Região"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dedicatedCloud.service.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/dedicatedCloud.service.js
@@ -1725,6 +1725,12 @@ class DedicatedCloudService {
       })
       .then(({ data }) => data?.length > 0);
   }
+
+  getLocation(serviceName) {
+    return this.$http
+      .get(`/dedicatedCloud/${serviceName}/location`)
+      .then(({ data }) => data);
+  }
 }
 
 angular.module(moduleName, []).service('DedicatedCloud', DedicatedCloudService);

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.component.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.component.js
@@ -1,0 +1,24 @@
+import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
+import template from './dedicatedCloud-list.html';
+import controller from './dedicatedCloud-list.controller';
+
+export default {
+  bindings: {
+    ...ListLayoutHelper.componentBindings,
+    staticResources: '<?',
+    header: '@?',
+    id: '@',
+    description: '<',
+    columns: '<',
+    customizableColumns: '<?',
+    defaultFilterColumn: '<',
+    getServiceNameLink: '<?',
+    options: '<?',
+    formatters: '<?',
+    topbarOptions: '<?',
+    customizeColumnsMap: '<?',
+  },
+  controller,
+  template,
+  name: 'ovhManagerPccList',
+};

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.controller.js
@@ -1,0 +1,72 @@
+import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
+
+export default class extends ListLayoutHelper.ListLayoutCtrl {
+  /* @ngInject */
+  constructor($q, $translate, DedicatedCloud, Alerter, ouiDatagridService) {
+    super($q, ouiDatagridService);
+    this.$translate = $translate;
+    this.DedicatedCloud = DedicatedCloud;
+    this.Alerter = Alerter;
+    this.locationInfo = {};
+  }
+
+  $onInit() {
+    super.$onInit();
+  }
+
+  loadResource($row) {
+    if (this.locationInfo[$row.location]) {
+      return this.$q.when(this.buildRow($row));
+    }
+
+    return this.DedicatedCloud.getLocation($row.serviceName)
+      .then((locationInfo) => {
+        this.locationInfo[$row.location] = locationInfo;
+        return this.buildRow($row);
+      })
+      .catch((error) => {
+        const errorMessage = error.data?.message || error.data;
+        this.Alerter.error(
+          [
+            this.$translate.instant('dedicatedCloud_list_loadLocation_error'),
+            errorMessage ? `(${errorMessage})` : '',
+          ].join(' '),
+          'dedicatedCloud',
+        );
+        return this.buildRow($row);
+      });
+  }
+
+  buildRow($row) {
+    return {
+      ...$row,
+      regionLocation: this.buildLocationInfo($row, 'regionLocation'),
+      region: this.buildLocationInfo($row, 'region'),
+      softwareSolution: this.buildSoftwareSolution($row),
+    };
+  }
+
+  buildLocationInfo($row, field) {
+    if (
+      this.locationInfo[$row.location] &&
+      this.locationInfo[$row.location][field]
+    ) {
+      return this.locationInfo[$row.location][field];
+    }
+    return null;
+  }
+
+  buildSoftwareSolution($row) {
+    const solution = {
+      displayName: this.$translate.instant(
+        `dedicatedCloud_list_softwareSolution_definition_displayName_${$row.managementInterface.toUpperCase()}`,
+      ),
+      displayMajorVersionNumber:
+        $row.version && $row.version.major ? $row.version.major : '',
+      displayMinorVersionNumber:
+        $row.version && $row.version.minor ? $row.version.minor : '',
+    };
+
+    return `${solution.displayName} ${solution.displayMajorVersionNumber} ${solution.displayMinorVersionNumber}`.trim();
+  }
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/dedicatedCloud-list.html
@@ -1,0 +1,91 @@
+<oui-header
+    data-ng-if="$ctrl.header"
+    class="mb-2"
+    data-heading="{{:: $ctrl.header }}"
+></oui-header>
+<div data-ng-bind-html="$ctrl.description"></div>
+
+<div data-ovh-alert="dedicatedCloud"></div>
+
+<oui-datagrid
+    class="table-striped"
+    id="{{ $ctrl.datagridId }}"
+    rows="$ctrl.resources"
+    data-page-size="{{ $ctrl.paginationSize }}"
+    data-row-loader="$ctrl.loadResource($row)"
+    data-criteria="$ctrl.criteria"
+    data-on-page-change="$ctrl.onPageChange($pagination)"
+    data-customizable
+>
+    <oui-datagrid-column
+        data-title=":: 'dedicatedCloud_list_serviceName' | translate"
+        data-property="serviceName"
+        data-filterable
+        data-sortable
+        data-type="string"
+        data-prevent-customization
+    >
+        <a data-ng-href="{{ $ctrl.getServiceNameLink($row) }}"
+            >{{ $row.serviceName }}</a
+        >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        data-title=":: 'dedicatedCloud_list_description' | translate"
+        data-property="description"
+        data-filterable
+        data-sortable
+        data-type="string"
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        data-title=":: 'dedicatedCloud_list_softwareSolution' | translate"
+        data-property="softwareSolution"
+        data-filterable
+        data-sortable
+        data-type="string"
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        data-title=":: 'dedicatedCloud_list_commercialRange' | translate"
+        data-property="commercialRange"
+        data-filterable
+        data-sortable
+        data-type="string"
+        data-hidden
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        title=":: 'dedicatedCloud_list_zone' | translate"
+        data-property="location"
+        data-filterable
+        data-sortable
+        data-type="string"
+        data-hidden
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        title=":: 'dedicatedCloud_list_regionLocation' | translate"
+        data-property="regionLocation"
+        data-filterable
+        data-sortable
+        data-type="string"
+    >
+    </oui-datagrid-column>
+    <oui-datagrid-column
+        title=":: 'dedicatedCloud_list_region' | translate"
+        data-property="region"
+        data-filterable
+        data-sortable
+        data-type="string"
+        data-hidden
+    >
+    </oui-datagrid-column>
+    <oui-action-menu compact data-placement="end">
+        <oui-action-menu-item href="{{ $ctrl.getServiceNameLink($row) }}"
+            ><span data-translate="dedicatedCloud_list_popover_details"></span>
+        </oui-action-menu-item>
+    </oui-action-menu>
+    <oui-datagrid-topbar data-ng-if="$ctrl.topbarOptions">
+        <topbar-cta data-options="$ctrl.topbarOptions"> </topbar-cta>
+    </oui-datagrid-topbar>
+</oui-datagrid>

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/index.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/index.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
+import '@ovh-ux/ng-translate-async-loader';
+
+import component from './dedicatedCloud-list.component';
+
+const moduleName = 'ovhManagerPccList';
+
+angular
+  .module(moduleName, [
+    'oui',
+    'ngTranslateAsyncLoader',
+    'pascalprecht.translate',
+  ])
+  .component('ovhManagerPccList', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_de_DE.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Name",
+  "dedicatedCloud_list_description": "Beschreibung",
+  "dedicatedCloud_list_softwareSolution": "Softwarelösung",
+  "dedicatedCloud_list_commercialRange": "Kaufmännische Reihe",
+  "dedicatedCloud_list_zone": "Private-Cloud-Zone",
+  "dedicatedCloud_list_regionLocation": "Standort",
+  "dedicatedCloud_list_region": "Region",
+  "dedicatedCloud_list_loadLocation_error": "Beim Abrufen der Daten, die zum Anzeigen der Standortinformationen erforderlich sind, ist ein Fehler aufgetreten.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Details"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_en_GB.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Name",
+  "dedicatedCloud_list_description": "Description",
+  "dedicatedCloud_list_softwareSolution": "Software solution",
+  "dedicatedCloud_list_commercialRange": "Commercial range",
+  "dedicatedCloud_list_zone": "Private Cloud Area",
+  "dedicatedCloud_list_regionLocation": "Location",
+  "dedicatedCloud_list_region": "Region",
+  "dedicatedCloud_list_loadLocation_error": "An error has occurred retrieving the data required to display location information.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Details"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_es_ES.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Nombre",
+  "dedicatedCloud_list_description": "Descripción",
+  "dedicatedCloud_list_softwareSolution": "Solución de software",
+  "dedicatedCloud_list_commercialRange": "Gama comercial",
+  "dedicatedCloud_list_zone": "Zona Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Localización",
+  "dedicatedCloud_list_region": "Región",
+  "dedicatedCloud_list_loadLocation_error": "Se ha producido un error al cargar la información necesaria para mostrar los datos de localización.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Detalles"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_fr_CA.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Nom",
+  "dedicatedCloud_list_description": "Description",
+  "dedicatedCloud_list_softwareSolution": "Solution logicielle",
+  "dedicatedCloud_list_commercialRange": "Gamme commerciale",
+  "dedicatedCloud_list_zone": "Zone Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Localisation",
+  "dedicatedCloud_list_region": "Région",
+  "dedicatedCloud_list_loadLocation_error": "Une erreur est survenue lors de la récupération des données nécessaires à l'affichage des informations de localisation.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Détails"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_fr_FR.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Nom",
+  "dedicatedCloud_list_description": "Description",
+  "dedicatedCloud_list_softwareSolution": "Solution logicielle",
+  "dedicatedCloud_list_commercialRange": "Gamme commerciale",
+  "dedicatedCloud_list_zone": "Zone Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Localisation",
+  "dedicatedCloud_list_region": "Région",
+  "dedicatedCloud_list_loadLocation_error": "Une erreur est survenue lors de la récupération des données nécessaires à l'affichage des informations de localisation.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Détails"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_it_IT.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Cognome",
+  "dedicatedCloud_list_description": "Descrizione",
+  "dedicatedCloud_list_softwareSolution": "Soluzione software",
+  "dedicatedCloud_list_commercialRange": "Gamma commerciale",
+  "dedicatedCloud_list_zone": "Zona Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Localizzazione",
+  "dedicatedCloud_list_region": "Region",
+  "dedicatedCloud_list_loadLocation_error": "Si è verificato un errore durante il recupero dei dati necessari alla visualizzazione delle informazioni di localizzazione.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Dettagli"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_pl_PL.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Nazwisko",
+  "dedicatedCloud_list_description": "Opis",
+  "dedicatedCloud_list_softwareSolution": "Rozwiązanie logistyczne",
+  "dedicatedCloud_list_commercialRange": "Gama",
+  "dedicatedCloud_list_zone": "Strefa Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Lokalizacja",
+  "dedicatedCloud_list_region": "Region",
+  "dedicatedCloud_list_loadLocation_error": "Wystąpił błąd podczas pobierania danych niezbędnych do wyświetlenia informacji o lokalizacji.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Szczegóły"
+}

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/list/translations/Messages_pt_PT.json
@@ -1,0 +1,16 @@
+{
+  "dedicatedCloud_list_serviceName": "Nome",
+  "dedicatedCloud_list_description": "Descrição",
+  "dedicatedCloud_list_softwareSolution": "Solução de software",
+  "dedicatedCloud_list_commercialRange": "Gama comercial",
+  "dedicatedCloud_list_zone": "Zona Private Cloud",
+  "dedicatedCloud_list_regionLocation": "Localização",
+  "dedicatedCloud_list_region": "Região",
+  "dedicatedCloud_list_loadLocation_error": "Ocorreu um erro aquando da recuperação dos dados necessários à apresentação das informações de localização.",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VSPHERE": "vSphere",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCLOUD": "vCloud",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_SYSTEMCENTER": "VMM",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_AZURE": "Azure",
+  "dedicatedCloud_list_softwareSolution_definition_displayName_VCSA": "vCSA",
+  "dedicatedCloud_list_popover_details": "Detalhes"
+}

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedClouds.module.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedClouds.module.js
@@ -6,6 +6,8 @@ import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 
 import routing from './dedicatedClouds.routing';
+import dedicatedCloudListComponent from '../components/dedicated-cloud/list';
+import dedicatedCloudService from '../components/dedicated-cloud/dedicatedCloud.service';
 
 const moduleName = 'ovhManagerDedicatedCloud';
 
@@ -16,6 +18,8 @@ angular
     'pascalprecht.translate',
     ListLayoutHelper.moduleName,
     'ui.router',
+    dedicatedCloudService,
+    dedicatedCloudListComponent,
   ])
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedClouds.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/dedicatedClouds.routing.js
@@ -4,7 +4,7 @@ import { getDedicatedCloudOrderUrl } from './dedicatedClouds-order';
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.dedicatedCloud.index', {
     url: `?${ListLayoutHelper.urlQueryParams}`,
-    component: 'managerListLayout',
+    component: 'ovhManagerPccList',
     params: ListLayoutHelper.stateParams,
     redirectTo: (transition) =>
       transition

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/index.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/index.js
@@ -6,45 +6,48 @@ import onboarding from './onboarding';
 
 const moduleName = 'ovhManagerDedicatedCloudLazyLoading';
 
-angular.module(moduleName, ['ui.router', 'oc.lazyLoad', onboarding]).config(
-  /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
-    $stateProvider.state('app.dedicatedCloud', {
-      url: '/dedicated_cloud',
-      redirectTo: 'app.dedicatedCloud.index',
-      template: '<div data-ui-view></div>',
-      resolve: {
-        breadcrumb: /* @ngInject */ () => 'Private Cloud',
-      },
-    });
+angular
+  .module(moduleName, ['ui.router', 'oc.lazyLoad', onboarding])
+  .config(
+    /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
+      $stateProvider.state('app.dedicatedCloud', {
+        url: '/dedicated_cloud',
+        redirectTo: 'app.dedicatedCloud.index',
+        template: '<div data-ui-view></div>',
+        resolve: {
+          breadcrumb: /* @ngInject */ ($translate) =>
+            $translate.instant('dedicated_clouds_title'),
+        },
+      });
 
-    $stateProvider.state('app.dedicatedCloud.index.**', {
-      url: '',
-      lazyLoad: ($transition$) => {
-        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+      $stateProvider.state('app.dedicatedCloud.index.**', {
+        url: '',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+          return import('./dedicatedClouds.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
 
-        return import('./dedicatedClouds.module').then((mod) =>
-          $ocLazyLoad.inject(mod.default || mod),
+      $stateProvider.state('app.dedicatedCloud.details.**', {
+        url: '/:productId',
+        lazyLoad: ($transition$) => {
+          const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+          return import('./details/dedicatedCloud.module').then((mod) =>
+            $ocLazyLoad.inject(mod.default || mod),
+          );
+        },
+      });
+
+      $urlRouterProvider.when(/^\/configuration\/dedicated_cloud/, () => {
+        window.location.href = window.location.href.replace(
+          '/configuration/dedicated_cloud',
+          '/dedicated_cloud',
         );
-      },
-    });
-
-    $stateProvider.state('app.dedicatedCloud.details.**', {
-      url: '/:productId',
-      lazyLoad: ($transition$) => {
-        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
-        return import('./details/dedicatedCloud.module').then((mod) =>
-          $ocLazyLoad.inject(mod.default || mod),
-        );
-      },
-    });
-
-    $urlRouterProvider.when(/^\/configuration\/dedicated_cloud/, () => {
-      window.location.href = window.location.href.replace(
-        '/configuration/dedicated_cloud',
-        '/dedicated_cloud',
-      );
-    });
-  },
-);
+      });
+    },
+  )
+  .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_de_DE.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Bestellen"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_en_GB.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Order"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_fr_CA.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Commander"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_fr_FR.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Commander"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_it_IT.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Ordina"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_pl_PL.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Zamów"
 }

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/translations/Messages_pt_PT.json
@@ -1,4 +1,4 @@
 {
-  "dedicated_clouds_title": "Private Cloud",
+  "dedicated_clouds_title": "Hosted Private Cloud",
   "dedicated_clouds_order": "Encomendar"
 }

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/index.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/index.js
@@ -12,8 +12,8 @@ angular
     /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
       $stateProvider.state('app.managedBaremetal', {
         url: '/managedBaremetal',
-        template: '<div ui-view></div>',
         redirectTo: 'app.managedBaremetal.index',
+        template: '<div ui-view></div>',
         resolve: {
           breadcrumb: /* @ngInject */ ($translate) =>
             $translate.instant('managed_baremetal_title'),

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.module.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.module.js
@@ -1,14 +1,26 @@
 import angular from 'angular';
+import 'angular-translate';
+import '@ovh-ux/ui-kit';
 import '@uirouter/angularjs';
-
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
 import { ListLayoutHelper } from '@ovh-ux/manager-ng-layout-helpers';
 
 import routing from './managed-baremetal.routing';
+import dedicatedCloudListComponent from '../components/dedicated-cloud/list';
+import dedicatedCloudService from '../components/dedicated-cloud/dedicatedCloud.service';
 
 const moduleName = 'ovhManagerManagedBaremetal';
 
 angular
-  .module(moduleName, ['ui.router', ListLayoutHelper.moduleName])
+  .module(moduleName, [
+    ngTranslateAsyncLoader,
+    'oui',
+    'pascalprecht.translate',
+    ListLayoutHelper.moduleName,
+    'ui.router',
+    dedicatedCloudService,
+    dedicatedCloudListComponent,
+  ])
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);
 

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.routing.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/managed-baremetal.routing.js
@@ -4,8 +4,15 @@ import { getManagedBareMetalOrderUrl } from './managed-baremetal-order';
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('app.managedBaremetal.index', {
     url: `/managedBaremetal?${ListLayoutHelper.urlQueryParams}`,
-    component: 'managerListLayout',
+    component: 'ovhManagerPccList',
     params: ListLayoutHelper.stateParams,
+    redirectTo: (transition) =>
+      transition
+        .injector()
+        .getAsync('resources')
+        .then((resources) =>
+          resources.length === 0 ? 'app.managedBaremetal.onboarding' : false,
+        ),
     resolve: {
       ...ListLayoutHelper.stateResolves,
       staticResources: () => true,
@@ -56,12 +63,5 @@ export default /* @ngInject */ ($stateProvider) => {
       }),
       hideBreadcrumb: () => true,
     },
-    redirectTo: (transition) =>
-      transition
-        .injector()
-        .getAsync('resources')
-        .then((resources) =>
-          resources.length === 0 ? 'app.managedBaremetal.onboarding' : false,
-        ),
   });
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-15038
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Adding region data in HPC general information section and listing page.
Also fixes version display (previously not showing minor part of version number).
Refactoring listing page with translated columns and useful ones.

### General information view
 * Removed access policy section
 * Added region and location into location section
 * Fixed software solution section (showing minor part of version)

#### Before :
<img width="300" alt="before-general-info" src="https://github.com/user-attachments/assets/3f15d6ab-5415-46d0-99e8-f38f96f0f9a9">


#### After :
<img width="300" alt="after-general-info" src="https://github.com/user-attachments/assets/a666dfbc-eb9e-418e-8860-86ec241ece06">

### Listing page
 * New listing table with only useful columns
 * Added region and location columns
 * Added software solution column

#### Before :
<img width="500" alt="before-global-list-censored" src="https://github.com/user-attachments/assets/f7db4f28-b2f5-4b03-8318-b922b5e74637">
<img width="100" alt="before-global-list-cols" src="https://github.com/user-attachments/assets/110059bb-b8b8-4e8d-b713-06c4739a9484">

#### After :
<img width="500" alt="after-global-list-censored" src="https://github.com/user-attachments/assets/1eeca88b-0d82-4560-890b-da076db875bb">
<img width="200" alt="after-global-list-cols" src="https://github.com/user-attachments/assets/8d06d8c7-ab80-480f-b333-249e15f36a67">
<img width="500" alt="after-global-list-2-censored" src="https://github.com/user-attachments/assets/6894f52e-1707-49c1-955d-52e507146181">
