### PR TITLE
test(manager-react-components): add testid props to Clipboard

### DIFF
--- a/packages/manager-react-components/src/components/clipboard/clipboard.component.tsx
+++ b/packages/manager-react-components/src/components/clipboard/clipboard.component.tsx
@@ -5,15 +5,22 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import './translations';
 
-export const Clipboard: React.FC<OdsClipboardAttribute> = (props) => {
+interface IClipboardAttibutes extends OdsClipboardAttribute {
+  'data-testid': string;
+}
+
+export const Clipboard: React.FC<IClipboardAttibutes> = ({
+  'data-testid': testId = 'clipboard',
+  ...props
+}) => {
   const { t } = useTranslation('clipboard');
 
   return (
-    <OsdsClipboard {...props} data-testid="clipboard">
+    <OsdsClipboard {...props} data-testid={testId}>
       <span slot="success-message">
         <OsdsText
           color={ODS_THEME_COLOR_INTENT.success}
-          data-testid="clipboard-success"
+          data-testid={`${testId}-success`}
         >
           {t('clipboard_copy_success')}
         </OsdsText>
@@ -21,7 +28,7 @@ export const Clipboard: React.FC<OdsClipboardAttribute> = (props) => {
       <span slot="error-message">
         <OsdsText
           color={ODS_THEME_COLOR_INTENT.error}
-          data-testid="clipboard-error"
+          data-testid={`${testId}-error`}
         >
           {t('clipboard_copy_error')}
         </OsdsText>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #13072
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

Add `data-testid` prop to `Clipboard` component.
