### PR TITLE
feat(shell): add method to notify container a modal action is done

### DIFF
--- a/packages/components/ovh-shell/src/client/api.ts
+++ b/packages/components/ovh-shell/src/client/api.ts
@@ -209,6 +209,11 @@ export default function exposeApi(shellClient: ShellClient) {
           plugin: 'ux',
           method: 'showPreloader',
         }),
+      notifyModalActionDone: () =>
+        shellClient.invokePluginMethod<void>({
+          plugin: 'ux',
+          method: 'notifyModalActionDone',
+        }),
     },
     navigation: clientNavigation(shellClient),
     tracking: exposeTrackingAPI(shellClient),

--- a/packages/components/ovh-shell/src/plugin/ux/index.ts
+++ b/packages/components/ovh-shell/src/plugin/ux/index.ts
@@ -20,6 +20,8 @@ export interface IUXPlugin {
   toggleNotificationsSidebarVisibility(): void;
   toggleAccountSidebarVisibility(): void;
   getUserIdCookie(): string;
+  registerModalActionDoneListener(callback: CallableFunction): void;
+  notifyModalActionDone(): void;
 }
 
 // TODO: remove this once we have a more generic Plugin class
@@ -33,6 +35,8 @@ export class UXPlugin implements IUXPlugin {
   private shellUX: ShellUX;
 
   private sidebarMenuUpdateItemLabelListener?: CallableFunction;
+
+  private onModalActionDone?: CallableFunction;
 
   constructor(shell: Shell) {
     this.shell = shell;
@@ -252,5 +256,16 @@ export class UXPlugin implements IUXPlugin {
   // request the client application to open his sidebar
   requestClientSidebarOpen() {
     this.shell.emitEvent('ux:client-sidebar-open');
+  }
+
+  /* ----------- Modal action methods -----------*/
+  registerModalActionDoneListener(callback: CallableFunction) {
+    this.onModalActionDone = callback;
+  }
+
+  notifyModalActionDone() {
+    if (this.onModalActionDone) {
+      this.onModalActionDone();
+    }
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15988
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added a new method in UX plugin in order to be able to notify the container that an action required by a modal has been done from any app.

## Related

<!-- Link dependencies of this PR -->
