### PR TITLE
feat(savings-plan): display banner for Prod Day

### DIFF
--- a/packages/manager/apps/pci-rancher/src/components/layout-helpers/CreateRancher/CreateRancher.component.tsx
+++ b/packages/manager/apps/pci-rancher/src/components/layout-helpers/CreateRancher/CreateRancher.component.tsx
@@ -186,8 +186,6 @@ const CreateRancher: React.FC<CreateRancherProps> = ({
     b.name.localeCompare(a.name),
   );
 
-  const ENABLE_AFTER_PROD = false;
-
   return (
     <div>
       <Title>{t('createRancherTitle')}</Title>
@@ -264,34 +262,32 @@ const CreateRancher: React.FC<CreateRancherProps> = ({
             <Trans>{t('createRancherServiceLevelDescription')}</Trans>
           </OsdsText>
         </div>
-        {ENABLE_AFTER_PROD && (
-          <OsdsMessage
-            color={ODS_THEME_COLOR_INTENT.info}
-            type={ODS_MESSAGE_TYPE.info}
-            className="my-6 flex items-center max-w-5xl"
+        <OsdsMessage
+          color={ODS_THEME_COLOR_INTENT.info}
+          type={ODS_MESSAGE_TYPE.info}
+          className="my-6 flex items-center max-w-5xl"
+        >
+          <OsdsText
+            color={ODS_THEME_COLOR_INTENT.text}
+            className="flex items-center"
           >
-            <OsdsText
-              color={ODS_THEME_COLOR_INTENT.text}
-              className="flex items-center"
-            >
-              <Trans>{t('savingsPlanMessage')}</Trans>
-            </OsdsText>
-            <OsdsLink
-              className="sm:mt-0 mt-4 sm:ml-4 ml-0"
-              color={ODS_THEME_COLOR_INTENT.primary}
-              href={`${url}/savings-plan`}
-              target={OdsHTMLAnchorElementTarget._blank}
-            >
-              {t('savingsPlanCTA')}
-            </OsdsLink>
-            <OsdsIcon
-              className="ml-3"
-              name={ODS_ICON_NAME.ARROW_RIGHT}
-              size={ODS_ICON_SIZE.sm}
-              color={ODS_THEME_COLOR_INTENT.primary}
-            />
-          </OsdsMessage>
-        )}
+            <Trans>{t('savingsPlanMessage')}</Trans>
+          </OsdsText>
+          <OsdsLink
+            className="sm:mt-0 mt-4 sm:ml-4 ml-0"
+            color={ODS_THEME_COLOR_INTENT.primary}
+            href={`${url}/savings-plan`}
+            target={OdsHTMLAnchorElementTarget._blank}
+          >
+            {t('savingsPlanCTA')}
+          </OsdsLink>
+          <OsdsIcon
+            className="ml-3"
+            name={ODS_ICON_NAME.ARROW_RIGHT}
+            size={ODS_ICON_SIZE.sm}
+            color={ODS_THEME_COLOR_INTENT.primary}
+          />
+        </OsdsMessage>
         <div className="flex my-5">
           <ul
             className={clsx(

--- a/packages/manager/modules/pci/src/projects/project/instances/add/add.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/add.html
@@ -68,7 +68,6 @@
                 >
                     <div class="container-fluid px-0">
                         <span
-                            ng-if="'ENABLE_AFTER_PROD' === true"
                             data-translate="pci_project_instances_instance_add_region_savings_plan_info"
                         ></span>
                         <div class="row">
@@ -987,14 +986,24 @@
     >
         <oui-message
             data-type="info"
-            data-ng-if="$ctrl.IsComingSoonPricingBannerDisplayed() && !$ctrl.isAddingPrivateNetwork && !$ctrl.isAddingPrivateNetworkError"
+            data-ng-if="$ctrl.IsSavingsPlanBannerDisplayed() && !$ctrl.isAddingPrivateNetwork && !$ctrl.isAddingPrivateNetworkError"
         >
-            <h6
-                data-translate="pci_projects_project_instances_add_billing_coming_soon_message_title"
-            ></h6>
             <p
-                data-translate="pci_projects_project_instances_add_billing_coming_soon_message_description"
+                data-translate="pci_projects_project_instances_add_billing_savings_plan_banner"
             ></p>
+            <a
+                class="oui-link oui-link_icon"
+                data-ng-href="{{:: $ctrl.savingsPlanUrl }}"
+                target="_blank"
+            >
+                <span
+                    data-translate="pci_projects_project_instances_add_billing_savings_plan_cta"
+                ></span>
+                <span
+                    class="oui-icon oui-icon-arrow-right"
+                    aria-hidden="true"
+                ></span>
+            </a>
         </oui-message>
 
         <p

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_de_DE.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "Wählen Sie eine kompatible Region aus, um ein privates Netzwerk über mehrere Regionen hinweg einzurichten.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Ort ändern",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Diese Option ist nicht verfügbar, wenn mehrere Instanzen konfiguriert werden. Gehen Sie zu „Public IPs“, um Ihren Instanzen eine Floating-IP zuzuweisen.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "Die Local Zones kommen für Savings Plans nicht infrage."
+  "pci_project_instances_instance_add_region_savings_plan_info": "Die Local Zones kommen für Savings Plans nicht infrage.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Profitieren Sie von günstigen monatlichen Preisen mit den Savings Plans und behalten Sie die Flexibilität der Instanzen auf Stundenbasis bei."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_en_GB.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "To set up an extended private network across multiple regions, please select a compatible region.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Select another location",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Option not available when configuring multiple instances. Please go to Public IPs to link a Floating IP to your instances.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "Local Zones are not eligible for Savings Plans."
+  "pci_project_instances_instance_add_region_savings_plan_info": "Local Zones are not eligible for Savings Plans.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Get low monthly rates with Savings Plans, while keeping the flexibility of instances on time."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_es_ES.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "Para crear una red privada extensa entre varias regiones, seleccione una región compatible.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Cambiar la localización",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Opción no disponible durante la configuración de varias instancias. Acceda a «Public IP» para asociar una Floating IP a sus instancias.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "Las Locals Zones no son compatibles con los Savings Plans."
+  "pci_project_instances_instance_add_region_savings_plan_info": "Las Locals Zones no son compatibles con los Savings Plans.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Disfrute de tarifas mensuales más bajas gracias a los Savings Plans, conservando la flexibilidad de las instancias por horas."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_fr_CA.json
@@ -80,6 +80,7 @@
   "pci_projects_project_instances_add_automated_backup_infos": "Cette fonctionnalité vous permet de sauvegarder votre instance de manière automatique selon l'ordonnancement de votre choix.",
 
   "pci_projects_project_instances_add_billing_title": "Sélectionnez une période de facturation",
+  "pci_projects_project_instances_add_billing_coming_soon_message_title": "Prix mensuels",
   "pci_projects_project_instances_add_billing_coming_soon_message_description": "Les tarifications mensuelles seront prochainement disponibles avec l'arrivée des Saving Plans.",
   "pci_projects_project_instances_add_billing_montly_discount_message": "Réduisez le montant de votre facture en passant votre instance au forfait mensuel.",
   "pci_projects_project_instances_add_billing_montly_discount_message_link": "Voir les prix",

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_it_IT.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "Per creare una rete privata estesa tra più Region, seleziona una Region compatibile.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Modificare la localizzazione",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Opzione non disponibile durante la configurazione di più istanze. Accedi a “Public IP” per associare un Floating IP alle tue istanze.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "Le Local Zone non sono compatibili con i Savings Plan."
+  "pci_project_instances_instance_add_region_savings_plan_info": "Le Local Zone non sono compatibili con i Savings Plan.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Usufruisci di tariffe mensili vantaggiose grazie ai Savings Plans, mantenendo la flessibilità delle istanze su base oraria."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pl_PL.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "Aby uruchomić prywatną sieć obejmującą kilka regionów, wybierz kompatybilny region.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Zmień lokalizację",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Opcja niedostępna podczas konfiguracji wielu instancji. Przejdź do adresów Public IP, aby przypisać floating IP do instancji.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "W przypadku Local Zones Savings Plans nie ma zastosowania."
+  "pci_project_instances_instance_add_region_savings_plan_info": "W przypadku Local Zones Savings Plans nie ma zastosowania.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Korzystaj z atrakcyjnych cen miesięcznych dzięki Savings Plan, zachowując jednocześnie elastyczność instancji na godzinę."
 }

--- a/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/pci/src/projects/project/instances/add/translations/Messages_pt_PT.json
@@ -123,5 +123,6 @@
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description2": "Para implementar uma rede privada alargada entre várias regiões, escolha uma região compatível.",
   "pci_projects_project_instances_add_attch_floating_ip_banner_localzone_description3": "Modificar a localização",
   "pci_projects_project_instances_add_attch_floating_ip_checkbox_label_tooltip": "Opção indisponível durante a configuração de várias instâncias. Sugerimos que aceda a “Public IP” para associar um Floating IP às suas instâncias.",
-  "pci_project_instances_instance_add_region_savings_plan_info": "As Local Zones não são elegíveis para os Savings Plans."
+  "pci_project_instances_instance_add_region_savings_plan_info": "As Local Zones não são elegíveis para os Savings Plans.",
+  "pci_projects_project_instances_add_billing_savings_plan_banner": "Beneficie de preços mensais vantajosos graças aos Savings Plans, mantendo a flexibilidade das instâncias à hora."
 }


### PR DESCRIPTION
This reverts commit c6a73c11033c52b2522caf8102c3b31cac33b798.

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #TAPC-1866
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [ ] Try to keep pull requests small so they can be easily reviewed.
- [ ] Commits are signed-off
- [ ] Only FR translations have been updated
- [ ] Branch is up-to-date with target branch
- [ ] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

To prepare the production of savings plan we display the banner in rancher and in instance page

## Related

<!-- Link dependencies of this PR -->
