### PR TITLE
feat(hub-react): handle notifications translations in front end

### DIFF
--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_de_DE.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_de_DE.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Allgemeine Informationen",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Betrügerische E-Mails sind im Umlauf und leiten Sie auf gefälschte OVHcloud-Seiten um. <anchor>Mehr erfahren</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_en_GB.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_en_GB.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "General information",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Fraudulent emails circulate and direct to scam websites claiming to be OVHcloud. <anchor>Find out more</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_es_ES.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_es_ES.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Información general",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "¡Tenga cuidado con los mensajes de correo electrónico fraudulentos que circulan online y redirigen hacia páginas falsas de OVHcloud! <anchor>Más información</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_fr_CA.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_fr_CA.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Informations générales",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Des emails frauduleux circulent et dirigent vers de faux sites OVHcloud. <anchor>En savoir plus</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_fr_FR.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_fr_FR.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Informations générales",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Des emails frauduleux circulent et dirigent vers de faux sites OVHcloud. <anchor>En savoir plus</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_it_IT.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_it_IT.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Informazioni generali",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Circolano email fraudolente che reindirizzano verso falsi siti OVHcloud. <anchor>Scopri di più</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_pl_PL.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_pl_PL.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Informacje ogólne",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "W sieci krążą fałszywe e-maile przekierowujące do fałszywych stron OVHcloud. <anchor>Dowiedz się więcej</anchor>"
+}

--- a/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_pt_PT.json
+++ b/packages/manager/apps/hub-react/public/translations/hub/notifications/Messages_pt_PT.json
@@ -1,0 +1,4 @@
+{
+  "GLOBAL_COMMUNICATION_PHISHING_title": "Informações gerais",
+  "GLOBAL_COMMUNICATION_PHISHING_description": "Circulam e-mails fraudulentos que redirecionam para falsos websites da OVHcloud. <anchor>Mais informações</anchor>"
+}

--- a/packages/manager/apps/hub-react/src/hooks/guides/useGuideUtils.tsx
+++ b/packages/manager/apps/hub-react/src/hooks/guides/useGuideUtils.tsx
@@ -1,0 +1,41 @@
+import { useContext, useEffect, useState } from 'react';
+import { CountryCode } from '@ovh-ux/manager-config';
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+
+type GetGuideLinkProps = {
+  name?: string;
+  subsidiary: CountryCode | string;
+};
+
+function useGuideUtils(
+  guides: Record<string, Partial<Record<CountryCode, string>>>,
+) {
+  const { shell } = useContext(ShellContext);
+  const { environment } = shell;
+  const [list, setList] = useState({});
+
+  const getGuideListLink = ({ subsidiary }: GetGuideLinkProps) => {
+    const keys = Object.keys(guides);
+    return keys.reduce<Record<string, string>>(
+      (links, key: string) => ({
+        ...links,
+        [key]:
+          guides[key][subsidiary as CountryCode] ?? guides[key][CountryCode.GB],
+      }),
+      {} as Record<string, string>,
+    );
+  };
+
+  useEffect(() => {
+    const getSubSidiary = async () => {
+      const env = await environment.getEnvironment();
+      const { ovhSubsidiary } = env.getUser();
+      const guideList = getGuideListLink({ subsidiary: ovhSubsidiary });
+      setList(guideList);
+    };
+    getSubSidiary();
+  }, []);
+  return list as Record<string, string>;
+}
+
+export default useGuideUtils;

--- a/packages/manager/apps/hub-react/src/index.tsx
+++ b/packages/manager/apps/hub-react/src/index.tsx
@@ -48,6 +48,7 @@ const init = async (appName: string) => {
       `${appName}/payment-status`,
       `${appName}/siret`,
       `${appName}/kyc`,
+      `${appName}/notifications`,
       `billing/actions`,
       `billing/status`,
     ],

--- a/packages/manager/apps/hub-react/src/pages/layout/NotificationsCarousel.component.tsx
+++ b/packages/manager/apps/hub-react/src/pages/layout/NotificationsCarousel.component.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   OsdsIcon,
+  OsdsLink,
   OsdsMessage,
   OsdsText,
 } from '@ovhcloud/ods-components/react';
@@ -14,8 +15,12 @@ import {
 } from '@ovhcloud/ods-components';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { useOvhTracking } from '@ovh-ux/manager-react-shell-client';
+import { Trans, useTranslation } from 'react-i18next';
+import { OdsHTMLAnchorElementTarget } from '@ovhcloud/ods-common-core';
 import { useFetchHubNotifications } from '@/data/hooks/notifications/useNotifications';
 import { Notification, NotificationType } from '@/types/notifications.type';
+import useGuideUtils from '@/hooks/guides/useGuideUtils';
+import { NOTIFICATIONS_LINKS } from '@/pages/layout/layout.constants';
 
 const getMessageColor = (type: NotificationType) => {
   switch (type) {
@@ -63,9 +68,11 @@ const getTextColor = (type: NotificationType) => {
 };
 
 export default function NotificationsCarousel() {
+  const { t } = useTranslation('hub/notifications');
   const { trackClick } = useOvhTracking();
   const { data: notifications } = useFetchHubNotifications();
   const [currentIndex, setCurrentIndex] = useState(0);
+  const notificationsLinks = useGuideUtils(NOTIFICATIONS_LINKS);
 
   const showNextNotification = () => {
     setCurrentIndex(
@@ -76,6 +83,10 @@ export default function NotificationsCarousel() {
       actions: ['hub', 'dashboard', 'alert', 'action'],
     });
   };
+
+  const notificationLink =
+    notifications?.[currentIndex] &&
+    notificationsLinks[notifications[currentIndex].id];
 
   return (
     <>
@@ -93,11 +104,19 @@ export default function NotificationsCarousel() {
             level={ODS_TEXT_LEVEL.body}
             size={ODS_TEXT_SIZE._500}
           >
-            <span
-              dangerouslySetInnerHTML={{
-                __html: notifications[currentIndex].description,
+            <Trans
+              t={t}
+              i18nKey={`${notifications[currentIndex].id}_description`}
+              components={{
+                anchor: (
+                  <OsdsLink
+                    href={notificationLink}
+                    color={ODS_THEME_COLOR_INTENT.primary}
+                    target={OdsHTMLAnchorElementTarget._blank}
+                  ></OsdsLink>
+                ),
               }}
-            ></span>
+            ></Trans>
           </OsdsText>
           {notifications?.length > 1 && (
             <>

--- a/packages/manager/apps/hub-react/src/pages/layout/layout.constants.ts
+++ b/packages/manager/apps/hub-react/src/pages/layout/layout.constants.ts
@@ -16,6 +16,47 @@ export const BILLING_SUMMARY_PERIODS_IN_MONTHS = [1, 3, 6];
 
 export const LINK = 'https://billing.us.ovhcloud.com/login';
 
+export const NOTIFICATIONS_LINKS = {
+  GLOBAL_COMMUNICATION_PHISHING: {
+    DE:
+      'https://help.ovhcloud.com/csm/de-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0030035',
+    ES:
+      'https://help.ovhcloud.com/csm/es-es-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043067',
+    IE:
+      'https://help.ovhcloud.com/csm/en-ie-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043341',
+    IT:
+      'https://help.ovhcloud.com/csm/it-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043072',
+    PL:
+      'https://help.ovhcloud.com/csm/pl-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043071',
+    PT:
+      'https://help.ovhcloud.com/csm/pt-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043070',
+    FR:
+      'https://help.ovhcloud.com/csm/fr-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043069',
+    MA:
+      'https://help.ovhcloud.com/csm/fr-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043069',
+    SN:
+      'https://help.ovhcloud.com/csm/fr-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043069',
+    TN:
+      'https://help.ovhcloud.com/csm/fr-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043069',
+    NL:
+      'https://help.ovhcloud.com/csm/en-nl-documentation-account-and-service-management?id=kb_browse_cat&kb_id=7c798fe1551974502d4c6e78b74219bb',
+    GB:
+      'https://help.ovhcloud.com/csm/en-gb-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043064',
+    CA:
+      'https://help.ovhcloud.com/csm/en-ca-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043351',
+    QC:
+      'https://help.ovhcloud.com/csm/fr-ca-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043068',
+    IN:
+      'https://help.ovhcloud.com/csm/asia-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043063',
+    SG:
+      'https://help.ovhcloud.com/csm/en-sg-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043062',
+    ASIA:
+      'https://help.ovhcloud.com/csm/asia-account-scams-fraud-phishing?id=kb_article_view&sysparm_article=KB0043063',
+    US:
+      'https://support.us.ovhcloud.com/hc/en-us/articles/28330641929491-VMware-Cloud-Director-How-to-Use-the-vCD-User-Interface',
+  },
+};
+
 export const KYC_FRAUD_TRACK_IMPRESSION = {
   campaignId: 'kyc-fraud',
   creation: 'notification',
@@ -27,4 +68,5 @@ export default {
   features,
   BILLING_SUMMARY_PERIODS_IN_MONTHS,
   LINK,
+  NOTIFICATIONS_LINKS,
 };

--- a/packages/manager/apps/hub-react/src/setupTests.ts
+++ b/packages/manager/apps/hub-react/src/setupTests.ts
@@ -1,12 +1,17 @@
 import '@testing-library/jest-dom';
 import 'element-internals-polyfill';
 import { vi } from 'vitest';
+import * as i18nextModule from 'react-i18next';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (translationKey: string) => translationKey,
-    i18n: {
-      changeLanguage: () => new Promise(() => {}),
-    },
-  }),
-}));
+vi.mock('react-i18next', async (importOriginal) => {
+  const original: typeof i18nextModule = await importOriginal();
+  return {
+    ...original,
+    useTranslation: () => ({
+      t: (translationKey: string) => translationKey,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    }),
+  };
+});


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-16215
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Stop using translations given by the API to handle it on front side
Make notification link dependant on subsidiary

## Related

<!-- Link dependencies of this PR -->
