### PR TITLE
fix(manager-component): fix and refactor useResourcesIcebergV6

### DIFF
--- a/packages/manager-react-components/src/hooks/datagrid/useIcebergV6.tsx
+++ b/packages/manager-react-components/src/hooks/datagrid/useIcebergV6.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { IcebergFetchParamsV6, fetchIcebergV6 } from '@ovh-ux/manager-core-api';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { ColumnSort } from '../../components';
@@ -6,11 +6,6 @@ import { ColumnSort } from '../../components';
 interface IcebergV6Hook {
   queryKey: string[];
   defaultSorting?: ColumnSort;
-}
-
-interface QueryParams {
-  pageIndex: number;
-  sorting?: ColumnSort;
 }
 
 /**
@@ -24,77 +19,41 @@ export function useResourcesIcebergV6<T = unknown>({
   queryKey,
   defaultSorting = undefined,
 }: IcebergFetchParamsV6 & IcebergV6Hook) {
-  const [totalCount, setTotalCount] = useState(0);
-  const [flattenData, setFlattenData] = useState<T[]>([]);
-  const [queryParams, setQueryParams] = useState<QueryParams>({
-    pageIndex: 1,
-    sorting: { desc: false, id: '' },
-  });
   const [sorting, setSorting] = useState<ColumnSort>(defaultSorting);
 
-  const {
-    data,
-    fetchNextPage,
-    isError,
-    isLoading,
-    error,
-    status,
-  } = useInfiniteQuery({
-    initialPageParam: null,
-    queryKey: [...queryKey, sorting],
-    queryFn: ({ pageParam }) =>
+  const { data: dataSelected, ...rest } = useInfiniteQuery({
+    initialPageParam: 1,
+    queryKey: [...queryKey, pageSize, sorting],
+    staleTime: Infinity,
+    retry: false,
+    queryFn: ({ pageParam: pageIndex }) =>
       fetchIcebergV6<T>({
         route,
         pageSize,
-        page: pageParam,
+        page: pageIndex,
         sortBy: sorting?.id || null,
         sortReverse: sorting?.desc,
       }),
-    staleTime: Infinity,
-    retry: false,
-    getNextPageParam: () => queryParams.pageIndex,
+    getNextPageParam: (lastPage, _allPages, lastPageIndex) => {
+      if (lastPage.totalCount / pageSize > lastPageIndex) return null;
+      return lastPageIndex + 1;
+    },
+    select: (data) => {
+      const pageIndex = data.pageParams[data.pageParams.length - 1];
+      const { totalCount } = data.pages[0];
+      return {
+        data,
+        pageIndex,
+        totalCount,
+        flattenData: data.pages.flatMap((page) => page.data),
+        hasNextPage: totalCount / pageSize > pageIndex,
+      };
+    },
   });
 
-  useEffect(() => {
-    const flatten = data?.pages.map((page) => page.data).flat();
-    setFlattenData(flatten);
-  }, [data]);
-
-  useEffect(() => {
-    if (totalCount === 0 && data?.pages) {
-      setTotalCount(data.pages[0].totalCount);
-    }
-  }, [data]);
-
-  useEffect(() => {
-    if (sorting) {
-      setQueryParams(() => ({ pageIndex: 1, sorting }));
-    }
-  }, [sorting]);
-
-  useEffect(() => {
-    fetchNextPage();
-  }, [queryParams]);
-
-  const onFetchNextPage = () => {
-    setQueryParams((previousParams: QueryParams) => ({
-      ...previousParams,
-      pageIndex: previousParams.pageIndex + 1,
-    }));
-  };
-
   return {
-    data,
-    fetchNextPage: onFetchNextPage,
-    setFlattenData,
-    flattenData,
-    totalCount,
-    pageIndex: queryParams.pageIndex,
-    hasNextPage: totalCount / pageSize > queryParams.pageIndex,
-    isError,
-    error,
-    isLoading,
-    status,
+    ...(dataSelected ?? { totalCount: 0, hasNextPage: false }),
+    ...rest,
     sorting,
     setSorting,
   };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-14495 #MANAGER-15573
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~Standalone app was ran and tested locally~
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Fix `useResoucesIceberg` because when I read the code we can see if 2 components call this `useResoucesIceberg` or we go back on page with the same app we trigger more one time fetchNextPage.

So we have multiple same data in result. Multiple same pages on data.

So : I proposal use `fetchNextPage` only on `onFetchNextPage` callback call.

I refactor too variable only managed with `useEffect`. I think `useMemo` is more efficient and more readable on this case.


