### PR TITLE
fix(dedicated.ip): fix ipv4 vrack order on us

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.service.js
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.service.js
@@ -81,7 +81,7 @@ export default class IpAgoraOrder {
       const [region] = productRegionName?.split('-') || [];
       productToOrder.configuration.push({
         label: 'region',
-        value: region?.trim()?.toLowerCase(),
+        value: region === 'USA' ? 'us' : region?.trim()?.toLowerCase(),
       });
     }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #PRB0041819
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Quick fix for ordering ipv4 for vRack in US region.

## Related

<!-- Link dependencies of this PR -->
