### PR TITLE
fix(web.ssl): change ssl provider name from COMODO to SECTIGO

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/ssl/hosting-ssl.certificateType.service.js
+++ b/packages/manager/apps/web/client/app/hosting/ssl/hosting-ssl.certificateType.service.js
@@ -39,10 +39,15 @@ angular.module('services').service(
           isFree: true,
           providerName: 'LETSENCRYPT',
         },
-        PAID: {
-          name: 'paid',
+        SECTIGO: {
+          name: 'sectigo',
           isFree: false,
           providerName: 'COMODO',
+        },
+        COMODO: {
+          name: 'comodo',
+          isFree: false,
+          providerName: 'SECTIGO',
         },
         IMPORTED: {
           name: 'imported',
@@ -97,9 +102,15 @@ angular.module('services').service(
      * @returns {boolean}   True if the certificate is a paid certificate
      */
     static isPaid(mysteryCertificateType) {
-      return HostingSSLCertificateType.isCertificateType(
-        mysteryCertificateType,
-        HostingSSLCertificateType.getCertificateTypes().PAID.name,
+      return (
+        HostingSSLCertificateType.isCertificateType(
+          mysteryCertificateType,
+          HostingSSLCertificateType.getCertificateTypes().COMODO.name,
+        ) ||
+        HostingSSLCertificateType.isCertificateType(
+          mysteryCertificateType,
+          HostingSSLCertificateType.getCertificateTypes().SECTIGO.name,
+        )
       );
     }
 

--- a/packages/manager/apps/web/client/app/hosting/ssl/order/hosting-order-ssl.html
+++ b/packages/manager/apps/web/client/app/hosting/ssl/order/hosting-order-ssl.html
@@ -55,7 +55,7 @@
                                 class="oui-radio__input"
                                 id="sslTypePaid"
                                 name="sslType"
-                                data-ng-value="$ctrl.certificateTypes.PAID.name"
+                                data-ng-value="$ctrl.certificateTypes.SECTIGO.name"
                                 data-ng-model="$ctrl.selectedCertificateType"
                                 required
                             />


### PR DESCRIPTION

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | #WEB-19278
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Hello,

Small fix to support both `COMODO` and `SECTIGO`.

Right now, customers can't delete their PAID SSL offering. This PR fixes this.
