### PR TITLE
fix(nvmrc): set target to lts/hydrogen to match package.json

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/hydrogen


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] ~~Ticket reference is mentioned in linked commits (internal only)~~
- [x] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Change the `.nvmrc` target version to match the `package.json` engine version.

If you have a node lts version greater than `lts/hydrogen` (^18), nvm will use that version and you will have an error when the version used is checked with the version mentionned in `package.json`

```shell
❯ nvm use
Found '/manager/.nvmrc' with version <lts/*>
Now using node v20.17.0 (npm v10.8.2)
❯ nvm ls
       v18.20.4
->     v20.17.0
default -> lts/* (-> v20.17.0)
❯ yarn install
yarn install v1.22.22
[1/5] 🔍  Validating package.json...
error manager@0.0.0: The engine "node" is incompatible with this module. Expected version "^18". Got "20.17.0"
error Found incompatible module.
```

<img width="683" alt="Screenshot 2024-09-09 at 10 52 18" src="https://github.com/user-attachments/assets/86b49be0-9e70-4553-88ad-c316409ee3f7">

## Related

<!-- Link dependencies of this PR -->

Closes #8421 