### PR TITLE
fix(pci-kubernetes): sticky dicovery banner

### DIFF
--- a/packages/manager/apps/pci-kubernetes/src/pages/new/New.page.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/new/New.page.tsx
@@ -143,7 +143,7 @@ export default function NewPage() {
       </div>
       <Notifications />
 
-      <div className="mb-5">
+      <div className="mb-5 sticky top-0 z-50">
         <PciDiscoveryBanner project={project} />
       </div>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | master
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2599
| License          | BSD 3-Clause

## Description

make k8s discovery banner sticky in creation page