### PR TITLE
fix(manager-react-components): make data-testid optional on clipboard

### DIFF
--- a/packages/manager-react-components/src/components/clipboard/clipboard.component.tsx
+++ b/packages/manager-react-components/src/components/clipboard/clipboard.component.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import './translations';
 
 interface IClipboardAttibutes extends OdsClipboardAttribute {
-  'data-testid': string;
+  'data-testid'?: string;
 }
 
 export const Clipboard: React.FC<IClipboardAttibutes> = ({


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #13072
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Make `data-testid` optional prop on `Clipboard` component
