### PR TITLE
fix(dedicated.cdn): fix invalid activation label

### DIFF
--- a/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.html
+++ b/packages/manager/apps/dedicated/client/app/cdn/dedicated/domain/statistics/cdn-dedicated-domain-statistics.html
@@ -51,7 +51,7 @@
                                 aria-label="{{ domain.mode === 'ON' ? ('cdn_domain_configuration_bypass_title_button' | translate) : ('cdn_domain_configuration_reactive_title_button' | translate) }}"
                                 data-on-click="setAction('domain/update/cdn-dedicated-domain-domain', domain)"
                                 ><span
-                                    data-translate="cdn_domain_configuration_bypass_title_button"
+                                    data-translate="{{  domain.mode === 'ON' ? 'cdn_domain_configuration_bypass_title_button' : 'cdn_domain_configuration_reactive_title_button' }}"
                                 ></span
                             ></oui-action-menu-item>
                             <oui-action-menu-item


### PR DESCRIPTION
Fix(dedicated.cdn) invalid label when trying to reactivate CDN on a domain
ref: CDN-1157


| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | CDN-1157
| License          | BSD 3-Clause


- [*] Try to keep pull requests small so they can be easily reviewed.
- [*] Commits are signed-off
- [-] Only FR translations have been updated
- [*] Branch is up-to-date with target branch
- [*] Lint has passed locally
- [*] Standalone app was ran and tested locally
- [*] Ticket reference is mentioned in linked commits (internal only)
- [*] Breaking change is mentioned in relevant commits

## Description

Fix invalid label when trying to reactivate CDN on a domain

## Related

<!-- Link dependencies of this PR -->
