### PR TITLE
feat(zimbra): add auto replies tab and datagrid

### DIFF
--- a/packages/manager/apps/zimbra/public/translations/autoReplies/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/autoReplies/Messages_fr_FR.json
@@ -1,0 +1,6 @@
+{
+  "zimbra_auto_replies_name": "Nom",
+  "zimbra_auto_replies_from": "Du",
+  "zimbra_auto_replies_until": "Jusqu'au",
+  "zimbra_auto_replies_copyTo": "Copier vers"
+}

--- a/packages/manager/apps/zimbra/public/translations/dashboard/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/dashboard/Messages_fr_FR.json
@@ -41,5 +41,6 @@
   "zimbra_dashboard_tile_serviceConsumption_title": "Statistiques",
   "zimbra_dashboard_tile_serviceConsumption_accountOffer": "Compte par offre",
   "zimbra_dashboard_tile_serviceConsumption_noAccountOffer": "Vous ne possedez actuellement aucune boite email.",
-  "zimbra_dashboard_tile_usefulLinks_title": "Liens utiles"
+  "zimbra_dashboard_tile_usefulLinks_title": "Liens utiles",
+  "zimbra_dashboard_auto_replies": "Répondeurs"
 }

--- a/packages/manager/apps/zimbra/src/components/layout-helpers/Dashboard/Dashboard.tsx
+++ b/packages/manager/apps/zimbra/src/components/layout-helpers/Dashboard/Dashboard.tsx
@@ -98,6 +98,12 @@ export const Dashboard: React.FC = () => {
         urls.redirections_edit,
       ]),
     },
+    {
+      name: 'auto_replies',
+      title: t('zimbra_dashboard_auto_replies'),
+      to: `${basePath}/auto_replies`,
+      pathMatchers: computePathMatchers([urls.auto_replies]),
+    },
   ];
 
   return (

--- a/packages/manager/apps/zimbra/src/pages/dashboard/AutoReplies/AutoReplies.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/AutoReplies/AutoReplies.tsx
@@ -1,0 +1,103 @@
+import {
+  Datagrid,
+  DatagridColumn,
+  Notifications,
+} from '@ovh-ux/manager-react-components';
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+import {
+  ODS_BUTTON_SIZE,
+  ODS_BUTTON_VARIANT,
+  ODS_ICON_NAME,
+  ODS_ICON_SIZE,
+} from '@ovhcloud/ods-components';
+import { OsdsButton, OsdsIcon } from '@ovhcloud/ods-components/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Outlet } from 'react-router-dom';
+
+export type AutoRepliesItem = {
+  id: string;
+  name: string;
+  from: string;
+  until: string;
+  copyTo: string;
+};
+
+const items: AutoRepliesItem[] = [
+  {
+    id: '1',
+    name: 'to@example1.com',
+    from: '11/02/2023',
+    until: '11/02/2024',
+    copyTo: 'copy@example1.com',
+  },
+  {
+    id: '2',
+    name: 'to@example2.com',
+    from: '11/03/2023',
+    until: '11/03/2024',
+    copyTo: 'copy@example2.com',
+  },
+];
+const columns: DatagridColumn<AutoRepliesItem>[] = [
+  {
+    id: 'name',
+    cell: (item) => <div>{item.name}</div>,
+    label: 'zimbra_auto_replies_name',
+  },
+  {
+    id: 'from',
+    cell: (item) => <div>{item.from}</div>,
+    label: 'zimbra_auto_replies_from',
+  },
+  {
+    id: 'until',
+    cell: (item) => <div>{item.until}</div>,
+    label: 'zimbra_auto_replies_until',
+  },
+  {
+    id: 'copyTo',
+    cell: (item) => <div>{item.copyTo}</div>,
+    label: 'zimbra_auto_replies_copyTo',
+  },
+  {
+    id: 'deleteButton',
+    cell: () => (
+      <>
+        <OsdsButton
+          inline
+          size={ODS_BUTTON_SIZE.sm}
+          color={ODS_THEME_COLOR_INTENT.primary}
+          variant={ODS_BUTTON_VARIANT.ghost}
+        >
+          <OsdsIcon
+            name={ODS_ICON_NAME.BIN}
+            size={ODS_ICON_SIZE.xs}
+            color={ODS_THEME_COLOR_INTENT.primary}
+          ></OsdsIcon>
+        </OsdsButton>
+      </>
+    ),
+    label: '',
+  },
+];
+export function AutoReplies() {
+  const { t } = useTranslation('autoReplies');
+
+  return (
+    <div className="py-6 mt-8">
+      <Notifications />
+      <Outlet />
+      <Datagrid
+        columns={columns.map((column) => ({
+          ...column,
+          label: t(column.label),
+        }))}
+        items={items}
+        totalItems={items.length}
+      />
+    </div>
+  );
+}
+
+export default AutoReplies;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/AutoReplies/__test__/AutoReplies.spec.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/AutoReplies/__test__/AutoReplies.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { vi, describe, expect } from 'vitest';
+import AutoReplies from '../AutoReplies';
+import { render } from '@/utils/test.provider';
+import { platformMock } from '@/api/_mock_';
+
+vi.mock('@/hooks', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    usePlatform: vi.fn(() => ({
+      platformUrn: platformMock[0].iam.urn,
+    })),
+    useGenerateUrl: vi.fn(
+      () => '#/00000000-0000-0000-0000-000000000001/auto_replies',
+    ),
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Redirections page', () => {
+  it('should display page correctly', () => {
+    const { getByTestId } = render(<AutoReplies />);
+    const button = getByTestId('header-until');
+
+    expect(button).toHaveTextContent('zimbra_auto_replies_until');
+  });
+});

--- a/packages/manager/apps/zimbra/src/routes/routes.constants.ts
+++ b/packages/manager/apps/zimbra/src/routes/routes.constants.ts
@@ -31,4 +31,5 @@ export const urls = {
   redirections_add: '/:serviceName/redirections/add',
   redirections_edit: '/:serviceName/redirections/edit',
   redirections_delete: '/:serviceName/redirections/delete',
+  auto_replies: '/:serviceName/auto_replies',
 };

--- a/packages/manager/apps/zimbra/src/routes/routes.tsx
+++ b/packages/manager/apps/zimbra/src/routes/routes.tsx
@@ -249,8 +249,15 @@ export const Routes: any = [
               },
             ],
           },
+          {
+            path: 'auto_replies',
+            ...lazyRouteConfig(() =>
+              import('@/pages/dashboard/AutoReplies/AutoReplies'),
+            ),
+          },
         ],
       },
+
       {
         path: 'onboarding',
         ...lazyRouteConfig(() => import('@/pages/onboarding')),


### PR DESCRIPTION
ref:MANAGER-15496

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/zimbra-ga
| Bug fix?         |no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15496
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

I added auto replies tab and datagrid

## Related

<!-- Link dependencies of this PR -->
