### PR TITLE
fix(manager-components): ssh-key-selector margin issues

### DIFF
--- a/packages/manager/modules/manager-components/src/ssh-key-selector/ssh-key-selector.template.html
+++ b/packages/manager/modules/manager-components/src/ssh-key-selector/ssh-key-selector.template.html
@@ -5,6 +5,7 @@
         data-label-popover="{{:: 'manager_components_select_ssh_key_help' | translate }}"
     >
         <oui-select
+            class="mt-3"
             id="sshKeys"
             name="sshKeys"
             data-items="$ctrl.userSshKeys"


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix MANAGER-15969 (2 of 2)
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
~Breaking change is mentioned in relevant commits~

## Description

Add a little margin top to oui-select

## Related

[fix(dedicated,vps): margin issues around sshkey component by JayBeeDe · Pull Request #14010 · ovh/manager](https://github.com/ovh/manager/pull/14010)