### PR TITLE
feat(procedures): use manager locale detection instead of support one

### DIFF
--- a/packages/manager/apps/procedures/src/App.tsx
+++ b/packages/manager/apps/procedures/src/App.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { odsSetup } from '@ovhcloud/ods-common-core';
+import {
+  useDefaultLanguage,
+  findAvailableLocale,
+  detectUserLocale,
+} from '@ovh-ux/manager-config';
 import { RouterProvider, createHashRouter } from 'react-router-dom';
 import '@ovhcloud/ods-theme-blue-jeans';
 import queryClient from './query.client';
@@ -21,13 +26,16 @@ function getSubsidiary(subsidiary: string, locale: string) {
 
 const token = extractToken();
 const user = decodeToken(token);
-const { language: locale, subsidiary } = user || {};
+const { subsidiary } = user || {};
 
 if (!user) {
   const redirectUrl = getRedirectLoginUrl(user);
   window.location.assign(redirectUrl);
 } else {
-  initI18n(locale || 'en_GB', getSubsidiary(subsidiary, locale));
+  useDefaultLanguage('en_GB');
+  const locale = findAvailableLocale(detectUserLocale());
+
+  initI18n(locale, getSubsidiary(subsidiary, locale));
   initAuthenticationInterceptor(token);
   initInterceptor();
 

--- a/packages/manager/apps/procedures/src/app.spec.tsx
+++ b/packages/manager/apps/procedures/src/app.spec.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+  user: {
+    subsidiary: 'FR',
+  },
+  initI18n: {
+    default: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('./i18n', () => mocks.initI18n);
+
+vi.mock('@/utils/token', () => ({
+  extractToken: () => '',
+  decodeToken: () => mocks.user,
+}));
+
+describe('App', () => {
+  beforeEach(() => {
+    // This is done because the code using navigator.language is outside the App component's function
+    // This denote bad code, we should probably rethink how language is extracted
+    vi.resetModules();
+    // This is done to have initI18n call history reset, and expectations working
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['fr_FR', 'FR', 'fr_FR'],
+    ['fr_MA', 'FR', 'fr_FR'],
+    ['en_CA', 'CA', 'en_GB'],
+    ['hi_IN', 'IN', 'en_GB'],
+    ['es_MX', 'WS', 'es_ES'],
+    ['es-419', 'ES', 'es_ES'],
+  ])(
+    'should call init18n with %s locale and %s subsidiary',
+    async (locale, subsidiary, firstParam) => {
+      vi.spyOn(global.window.navigator, 'language', 'get').mockImplementation(
+        () => locale,
+      );
+      mocks.user.subsidiary = subsidiary;
+
+      const { default: App } = await import('@/App');
+
+      render(<App />);
+      expect(mocks.initI18n.default).toHaveBeenCalledWith(
+        firstParam,
+        subsidiary,
+      );
+    },
+  );
+});


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15085
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Switched from support language (given through the token) to the language used in the manager (or determined the same way as in the manager)
Set up English as default language for procedures

## Related

<!-- Link dependencies of this PR -->
