### PR TITLE
fix(container): avoid overriding selected project when url has an id

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -108,10 +108,12 @@ export const PublicCloudPanel: React.FC<ComponentProps<
   }, [pciProjects, rootNode, containerURL]);
 
   useEffect(() => {
-    if (defaultPciProjectStatus === 'success') {
-      setSelectedPciProject(defaultPciProject);
-    } else if (defaultPciProjectStatus === 'error' && pciProjects?.length) {
-      setSelectedPciProject(pciProjects[0]);
+    if (selectedPciProject === null) {
+      if (defaultPciProjectStatus === 'success') {
+        setSelectedPciProject(defaultPciProject);
+      } else if (defaultPciProjectStatus === 'error' && pciProjects?.length) {
+        setSelectedPciProject(pciProjects[0]);
+      }
     }
   }, [defaultPciProject, defaultPciProjectStatus, pciProjects]);
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-15914
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Added condition to avoid setting default project as the selected one when we found one matching the url

## Related

<!-- Link dependencies of this PR -->
