### PR TITLE
feat(account): set up retry on error for kyc india procedure creation

### DIFF
--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.constant.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.constant.js
@@ -40,6 +40,10 @@ export const KYC_STATUS = {
 
 export const KYC_ALLOWED_FILE_EXTENSIONS = ['jpg', 'jpeg', 'pdf', 'png'];
 
+export const DELAY_BETWEEN_RETRY = 3 * 1000;
+
+export const MAX_RETRIES = 1;
+
 export default {
   USER_TYPE,
   MAX_SIZE,
@@ -50,4 +54,6 @@ export default {
   LEGAL_LINK3,
   KYC_STATUS,
   KYC_ALLOWED_FILE_EXTENSIONS,
+  DELAY_BETWEEN_RETRY,
+  MAX_RETRIES,
 };

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.controller.js
@@ -7,6 +7,8 @@ import {
   LEGAL_LINK3,
   KYC_STATUS,
   KYC_ALLOWED_FILE_EXTENSIONS,
+  DELAY_BETWEEN_RETRY,
+  MAX_RETRIES,
 } from './user-identity-documents.constant';
 
 export default class AccountUserIdentityDocumentsController {
@@ -32,6 +34,7 @@ export default class AccountUserIdentityDocumentsController {
   $onInit() {
     this.currentUser = this.coreConfig.getUser().legalform;
     this.files = [];
+    this.links = null;
     this.loading = false;
     this.showUploadOption = true;
     this.displayError = false;
@@ -51,13 +54,28 @@ export default class AccountUserIdentityDocumentsController {
     this.loading = true;
     this.displayError = false;
     this.trackClick(TRACKING_TASK_TAG.upload);
+    // We should mutualize this, as we should have the same behavior for KYC Fraud: MANAGER-15202
     if (!this.form.$invalid && this.isFileExtensionsValid()) {
-      this.getUploadDocumentsLinks(this.files.length)
+      const promise = this.links
+        ? // We cannot re call getUploadDocumentsLinks if it answered successfully, so if we already
+          // retrieve the links we directly try to "finalize" the procedure
+          this.tryToFinalizeProcedure(this.links)
+        : // In order to start the KYC procedure we need to request the upload links for the number of documents
+          // the user wants to upload
+          this.getUploadDocumentsLinks(this.files.length)
+            // Once we retrieved the upload links, we'll try to upload them and then "finalize" the procedure creation
+            .then(({ data: { uploadLinks } }) => {
+              this.links = uploadLinks;
+              return this.tryToFinalizeProcedure(uploadLinks);
+            });
+      promise
         .then(() => {
+          this.showUploadOption = false;
           this.loading = false;
           this.kycStatus.status = KYC_STATUS.OPEN;
           this.trackPage(TRACKING_TASK_TAG.uploadSuccess);
         })
+        // In case of any error, we display a banner to the user to inform them
         .catch(() => {
           this.displayErrorBanner();
         });
@@ -72,35 +90,53 @@ export default class AccountUserIdentityDocumentsController {
   }
 
   getUploadDocumentsLinks(count) {
-    return this.$http
-      .post(`/me/procedure/identity`, {
-        numberOfDocuments: count,
-      })
-      .then(({ data: response }) => {
-        const { uploadLinks } = response;
-        return this.$q.all(
-          uploadLinks.map((uploadLink, index) =>
-            this.uploadDocumentsToS3usingLinks(uploadLink, this.files[index]),
-          ),
-        );
-      })
-      .then(() => {
-        this.$http.post(`/me/procedure/identity/finalize`);
-        this.showUploadOption = false;
-      })
-      .catch(() => {
-        this.displayErrorBanner();
-      });
+    return this.$http.post(`/me/procedure/identity`, {
+      numberOfDocuments: count,
+    });
   }
 
-  uploadDocumentsToS3usingLinks(uploadLink, uploadedfile) {
-    return this.$http
-      .put(uploadLink.link, uploadedfile, {
-        headers: { ...uploadLink.headers },
-      })
-      .catch(() => {
-        this.displayErrorBanner();
-      });
+  // In order to avoid false positive from file upload endpoint, we'll retry all the process from the start
+  tryToFinalizeProcedure(uploadLinks) {
+    let remainingRetries = MAX_RETRIES;
+    // First we try to upload the file using the retrieved link
+    return (
+      this.finalizeProcedure(uploadLinks)
+        // In case of any error, we'll retry until we hit some maximum retry amount
+        .catch(async () => {
+          let success = false;
+          // As we need to retry until the task in is success, or we exceed the max retry count, the following await
+          // in a loop is valid, so we'll ignore eslint on the following loop
+          while (!success && remainingRetries) {
+            /* eslint-disable no-await-in-loop */
+            await new Promise((resolve) => {
+              setTimeout(resolve, DELAY_BETWEEN_RETRY);
+            });
+            try {
+              /* eslint-disable no-await-in-loop */
+              await this.finalizeProcedure(uploadLinks);
+              success = true;
+            } catch (error) {
+              remainingRetries -= 1;
+            }
+          }
+          return success ? this.$q.resolve() : this.$q.reject();
+        })
+    );
+  }
+
+  finalizeProcedure(uploadLinks) {
+    return (
+      this.$q
+        .all(
+          uploadLinks.map((uploadLink, index) =>
+            this.$http.put(uploadLink.link, this.files[index], {
+              headers: { ...uploadLink.headers },
+            }),
+          ),
+        )
+        // If all goes well, we'll ask for the "finalization" of the procedure creation
+        .then(() => this.$http.post(`/me/procedure/identity/finalize`))
+    );
   }
 
   isFileExtensionsValid() {

--- a/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
+++ b/packages/manager/apps/dedicated/client/app/account/identity-documents/user-identity-documents.html
@@ -85,7 +85,7 @@
             data-multiple
             data-maxsize="$ctrl.maximum_size"
             data-name="files"
-            data-disabled="$ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN"
+            data-disabled="$ctrl.kycStatus.status === $ctrl.KYC_STATUS.OPEN || $ctrl.links"
         ></oui-file>
 
         <oui-form-actions


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-14992
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Split upload documents call into two separates "tasks" as to be able to avoid calling the first part after it is successful, since it would end up failing everytime.
Set up a retry mecanism, so in the case of a failure, we'll retry to upload the document automatically after 3s.
Also "fixed" the CTA, so that if the user want to retry, he should be able (thanks to the first split)

## Related

<!-- Link dependencies of this PR -->
