### PR TITLE
feat(container): always show tour after user chooses cookies

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/onboarding/introduction.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/onboarding/introduction.tsx
@@ -66,7 +66,7 @@ export const OnboardingIntroduction = () => {
 
   useClickAway(ref, () => {
     productNavReshuffle.reduceOnboarding();
-  });
+  }, ['click']);
 
   useEffect(() => {
     if (isPopoverVisible) {

--- a/packages/manager/apps/container/src/cookie-policy/CookiePolicy.tsx
+++ b/packages/manager/apps/container/src/cookie-policy/CookiePolicy.tsx
@@ -85,7 +85,7 @@ const CookiePolicy = ({ shell, onValidate }: Props): JSX.Element => {
   return (
     <>
       {show && (
-        <OsdsModal dismissible={false}>
+        <OsdsModal dismissible={false} onClick={(e) => e.stopPropagation()}>
           <div className="p-1">
             <div className="w-full flex justify-center items-center">
               <img src={ovhCloudLogo} alt="ovh-cloud-logo" />


### PR DESCRIPTION
ref: MANAGER-15595

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15595
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

PNRV2: Ensures the guided tour popover appears even after the user accepts or declines the cookie policy

old pr link : https://github.com/ovh/manager/pull/13746

## Related

<!-- Link dependencies of this PR -->
