### PR TITLE
fix(pci-common): import styles from manager-pci-common

### DIFF
--- a/packages/manager/apps/pci-block-storage/src/main.tsx
+++ b/packages/manager/apps/pci-block-storage/src/main.tsx
@@ -7,6 +7,7 @@ import {
 } from '@ovh-ux/manager-react-shell-client';
 import App from './App';
 
+import '@ovh-ux/manager-pci-common/dist/style.css';
 import './index.css';
 
 import '@/vite-hmr.ts';

--- a/packages/manager/apps/pci-kubernetes/src/main.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/main.tsx
@@ -7,6 +7,7 @@ import {
 } from '@ovh-ux/manager-react-shell-client';
 import App from './App';
 
+import '@ovh-ux/manager-pci-common/dist/style.css';
 import './index.css';
 
 import '@/vite-hmr.ts';

--- a/packages/manager/apps/pci-load-balancer/src/main.tsx
+++ b/packages/manager/apps/pci-load-balancer/src/main.tsx
@@ -7,6 +7,7 @@ import {
 } from '@ovh-ux/manager-react-shell-client';
 import App from './App';
 
+import '@ovh-ux/manager-pci-common/dist/style.css';
 import './index.css';
 
 import '@/vite-hmr.ts';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `release/public-cloud-w50`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-2392
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->
After publishing pci-common library the css files weren't imported by the javascript files so we need to import it manually in projects or find a way to fix the build of pci-common.

Fixing pci-common would take too much time, while only 3 projects are concerned.

## Related

<!-- Link dependencies of this PR -->
