### PR TITLE
fix(savings-plan): order button display with flavor

### DIFF
--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_FR.json
@@ -18,10 +18,11 @@
   "edit": "Editer",
   "enableAutoRenew": "Activer le renouvellement automatique",
   "disableAutoRenew": "Désactiver le renouvellement automatique",
+  "order": "Commander",
   "listing_resultats": "résultats",
   "months": "{{monthValue}} mois",
   "banner_renew_activate": "Le renouvellement automatique du Savings Plan a été activé avec succès.",
   "banner_renew_deactivate": "Le renouvellement automatique du Savings Plan a été désactivé avec succès.",
   "banner_edit_name": "Le nom du Savings Plan a été modifié avec succès.",
-  "banner_create_sp": "Votre Savings Plan a été créé avec succès. Celui-ci sera actif à compté du {{startDate}}"
+  "banner_create_sp": "Votre Savings Plan a été créé avec succès. Celui-ci sera actif à compter du {{startDate}}"
 }

--- a/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.tsx
@@ -1,19 +1,20 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  OsdsButton,
-  OsdsMenu,
-  OsdsMenuItem,
-  OsdsIcon,
-} from '@ovhcloud/ods-components/react';
+
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import {
   ODS_BUTTON_SIZE,
   ODS_BUTTON_TYPE,
   ODS_BUTTON_VARIANT,
   ODS_ICON_NAME,
   ODS_ICON_SIZE,
-} from '@ovhcloud/ods-components/';
-import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+} from '@ovhcloud/ods-components';
+import {
+  OsdsButton,
+  OsdsIcon,
+  OsdsMenu,
+  OsdsMenuItem,
+} from '@ovhcloud/ods-components/react';
 import {
   SavingsPlanPlanedChangeStatus,
   SavingsPlanStatus,
@@ -23,39 +24,35 @@ interface SavingsPlanActionsCell {
   onClickEditName: (path: string) => void;
   onClickRenew: () => void;
   id: string;
+  flavor: string;
   status: SavingsPlanStatus;
   periodEndAction: SavingsPlanPlanedChangeStatus;
+  pciUrl: string;
 }
 
-export default function ActionsCell({
+const MenuItems = ({
   status,
-  periodEndAction,
-  id,
-  onClickEditName,
+  flavor,
+  onClickEdit,
   onClickRenew,
-}: Readonly<SavingsPlanActionsCell>) {
-  const editable = true;
+  periodEndAction,
+  pciUrl,
+}: {
+  status: SavingsPlanStatus;
+  flavor: string;
+  onClickEdit: () => void;
+  onClickRenew: () => void;
+  periodEndAction: SavingsPlanPlanedChangeStatus;
+  pciUrl: string;
+}) => {
   const { t } = useTranslation('listing');
 
-  const onClick = () => onClickEditName(id);
+  // We don't have a better way to check that, api return only a specific code and not an id related to scope (instance, rancher),
+  // So if we have number in the flavor (b3-8, c3-16) it's an instance else it's a Rancher
+  const isInstance = /\d/.test(flavor);
+
   return (
-    <OsdsMenu className="absolute  mt-[-15px]">
-      <OsdsButton
-        slot="menu-title"
-        inline
-        circle
-        color={ODS_THEME_COLOR_INTENT.info}
-        variant={ODS_BUTTON_VARIANT.stroked}
-        type={ODS_BUTTON_TYPE.button}
-        size={ODS_BUTTON_SIZE.sm}
-        disabled={!editable || undefined}
-      >
-        <OsdsIcon
-          color={ODS_THEME_COLOR_INTENT.primary}
-          name={ODS_ICON_NAME.ELLIPSIS}
-          size={ODS_ICON_SIZE.xs}
-        />
-      </OsdsButton>
+    <>
       {status === SavingsPlanStatus.ACTIVE && (
         <OsdsMenuItem>
           <OsdsButton
@@ -63,7 +60,7 @@ export default function ActionsCell({
             size={ODS_BUTTON_SIZE.sm}
             variant={ODS_BUTTON_VARIANT.ghost}
             text-align="start"
-            onClick={onClick}
+            onClick={onClickEdit}
           >
             <span slot="start">
               <span>{t('edit')}</span>
@@ -89,6 +86,63 @@ export default function ActionsCell({
           </span>
         </OsdsButton>
       </OsdsMenuItem>
+
+      <OsdsMenuItem>
+        <OsdsButton
+          color={ODS_THEME_COLOR_INTENT.primary}
+          size={ODS_BUTTON_SIZE.sm}
+          variant={ODS_BUTTON_VARIANT.ghost}
+          text-align="start"
+          href={isInstance ? `${pciUrl}/instances` : `${pciUrl}/rancher`}
+        >
+          <span slot="start">
+            <span>{t('order')}</span>
+          </span>
+        </OsdsButton>
+      </OsdsMenuItem>
+    </>
+  );
+};
+
+export default function ActionsCell({
+  status,
+  periodEndAction,
+  id,
+  flavor,
+  onClickEditName,
+  onClickRenew,
+  pciUrl,
+}: Readonly<SavingsPlanActionsCell>) {
+  const editable = true;
+
+  const onClickEdit = useCallback(() => onClickEditName(id), [id]);
+
+  return (
+    <OsdsMenu className="absolute  mt-[-15px]">
+      <OsdsButton
+        slot="menu-title"
+        inline
+        circle
+        color={ODS_THEME_COLOR_INTENT.info}
+        variant={ODS_BUTTON_VARIANT.stroked}
+        type={ODS_BUTTON_TYPE.button}
+        size={ODS_BUTTON_SIZE.sm}
+        disabled={!editable || undefined}
+      >
+        <OsdsIcon
+          color={ODS_THEME_COLOR_INTENT.primary}
+          name={ODS_ICON_NAME.ELLIPSIS}
+          size={ODS_ICON_SIZE.xs}
+        />
+      </OsdsButton>
+      <MenuItems
+        pciUrl={pciUrl}
+        flavor={flavor}
+        status={status}
+        periodEndAction={periodEndAction}
+        onClickEdit={onClickEdit}
+        onClickRenew={onClickRenew}
+      />
     </OsdsMenu>
   );
 }

--- a/packages/manager/apps/pci-savings-plan/src/pages/listing/index.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/pages/listing/index.tsx
@@ -54,6 +54,7 @@ export interface ListingProps {
   data: SavingsPlanService[];
   refetchSavingsPlans: () => void;
 }
+
 const ListingTablePage: React.FC<ListingProps> = ({
   data,
   refetchSavingsPlans,
@@ -81,6 +82,9 @@ const ListingTablePage: React.FC<ListingProps> = ({
 
   const mutationSpCreate = useMutationState<{
     status: MutationStatus;
+    error?: {
+      code: string;
+    };
   }>({
     filters: { mutationKey: getMutationKeyCreateSavingsPlan(serviceId) },
   });
@@ -116,7 +120,7 @@ const ListingTablePage: React.FC<ListingProps> = ({
           }
         />
       )}
-      {mutationSpCreate.length > 0 && (
+      {mutationSpCreate.length > 0 && !mutationSpCreate[0].error.code && (
         <Banner
           message={t('banner_create_sp', {
             startDate: formatDateString(

--- a/packages/manager/apps/pci-savings-plan/src/types/api.type.ts
+++ b/packages/manager/apps/pci-savings-plan/src/types/api.type.ts
@@ -1,14 +1,14 @@
 export interface PciProject {
-    project_id: string;
-    projectName: string;
-    description: string;
-    planCode: PciProjectPlanCode;
-    access: string;
-    creationDate: string;
-    serviceId: number;
-    unleash: boolean;
-    status: string;
-  }
+  project_id: string;
+  projectName: string;
+  description: string;
+  planCode: PciProjectPlanCode;
+  access: string;
+  creationDate: string;
+  serviceId: number;
+  unleash: boolean;
+  status: string;
+}
 
 export enum PciProjectPlanCode {
   DISCOVERY = 'project.discovery',
@@ -40,21 +40,22 @@ export interface SavingsPlanTask {
 export interface SavingsPlanService {
   id: string;
   model: string;
+  flavor: string;
   displayName: string;
   offerId: string;
   endDate: string;
   period: string;
   periodEndAction: SavingsPlanPlanedChangeStatus;
   periodEndDate: string;
-  periodStartDate: string
+  periodStartDate: string;
   plannedChanges: [
     {
       plannedOn: string;
       properties: {
         status: string;
-      }
-    }
-  ],
+      };
+    },
+  ];
   size: number;
   startDate: string;
   status: SavingsPlanStatus;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/savings-plan-epic` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-804
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix order button to redirect to good order instance

## Related

<!-- Link dependencies of this PR -->
