### PR TITLE
fix(billing us): ldp enterprise offers should be terminated by Agora

### DIFF
--- a/packages/manager/modules/billing-components/src/components/cancellation-form/confirm-terminate.constants.js
+++ b/packages/manager/modules/billing-components/src/components/cancellation-form/confirm-terminate.constants.js
@@ -6,6 +6,8 @@ export const SERVICE_WITH_AGORA_TERMINATION = [
   'vrack-services',
   'okms',
   'logs-account',
+  'logs-enterprise',
+  'logs-enterprise-hds',
 ];
 
 export default {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-15087
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Logs Data Platform have been launched in the US subsidiary.
We spotted an issue: if a customer with an enterprise offer try to resiliate/terminate it, it currently try to call a non-existing API `/dbaas/logs/{serviceName]/confirmTermination`.

This route should not be called, as the full lifecycle of LDP products are managed by Agora. 

This PR fix this issue.