### PR TITLE
feat(web): add test suffix to domain renewal info

### DIFF
--- a/packages/manager/apps/web/client/app/components/expiration/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/components/expiration/translations/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "expiration_new_tab": "S'ouvre dans un nouvel onglet",
   "expiration_expired_date": "Expiré le <strong>{{t0}}</strong>",
-  "expiration_renew_date": "Renouvellement automatique prévu en <strong>{{t0}}</strong>",
+  "expiration_renew_date": "Renouvellement automatique prévu en <strong>{{t0}}</strong> - Test",
   "expiration_resiliation_cancel_label": "Annuler la résiliation",
   "expiration_wizard_renew": "Renouveler",
   "expiration_wizard_restore": "Restaurer",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-14673
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

This adds the `Test` suffix to the Domain's renewal information.

## Related

<!-- Link dependencies of this PR -->
