### PR TITLE
feat(dedicated): make hostname dynamic in os installation wizard

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/clusters/nodes/node/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/clusters/nodes/node/translations/Messages_fr_FR.json
@@ -357,8 +357,6 @@
   "server_configuration_installation_form_option": "Options d'installation :",
   "server_configuration_installation_form_gabaritNameSave": "Nom du gabarit :",
   "server_configuration_installation_form_gabaritNameSave_pattern": "Format invalide.",
-  "server_configuration_installation_form_customHostname": "Hostname :",
-  "server_configuration_installation_form_customHostname_pattern": "Format invalide.",
   "server_configuration_installation_form_useSpla": "Utiliser licence SPLA",
   "server_configuration_installation_form_ssh": "Clés ssh :",
   "server_configuration_installation_form_ssh_fail": "Impossible d'afficher vos clés ssh",

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/server/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/server/translations/Messages_fr_FR.json
@@ -356,8 +356,6 @@
   "server_configuration_installation_form_option": "Options d'installation :",
   "server_configuration_installation_form_gabaritNameSave": "Nom du gabarit :",
   "server_configuration_installation_form_gabaritNameSave_pattern": "Format invalide.",
-  "server_configuration_installation_form_customHostname": "Hostname :",
-  "server_configuration_installation_form_customHostname_pattern": "Format invalide.",
   "server_configuration_installation_form_nbdisk": "Nombre de disques partitionnés :",
   "server_configuration_installation_ovh_title": "Installation à partir d'un template OVHcloud",
   "server_configuration_installation_ovh_fail_os": "Une erreur s'est produite lors de la récupération des distributions disponible pour le serveur {{t0}}",

--- a/packages/manager/modules/bm-server-components/src/general-information/inputs/constants.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/inputs/constants.js
@@ -11,6 +11,10 @@ export const INPUTS_RULES = {
     maxsize: 256,
     pattern: /^[a-f0-9]{1,256}$/i,
   },
+  hostname: {
+    maxsize: 253,
+    pattern: /^([a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)+(\.[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
+  },
   ip: {
     maxsize: 15,
     pattern: /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/,

--- a/packages/manager/modules/bm-server-components/src/general-information/inputs/template.html
+++ b/packages/manager/modules/bm-server-components/src/general-information/inputs/template.html
@@ -191,6 +191,18 @@
             maxlength="{{$ctrl.inputRules.hexstring.maxsize}}"
             placeholder="{{:: 'server_configuration_installation_inputs_item_placeholder' | translate:{ t0: 'hexstring' } }}"
         />
+        <!-- hostname -->
+        <input
+            data-ng-switch-when="hostname"
+            class="oui-input form-control"
+            data-ng-model="$ctrl.installation.input[input.name]"
+            data-ng-required="input.mandatory"
+            data-ng-pattern="$ctrl.inputRules.hostname.pattern"
+            name="{{input.name}}"
+            type="text"
+            maxlength="{{$ctrl.inputRules.hostname.maxsize}}"
+            placeholder="{{:: 'server_configuration_installation_inputs_item_placeholder' | translate:{ t0: 'hostname' } }}"
+        />
         <!-- url -->
         <!-- native HTML url type is too permissive -->
         <input

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/gabarit/server-installation-gabarit.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/gabarit/server-installation-gabarit.controller.js
@@ -52,7 +52,6 @@ export default class ServerInstallationGabaritCtrl {
       options: {
         saveGabarit: false,
         gabaritNameSave: null,
-        customHostname: null,
         validForm: true,
       },
     };
@@ -207,7 +206,6 @@ export default class ServerInstallationGabaritCtrl {
     this.$scope.installation.options = {
       saveGabarit: false,
       gabaritNameSave: null,
-      customHostname: this.$scope.installation.selectGabarit.customHostname,
       validForm: true,
     };
 
@@ -360,7 +358,6 @@ export default class ServerInstallationGabaritCtrl {
       this.$scope.installation.selectGabarit.id,
       this.$scope.installation.selectPartitionScheme,
       {
-        customHostname: this.$scope.installation.options.customHostname,
         softRaidDevices:
           this.$scope.informations.nbDisk > 2 &&
           this.$scope.installation.nbDiskUse > 1
@@ -402,9 +399,6 @@ export default class ServerInstallationGabaritCtrl {
         this.$stateParams.productId,
         this.$scope.installation.selectGabarit.id,
         this.$scope.installation.options.gabaritNameSave,
-        {
-          customHostname: this.$scope.installation.options.customHostname,
-        },
       ).then(
         () => {
           this.$scope.installation.selectGabarit.displayName = angular.copy(

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/gabarit/server-installation-gabarit.html
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/gabarit/server-installation-gabarit.html
@@ -213,37 +213,6 @@
                         </span>
                     </div>
 
-                    <!-- customHostname -->
-                    <div
-                        class="form-group"
-                        data-ng-class="{
-                             'has-error': optionForm.customHostname.$touched && optionForm.customHostname.$invalid
-                         }"
-                    >
-                        <label
-                            for="customHostname"
-                            class="control-label"
-                            data-translate="server_configuration_installation_form_customHostname"
-                        >
-                        </label>
-                        <input
-                            type="text"
-                            name="customHostname"
-                            id="customHostname"
-                            class="form-control"
-                            data-ng-model="installation.options.customHostname"
-                            data-ng-pattern="/^[a-zA-Z0-9._-]{1,50}$/"
-                            data-ng-trim="true"
-                        />
-                        <span
-                            class="help-block errorFormLabel"
-                            role="alert"
-                            data-ng-if="optionForm.customHostname.$invalid && optionForm.$dirty"
-                            data-translate="server_configuration_installation_form_customHostname_pattern"
-                        >
-                        </span>
-                    </div>
-
                     <!-- diskgroup -->
                     <oui-field
                         data-label="{{ 'server_configuration_installation_ovh_step1_disk_group' | translate }}"

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -158,7 +158,6 @@ export default class ServerInstallationOvhCtrl {
       options: {
         saveGabarit: false,
         gabaritNameSave: null,
-        customHostname: null,
         variablePartition: null,
         validForm: true,
       },
@@ -2198,7 +2197,6 @@ export default class ServerInstallationOvhCtrl {
     this.$scope.installation.options = {
       saveGabarit: false,
       gabaritNameSave: null,
-      customHostname: null,
       variablePartition: null,
       validForm: true,
     };
@@ -2320,7 +2318,6 @@ export default class ServerInstallationOvhCtrl {
       this.$scope.informations.gabaritName,
       this.$scope.installation.selectPartitionScheme,
       {
-        customHostname: this.$scope.installation.options.customHostname,
         softRaidDevices:
           this.$scope.informations.nbDisk > 2 &&
           this.$scope.installation.nbDiskUse > 1
@@ -2397,9 +2394,6 @@ export default class ServerInstallationOvhCtrl {
       this.$stateParams.productId,
       this.$scope.informations.gabaritName,
       this.$scope.installation.options.gabaritNameSave,
-      {
-        customHostname: this.$scope.installation.options.customHostname,
-      },
     ).then(
       () => {
         this.$scope.informations.gabaritName = angular.copy(

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.html
@@ -1829,37 +1829,6 @@
                             </select>
                         </div>
 
-                        <!-- customHostname -->
-                        <div
-                            class="form-group"
-                            data-ng-class="{
-                                'has-error': optionForm.customHostname.$invalid && optionForm.$dirty
-                            }"
-                        >
-                            <label
-                                for="customHostname"
-                                class="control-label"
-                                data-translate="server_configuration_installation_form_customHostname"
-                            >
-                            </label>
-                            <input
-                                type="text"
-                                class="form-control"
-                                id="customHostname"
-                                name="customHostname"
-                                data-ng-model="installation.options.customHostname"
-                                data-ng-pattern="/^[a-zA-Z0-9._-]{1,50}$/"
-                                data-ng-trim="true"
-                            />
-                            <span
-                                class="help-block"
-                                role="alert"
-                                data-ng-if="optionForm.customHostname.$invalid && optionForm.$dirty"
-                                data-translate="server_configuration_installation_form_customHostname_pattern"
-                            >
-                            </span>
-                        </div>
-
                         <!-- nbDisk -->
                         <div
                             class="form-inline"

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_de_DE.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_de_DE.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Klicken Sie hier, um ein Schlüssel-Wert-Paar hinzuzufügen.",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Klicken Sie hier, um dieses Schlüssel-Wert-Paar zu löschen.",
   "dedicated_server_dashboard_region_unknown": "Information nicht verfügbar",
-  "dedicated_server_dashboard_zone_unknown": "Information nicht verfügbar"
+  "dedicated_server_dashboard_zone_unknown": "Information nicht verfügbar",
+  "server_configuration_installation_inputs_bad_hostname": "Der Hostname darf nur aus Ziffern, Buchstaben, Bindestrichen und Punkten entsprechend dem in RFC 1035 definierten Format bestehen."
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_en_GB.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_en_GB.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Click here to add a key-value pair",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Click here to delete this key-value pair",
   "dedicated_server_dashboard_region_unknown": "Information unavailable",
-  "dedicated_server_dashboard_zone_unknown": "Information unavailable"
+  "dedicated_server_dashboard_zone_unknown": "Information unavailable",
+  "server_configuration_installation_inputs_bad_hostname": "The host name must contain numbers, letters, hyphens and full stops, according to the format defined in RFC 1035"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_es_ES.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_es_ES.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Haga clic aquí para agregar un par clave-valor",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Haga clic aquí para eliminar este par clave-valor",
   "dedicated_server_dashboard_region_unknown": "Información no disponible",
-  "dedicated_server_dashboard_zone_unknown": "Información no disponible"
+  "dedicated_server_dashboard_zone_unknown": "Información no disponible",
+  "server_configuration_installation_inputs_bad_hostname": "El «hostname» solo debe estar compuesto por números, letras, guiones y puntos según el formato establecido en la RFC 1035"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_CA.json
@@ -46,6 +46,7 @@
   "server_configuration_installation_inputs_item_mandatory": "Ce champ est obligatoire",
   "server_configuration_installation_inputs_bad_email": "L'adresse email saisie n'est pas valide",
   "server_configuration_installation_inputs_bad_hexstring": "La chaîne de caractères doit être composée uniquement de chiffres et de lettres comprises entre A et F",
+  "server_configuration_installation_inputs_bad_hostname": "Le hostname doit être composé uniquement de chiffres, lettres, traits d'union et points selon le format défini dans la RFC 1035",
   "server_configuration_installation_inputs_bad_ip": "L'adresse IPv4 saisie n'est pas valide",
   "server_configuration_installation_inputs_bad_required": "Ce champ est requis",
   "server_configuration_installation_inputs_bad_sshPubKey": "La clé publique SSH est invalide: seules les clés RSA, ECDSA et EdDSA au format OpenSSH sont acceptées",

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_fr_FR.json
@@ -46,6 +46,7 @@
   "server_configuration_installation_inputs_item_mandatory": "Ce champ est obligatoire",
   "server_configuration_installation_inputs_bad_email": "L'adresse email saisie n'est pas valide",
   "server_configuration_installation_inputs_bad_hexstring": "La chaîne de caractères doit être composée uniquement de chiffres et de lettres comprises entre A et F",
+  "server_configuration_installation_inputs_bad_hostname": "Le hostname doit être composé uniquement de chiffres, lettres, traits d'union et points selon le format défini dans la RFC 1035",
   "server_configuration_installation_inputs_bad_ip": "L'adresse IPv4 saisie n'est pas valide",
   "server_configuration_installation_inputs_bad_required": "Ce champ est requis",
   "server_configuration_installation_inputs_bad_sshPubKey": "La clé publique SSH est invalide: seules les clés RSA, ECDSA et EdDSA au format OpenSSH sont acceptées",

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_it_IT.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_it_IT.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Clicca qui per aggiungere una coppia chiave-valore",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Clicca qui per eliminare questa coppia chiave-valore",
   "dedicated_server_dashboard_region_unknown": "Informazione non disponibile",
-  "dedicated_server_dashboard_zone_unknown": "Informazione non disponibile"
+  "dedicated_server_dashboard_zone_unknown": "Informazione non disponibile",
+  "server_configuration_installation_inputs_bad_hostname": "L'hostname deve essere composto esclusivamente da cifre, lettere, trattini e punti nel formato definito nella RFC 1035"
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pl_PL.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Kliknij tutaj, aby dodać parę klucz-wartość",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Kliknij tutaj, aby usunąć parę klucz-wartość",
   "dedicated_server_dashboard_region_unknown": "Informacja niedostępna",
-  "dedicated_server_dashboard_zone_unknown": "Informacja niedostępna"
+  "dedicated_server_dashboard_zone_unknown": "Informacja niedostępna",
+  "server_configuration_installation_inputs_bad_hostname": "Nazwa hosta może zawierać wyłącznie cyfry, litery, łączniki i punkty w formacie określonym w RFC 1035."
 }

--- a/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/bm-server-components/src/general-information/translations/Messages_pt_PT.json
@@ -55,5 +55,6 @@
   "server_configuration_installation_inputs_item_keyValue_add_tooltip": "Clique aqui para adicionar um par chave-valor",
   "server_configuration_installation_inputs_item_keyValue_remove_tooltip": "Clique aqui para eliminar este par chave-valor",
   "dedicated_server_dashboard_region_unknown": "Informação indisponível",
-  "dedicated_server_dashboard_zone_unknown": "Informação indisponível"
+  "dedicated_server_dashboard_zone_unknown": "Informação indisponível",
+  "server_configuration_installation_inputs_bad_hostname": "O hostname deve ser composto unicamente por números, letras, hífenes e pontos conforme o formato definido na RFC 1035"
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15792
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

Host name field should not be hardcoded and in the "installation options" section
hostname should be a dynamic input of type hostname (create the new type) and in the "Specific options" section

## Related

:flags: Translation

- [x] CMT-18270
