### PR TITLE
fix(docs): fixed nullability for applications

### DIFF
--- a/docs/docs/components/ListPackages.vue
+++ b/docs/docs/components/ListPackages.vue
@@ -9,18 +9,23 @@
     </p>
 
     <ul v-if="success">
-      <li
-        v-for="{ package: { name, description, repository, version } } in packages"
-        v-bind:key="name">
+      <li v-if="packages.length === 0">
+        No packages found.
+      </li>
+      <li v-for="pkg in packages" :key="pkg?.package?.name">
         <a
-          v-bind:href="'https://github.com/ovh/manager/tree/master/' + repository.directory"
+          v-if="pkg?.package?.repository"
+          :href="'https://github.com/ovh/manager/tree/master/' + pkg?.package?.repository?.directory"
           rel="noopener noreferrer"
           target="_blank">
-          {{ name }}@{{ version }}
+          {{ pkg?.package?.name || 'n/a' }}@{{ pkg?.package?.version || 'n/a' }}
         </a>
+        <span v-else>
+          {{ pkg?.package?.name || 'n/a' }}@{{ pkg?.package?.version || 'n/a' }}
+        </span>
         <br>
         <span>
-          <strong>Description</strong>: {{ description || 'n/a' }}
+          <strong>Description</strong>: {{ pkg?.package?.description || 'n/a' }}
         </span>
         <hr>
       </li>
@@ -54,6 +59,7 @@ export default {
   },
   async mounted () {
     this.loading = true;
+
     try {
       const packages = await fetch('/manager/assets/json/packages.json');
       const packagesAsJson = await packages.json();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |  `develop` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          |  <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR fixes the `ListPackages.vue` component not properly handling cases where the repository can be null. Currently, if the repository in the package object is null, it won't render any app as there is a quiet error which shows in the console as a warning. I have also added better nullability checks and nullability handling in general to this component.

Some packages which have a nullable repository:

- @ovh-ux/manager-pci-block-storage-app@0.4.1
- @ovh-ux/manager-pci-gateway-app@0.6.1
- @ovh-ux/manager-pci-private-network-app@0.4.1
- @ovh-ux/manager-pci-public-ip-app@0.4.1
- @ovh-ux/manager-pci-ssh-keys-app@0.5.1
- @ovh-ux/manager-pci-users-app@0.8.1
- @ovh-ux/manager-pci-vouchers-app@0.7.1
