### PR TITLE
fix(mrc): ensure useAuthorizationIam query option enabled is a boolean

### DIFF
--- a/packages/manager-react-components/src/hooks/iam/useOvhIam.spec.ts
+++ b/packages/manager-react-components/src/hooks/iam/useOvhIam.spec.ts
@@ -1,9 +1,0 @@
-import { getAuthorizationCheckUrl } from './useOvhIam';
-
-describe('getAuthorizationCheckUrl', () => {
-  it('encodes the urn if it contains /', () => {
-    expect(getAuthorizationCheckUrl('test/urn')).toBe(
-      '/iam/resource/test%2Furn/authorization/check',
-    );
-  });
-});

--- a/packages/manager-react-components/src/hooks/iam/useOvhIam.spec.tsx
+++ b/packages/manager-react-components/src/hooks/iam/useOvhIam.spec.tsx
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import {
+  ShellContext,
+  ShellContextType,
+} from '@ovh-ux/manager-react-shell-client';
+import { getAuthorizationCheckUrl, useAuthorizationIam } from './useOvhIam';
+
+const shellContext = {
+  environment: {
+    getUser: () => ({ ovhSubsidiary: 'mocked_ovhSubsidiary' }),
+  },
+  shell: {
+    navigation: {
+      getURL: vi.fn(),
+    },
+  },
+};
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <ShellContext.Provider value={shellContext as unknown as ShellContextType}>
+      {children}
+    </ShellContext.Provider>
+  </QueryClientProvider>
+);
+
+vi.mock('@ovh-ux/manager-core-api', () => ({
+  apiClient: {
+    v2: {
+      get: vi.fn(),
+    },
+  },
+}));
+
+describe('getAuthorizationCheckUrl', () => {
+  it('encodes the urn if it contains /', () => {
+    expect(getAuthorizationCheckUrl('test/urn')).toBe(
+      '/iam/resource/test%2Furn/authorization/check',
+    );
+  });
+});
+
+describe('useAuthorizationIam', () => {
+  it('should not fetch data if urn is nil', () => {
+    const { result } = renderHook(
+      () => useAuthorizationIam(['test'], undefined),
+      {
+        wrapper,
+      },
+    );
+    expect(result.current?.isFetching).toBe(false);
+  });
+  it('should not fetch data if actions is nil', () => {
+    const { result } = renderHook(() => useAuthorizationIam(undefined, 'urn'), {
+      wrapper,
+    });
+    expect(result.current?.isFetching).toBe(false);
+  });
+  it('should fetch data if both actions and urn are not nil', () => {
+    const { result } = renderHook(() => useAuthorizationIam(['test'], 'urn'), {
+      wrapper,
+    });
+    expect(result.current?.isFetching).toBe(true);
+  });
+});

--- a/packages/manager-react-components/src/hooks/iam/useOvhIam.tsx
+++ b/packages/manager-react-components/src/hooks/iam/useOvhIam.tsx
@@ -51,7 +51,11 @@ export function useAuthorizationIam(
     queryKey: [urn, actions],
     queryFn: () => fetchAuthorizationCheck(actions, urn),
     enabled:
-      urn && urn.length > 0 && actions && actions.length > 0 && isTrigger,
+      Boolean(urn) &&
+      urn.length > 0 &&
+      Boolean(actions) &&
+      actions.length > 0 &&
+      isTrigger,
     placeholderData: keepPreviousData,
   });
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `maintenance/manager-react-components-v1.x`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #13791 
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Casted `actions` and `urn` to Boolean when using them in the useQuery options, to ensure we do not fetch data with incorrect values

## Related

<!-- Link dependencies of this PR -->
