### PR TITLE
fix(netapp): show creation date in UTC timezone

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
@@ -49,11 +49,14 @@
             <oui-datagrid-column
                 title=":: 'netapp_volumes_snapshots_created_at' | translate"
                 property="createdAt"
+                helper=":: 'netapp_volumes_snapshots_created_at_helper' | translate"
                 sortable
                 searchable
                 filterable
             >
-                <span data-ng-bind=":: $row.createdAt | date:'medium'"></span>
+                <span
+                    data-ng-bind=":: $row.createdAt | date:'medium':'UTC'"
+                ></span>
             </oui-datagrid-column>
             <oui-datagrid-column
                 title=":: 'netapp_volumes_snapshots_type' | translate"

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_de_DE.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_de_DE.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "Die Regel wurde angewandt.",
   "netapp_volumes_snapshots_policies_apply_error": "Die Regel konnte nicht angewandt werden. Bitte versuchen Sie es später erneut.",
   "netapp_volumes_snapshots_type_automatic": "Automatisch",
-  "netapp_volumes_snapshots_type_system": "System"
+  "netapp_volumes_snapshots_type_system": "System",
+  "netapp_volumes_snapshots_created_at_helper": "Datumsangaben werden im UTC-Format gemacht."
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_en_GB.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_en_GB.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "Policy applied successfully.",
   "netapp_volumes_snapshots_policies_apply_error": "The policy could not be applied. Please try again later.",
   "netapp_volumes_snapshots_type_automatic": "Automatic",
-  "netapp_volumes_snapshots_type_system": "System"
+  "netapp_volumes_snapshots_type_system": "System",
+  "netapp_volumes_snapshots_created_at_helper": "Dates are expressed in UTC format"
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_es_ES.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_es_ES.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "La regla se ha aplicado correctamente.",
   "netapp_volumes_snapshots_policies_apply_error": "No se ha podido aplicar la regla. Por favor, vuelva a intentarlo más adelante.",
   "netapp_volumes_snapshots_type_automatic": "Automática",
-  "netapp_volumes_snapshots_type_system": "Sistema"
+  "netapp_volumes_snapshots_type_system": "Sistema",
+  "netapp_volumes_snapshots_created_at_helper": "Las fechas se muestran en formato UTC"
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_fr_CA.json
@@ -10,6 +10,7 @@
   "netapp_volumes_snapshots_name": "Nom",
   "netapp_volumes_snapshots_description": "Description",
   "netapp_volumes_snapshots_created_at": "Date de création",
+  "netapp_volumes_snapshots_created_at_helper": "Les dates sont spécifiées au format UTC",
   "netapp_volumes_snapshots_type": "Type",
   "netapp_volumes_snapshots_type_manual": "Manuelle",
   "netapp_volumes_snapshots_type_automatic": "Automatique",

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_fr_FR.json
@@ -10,6 +10,7 @@
   "netapp_volumes_snapshots_name": "Nom",
   "netapp_volumes_snapshots_description": "Description",
   "netapp_volumes_snapshots_created_at": "Date de création",
+  "netapp_volumes_snapshots_created_at_helper": "Les dates sont spécifiées au format UTC",
   "netapp_volumes_snapshots_type": "Type",
   "netapp_volumes_snapshots_type_manual": "Manuelle",
   "netapp_volumes_snapshots_type_automatic": "Automatique",

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_it_IT.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_it_IT.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "La regola è stata applicata correttamente.",
   "netapp_volumes_snapshots_policies_apply_error": "Non è stato possibile applicare la regola. Ti preghiamo di riprovare.",
   "netapp_volumes_snapshots_type_automatic": "Automatico",
-  "netapp_volumes_snapshots_type_system": "Sistema"
+  "netapp_volumes_snapshots_type_system": "Sistema",
+  "netapp_volumes_snapshots_created_at_helper": "Le date sono specificate in formato UTC"
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_pl_PL.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "Reguła została zastosowana.",
   "netapp_volumes_snapshots_policies_apply_error": "Reguła nie mogła zostać zastosowana. Spróbuj później.",
   "netapp_volumes_snapshots_type_automatic": "Automatycznie",
-  "netapp_volumes_snapshots_type_system": "System"
+  "netapp_volumes_snapshots_type_system": "System",
+  "netapp_volumes_snapshots_created_at_helper": "Daty są podane w formacie UTC"
 }

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/translations/Messages_pt_PT.json
@@ -29,5 +29,6 @@
   "netapp_volumes_snapshots_policies_apply_success": "A regra foi aplicada com sucesso.",
   "netapp_volumes_snapshots_policies_apply_error": "Não foi possível aplicar a regra. Tente novamente mais tarde.",
   "netapp_volumes_snapshots_type_automatic": "Automático",
-  "netapp_volumes_snapshots_type_system": "Sistema"
+  "netapp_volumes_snapshots_type_system": "Sistema",
+  "netapp_volumes_snapshots_created_at_helper": "As datas são especificadas no formato UTC"
 }


### PR DESCRIPTION
ref: MANAGER-15267

ref: MANAGER-14822

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-15267
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [x] Breaking change is mentioned in relevant commits

## Description

Show snapshot creation date in UTC timezone.

## Related

<!-- Link dependencies of this PR -->
