### PR TITLE
fix(pci-kubernetes): remove dbaas logs iceberg cache

### DIFF
--- a/packages/manager/apps/pci-kubernetes/src/api/data/dbaas-logs.ts
+++ b/packages/manager/apps/pci-kubernetes/src/api/data/dbaas-logs.ts
@@ -21,6 +21,7 @@ export type TDbaasLog = {
 export async function getLogs() {
   const { data } = await fetchIcebergV6<TDbaasLog>({
     route: `/dbaas/logs`,
+    disableCache: true,
   });
   return data;
 }
@@ -63,6 +64,7 @@ export async function getStreams(
     page: pagination.pageIndex,
     pageSize: pagination.pageSize,
     filters,
+    disableCache: true,
   });
   return { data, totalCount };
 }
@@ -112,6 +114,7 @@ export type TSubscription = {
 export async function getSubscriptions(serviceName: string, streamId: string) {
   const { data } = await fetchIcebergV6<TSubscription>({
     route: `/dbaas/logs/${serviceName}/output/graylog/stream/${streamId}/subscription`,
+    disableCache: true,
   });
   return data;
 }

--- a/packages/manager/apps/pci-kubernetes/src/api/data/kubernetes.ts
+++ b/packages/manager/apps/pci-kubernetes/src/api/data/kubernetes.ts
@@ -217,6 +217,7 @@ export const getSubscribedLogs = async (
 ) => {
   const { data } = await fetchIcebergV6<TSubscription>({
     route: `/cloud/project/${projectId}/kube/${kubeId}/log/subscription?kind=${kind}`,
+    disableCache: true,
   });
   return data;
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-kubernetes
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2546
| License          | BSD 3-Clause

## Description

disable iceberg cache to avoid double caching with tanstack query