### PR TITLE
fix(kms): change wording in service key headline translations

### DIFF
--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_de_DE.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_de_DE.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Verschlüsselungsschlüssel",
-  "key_management_service_service-keys_headline": "Erstellen, importieren und verwalten Sie Ihre CMK-Verschlüsselungsschlüssel (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Erstellen und verwalten Sie Ihre CMK-Verschlüsselungsschlüssel (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Name",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Typ",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_en_GB.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_en_GB.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Encryption keys",
-  "key_management_service_service-keys_headline": "Create, import and manage your Customer Managed Keys (CMK) encryption keys.",
+  "key_management_service_service-keys_headline": "Create and manage your Customer Managed Keys (CMK).",
   "key_management_service_service-keys_column_name": "Name",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Type",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_es_ES.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_es_ES.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Claves de cifrado",
-  "key_management_service_service-keys_headline": "Cree, importe y gestione sus claves de cifrado CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Cree y gestione sus claves de cifrado CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Apellido",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Tipo",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_fr_CA.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_fr_CA.json
@@ -1,7 +1,7 @@
 {
   "key_management_service_service_keys": "Clés de chiffrement",
   "key_management_service_service_keys_back_link": "Retour à la liste des clés",
-  "key_management_service_service-keys_headline": "Créez, importez et gérez vos clés de chiffrements CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Créez et gérez vos clés de chiffrements CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Nom",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Type",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_fr_FR.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_fr_FR.json
@@ -1,7 +1,7 @@
 {
   "key_management_service_service_keys": "Clés de chiffrement",
   "key_management_service_service_keys_back_link": "Retour à la liste des clés",
-  "key_management_service_service-keys_headline": "Créez, importez et gérez vos clés de chiffrements CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Créez et gérez vos clés de chiffrements CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Nom",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Type",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_it_IT.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_it_IT.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Chiavi di crittografia",
-  "key_management_service_service-keys_headline": "Crea, importa e gestisci le tue chiavi di cifratura CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Crea e gestisci le tue chiavi di crittografia CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Cognome",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Tipo",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_pl_PL.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_pl_PL.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Klucze szyfrowania",
-  "key_management_service_service-keys_headline": "Twórz, importuj i zarządzaj kluczami szyfrującymi CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Twórz i zarządzaj kluczami do szyfrowania CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Nazwisko",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Typ",

--- a/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_pt_PT.json
+++ b/packages/manager/apps/key-management-service/public/translations/key-management-service/serviceKeys/Messages_pt_PT.json
@@ -1,6 +1,6 @@
 {
   "key_management_service_service_keys": "Chaves de encriptação",
-  "key_management_service_service-keys_headline": "Crie, importe e faça a gestão das suas chaves de encriptação CMK (Customer Managed Keys).",
+  "key_management_service_service-keys_headline": "Crie e faça a gestão das suas chaves de encriptação CMK (Customer Managed Keys).",
   "key_management_service_service-keys_column_name": "Nome",
   "key_management_service_service-keys_column_id": "ID",
   "key_management_service_service-keys_column_type": "Tipo",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | release/infra-hpc-enable-w42
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-15153
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

In the listing page of keys, remove the word "importez" from the label "Créez, importez et gérez vos clés de chiffrements CMK (Customer Managed Keys). "because the import feature is not yet available.

The new wording is: "Créez et gérez vos clés de chiffrements CMK (Customer Managed Keys)."

## Related

- [x] CMT-16760

<!-- Link dependencies of this PR -->
