### PR TITLE
fix(pci-kubernetes): subnet dropdown refresh

### DIFF
--- a/packages/manager/apps/pci-kubernetes/src/components/network/SubnetSelector.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/components/network/SubnetSelector.component.tsx
@@ -98,6 +98,10 @@ export const SubnetSelector = ({
         <OsdsSelect
           name="subnet"
           size={ODS_SELECT_SIZE.md}
+          key={
+            `${projectId}${region}${networkId}`
+            /* fixes ODS select not refreshing correctly */
+          }
           value={subnet?.id}
           onOdsValueChange={({ detail }) => {
             const sub = availableSubnets?.find(


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-kubernetes
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2552
| License          | BSD 3-Clause

## Description

fix subnet dropdown not correctly refreshed (ODS issue)