### PR TITLE
feat(procedures): added retry loop on document upload

### DIFF
--- a/packages/manager/apps/procedures/src/components/FileInput/FileInput.tsx
+++ b/packages/manager/apps/procedures/src/components/FileInput/FileInput.tsx
@@ -21,7 +21,16 @@ export const FileInput: FunctionComponent<Props> = ({ className }) => {
       'The component <FileInput /> must be a child of FileInputContainer',
     );
   }
-  const { onChange, id, multiple, accept, value, maxFiles, maxSize } = context;
+  const {
+    onChange,
+    id,
+    multiple,
+    accept,
+    value,
+    maxFiles,
+    maxSize,
+    disabled: isInputDisabled,
+  } = context;
 
   const { t } = useTranslation('account-disable-2fa');
 
@@ -76,7 +85,7 @@ export const FileInput: FunctionComponent<Props> = ({ className }) => {
     });
     fileInputRef.current.value = '';
   };
-  const disabled = value?.length >= maxFiles && multiple;
+  const disabled = isInputDisabled || (value?.length >= maxFiles && multiple);
   return (
     <>
       <input

--- a/packages/manager/apps/procedures/src/components/FileInput/FileInputContainer.tsx
+++ b/packages/manager/apps/procedures/src/components/FileInput/FileInputContainer.tsx
@@ -29,6 +29,7 @@ export type FileInputProps = {
   maxFiles: number;
   children: React.ReactNode;
   className?: string;
+  disabled: boolean;
 };
 
 export const FileInputContext = createContext<FileInputProps | undefined>(

--- a/packages/manager/apps/procedures/src/components/FileInput/FileInputList.tsx
+++ b/packages/manager/apps/procedures/src/components/FileInput/FileInputList.tsx
@@ -16,7 +16,7 @@ export const FileInputList: FunctionComponent<Props> = ({ className }) => {
   }
   const { t } = useTranslation('account-disable-2fa');
 
-  const { value, multiple, onChange, accept, maxSize } = context;
+  const { value, multiple, onChange, accept, maxSize, disabled } = context;
 
   const handleDeleteFile = (
     e: MouseEvent<HTMLOsdsIconElement, globalThis.MouseEvent>,
@@ -37,6 +37,7 @@ export const FileInputList: FunctionComponent<Props> = ({ className }) => {
           maxSize={maxSize}
           file={file}
           deleteFile={handleDeleteFile}
+          disabled={disabled}
         />
       ))}
     </div>

--- a/packages/manager/apps/procedures/src/components/FileInput/FileInputList.tsx
+++ b/packages/manager/apps/procedures/src/components/FileInput/FileInputList.tsx
@@ -33,8 +33,6 @@ export const FileInputList: FunctionComponent<Props> = ({ className }) => {
       {value.map((file, index) => (
         <FileInputListItem
           key={index}
-          accept={accept}
-          maxSize={maxSize}
           file={file}
           deleteFile={handleDeleteFile}
           disabled={disabled}

--- a/packages/manager/apps/procedures/src/components/FileInput/FileInputListItem.tsx
+++ b/packages/manager/apps/procedures/src/components/FileInput/FileInputListItem.tsx
@@ -10,13 +10,13 @@ type FileInputListItemProps = {
     e: MouseEvent<HTMLOsdsIconElement, globalThis.MouseEvent>,
     file: FileWithError,
   ) => void;
-  accept: string;
-  maxSize: number;
+  disabled: boolean;
 };
 
 export const FileInputListItem: FunctionComponent<FileInputListItemProps> = ({
   file,
   deleteFile,
+  disabled,
 }) => {
   const bytesToSize = (bytes: number): string => {
     if (bytes < 1024 * 1024) {
@@ -62,7 +62,9 @@ export const FileInputListItem: FunctionComponent<FileInputListItemProps> = ({
         }
         className="ml-auto cursor-pointer"
         size={ODS_ICON_SIZE.sm}
-        onClick={(e) => deleteFile(e, file)}
+        onClick={(e) => {
+          if (!disabled) deleteFile(e, file);
+        }}
       />
     </div>
   );

--- a/packages/manager/apps/procedures/src/data/api/documentsApi.ts
+++ b/packages/manager/apps/procedures/src/data/api/documentsApi.ts
@@ -1,7 +1,7 @@
 import { v6 } from '@ovh-ux/manager-core-api';
 import axios from 'axios';
 
-type UploadLink = {
+export type UploadLink = {
   link: string;
   method: string;
   headers: any;
@@ -9,7 +9,7 @@ type UploadLink = {
 
 const s3AxiosInstance = axios.create({});
 
-const getUploadDocumentsLinks = (
+export const getUploadDocumentsLinks = (
   numberOfDocuments: number,
 ): Promise<UploadLink[]> => {
   return v6
@@ -34,10 +34,10 @@ const uploadDocument: (link: UploadLink, file: File) => Promise<void> = (
   });
 };
 
-export const uploadDocuments: (files: File[]) => Promise<void> = async (
-  files,
-) => {
-  const links = await getUploadDocumentsLinks(files.length);
+export const uploadDocuments: (
+  files: File[],
+  links: UploadLink[],
+) => Promise<void> = async (files, links) => {
   await Promise.all(
     links.map((link, index) => uploadDocument(link, files[index])),
   );

--- a/packages/manager/apps/procedures/src/data/hooks/useDocuments.tsx
+++ b/packages/manager/apps/procedures/src/data/hooks/useDocuments.tsx
@@ -1,9 +1,32 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { uploadDocuments } from '../api/documentsApi';
+import { useMutation } from '@tanstack/react-query';
+import {
+  getUploadDocumentsLinks,
+  uploadDocuments,
+  UploadLink,
+} from '../api/documentsApi';
 
 type UploadDocumentsProps = {
   files: File[];
+  links: UploadLink[];
 };
+
+export const useUploadLinks = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (links: UploadLink[]) => void;
+  onError: () => void;
+}) =>
+  useMutation({
+    mutationFn: (numberOfDocuments: number) =>
+      getUploadDocumentsLinks(numberOfDocuments),
+    onSuccess: (links) => {
+      onSuccess?.(links);
+    },
+    onError: () => {
+      onError?.();
+    },
+  });
 
 export const useUploadDocuments = ({
   onSuccess,
@@ -13,13 +36,16 @@ export const useUploadDocuments = ({
   onError: () => void;
 }) =>
   useMutation({
-    mutationFn: ({ files }: UploadDocumentsProps) => {
-      return uploadDocuments(files);
+    mutationFn: ({ files, links }: UploadDocumentsProps) => {
+      return uploadDocuments(files, links);
     },
     onSuccess: () => {
       onSuccess?.();
     },
     onError: () => {
+      // TODO: add logs to better understand what is going wrong on procedure finalization (MANAGER-15281)
       onError?.();
     },
+    retry: 1,
+    retryDelay: 3000,
   });

--- a/packages/manager/apps/procedures/src/pages/create/form/Form.page.test.tsx
+++ b/packages/manager/apps/procedures/src/pages/create/form/Form.page.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -142,6 +148,9 @@ describe('Form.page', () => {
 
   it('should show SuccessModal on successful document upload', async () => {
     const { getByText, getByTestId } = renderFormComponent();
+    vi.spyOn(useDocumentsModule, 'getUploadDocumentsLinks').mockReturnValue(
+      Promise.resolve([]),
+    );
     vi.spyOn(useDocumentsModule, 'uploadDocuments').mockReturnValue(
       Promise.resolve(),
     );
@@ -168,11 +177,15 @@ describe('Form.page', () => {
     ).not.toBeNull();
   });
 
-  it('should show error message when document upload is not successful', async () => {
+  it('should enable file inputs until links retrieval is successful', async () => {
     const { getByText, getByTestId } = renderFormComponent();
-    vi.spyOn(useDocumentsModule, 'uploadDocuments').mockRejectedValue(null);
+    vi.spyOn(useDocumentsModule, 'getUploadDocumentsLinks').mockRejectedValue(
+      null,
+    );
 
     const fileInput = getByTestId('18');
+    // File input should be disabled after getUploadDocumentsLinks is successful
+    expect(fileInput).not.toHaveAttribute('disabled');
     await act(() =>
       fireEvent.change(fileInput, {
         target: {
@@ -187,8 +200,55 @@ describe('Form.page', () => {
     const confirmBtn = getByText('account-disable-2fa-confirm-modal-yes');
     await act(() => fireEvent.click(confirmBtn));
 
-    expect(
-      getByText('account-disable-2fa-create-form-error-message-send-document'),
-    ).not.toBeNull();
+    await waitFor(() =>
+      expect(
+        getByText(
+          'account-disable-2fa-create-form-error-message-send-document',
+        ),
+      ).not.toBeNull(),
+    );
+    // File input should not be disabled if getUploadDocumentsLinks is not successful
+    expect(fileInput).not.toHaveAttribute('disabled');
   });
+
+  it(
+    'should show error message when document upload is not successful',
+    async () => {
+      const { getByText, getByTestId } = renderFormComponent();
+      vi.spyOn(useDocumentsModule, 'getUploadDocumentsLinks').mockReturnValue(
+        Promise.resolve([]),
+      );
+      vi.spyOn(useDocumentsModule, 'uploadDocuments').mockRejectedValue(null);
+
+      const fileInput = getByTestId('18');
+      await act(() =>
+        fireEvent.change(fileInput, {
+          target: {
+            files: [
+              new File(['test'], 'chucknorris.png', { type: 'image/png' }),
+            ],
+          },
+        }),
+      );
+
+      const submitBtn = getByText('account-disable-2fa-create-form-submit');
+      await act(() => fireEvent.click(submitBtn));
+
+      const confirmBtn = getByText('account-disable-2fa-confirm-modal-yes');
+      await act(() => fireEvent.click(confirmBtn));
+
+      await waitFor(
+        () =>
+          expect(
+            getByText(
+              'account-disable-2fa-create-form-error-message-send-document',
+            ),
+          ).not.toBeNull(),
+        { timeout: 30000 },
+      );
+      // File input should be disabled after getUploadDocumentsLinks is successful
+      expect(fileInput).toHaveAttribute('disabled');
+    },
+    { timeout: 60000 },
+  );
 });

--- a/packages/manager/apps/procedures/src/pages/create/form/Form.page.test.tsx
+++ b/packages/manager/apps/procedures/src/pages/create/form/Form.page.test.tsx
@@ -184,7 +184,8 @@ describe('Form.page', () => {
     );
 
     const fileInput = getByTestId('18');
-    // File input should be disabled after getUploadDocumentsLinks is successful
+    // File input should not be disabled if getUploadDocumentsLinks has not yet been called and
+    // at least a document has been selected
     expect(fileInput).not.toHaveAttribute('disabled');
     await act(() =>
       fireEvent.change(fileInput, {

--- a/packages/manager/apps/procedures/src/pages/create/form/FormDocumentFields/FormDocumentFieldItem.tsx
+++ b/packages/manager/apps/procedures/src/pages/create/form/FormDocumentFields/FormDocumentFieldItem.tsx
@@ -21,6 +21,7 @@ type Props = {
   maxSize: number;
   maxFiles: number;
   id?: string;
+  disabled: boolean;
 };
 
 export const FormDocumentFieldItem: FunctionComponent<Props> = ({
@@ -33,6 +34,7 @@ export const FormDocumentFieldItem: FunctionComponent<Props> = ({
   maxFiles,
   maxSize,
   id,
+  disabled,
 }) => {
   return (
     <FileInputContainer
@@ -43,6 +45,7 @@ export const FormDocumentFieldItem: FunctionComponent<Props> = ({
       onChange={onChange}
       maxSize={maxSize}
       multiple={multiple}
+      disabled={disabled}
     >
       <OsdsText
         color={ODS_THEME_COLOR_INTENT.text}

--- a/packages/manager/apps/procedures/src/pages/create/form/FormDocumentFields/FormDocumentFieldList.tsx
+++ b/packages/manager/apps/procedures/src/pages/create/form/FormDocumentFields/FormDocumentFieldList.tsx
@@ -15,6 +15,7 @@ type Props = {
   legalForm: LegalFrom | 'default';
   subsidiary: Subsidiary | 'DEFAULT';
   control: Control<FieldValues>;
+  disabled?: boolean;
 };
 
 type FieldDefinition = {
@@ -36,6 +37,7 @@ export const FormDocumentFieldList: FunctionComponent<Props> = ({
   control,
   legalForm,
   subsidiary,
+  disabled = false,
 }) => {
   const rules = documentsFieldRules as DocumentsFieldRules;
 
@@ -83,6 +85,7 @@ export const FormDocumentFieldList: FunctionComponent<Props> = ({
               tooltips={field.tooltips.map((tooltip) =>
                 tdoc(tooltip, { maxFiles }),
               )}
+              disabled={disabled}
             />
           )}
           name={field.field.replace('.', '')}

--- a/packages/manager/apps/procedures/vite.config.mjs
+++ b/packages/manager/apps/procedures/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { getBaseConfig } from '@ovh-ux/manager-vite-config';
 
-const baseConfig = getBaseConfig({});
+const baseConfig = getBaseConfig({ isLABEU: true });
 
 export default defineConfig({
   ...baseConfig,

--- a/packages/manager/apps/procedures/vite.config.mjs
+++ b/packages/manager/apps/procedures/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { getBaseConfig } from '@ovh-ux/manager-vite-config';
 
-const baseConfig = getBaseConfig({ isLABEU: true });
+const baseConfig = getBaseConfig({});
 
 export default defineConfig({
   ...baseConfig,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-15292
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a retry loop to automatically retry the file upload when an error occurs.
Split the calls made in order to ignore the initial call if it is successful (otherwise it would always failed and deny the user any possibility of retrying by himself)
Disabled the file inputs when the first call is succesfull as it cannot be remade and as a result the selected files cannot be changed
Added tests to cover this behavior

## Related

<!-- Link dependencies of this PR -->
