### PR TITLE
fix(hub-react): display error in support tile when api send an error

### DIFF
--- a/packages/manager/apps/hub-react/src/components/hub-support/HubSupport.spec.tsx
+++ b/packages/manager/apps/hub-react/src/components/hub-support/HubSupport.spec.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import {
   render,
   screen,
@@ -7,27 +7,12 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import HubSupport from '@/components/hub-support/HubSupport.component';
 import '@testing-library/jest-dom';
 import { Ticket } from '@/types/support.type';
 
-const { fetch, apiResponse } = vi.hoisted(() => {
-  return {
-    fetch: {
-      isFetched: true,
-      isLoading: false,
-      error: false,
-      refetch: vi.fn(),
-    },
-    apiResponse: {
-      data: {
-        count: 3,
-        data: [],
-      },
-      status: 'OK',
-    },
-  };
+const { refetch } = vi.hoisted(() => {
+  return { refetch: vi.fn() };
 });
 
 vi.mock('../skeletons/Skeletons.component', () => ({
@@ -48,13 +33,15 @@ vi.mock('./hub-support-help/HubSupportHelp.component', () => ({
   HubSupportHelp: () => <div data-testid="hub-support-help"></div>,
 }));
 
+const useFetchMockValue: any = {
+  data: { count: 3, data: [] },
+  isFetched: true,
+  isLoading: false,
+  refetch,
+};
+
 vi.mock('@/data/hooks/apiHubSupport/useHubSupport', () => ({
-  useFetchHubSupport: vi.fn(() => {
-    return {
-      ...fetch,
-      ...apiResponse,
-    };
-  }),
+  useFetchHubSupport: vi.fn(() => useFetchMockValue),
 }));
 
 const mocks = vi.hoisted(() => ({
@@ -69,13 +56,6 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-const queryClient = new QueryClient();
-const renderComponent = (component: ReactNode) => {
-  return render(
-    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,
-  );
-};
-
 vi.mock('@ovh-ux/manager-react-shell-client', () => ({
   ShellContext: React.createContext({
     shell: mocks.shell,
@@ -89,24 +69,11 @@ vi.mock('@ovh-ux/manager-react-shell-client', () => ({
   },
 }));
 
-vi.mock('@ovh-ux/manager-core-api', () => {
-  const get = vi.fn(() => {
-    return Promise.resolve(apiResponse);
-  });
-  return {
-    apiClient: {
-      aapi: {
-        get,
-      },
-    },
-  };
-});
-
 describe('HubSupport Component', () => {
   it('renders correctly with data for EU', async () => {
     mocks.environment.getRegion.mockReturnValue('EU');
 
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     const seeMoreLink = screen.getByText('hub_support_see_more');
     expect(seeMoreLink).toBeInTheDocument();
@@ -126,7 +93,7 @@ describe('HubSupport Component', () => {
   it('renders correctly with data for US', async () => {
     mocks.environment.getRegion.mockReturnValue('US');
 
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     await waitFor(() => {
       const seeMoreLink = screen.getByText('hub_support_see_more');
@@ -142,46 +109,39 @@ describe('HubSupport Component', () => {
   });
 
   it('calls refetch on refresh icon click', async () => {
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     const refreshIcon = screen.getByTestId('refresh-icon');
     expect(refreshIcon).toBeInTheDocument();
-    expect(fetch.refetch).toBeDefined();
+    expect(refetch).toBeDefined();
     await act(() => fireEvent.click(refreshIcon));
-    expect(fetch.refetch).toHaveBeenCalled();
+    expect(refetch).toHaveBeenCalled();
   });
 
   it('displays loading skeleton when isLoading is true', () => {
-    fetch.isLoading = true;
+    useFetchMockValue.isLoading = true;
+    useFetchMockValue.data = undefined;
 
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     const skeleton = screen.getByTestId('tile-skeleton');
     expect(skeleton).toBeInTheDocument();
   });
 
   it('displays HubSupportHelp when there are no tickets and loading is false', () => {
-    fetch.isLoading = false;
-    apiResponse.data.count = 0;
+    useFetchMockValue.isLoading = false;
+    useFetchMockValue.data = { count: 0, data: [] };
 
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     const helpHubSupport = screen.getByTestId('hub-support-help');
     expect(helpHubSupport).toBeInTheDocument();
   });
 
   it('displays TileError when there is an error', () => {
-    fetch.error = true;
+    useFetchMockValue.error = true;
 
-    renderComponent(<HubSupport />);
-
-    const helpHubSupport = screen.getByTestId('tile-error');
-    expect(helpHubSupport).toBeInTheDocument();
-  });
-
-  it('displays TileError when API respond a 200 with an error', () => {
-    apiResponse.status = 'ERROR';
-    renderComponent(<HubSupport />);
+    render(<HubSupport />);
 
     const helpHubSupport = screen.getByTestId('tile-error');
     expect(helpHubSupport).toBeInTheDocument();

--- a/packages/manager/apps/hub-react/src/data/api/apiHubSupport.ts
+++ b/packages/manager/apps/hub-react/src/data/api/apiHubSupport.ts
@@ -1,12 +1,11 @@
 import { aapi } from '@ovh-ux/manager-core-api';
-import { AxiosResponse } from 'axios';
 import { SupportResponse } from '@/types/support.type';
 import { ApiEnvelope } from '@/types/apiEnvelope.type';
 
 export const getHubSupport: (
   cached: boolean,
-) => Promise<AxiosResponse<ApiEnvelope<SupportResponse>>> = (cached: boolean) =>
-  aapi.get(
+) => Promise<ApiEnvelope<SupportResponse>> = async (cached: boolean) => {
+  const { data } = await aapi.get<ApiEnvelope<SupportResponse>>(
     '/hub/support',
     !cached && {
       headers: {
@@ -14,3 +13,8 @@ export const getHubSupport: (
       },
     },
   );
+  if (data?.data?.support?.status === 'ERROR') {
+    throw new Error();
+  }
+  return data;
+};

--- a/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.spec.tsx
+++ b/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.spec.tsx
@@ -1,7 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { AxiosResponse } from 'axios';
 import { describe, it, vi } from 'vitest';
 import { useFetchHubSupport } from '@/data/hooks/apiHubSupport/useHubSupport';
 import { SupportResponse } from '@/types/support.type';

--- a/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.spec.tsx
+++ b/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.spec.tsx
@@ -29,8 +29,9 @@ describe('useFetchHubSupport', () => {
       .spyOn(hubSupportApi, 'getHubSupport')
       .mockReturnValue(
         Promise.resolve({
-          data: { data: supportDataResponse, status: 'OK' },
-        } as AxiosResponse),
+          data: supportDataResponse,
+          status: 'OK',
+        }),
       );
 
     const { result } = renderHook(() => useFetchHubSupport(), {
@@ -52,8 +53,9 @@ describe('useFetchHubSupport', () => {
       .spyOn(hubSupportApi, 'getHubSupport')
       .mockReturnValue(
         Promise.resolve({
-          data: { data: supportDataResponse, status: 'OK' },
-        } as AxiosResponse),
+          data: supportDataResponse,
+          status: 'OK',
+        }),
       );
 
     const { result } = renderHook(() => useFetchHubSupport(), {

--- a/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.tsx
+++ b/packages/manager/apps/hub-react/src/data/hooks/apiHubSupport/useHubSupport.tsx
@@ -1,13 +1,10 @@
 import { DefinedInitialDataOptions, useQuery } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import { SupportDataResponse, SupportResponse } from '@/types/support.type';
 import { getHubSupport } from '@/data/api/apiHubSupport';
 import queryClient from '@/queryClient';
 import { ApiEnvelope } from '@/types/apiEnvelope.type';
 
 const queryKey = ['get-hub-support'];
-
-type ApiResponse = AxiosResponse<ApiEnvelope<SupportResponse>>;
 
 const DEFAULT_RESULT: SupportDataResponse = {
   data: [],
@@ -16,7 +13,11 @@ const DEFAULT_RESULT: SupportDataResponse = {
 
 export const useFetchHubSupport = (
   options?: Partial<
-    DefinedInitialDataOptions<ApiResponse, any, SupportDataResponse>
+    DefinedInitialDataOptions<
+      ApiEnvelope<SupportResponse>,
+      any,
+      SupportDataResponse
+    >
   >,
 ) =>
   useQuery({
@@ -25,7 +26,7 @@ export const useFetchHubSupport = (
       const hasBeenFetched = Boolean(queryClient.getQueryData(queryKey));
       return getHubSupport(!hasBeenFetched);
     },
-    select: ({ data }: ApiResponse) =>
-      data?.data?.support?.data ?? DEFAULT_RESULT,
+    select: ({ data }: ApiEnvelope<SupportResponse>) =>
+      data?.support?.data ?? DEFAULT_RESULT,
     ...(options ?? {}),
   });


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-16529
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Handle the case where /hub/support API send a 200 but with an error inside, so we display an error message to the customer instead of a blank tile

## Related

<!-- Link dependencies of this PR -->
