### PR TITLE
feat(mrc): allow useFeatureAvailability query options override

### DIFF
--- a/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.spec.tsx
+++ b/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.spec.tsx
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { useFeatureAvailability } from './useFeatureAvailability';
+
+const wrapper = ({ children }) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+vi.mock('@ovh-ux/manager-core-api', () => ({
+  apiClient: {
+    aapi: {
+      get: vi.fn(),
+    },
+  },
+}));
+
+describe('useFeatureAvailability', () => {
+  it('should fetch data if no options is given', () => {
+    const { result } = renderHook(() => useFeatureAvailability(['test']), {
+      wrapper,
+    });
+    expect(result.current?.isFetching).toBe(true);
+  });
+
+  it('should not fetch data if enabled option is false', () => {
+    const { result } = renderHook(
+      () => useFeatureAvailability(['test'], { enabled: false }),
+      {
+        wrapper,
+      },
+    );
+    expect(result.current?.isFetching).toBe(false);
+  });
+});

--- a/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.ts
+++ b/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.ts
@@ -1,5 +1,9 @@
 import { apiClient, ApiError } from '@ovh-ux/manager-core-api';
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import {
+  DefinedInitialDataOptions,
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
 
 export type UseFeatureAvailabilityResult<T = Record<string, boolean>> =
   UseQueryResult<T, ApiError>;
@@ -34,10 +38,14 @@ export const getFeatureAvailabilityQueryKey = <T extends string[]>(
  */
 export const useFeatureAvailability = <T extends string[]>(
   featureList: [...T],
+  options: Partial<
+    DefinedInitialDataOptions<Record<(typeof featureList)[number], boolean>>
+  > = {},
 ): UseFeatureAvailabilityResult<
   Record<(typeof featureList)[number], boolean>
 > =>
   useQuery<Record<(typeof featureList)[number], boolean>, ApiError>({
+    ...options,
     queryKey: getFeatureAvailabilityQueryKey(featureList),
     queryFn: () => fetchFeatureAvailabilityData(featureList),
   });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `maintenant/manager-react-components-v1.x`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | #14465 
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Add the capability to use custom query option to useFeatureAvailability

## Related

<!-- Link dependencies of this PR -->
