### PR TITLE
fix(web.exchange): add veeam backup guide link for private

### DIFF
--- a/packages/manager/modules/exchange/src/dashboard/exchange.constants.js
+++ b/packages/manager/modules/exchange/src/dashboard/exchange.constants.js
@@ -44,6 +44,34 @@ export const EXCHANGE_CONFIG_URL = {
 export const EXCHANGE_CONFIG = {
   URLS: {
     GUIDES: {
+      BACKUP: {
+        FR:
+          'https://help.ovhcloud.com/csm/fr-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065635',
+        ES:
+          'https://help.ovhcloud.com/csm/es-es-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065716',
+        DE:
+          'https://help.ovhcloud.com/csm/de-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065715',
+        IE:
+          'https://help.ovhcloud.com/csm/en-ie-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065713',
+        IT:
+          'https://help.ovhcloud.com/csm/it-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065718',
+        PL:
+          'https://help.ovhcloud.com/csm/pl-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065717',
+        PT:
+          'https://help.ovhcloud.com/csm/pt-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065714',
+        GB:
+          'https://help.ovhcloud.com/csm/en-gb-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065712',
+        MA:
+          'https://help.ovhcloud.com/csm/fr-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065635',
+        SN:
+          'https://help.ovhcloud.com/csm/fr-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065635',
+        TN:
+          'https://help.ovhcloud.com/csm/fr-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065635',
+        WE:
+          'https://help.ovhcloud.com/csm/en-ie-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065713',
+        DEFAULT:
+          'https://help.ovhcloud.com/csm/en-ie-exchange-veeam-backup?id=kb_article_view&sysparm_article=KB0065713',
+      },
       RESOURCES: {
         CA: '',
         CZ: '',

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_de_DE.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "Der Bestellschein wurde erfolgreich erstellt. Ihre Bestellung wird bearbeitet.",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "Bitte beachten Sie, dass die Erstellung des Accounts etwa 10 Minuten in Anspruch nimmt.",
   "exchange_tab_RESOURCES_add_resource_company": "Unternehmen",
-  "exchange_GROUPS_add_group_company_label": "Unternehmen"
+  "exchange_GROUPS_add_group_company_label": "Unternehmen",
+  "exchange_tab_INFORMATIONS_backup": "Backup",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "E-Mail-Accounts sichern"
 }

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_en_GB.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "The purchase order has been generated. Your order is being processed.",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "It will take around 10 minutes to set up your account.",
   "exchange_tab_RESOURCES_add_resource_company": "Company",
-  "exchange_GROUPS_add_group_company_label": "Company"
+  "exchange_GROUPS_add_group_company_label": "Company",
+  "exchange_tab_INFORMATIONS_backup": "Backup",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Backing up your email accounts"
 }

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_es_ES.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "La orden de pedido se ha generado correctamente. El pedido se está procesando.",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "La cuenta tardará aproximadamente unos 10 minutos en terminar de crearse.",
   "exchange_tab_RESOURCES_add_resource_company": "Empresa",
-  "exchange_GROUPS_add_group_company_label": "Empresa"
+  "exchange_GROUPS_add_group_company_label": "Empresa",
+  "exchange_tab_INFORMATIONS_backup": "Copia de seguridad",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Guardar una copia de seguridad de sus cuentas de correo"
 }

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_CA.json
@@ -99,6 +99,8 @@
   "exchange_tab_INFORMATIONS_stats": "Statistiques",
   "exchange_tab_INFORMATIONS_server": "Serveur",
   "exchange_tab_INFORMATIONS_connexion": "Connexion",
+  "exchange_tab_INFORMATIONS_backup": "Sauvegarde",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Sauvegarder ses comptes e-mail",
   "exchange_tab_INFORMATIONS_sharepoint": "SharePoint associé",
   "exchange_tab_INFORMATIONS_sharepoint_url": "URL consultation",
   "exchange_tab_INFORMATIONS_wait_activation": "En attente d'activation",

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
@@ -99,6 +99,8 @@
   "exchange_tab_INFORMATIONS_stats": "Statistiques",
   "exchange_tab_INFORMATIONS_server": "Serveur",
   "exchange_tab_INFORMATIONS_connexion": "Connexion",
+  "exchange_tab_INFORMATIONS_backup": "Sauvegarde",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Sauvegarder ses comptes e-mail",
   "exchange_tab_INFORMATIONS_sharepoint": "SharePoint associé",
   "exchange_tab_INFORMATIONS_sharepoint_url": "URL consultation",
   "exchange_tab_INFORMATIONS_wait_activation": "En attente d'activation",

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_it_IT.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "L’ordine è stato generato correttamente Elaborazione dell'ordine in corso...",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "Ti ricordiamo che la creazione dell'account richiederà circa 10 minuti.",
   "exchange_tab_RESOURCES_add_resource_company": "Società",
-  "exchange_GROUPS_add_group_company_label": "Società"
+  "exchange_GROUPS_add_group_company_label": "Società",
+  "exchange_tab_INFORMATIONS_backup": "Backup",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Effettuare il backup dei tuoi account email"
 }

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_pl_PL.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "Zamówienie zostało wygenerowane. Trwa przetwarzanie Twojego zamówienia.",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "Utworzenie konta zajmie około 10 minut.",
   "exchange_tab_RESOURCES_add_resource_company": "Firma",
-  "exchange_GROUPS_add_group_company_label": "Firma"
+  "exchange_GROUPS_add_group_company_label": "Firma",
+  "exchange_tab_INFORMATIONS_backup": "Kopie zapasowe",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Tworzenie kopii zapasowych kont e-mail"
 }

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_pt_PT.json
@@ -1689,5 +1689,7 @@
   "exchange_ACTION_order_accounts_step3_bc_ovhtel": "A nota de encomenda foi gerada com sucesso. A sua encomenda está a ser tratada.",
   "exchange_ACTION_order_accounts_step3_explication_ovhtel": "Tenha em conta que é necessário aguardar cerca de 10 minutos para que a conta seja criada.",
   "exchange_tab_RESOURCES_add_resource_company": "Empresa",
-  "exchange_GROUPS_add_group_company_label": "Empresa"
+  "exchange_GROUPS_add_group_company_label": "Empresa",
+  "exchange_tab_INFORMATIONS_backup": "Backup",
+  "exchange_tab_INFORMATIONS_backup_guide_title": "Fazer o backup das contas de e-mail"
 }

--- a/packages/manager/modules/exchange/src/information/information.controller.js
+++ b/packages/manager/modules/exchange/src/information/information.controller.js
@@ -63,6 +63,9 @@ export default class ExchangeTabInformationCtrl {
           this.displayGuides = this.EXCHANGE_CONFIG.URLS.GUIDES.DOCS_HOME[
             data.ovhSubsidiary
           ];
+          this.backupGuideUrl =
+            this.EXCHANGE_CONFIG.URLS.GUIDES.BACKUP[data.ovhSubsidiary] ||
+            this.EXCHANGE_CONFIG.URLS.GUIDES.BACKUP.DEFAULT;
         } catch (exception) {
           this.displayGuides = null;
         }
@@ -274,5 +277,12 @@ export default class ExchangeTabInformationCtrl {
     )} / ${this.exchange.totalDiskSize.value} ${this.$translate.instant(
       `unit_size_${this.exchange.totalDiskSize.unit}`,
     )}`;
+  }
+
+  canVeeamBackup() {
+    return (
+      this.exchangeServiceInfrastructure.isDedicated() ||
+      this.exchangeServiceInfrastructure.isDedicatedCluster()
+    );
   }
 }

--- a/packages/manager/modules/exchange/src/information/information.html
+++ b/packages/manager/modules/exchange/src/information/information.html
@@ -243,7 +243,7 @@
                 >
                     <oui-tile-description>
                         <a
-                            class="oui-link"
+                            class="oui-link_icon"
                             data-ng-href="{{ctrl.displayGuides}}"
                             target="_blank"
                             rel="noopener"
@@ -256,7 +256,32 @@
                                 data-translate="exchange_dashboard_guides_url"
                             ></span>
                             <span
-                                class="fa fa-external-link"
+                                class="oui-icon oui-icon-external-link"
+                                aria-hidden="true"
+                            ></span>
+                        </a>
+                    </oui-tile-description>
+                </oui-tile-definition>
+            </oui-tile>
+
+            <oui-tile
+                class="h-100 mb-5"
+                data-ng-if=":: ctrl.canVeeamBackup()"
+                data-heading="{{ :: 'exchange_tab_INFORMATIONS_backup' | translate }}"
+            >
+                <oui-tile-definition>
+                    <oui-tile-description class="pt-2">
+                        <a
+                            class="oui-link_icon"
+                            data-ng-href="{{ ctrl.backupGuideUrl }}"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            <span
+                                data-translate="exchange_tab_INFORMATIONS_backup_guide_title"
+                            ></span>
+                            <span
+                                class="oui-icon oui-icon-external-link"
                                 aria-hidden="true"
                             ></span>
                         </a>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `master` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-15461 <!-- prefix each issue number with "Fix #", if any -->
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description
I added a tile with veeam backup guide link for private exchange
<!-- Write a brief description of the changes introduced by this PR -->

## Related
:flags: Translations:
- [x] CMT-20239
<!-- Link dependencies of this PR -->
