### PR TITLE
feat(zimbra): add redirection tab datagrid no api

### DIFF
--- a/packages/manager/apps/zimbra/public/translations/dashboard/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/dashboard/Messages_fr_FR.json
@@ -19,6 +19,7 @@
   "zimbra_dashboard_organizations_add": "Ajouter une organisation",
   "zimbra_dashboard_organizations_edit": "Modifier l'organisation",
   "zimbra_dashboard_organizations_delete": "Supprimer l'organisation",
+  "zimbra_dashboard_redirections": "Redirections",
   "zimbra_dashboard_title": "Zimbra",
   "zimbra_dashboard_usefull_links": "Liens utiles",
   "zimbra_dashboard_user_guides": "Guide d'utilisateur",

--- a/packages/manager/apps/zimbra/public/translations/redirections/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/redirections/Messages_fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "zimbra_redirections_from": "De",
+  "zimbra_redirections_to": "À",
+  "zimbra_redirections_organization": "Organisation"
+}

--- a/packages/manager/apps/zimbra/src/components/layout-helpers/Dashboard/Dashboard.tsx
+++ b/packages/manager/apps/zimbra/src/components/layout-helpers/Dashboard/Dashboard.tsx
@@ -88,6 +88,12 @@ export const Dashboard: React.FC = () => {
         urls.mailing_lists_delete,
       ]),
     },
+    {
+      name: 'redirections',
+      title: t('zimbra_dashboard_redirections'),
+      to: `${basePath}/redirections`,
+      pathMatchers: computePathMatchers([urls.redirections]),
+    },
   ];
 
   return (

--- a/packages/manager/apps/zimbra/src/pages/dashboard/Redirections/Redirections.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/Redirections/Redirections.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Datagrid, DatagridColumn } from '@ovh-ux/manager-react-components';
+import { useTranslation } from 'react-i18next';
+
+export type RedirectionsItem = {
+  from: string;
+  to: string;
+  organization: string;
+};
+
+const columns: DatagridColumn<RedirectionsItem>[] = [
+  {
+    id: 'from',
+    cell: () => <div>toto</div>,
+    label: 'zimbra_redirections_from',
+  },
+  {
+    id: 'to',
+    cell: () => <div></div>,
+    label: 'zimbra_redirections_to',
+  },
+  {
+    id: 'organization',
+    cell: () => <div></div>,
+    label: 'zimbra_redirections_organization',
+  },
+  {
+    id: 'tooltip',
+    cell: () => <div></div>,
+    label: '',
+  },
+];
+
+export default function Redirections() {
+  const { t } = useTranslation('redirections');
+
+  return (
+    <Datagrid
+      columns={columns.map((column) => ({
+        ...column,
+        label: t(column.label),
+      }))}
+      items={[]}
+      totalItems={0}
+    />
+  );
+}

--- a/packages/manager/apps/zimbra/src/routes/routes.constants.ts
+++ b/packages/manager/apps/zimbra/src/routes/routes.constants.ts
@@ -20,4 +20,5 @@ export const urls = {
   mailing_lists_configure_delegation:
     '/:serviceName/mailing_lists/configure_delegation',
   mailing_lists_define_members: '/:serviceName/mailing_lists/define_members',
+  redirections: '/:serviceName/redirections',
 };

--- a/packages/manager/apps/zimbra/src/routes/routes.tsx
+++ b/packages/manager/apps/zimbra/src/routes/routes.tsx
@@ -153,6 +153,12 @@ export const Routes: any = [
               import('@/pages/dashboard/MailingLists/MailingLists'),
             ),
           },
+          {
+            path: 'redirections',
+            ...lazyRouteConfig(() =>
+              import('@/pages/dashboard/Redirections/Redirections'),
+            ),
+          },
         ],
       },
       {


### PR DESCRIPTION
ref:MANAGER-15272

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | zimbra-ga
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15272
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] ~~Commits are signed-off~~
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

I added redirection tabs and datagrid with no api.

## Related

<!-- Link dependencies of this PR -->
