### PR TITLE
fix(pci-kubernetes): subnet dropdown refresh

### DIFF
--- a/packages/manager/apps/pci-kubernetes/src/pages/edit-network/EditNetwork.page.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/edit-network/EditNetwork.page.tsx
@@ -153,6 +153,7 @@ export default function EditNetworkPage() {
             />
             <SubnetSelector
               className="mt-6"
+              key={kubeDetail?.privateNetworkId}
               title={tAdd('kubernetes_network_form_label')}
               projectId={projectId}
               networkId={kubeDetail?.privateNetworkId}

--- a/packages/manager/apps/pci-kubernetes/src/pages/new/steps/NetworkClusterStep.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/new/steps/NetworkClusterStep.component.tsx
@@ -75,6 +75,7 @@ export default function NetworkClusterStep({
           {form.privateNetwork && (
             <div>
               <SubnetSelect
+                key={form.privateNetwork?.id}
                 className="mt-8"
                 projectId={projectId}
                 privateNetwork={form.privateNetwork}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-kubernetes
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2552
| License          | BSD 3-Clause

## Description

add key to force ods dropdown to refresh