### PR TITLE
feat(pci-private-registry): add rename modal and generic modal

### DIFF
--- a/packages/manager/apps/pci-private-registry/src/api/data/registry.ts
+++ b/packages/manager/apps/pci-private-registry/src/api/data/registry.ts
@@ -67,3 +67,17 @@ export const deleteRegistry = async (projectId: string, registryId: string) => {
   );
   return data;
 };
+
+export const renameRegistry = async (
+  projectId: string,
+  registryId: string,
+  name: string,
+) => {
+  const {
+    data,
+  } = await v6.put(
+    `/cloud/project/${projectId}/containerRegistry/${registryId}`,
+    { name },
+  );
+  return data;
+};

--- a/packages/manager/apps/pci-private-registry/src/api/hooks/useRegistry.ts
+++ b/packages/manager/apps/pci-private-registry/src/api/hooks/useRegistry.ts
@@ -7,6 +7,7 @@ import {
   deleteRegistry,
   getAllRegistries,
   getRegistryPlan,
+  renameRegistry,
   TRegistry,
 } from '../data/registry';
 import queryClient from '@/queryClient';
@@ -103,6 +104,35 @@ export const useDeleteRegistry = ({
   });
   return {
     deleteRegistry: () => mutation.mutate(),
+    ...mutation,
+  };
+};
+
+type RenameRegistryProps = {
+  projectId: string;
+  registryId: string;
+  onError: (cause: Error) => void;
+  onSuccess: () => void;
+};
+export const useRenameRegistry = ({
+  projectId,
+  registryId,
+  onError,
+  onSuccess,
+}: RenameRegistryProps) => {
+  const mutation = useMutation({
+    mutationFn: async (name: string) =>
+      renameRegistry(projectId, registryId, name),
+    onError,
+    onSuccess: async () => {
+      queryClient.invalidateQueries({
+        queryKey: getRegistryQueryPrefix(projectId),
+      });
+      onSuccess();
+    },
+  });
+  return {
+    renameRegistry: (name: string) => mutation.mutate(name),
     ...mutation,
   };
 };

--- a/packages/manager/apps/pci-private-registry/src/components/listing/Action.component.tsx
+++ b/packages/manager/apps/pci-private-registry/src/components/listing/Action.component.tsx
@@ -21,7 +21,7 @@ export default function ActionComponent({
   const hrefHarborUI = '';
   const hrefHarborAPI = '';
   const hrefRegenerateCredentials = '';
-  const hrefRename = '';
+  const hrefRename = useHref(`./update?registryId=${registry.id}`);
   const hrefDelete = useHref(`./delete?registryId=${registry.id}`);
 
   const items = [

--- a/packages/manager/apps/pci-private-registry/src/pages/update/Update.page.tsx
+++ b/packages/manager/apps/pci-private-registry/src/pages/update/Update.page.tsx
@@ -1,0 +1,162 @@
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { PciModal } from '@ovh-ux/manager-pci-common';
+import { Translation, useTranslation } from 'react-i18next';
+import {
+  ODS_INPUT_TYPE,
+  ODS_TEXT_SIZE,
+  OdsInputValueChangeEvent,
+} from '@ovhcloud/ods-components';
+import React, { useContext, useEffect, useState } from 'react';
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+import {
+  OsdsFormField,
+  OsdsInput,
+  OsdsText,
+} from '@ovhcloud/ods-components/react';
+import {
+  ODS_THEME_COLOR_INTENT,
+  ODS_THEME_TYPOGRAPHY_LEVEL,
+} from '@ovhcloud/ods-common-theming';
+import { ApiError } from '@ovh-ux/manager-core-api';
+import { useNotifications } from '@ovhcloud/manager-components';
+import {
+  useGetAllRegistries,
+  useRenameRegistry,
+} from '@/api/hooks/useRegistry';
+
+export default function UpdatePage() {
+  const { addSuccess, addError } = useNotifications();
+  const { t } = useTranslation();
+  const { t: tPciCommon } = useTranslation('pci-common');
+  const { tracking } = useContext(ShellContext)?.shell || {};
+  const { projectId } = useParams();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const registryId = searchParams.get('registryId');
+  const {
+    data: registries,
+    isPending: isPendingAllRegisters,
+  } = useGetAllRegistries(projectId);
+
+  const registry = registries?.find((r) => r.id === registryId);
+
+  const [formState, setFormState] = useState({
+    renameInput: registry?.name || '',
+    hasError: false,
+    isTouched: false,
+  });
+
+  useEffect(() => {
+    setFormState({
+      ...formState,
+      hasError: formState.isTouched && formState.renameInput === '',
+    });
+  }, [formState.renameInput, formState.isTouched]);
+
+  const onClose = () => {
+    tracking?.trackClick({
+      name: `PCI_PROJECTS_PRIVATEREGISTRY_UPDATE_CLOSE`,
+    });
+    navigate('..');
+  };
+
+  const handleInputRenameChange = (event: OdsInputValueChangeEvent) => {
+    setFormState({
+      ...formState,
+      renameInput: event.detail.value,
+    });
+  };
+
+  const { renameRegistry, isPending: isPendingRename } = useRenameRegistry({
+    projectId,
+    registryId,
+    onError(error: ApiError) {
+      addError(
+        <Translation ns="common">
+          {(_t) =>
+            _t('private_registry_update_error', {
+              message: error?.response?.data?.message || error?.message || null,
+              registryName: registry.name,
+            })
+          }
+        </Translation>,
+        true,
+      );
+      onClose();
+    },
+    onSuccess() {
+      addSuccess(
+        <Translation ns="common">
+          {(_t) =>
+            _t('private_registry_update_success', {
+              newRegistryName: formState.renameInput,
+            })
+          }
+        </Translation>,
+        true,
+      );
+      navigate('..');
+    },
+  });
+
+  const onConfirm = () => {
+    tracking?.trackClick({
+      name: `PCI_PROJECTS_PRIVATEREGISTRY_UPDATE_CONFIRM`,
+    });
+    renameRegistry(formState.renameInput);
+  };
+
+  const onCancel = () => {
+    tracking?.trackClick({
+      name: `PCI_PROJECTS_PRIVATEREGISTRY_UPDATE_CANCEL`,
+    });
+    navigate('..');
+  };
+
+  const isPending = isPendingAllRegisters || isPendingRename;
+  const isDisabled = isPending || formState.renameInput === '';
+  return (
+    <PciModal
+      title={t('private_registry_update_modal_title')}
+      isPending={isPending}
+      isDisabled={isDisabled}
+      onConfirm={onConfirm}
+      onClose={onClose}
+      onCancel={onCancel}
+    >
+      <OsdsFormField
+        class="mt-6"
+        data-testid="update-formfield"
+        error={
+          formState.hasError ? tPciCommon('common_field_error_required') : ''
+        }
+      >
+        <OsdsText
+          slot="label"
+          level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
+          color={ODS_THEME_COLOR_INTENT.text}
+          size={ODS_TEXT_SIZE._200}
+        >
+          {t('private_registry_update_name_label')}
+        </OsdsText>
+        <OsdsInput
+          value={formState.renameInput}
+          type={ODS_INPUT_TYPE.text}
+          data-testid="update-input"
+          onOdsValueChange={handleInputRenameChange}
+          className={
+            formState.hasError
+              ? 'bg-red-100 border-red-500 text-red-500 focus:text-red-500'
+              : 'border-color-[var(--ods-color-default-200)] bg-white'
+          }
+          onOdsInputBlur={() => {
+            setFormState({
+              ...formState,
+              isTouched: true,
+            });
+          }}
+        />
+      </OsdsFormField>
+    </PciModal>
+  );
+}

--- a/packages/manager/apps/pci-private-registry/src/routes.tsx
+++ b/packages/manager/apps/pci-private-registry/src/routes.tsx
@@ -39,6 +39,11 @@ export default [
             path: 'delete',
             ...lazyRouteConfig(() => import('@/pages/delete/Delete.page')),
           },
+          {
+            id: 'update',
+            path: 'update',
+            ...lazyRouteConfig(() => import('@/pages/update/Update.page')),
+          },
         ],
       },
       {

--- a/packages/manager/modules/manager-pci-common/src/components/deletion-modal/DeletionModal.component.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/deletion-modal/DeletionModal.component.tsx
@@ -76,7 +76,11 @@ export function DeletionModal({
 
   return (
     <OsdsModal
-      color={type === 'warning' ? ODS_THEME_COLOR_INTENT.warning : undefined}
+      color={
+        type === 'warning'
+          ? ODS_THEME_COLOR_INTENT.warning
+          : ODS_THEME_COLOR_INTENT.primary
+      }
       headline={title}
       onOdsModalClose={onClose}
     >

--- a/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.spec.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.spec.tsx
@@ -1,0 +1,195 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import { PciModal } from './PciModal.component';
+
+describe('PciModal', () => {
+  it('renders loading spinner when isPending is true', () => {
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('pciModal-spinner')).toBeInTheDocument();
+  });
+  it('renders modal with warning color', () => {
+    const { getByTestId } = render(
+      <PciModal
+        type="warning"
+        title="Test Modal"
+        isPending
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('pciModal-modal')).toHaveAttribute('color', 'warning');
+  });
+  it('renders modal with default color', () => {
+    const { getByTestId } = render(
+      <PciModal
+        title="Test Modal"
+        isPending
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('pciModal-modal')).toHaveAttribute('color', 'primary');
+  });
+
+  it('renders children content when isPending is false', () => {
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div data-testid="child-content">Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('child-content')).toBeInTheDocument();
+  });
+
+  it('disables submit button when isDisabled is true', () => {
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('pciModal-button_submit')).toBeDisabled();
+  });
+
+  it('enables submit button when isDisabled is false', () => {
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByTestId('pciModal-button_submit')).not.toBeDisabled();
+  });
+
+  it('calls onConfirm when submit button is clicked', () => {
+    const onConfirmMock = vi.fn();
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={onConfirmMock}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    fireEvent.click(getByTestId('pciModal-button_submit'));
+    expect(onConfirmMock).toHaveBeenCalled();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancelMock = vi.fn();
+    const { getByTestId } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        cancelText="Cancel"
+        submitText="Submit"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={onCancelMock}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    fireEvent.click(getByTestId('pciModal-button_cancel'));
+    expect(onCancelMock).toHaveBeenCalled();
+  });
+  it('renders submit button and cancel button with default text', () => {
+    const { getByText } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByText('common_confirm')).toBeInTheDocument();
+    expect(getByText('common_cancel')).toBeInTheDocument();
+  });
+  // tests when submit and cancel are provided
+  it('renders submit button and cancel button with custom text', () => {
+    const { getByText } = render(
+      <PciModal
+        type="default"
+        title="Test Modal"
+        isPending={false}
+        isDisabled={false}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+        onCancel={vi.fn()}
+        submitText="Custom Submit"
+        cancelText="Custom Cancel"
+      >
+        <div>Child Content</div>
+      </PciModal>,
+    );
+    expect(getByText('Custom Submit')).toBeInTheDocument();
+    expect(getByText('Custom Cancel')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.tsx
@@ -1,0 +1,80 @@
+import {
+  OsdsButton,
+  OsdsModal,
+  OsdsSpinner,
+} from '@ovhcloud/ods-components/react';
+import React from 'react';
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+import { ODS_BUTTON_VARIANT, ODS_SPINNER_SIZE } from '@ovhcloud/ods-components';
+import { useTranslation } from 'react-i18next';
+
+type PciModalProps = {
+  children: React.ReactNode;
+  type?: 'warning' | 'default';
+  title: string;
+  isPending?: boolean;
+  isDisabled?: boolean;
+  cancelText?: string;
+  submitText?: string;
+  onConfirm: () => void;
+  onClose: () => void;
+  onCancel: () => void;
+};
+
+export function PciModal({
+  children,
+  type,
+  title,
+  cancelText,
+  submitText,
+  isPending,
+  isDisabled,
+  onConfirm,
+  onClose,
+  onCancel,
+}: Readonly<PciModalProps>) {
+  const { t } = useTranslation('pci-common');
+  return (
+    <OsdsModal
+      color={
+        type === 'warning'
+          ? ODS_THEME_COLOR_INTENT.warning
+          : ODS_THEME_COLOR_INTENT.primary
+      }
+      headline={title}
+      data-testid="pciModal-modal"
+      onOdsModalClose={onClose}
+    >
+      <slot name="content">
+        {isPending ? (
+          <OsdsSpinner
+            inline
+            size={ODS_SPINNER_SIZE.md}
+            className="block text-center"
+            data-testid="pciModal-spinner"
+          />
+        ) : (
+          <div className="mt-6">{children}</div>
+        )}
+      </slot>
+      <OsdsButton
+        slot="actions"
+        color={ODS_THEME_COLOR_INTENT.primary}
+        variant={ODS_BUTTON_VARIANT.ghost}
+        onClick={onCancel}
+        data-testid="pciModal-button_cancel"
+      >
+        {cancelText || t('common_cancel')}
+      </OsdsButton>
+      <OsdsButton
+        slot="actions"
+        color={ODS_THEME_COLOR_INTENT.primary}
+        onClick={onConfirm}
+        disabled={isDisabled || undefined}
+        data-testid="pciModal-button_submit"
+      >
+        {submitText || t('common_confirm')}
+      </OsdsButton>
+    </OsdsModal>
+  );
+}

--- a/packages/manager/modules/manager-pci-common/src/components/modal/index.ts
+++ b/packages/manager/modules/manager-pci-common/src/components/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './PciModal.component';

--- a/packages/manager/modules/manager-pci-common/src/index.ts
+++ b/packages/manager/modules/manager-pci-common/src/index.ts
@@ -2,6 +2,7 @@ export * from './api/data';
 export * from './api/hook';
 export * from './components/banner';
 export * from './components/deletion-modal';
+export * from './components/modal';
 export * from './components/flavor-selector';
 export * from './components/region-selector/RegionSelector.component';
 export * from './components/region-selector/RegionSummary.component';

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_de_DE.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_de_DE.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "Kein Element ausgewählt",
   "common_dual_list_target_move": "Löschen",
   "common_dual_list_target_move_all": "Alles löschen",
-  "common_dual_list_target_search": "In den Zieldaten suchen"
+  "common_dual_list_target_search": "In den Zieldaten suchen",
+  "common_cancel": "Abbrechen",
+  "common_confirm": "Bestätigen"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_en_GB.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_en_GB.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "No items selected",
   "common_dual_list_target_move": "Delete",
   "common_dual_list_target_move_all": "Delete all",
-  "common_dual_list_target_search": "Search target content"
+  "common_dual_list_target_search": "Search target content",
+  "common_cancel": "Cancel",
+  "common_confirm": "Confirm"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_es_ES.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_es_ES.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "Ningún elemento seleccionado",
   "common_dual_list_target_move": "Eliminar",
   "common_dual_list_target_move_all": "Eliminar todo",
-  "common_dual_list_target_search": "Buscar en el contenido de destino"
+  "common_dual_list_target_search": "Buscar en el contenido de destino",
+  "common_cancel": "Cancelar",
+  "common_confirm": "Confirmar"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_fr_CA.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_fr_CA.json
@@ -87,5 +87,7 @@
   "common_password_bad_password": "Mot de passe incorrect.",
   "common_password_weak_password": "Mot de passe faible.",
   "common_password_good_password": "Mot de passe correct.",
-  "common_password_strong_password": "Mot de passe fort."
+  "common_password_strong_password": "Mot de passe fort.",
+  "common_cancel": "Annuler",
+  "common_confirm": "Confirmer"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_fr_FR.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_fr_FR.json
@@ -87,5 +87,7 @@
   "common_password_bad_password": "Mot de passe incorrect.",
   "common_password_weak_password": "Mot de passe faible.",
   "common_password_good_password": "Mot de passe correct.",
-  "common_password_strong_password": "Mot de passe fort."
+  "common_password_strong_password": "Mot de passe fort.",
+  "common_cancel": "Annuler",
+  "common_confirm": "Confirmer"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_it_IT.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_it_IT.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "Nessun elemento selezionato",
   "common_dual_list_target_move": "Elimina",
   "common_dual_list_target_move_all": "Elimina tutto",
-  "common_dual_list_target_search": "Cerca nel contenuto di destinazione"
+  "common_dual_list_target_search": "Cerca nel contenuto di destinazione",
+  "common_cancel": "Annulla",
+  "common_confirm": "Conferma"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_pl_PL.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_pl_PL.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "Brak wybranych elementów",
   "common_dual_list_target_move": "Usuń",
   "common_dual_list_target_move_all": "Usuń wszystko",
-  "common_dual_list_target_search": "Szukaj w treści docelowej"
+  "common_dual_list_target_search": "Szukaj w treści docelowej",
+  "common_cancel": "Anuluj",
+  "common_confirm": "Potwierdź"
 }

--- a/packages/manager/modules/manager-pci-common/src/translations/common/Messages_pt_PT.json
+++ b/packages/manager/modules/manager-pci-common/src/translations/common/Messages_pt_PT.json
@@ -87,5 +87,7 @@
   "common_dual_list_target_placeholder": "Nenhum elemento selecionado",
   "common_dual_list_target_move": "Eliminar",
   "common_dual_list_target_move_all": "Eliminar tudo",
-  "common_dual_list_target_search": "Procurar no conteúdo de destino"
+  "common_dual_list_target_search": "Procurar no conteúdo de destino",
+  "common_cancel": "Anular",
+  "common_confirm": "Confirmar"
 }


### PR DESCRIPTION
ref: DTCORE-2505

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/pci-private-registry`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | DTCORE-2505
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [ ] Commits are signed-off
- [ ] Only FR translations have been updated
- [ ] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
