### PR TITLE
Feat/pci rancher add mocks tapc 1849

### DIFF
--- a/packages/manager/apps/pci-rancher/mocks/data.ts
+++ b/packages/manager/apps/pci-rancher/mocks/data.ts
@@ -1,0 +1,144 @@
+import {
+  CreateRancherPayload,
+  RancherService,
+  RancherTaskType,
+  ResourceStatus,
+} from '../src/types/api.type';
+
+export const service = [
+  {
+    name: 'OVHCLOUD_EDITION',
+    status: 'AVAILABLE',
+  },
+  {
+    name: 'STANDARD',
+    status: 'AVAILABLE',
+  },
+];
+
+export const version = [
+  {
+    name: '2.7.6',
+    status: 'UNAVAILABLE',
+    cause: 'DEPRECATED',
+    message:
+      '(from msw) This Rancher version is deprecated, creations and updates to this version have been disabled.',
+    changelogUrl: 'https://github.com/rancher/rancher/releases/tag/v2.7.6',
+  },
+  {
+    name: '2.7.9',
+    status: 'AVAILABLE',
+    changelogUrl: 'https://github.com/rancher/rancher/releases/tag/v2.7.9',
+  },
+  {
+    name: '2.8.2',
+    status: 'AVAILABLE',
+    changelogUrl: 'https://github.com/rancher/rancher/releases/tag/v2.8.2',
+  },
+  {
+    name: '2.8.5',
+    status: 'AVAILABLE',
+    changelogUrl: 'https://github.com/rancher/rancher/releases/tag/v2.8.5',
+  },
+];
+
+export const deleteRancher: RancherService = {
+  id: '4c9040e8-b97b-4d24-8595-44eb2064ab8a',
+  createdAt: '2024-10-03T13:59:21.946141Z',
+  updatedAt: '2024-10-03T20:22:35.64413Z',
+  resourceStatus: ResourceStatus.DELETING,
+  targetSpec: {
+    name: 'elranchito2',
+    plan: 'OVHCLOUD_EDITION',
+    version: '2.8.2',
+    ipRestrictions: [],
+  },
+  currentState: {
+    name: 'elranchito2',
+    plan: 'OVHCLOUD_EDITION',
+    region: 'EU_WEST_RBX',
+    url: 'https://1i3kzy.p7mg.rancher.ovh.net',
+    version: '2.8.2',
+    ipRestrictions: [],
+  },
+  currentTasks: [
+    {
+      id: '3a3c3117-81c5-11ef-82e1-6289836149fb',
+      type: RancherTaskType.RANCHER_DELETE,
+    },
+  ],
+};
+
+export const postRancherService = (
+  data: CreateRancherPayload,
+): RancherService => ({
+  id: Math.random().toString(),
+  createdAt: '2024-10-03T13:56:51.809966Z',
+  updatedAt: '2024-10-03T13:56:51.809968Z',
+  resourceStatus: ResourceStatus.CREATING,
+  targetSpec: {
+    name: data.name,
+    plan: data.plan,
+    version: data.version,
+    ipRestrictions: [],
+  },
+  currentState: {
+    url: '',
+    name: data.name,
+    plan: data.plan,
+    region: 'EU_WEST_RBX',
+    version: data.version,
+    ipRestrictions: [],
+  },
+  currentTasks: [
+    {
+      id: '57762449-818f-11ef-82e1-6289836149fb',
+      type: RancherTaskType.RANCHER_CREATE,
+    },
+  ],
+});
+
+export const getRanchers: RancherService[] = [
+  {
+    id: 'aaa1a850-2af8-4a91-9453-9e8cbc7c87e5',
+    createdAt: '2024-10-03T13:56:51.809966Z',
+    updatedAt: '2024-10-03T13:57:36.589669Z',
+    resourceStatus: ResourceStatus.READY,
+    targetSpec: {
+      name: 'test (MSW)',
+      plan: 'OVHCLOUD_EDITION',
+      version: '2.8.5',
+      ipRestrictions: [],
+    },
+    currentState: {
+      name: 'test (MSW)',
+      plan: 'OVHCLOUD_EDITION',
+      region: 'EU_WEST_RBX',
+      url: 'https://lj9ohz.p7mg.rancher.ovh.net',
+      version: '2.8.5',
+      ipRestrictions: [],
+    },
+    currentTasks: [],
+  },
+  {
+    id: '4c9040e8-b97b-4d24-8595-44eb2064ab8a',
+    createdAt: '2024-10-03T13:59:21.946141Z',
+    updatedAt: '2024-10-03T13:59:21.946143Z',
+    resourceStatus: ResourceStatus.READY,
+    targetSpec: {
+      name: 'El-Ranchito (MSW)',
+      plan: 'OVHCLOUD_EDITION',
+      version: '2.8.2',
+      ipRestrictions: [],
+    },
+    currentState: {
+      name: 'El-Ranchito (MSW)',
+      plan: 'OVHCLOUD_EDITION',
+      url: 'https://lj9ohz.p7mg.rancher.ovh.net',
+      region: 'EU_WEST_RBX',
+      version: '2.8.2',
+      ipRestrictions: [],
+    },
+    currentTasks: [],
+  },
+];

--- a/packages/manager/apps/pci-rancher/mocks/handlers.ts
+++ b/packages/manager/apps/pci-rancher/mocks/handlers.ts
@@ -1,0 +1,218 @@
+import { Handler } from './utils';
+import {
+  CreateRancherPayload,
+  RancherService,
+  RancherTaskType,
+  ResourceStatus,
+} from '@/types/api.type';
+import {
+  deleteRancher,
+  getRanchers,
+  postRancherService,
+  service,
+  version,
+} from './data';
+
+// Define the base endpoint for the mock API
+const endpoint = '/publicCloud/project/:projectId';
+
+/**
+ * Function to create mock rancher services and add them to the getRanchers array.
+ * @param rancher - The rancher service to be added.
+ * @returns The updated getRanchers array.
+ */
+const createRancherServiceMocks = (rancher: RancherService) => {
+  getRanchers.push({ ...rancher });
+  return getRanchers;
+};
+
+/**
+ * Function to get a rancher service by its ID from the getRanchers array.
+ * @param rancherId - The ID of the rancher service to retrieve.
+ * @returns The rancher service with the specified ID.
+ * @throws If the rancher service with the specified ID is not found.
+ */
+const getRancherByIdMock = (rancherId: string) => {
+  const rancher = getRanchers.find((ranch) => ranch.id === rancherId);
+  if (!rancher) {
+    throw new Error(`Rancher with id ${rancherId} not found`);
+  }
+
+  return rancher;
+};
+
+/**
+ * Function to update a rancher service's target specification.
+ * @param data - The data containing the new target specification.
+ * @param rancherId - The ID of the rancher service to update.
+ * @param type - The type of update (default is 'plan').
+ * @returns The updated rancher service.
+ * @throws If the rancher service with the specified ID is not found.
+ */
+const updateRancher = (
+  data: { targetSpec: RancherService['targetSpec'] },
+  rancherId: string,
+) => {
+  const rancher = getRanchers.find((ranch) => ranch.id === rancherId);
+  if (!rancher) {
+    throw new Error(`Rancher with id ${rancherId} not found`);
+  }
+
+  rancher.currentState = { ...rancher.currentState, ...data.targetSpec };
+  rancher.targetSpec = data.targetSpec;
+  return rancher;
+};
+
+// Counter to track the number of times a rancher is created to be ready
+let countCreateToReady = 0;
+
+/**
+ * Function to get the mock handlers for the rancher API endpoints.
+ * @returns An array of Handler objects defining the mock API endpoints.
+ */
+export const getRancherMocks = (): Handler[] => [
+  {
+    url: `${endpoint}/reference/rancher/plan`,
+    method: 'get',
+    response: () => service,
+    status: 200,
+    api: 'v2',
+  },
+  {
+    url: `${endpoint}/reference/rancher/version`,
+    method: 'get',
+    response: () => version,
+    status: 200,
+    api: 'v2',
+  },
+  {
+    url: `${endpoint}/rancher`,
+    method: 'post',
+    async response({ request }) {
+      const data = (await request.json()) as {
+        targetSpec: CreateRancherPayload;
+      };
+      if (data) {
+        if (!data.targetSpec.name) {
+          return {
+            json: {
+              class: 'Client::BadRequest',
+              message: '[targetSpec.name] Property cannot be null',
+            },
+            newStatus: 400,
+          };
+        }
+        const rancher = postRancherService(data.targetSpec);
+        createRancherServiceMocks(rancher);
+        return rancher;
+      }
+      return {};
+    },
+    status: 201,
+    api: 'v2',
+  },
+  {
+    url: `${endpoint}/rancher`,
+    method: 'get',
+    async response() {
+      countCreateToReady += 1;
+      if (countCreateToReady === 3) {
+        countCreateToReady = 0;
+        return getRanchers
+          .map((rancher) => {
+            if (
+              rancher.currentTasks[0].type === RancherTaskType.RANCHER_CREATE
+            ) {
+              // eslint-disable-next-line no-param-reassign
+              rancher.resourceStatus = ResourceStatus.READY;
+              // eslint-disable-next-line no-param-reassign
+              rancher.currentTasks = [];
+            }
+
+            return rancher;
+          })
+          .filter(
+            (rancher) => rancher.resourceStatus !== ResourceStatus.DELETING,
+          );
+      }
+      return getRanchers;
+    },
+
+    status: 200,
+    api: 'v2',
+  },
+  {
+    method: 'get',
+    url: `${endpoint}/rancher/:rancherId`,
+    api: 'v2',
+    response: async ({ params, context }) => {
+      if (context.status === 404) {
+        return {
+          json: {
+            class: 'Client::NotFound (MSW)',
+            message: `Rancher  not found (MSW) ${params.rancherId as string}`,
+          },
+          newStatus: 404,
+        };
+      }
+
+      return getRancherByIdMock(params.rancherId as string);
+    },
+    status: 200,
+  },
+  {
+    method: 'put',
+    url: `${endpoint}/rancher/:rancherId`,
+    api: 'v2',
+    response: async ({ request, params, context }) => {
+      if (context.status === 404) {
+        return {
+          json: {
+            class: 'Client::NotFound (MSW)',
+            message: `Rancher  not found (MSW) ${params.rancherId as string}`,
+          },
+          newStatus: 404,
+        };
+      }
+      const data = await request.json();
+      return updateRancher(data, params.rancherId as string);
+    },
+    status: 200,
+  },
+
+  {
+    url: `${endpoint}/rancher/:rancherId`,
+    response: async ({ context, params }) => {
+      if (context.status === 404) {
+        return {
+          json: {
+            class: 'Client::NotFound (MSW)',
+            message: `Rancher not found ${params.rancherId as string}`,
+          },
+          newStatus: 404,
+        };
+      }
+      return deleteRancher;
+    },
+    method: 'delete',
+    api: 'v2',
+    status: 200,
+  },
+  {
+    url: `${endpoint}/rancher/:rancherId/adminCredentials`,
+    response: async ({ context }) => {
+      if (context.status === 404) {
+        return {
+          json: {
+            class: 'Client::NotFound (MSW)',
+          },
+          newStatus: 404,
+        };
+      }
+      return { username: 'admin', password: 'toto' };
+    },
+    method: 'post',
+    api: 'v2',
+    status: 403,
+  },
+];

--- a/packages/manager/apps/pci-rancher/mocks/setup.ts
+++ b/packages/manager/apps/pci-rancher/mocks/setup.ts
@@ -1,0 +1,8 @@
+import { setupWorker } from 'msw/browser';
+import { toMswHandlers } from './utils';
+import { getRancherMocks } from './handlers';
+
+export const setupMocks = async () =>
+  setupWorker(...toMswHandlers(getRancherMocks())).start({
+    onUnhandledRequest: 'bypass',
+  });

--- a/packages/manager/apps/pci-rancher/mocks/utils.ts
+++ b/packages/manager/apps/pci-rancher/mocks/utils.ts
@@ -1,0 +1,127 @@
+import { http, RequestHandler, HttpResponse, delay, PathParams } from 'msw';
+import { apiClient } from '@ovh-ux/manager-core-api';
+
+export const manageError = ({
+  status,
+  headers,
+  type,
+  statusText,
+}: {
+  status: number;
+  headers: HeadersInit;
+  type: ResponseType;
+  statusText: string;
+}) => {
+  if (status === 500) {
+    throw new Error(
+      'The Managed Rancher Service API is in maintenance mode. Only GET endpoints are available.',
+    );
+  }
+  if (status === 403) {
+    return HttpResponse.json(
+      {
+        status: 403,
+        code: 'ERR_KUBE_SERVICES',
+        response: {
+          data: { message: 'Error Kube Services' },
+        },
+      },
+      {
+        headers,
+        type,
+        statusText,
+      },
+    );
+  }
+  return null;
+};
+
+export const toMswHandlers = (handlers: Handler[] = []): RequestHandler[] =>
+  handlers
+    .filter(Boolean)
+    .filter(({ disabled }) => !disabled)
+    .map(
+      ({
+        url,
+        method = 'get',
+        headers,
+        type,
+        statusText,
+        delay: delayTime = 1000,
+        status = 200,
+        response,
+        responseText,
+        api = 'v6',
+        baseUrl,
+        once,
+      }: Handler) =>
+        http[method](
+          `${baseUrl ?? apiClient[api].getUri()}${
+            url.startsWith('/') ? '' : '/'
+          }${url}`,
+          async ({ request, params, cookies }) => {
+            manageError({ status, headers, type, statusText });
+            await delay(delayTime);
+            if (responseText) {
+              return HttpResponse.text(responseText);
+            }
+            const object =
+              typeof response === 'function'
+                ? ((await response({
+                    request,
+                    params,
+                    cookies,
+                    context: { url, status, method, headers, type },
+                  })) as { json: unknown; newStatus?: number })
+                : response;
+
+            return HttpResponse.json(
+              object.json && object.newStatus
+                ? object.json
+                : (object as unknown),
+              {
+                status,
+                headers,
+                type,
+                statusText,
+              },
+            );
+          },
+          { once },
+        ),
+    );
+
+export type Handler = {
+  url: string;
+  response?: ({
+    request,
+    params,
+    cookies,
+    context,
+  }: {
+    request: Request;
+    params: PathParams;
+    cookies: Record<string, string>;
+    context: Handler;
+  }) => Promise<{ json: unknown; newStatus?: number } | unknown> | unknown;
+
+  headers?: HeadersInit;
+  statusText?: string;
+  type?: ResponseType;
+  responseText?: string;
+  delay?: number;
+  method?:
+    | 'get'
+    | 'post'
+    | 'put'
+    | 'delete'
+    | 'all'
+    | 'head'
+    | 'options'
+    | 'patch';
+  status?: number;
+  api?: 'v2' | 'v6' | 'aapi' | 'ws';
+  baseUrl?: string;
+  disabled?: boolean;
+  once?: boolean;
+};

--- a/packages/manager/apps/pci-rancher/package.json
+++ b/packages/manager/apps/pci-rancher/package.json
@@ -62,6 +62,7 @@
     "babel-plugin-transform-import-meta": "^2.2.1",
     "element-internals-polyfill": "^1.3.10",
     "jest-environment-jsdom": "^29.7.0",
+    "msw": "^2.4.9",
     "rollup-plugin-visualizer": "^5.12.0",
     "tailwindcss": "^3.4.4",
     "ts-jest": "^29.1.1",
@@ -71,6 +72,11 @@
   },
   "peerDependencies": {
     "@ovhcloud/msc-utils": "*"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   },
   "regions": [
     "CA",

--- a/packages/manager/apps/pci-rancher/public/mockServiceWorker.js
+++ b/packages/manager/apps/pci-rancher/public/mockServiceWorker.js
@@ -1,0 +1,284 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.4.9'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const responseClone = response.clone()
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      )
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone()
+
+  function passthrough() {
+    const headers = Object.fromEntries(requestClone.headers.entries())
+
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer()
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}

--- a/packages/manager/apps/pci-rancher/src/main.tsx
+++ b/packages/manager/apps/pci-rancher/src/main.tsx
@@ -13,8 +13,15 @@ import '@/vite-hmr';
 
 const init = async (
   appName: string,
-  { reloadOnLocaleChange } = { reloadOnLocaleChange: false },
+  { reloadOnLocaleChange, mockNetwork } = {
+    reloadOnLocaleChange: false,
+    mockNetwork: false,
+  },
 ) => {
+  if (mockNetwork) {
+    const { setupMocks } = await import('../mocks/setup');
+    await setupMocks();
+  }
   const context = await initShellContext(appName);
 
   const region = context.environment.getRegion();
@@ -48,4 +55,9 @@ const init = async (
   );
 };
 
-init('pci-rancher', { reloadOnLocaleChange: true });
+init('pci-rancher', {
+  reloadOnLocaleChange: true,
+  mockNetwork:
+    process.env.NODE_ENV === 'development' &&
+    import.meta.env.VITE_TEST_BDD === 'true',
+});

--- a/packages/manager/apps/pci-rancher/src/types/api.type.ts
+++ b/packages/manager/apps/pci-rancher/src/types/api.type.ts
@@ -50,13 +50,13 @@ export interface RancherService {
   updatedAt: string;
   targetSpec: {
     name: string;
-    plan: string;
+    plan: RancherPlan['name'];
     version: string;
     ipRestrictions: [
       {
         cidrBlock: string;
         description: string;
-      },
+      }?,
     ];
   };
   currentState: {
@@ -73,7 +73,7 @@ export interface RancherService {
       {
         cidrBlock: string;
         description: string;
-      },
+      }?,
     ];
   };
   currentTasks: Array<RancherTask>;
@@ -83,7 +83,7 @@ export interface RancherService {
 export interface CreateRancherPayload {
   name: string;
   version: string;
-  plan: string;
+  plan: RancherPlanName;
 }
 
 export enum ResourceStatus {
@@ -98,7 +98,7 @@ export enum ResourceStatus {
 export type RancherReferenceStatus = 'AVAILABLE' | 'UNAVAILABLE';
 
 export interface RancherPlan {
-  name: 'OVHCLOUD_EDITION' | 'STANDARD';
+  name: RancherPlanName;
   status: RancherReferenceStatus;
 }
 

--- a/packages/manager/apps/pci-rancher/tsconfig.json
+++ b/packages/manager/apps/pci-rancher/tsconfig.json
@@ -24,5 +24,12 @@
     }
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "types", "src/__tests__"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "types",
+    "src/__tests__",
+    "*.spec.ts",
+    "*.test.ts"
+  ]
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | develop
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | TAPC-1849
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I have implemented mock API endpoints using the Mock Service Worker (MSW) library for testing purposes. The code includes a function  to handle specific HTTP status codes, such as 500 (maintenance mode) and 403 (forbidden access). 

Additionally, a function toMswHandlers converts custom Handler objects into MSW RequestHandler objects, managing errors, delays, and responses. 
Various mock API endpoints are defined for creating, retrieving, updating, and deleting rancher services, as well as handling admin credentials. 

These mock endpoints allow you to simulate different scenarios and test how your application handles various API responses without needing to interact with a real API.
## Related

<!-- Link dependencies of this PR -->
