### PR TITLE
feat(savings-plan): check savings plan before delete project

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/edit/remove/remove.component.js
+++ b/packages/manager/modules/pci/src/projects/project/edit/remove/remove.component.js
@@ -10,6 +10,7 @@ export default {
     trackClick: '<',
     trackPage: '<',
     isDiscoveryProject: '<',
+    projectId: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/pci/src/projects/project/edit/remove/remove.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/edit/remove/remove.controller.js
@@ -1,11 +1,22 @@
+import { SUPPORT_URL } from '../../../new/constants';
 import { MESSAGES_CONTAINER_NAME } from '../edit.constant';
 
 export default class {
   /* @ngInject */
-  constructor($translate, CucCloudMessage) {
+  constructor(
+    $translate,
+    CucCloudMessage,
+    OvhApiCloudProject,
+    $http,
+    coreConfig,
+  ) {
     this.$translate = $translate;
     this.CucCloudMessage = CucCloudMessage;
+    this.OvhApiCloudProject = OvhApiCloudProject;
     this.isLoading = false;
+    this.canDeleteProject = true;
+    this.$http = $http;
+    this.coreConfig = coreConfig;
   }
 
   cancel() {
@@ -15,14 +26,63 @@ export default class {
     this.goBack();
   }
 
+  $onInit() {
+    this.isLoading = true;
+    return this.$http({
+      url: '/services',
+      params: {
+        resourceName: this.projectId,
+      },
+    }).then(({ data }) => {
+      if (data.length) {
+        this.checkSavingsPlan(data[0]);
+      } else {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  checkSavingsPlan(serviceId) {
+    this.$http({
+      url: `/services/${serviceId}/savingsPlans/subscribed`,
+    }).then(({ data }) => {
+      this.isLoading = false;
+      if (data.length) {
+        const activePlan = data.some((p) => p.status === 'ACTIVE');
+        if (activePlan) {
+          this.canDeleteProject = false;
+        }
+      }
+    });
+  }
+
   getTranslationKey() {
+    if (!this.canDeleteProject) {
+      return 'pci_projects_project_discovery_edit_savings_plan';
+    }
     return `pci_projects_project_${
       this.isDiscoveryProject ? 'discovery_' : ''
     }edit_remove_please_note`;
   }
 
+  getPrimaryButtonLabel() {
+    if (!this.canDeleteProject) {
+      return 'pci_projects_project_edit_remove_submit_client_service';
+    }
+    return 'pci_projects_project_edit_remove_submit';
+  }
+
   remove() {
     this.isLoading = true;
+    if (!this.canDeleteProject) {
+      window.open(
+        SUPPORT_URL + this.coreConfig.getUser().ovhSubsidiary,
+        '_blank',
+        'noopener',
+      );
+      return this.goBack();
+    }
+
     this.trackClick(
       'PublicCloud::pci::projects::project::edit::remove::confirm',
     );

--- a/packages/manager/modules/pci/src/projects/project/edit/remove/remove.html
+++ b/packages/manager/modules/pci/src/projects/project/edit/remove/remove.html
@@ -1,7 +1,7 @@
 <oui-modal
     data-heading="{{:: 'pci_projects_project_edit_remove_title' | translate}}"
     data-primary-action="$ctrl.remove()"
-    data-primary-label="{{:: 'pci_projects_project_edit_remove_submit' | translate }}"
+    data-primary-label="{{ $ctrl.getPrimaryButtonLabel() | translate }}"
     data-primary-disabled="$ctrl.isLoading"
     data-secondary-action="$ctrl.cancel()"
     data-secondary-label="{{:: 'pci_projects_project_edit_remove_cancel' | translate }}"

--- a/packages/manager/modules/pci/src/projects/project/edit/remove/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/pci/src/projects/project/edit/remove/translations/Messages_fr_FR.json
@@ -2,7 +2,9 @@
   "pci_projects_project_edit_remove_title": "Supprimer le projet",
   "pci_projects_project_edit_remove_please_note": "Il est important de noter que tous vos services, ressources, paramètres et données seront détruits, sans possibilité de restauration ultérieure, à l'exception des IP Failovers, qui seront parkées.",
   "pci_projects_project_discovery_edit_remove_please_note": "Veuillez noter que la suppression de votre projet est irréversible. Vous devrez en recréer un pour profiter à nouveau de l’univers Public Cloud.",
+  "pci_projects_project_discovery_edit_savings_plan": "Vous avez un Savings Plan en cours sur ce projet. Vous ne pouvez pas le supprimer. Veuillez contacter le service client pour connaître la procédure de suppression.",
   "pci_projects_project_edit_remove_submit": "Supprimer le projet",
+  "pci_projects_project_edit_remove_submit_client_service": "Contacter le service client",
   "pci_projects_project_edit_remove_cancel": "Annuler",
   "pci_projects_project_edit_remove_error": "Une erreur est survenue lors de la suppression du projet : {{ error }}",
   "pci_projects_project_edit_remove_success": "Une confirmation de suppression vient de vous être envoyée par e-mail."


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/savings-plan-epic` <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-1281
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [ ] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Check if user have savings plan before deleting  a PCI project to display Support Message

## Related

<!-- Link dependencies of this PR -->
