### PR TITLE
ci: skip mrc from lerna version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -20,7 +20,8 @@
       "conventionalCommits": true
     },
     "version": {
-      "allowBranch": "master"
+      "allowBranch": "master",
+      "ignoreChanges": ["packages/manager-react-components/**"]
     }
   }
 }


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ [n/a]
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] ~~Standalone app was ran and tested locally~~ [n/a]
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ [n/a]

## Description

`lerna version` updates the version of the package automatically in µ-apps even if the changes include "Breaking Change" commits. So this PR excludes the `manager-react-components` from lerna's versioning.
