### PR TITLE
fix(container): fixed default public cloud project retrieval

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/data/api/defaultPublicCloudProject.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/data/api/defaultPublicCloudProject.ts
@@ -1,0 +1,13 @@
+import { v6 } from '@ovh-ux/manager-core-api';
+import { DefaultPublicCloudProjectPreference, Preference } from '@/types/preferences';
+
+export const getDefaultPublicCloudProjectId = async () => {
+  try {
+    const { data } = await v6.get<Preference>('/me/preferences/manager/PUBLIC_CLOUD_DEFAULT_PROJECT');
+    const defaultProject: DefaultPublicCloudProjectPreference = data?.value ? JSON.parse(data.value) : null;
+    return defaultProject.projectId;
+  }
+  catch (e) {
+    return null;
+  }
+}

--- a/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject.tsx
@@ -1,0 +1,10 @@
+import { DefinedInitialDataOptions, useQuery } from '@tanstack/react-query';
+import { getDefaultPublicCloudProjectId } from '@/container/nav-reshuffle/data/api/defaultPublicCloudProject';
+
+export const useDefaultPublicCloudProject = (options?: Partial<DefinedInitialDataOptions>) =>
+  useQuery<string | null>({
+    ...options,
+    queryKey: ['default-pci-project'],
+    queryFn: getDefaultPublicCloudProjectId,
+    retry: false,
+  });

--- a/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject.tsx
@@ -1,8 +1,9 @@
 import { DefinedInitialDataOptions, useQuery } from '@tanstack/react-query';
 import { getDefaultPublicCloudProjectId } from '@/container/nav-reshuffle/data/api/defaultPublicCloudProject';
+import { PciProject } from '@/container/nav-reshuffle/sidebar/ProjectSelector/PciProject';
 
-export const useDefaultPublicCloudProject = (options?: Partial<DefinedInitialDataOptions>) =>
-  useQuery<string | null>({
+export const useDefaultPublicCloudProject = (options?: Partial<DefinedInitialDataOptions<string | null, unknown, PciProject>>) =>
+  useQuery({
     ...options,
     queryKey: ['default-pci-project'],
     queryFn: getDefaultPublicCloudProjectId,

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.test.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.test.tsx
@@ -4,6 +4,7 @@ import { Node } from '../navigation-tree/node';
 import { PublicCloudPanel, PublicCloudPanelProps } from './PublicCloudPanel';
 import { mockShell } from '../mocks/sidebarMocks';
 import { PciProject } from '../ProjectSelector/PciProject';
+import { Props as ProjectSelectorProps } from '../ProjectSelector/ProjectSelector';
 import { pciNode } from '../navigation-tree/services/publicCloud';
 
 const node: Node = {
@@ -79,7 +80,7 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../ProjectSelector/ProjectSelector', () => ({
-  default: ({ selectedProject }) => {
+  default: ({ selectedProject }: ProjectSelectorProps) => {
     return (<div data-testid="public-cloud-panel-project-selector">{selectedProject?.project_id}</div>);
   },
 }));

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.test.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.test.tsx
@@ -1,5 +1,5 @@
 import { vi, it, describe, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { Node } from '../navigation-tree/node';
 import { PublicCloudPanel, PublicCloudPanelProps } from './PublicCloudPanel';
 import { mockShell } from '../mocks/sidebarMocks';
@@ -53,22 +53,24 @@ vi.mock('@/context', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: ({ queryKey }: { queryKey: Array<string> }) => {
-    return queryKey.includes('pci-projects')
-      ? {
-          data: () => pciProjects,
-          isError: () => false,
-          isSuccess: () => true,
-          refetch: () => {},
-        }
-      : {
-          data: () => pciProjects[0],
-          status: () => 'success',
-        };
+    return {
+      data: pciProjects,
+      isError: false,
+      isSuccess: true,
+      refetch: () => {},
+    };
   },
 }));
 
+vi.mock('@/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject', () => ({
+  useDefaultPublicCloudProject: () => ({
+    data: pciProjects[1],
+    status: 'success',
+  }),
+}));
+
 const location = {
-  pathname: '/pci/projects/12345/rancher',
+  pathname: '/public-cloud/pci/projects',
   search: '',
 };
 
@@ -77,12 +79,29 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../ProjectSelector/ProjectSelector', () => ({
-  default: () => <div data-testid="public-cloud-panel-project-selector" />,
+  default: ({ selectedProject }) => {
+    return (<div data-testid="public-cloud-panel-project-selector">{selectedProject?.project_id}</div>);
+  },
 }));
 
 describe('PublicCloudPanel.component', () => {
   it('should render', () => {
     const { queryByTestId } = renderPublicCloudPanelComponent(props);
     expect(queryByTestId('public-cloud-panel')).not.toBeNull();
+  });
+
+  it('should display default project id in project selector when url does not contain an id', () => {
+    const { queryByTestId } = renderPublicCloudPanelComponent(props);
+    const projectSelector = queryByTestId('public-cloud-panel-project-selector');
+    expect(projectSelector).not.toBeNull();
+    expect(projectSelector.innerHTML).toBe('54321');
+  });
+
+  it('should display project id in project selector when url contains an id', () => {
+    location.pathname = '/public-cloud/pci/projects/12345/rancher';
+    const { queryByTestId } = renderPublicCloudPanelComponent(props);
+    const projectSelector = queryByTestId('public-cloud-panel-project-selector');
+    expect(projectSelector).not.toBeNull();
+    expect(projectSelector.innerHTML).toBe('12345');
   });
 });

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -108,10 +108,12 @@ export const PublicCloudPanel: React.FC<ComponentProps<
   }, [pciProjects, rootNode, containerURL]);
 
   useEffect(() => {
-    if (defaultPciProjectStatus === 'success') {
-      setSelectedPciProject(defaultPciProject);
-    } else if (defaultPciProjectStatus === 'error' && pciProjects?.length) {
-      setSelectedPciProject(pciProjects[0]);
+    if (selectedPciProject === null) {
+      if (defaultPciProjectStatus === 'success') {
+        setSelectedPciProject(defaultPciProject);
+      } else if (defaultPciProjectStatus === 'error' && pciProjects?.length) {
+        setSelectedPciProject(pciProjects[0]);
+      }
     }
   }, [defaultPciProject, defaultPciProjectStatus, pciProjects]);
 

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -67,7 +67,7 @@ export const PublicCloudPanel: React.FC<ComponentProps<
 
   const { data: defaultPciProject, status: defaultPciProjectStatus } = useDefaultPublicCloudProject(
     {
-      select: (defaultProjectId: string | null) => {
+      select: (defaultProjectId: string | null): PciProject | null => {
         return defaultProjectId !== null
           ? pciProjects?.find((project: PciProject) => project.project_id === defaultProjectId) || null
           : null;

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -11,6 +11,9 @@ import { Location, useLocation } from 'react-router-dom';
 import style from '../style.module.scss';
 import SubTreeSection from '@/container/nav-reshuffle/sidebar/SubTree/SubTreeSection';
 import { PUBLICCLOUD_UNIVERSE_ID } from '../navigation-tree/services/publicCloud';
+import {
+  useDefaultPublicCloudProject
+} from '@/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject';
 
 export interface PublicCloudPanelProps {
   rootNode: Node;
@@ -62,19 +65,14 @@ export const PublicCloudPanel: React.FC<ComponentProps<
     },
   });
 
-  const { data: defaultPciProject, status: defaultPciProjectStatus } = useQuery(
+  const { data: defaultPciProject, status: defaultPciProjectStatus } = useDefaultPublicCloudProject(
     {
-      queryKey: ['default-pci-project'],
-      queryFn: () => {
-        return fetchIcebergV6<PciProject>({
-          route: '/me/preferences/manager/PUBLIC_CLOUD_DEFAULT_PROJECT',
-        });
-      },
-      select: (response) => {
-        return response?.data?.length ? (response.data[0] as PciProject) : null;
+      select: (defaultProjectId: string | null) => {
+        return defaultProjectId !== null
+          ? pciProjects?.find((project: PciProject) => project.project_id === defaultProjectId) || null
+          : null;
       },
       enabled: rootNode.id === PUBLICCLOUD_UNIVERSE_ID && !selectedPciProject,
-      retry: false,
     },
   );
 

--- a/packages/manager/apps/container/src/types/preferences.ts
+++ b/packages/manager/apps/container/src/types/preferences.ts
@@ -1,0 +1,8 @@
+export type Preference = {
+  key: string;
+  value: string;
+}
+
+export type DefaultPublicCloudProjectPreference = {
+  projectId: string;
+}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-16171
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Fixed default public cloud project retrieval
Splitted retrieval into separated file to tend to target architecture
Added test cases for this issue

## Related

<!-- Link dependencies of this PR -->
