### PR TITLE
fix(web): display last deployment logs instead of first one

### DIFF
--- a/packages/manager/apps/web/client/app/hosting/multisite/git-integration/view-last-deployment/git-view-last-deployment.controller.js
+++ b/packages/manager/apps/web/client/app/hosting/multisite/git-integration/view-last-deployment/git-view-last-deployment.controller.js
@@ -10,11 +10,11 @@ export default class HostingMultisiteGitViewLastDeploymentController {
       this.serviceName,
       this.websiteId,
     )
-      .then(([deploymentId]) => {
+      .then((deploymentIds) => {
         return this.HostingMultisiteGitViewLastDeploymentService.getWebsitesDeploymentLogs(
           this.serviceName,
           this.websiteId,
-          deploymentId,
+          deploymentIds.pop(),
         );
       })
       .then((logs) => {


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-15749
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Changed the parameter given to API to retrieve git deployment logs, as it is currently passing the id of the first deployment instead of the id of the last deployment.

## Related

<!-- Link dependencies of this PR -->
