### PR TITLE
feat(telecom): add the outbound proxy on sip account informations

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/details/details.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/details/details.html
@@ -231,6 +231,12 @@
                     <dt data-translate="telephony_line_details_sip_domain"></dt>
                     <dd data-ng-bind="::$ctrl.line.options.domain || '-'"></dd>
 
+                    <!-- OUTBOUND PROXY -->
+                    <dt
+                        data-translate="telephony_line_details_sip_outbound_proxy"
+                    ></dt>
+                    <dd data-ng-bind="::$ctrl.line.options.proxy || '-'"></dd>
+
                     <!-- INFRA -->
                     <dt data-translate="telephony_line_details_sip_infra"></dt>
                     <dd data-ng-bind="::$ctrl.line.infrastructure || '-'"></dd>

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/line/details/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/line/details/translations/Messages_fr_FR.json
@@ -27,6 +27,7 @@
   "telephony_line_details_sip_login": "Login / User name",
   "telephony_line_details_sip_auth_login": "Authorization user name",
   "telephony_line_details_sip_domain": "Domain / Registrar",
+  "telephony_line_details_sip_outbound_proxy": "Proxy sortant",
   "telephony_line_details_sip_infra": "Infrastructure",
   "telephony_line_details_sip_last_rec": "Date du dernier enregistrement",
   "telephony_line_details_sip_last_rec_info": "Un enregistrement sur le réseau est valable durant une heure.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | -
| License          | BSD 3-Clause

- [X] Try to keep pull requests small so they can be easily reviewed.
- [X] Commits are signed-off
- [X] Only FR translations have been updated
- [X] Branch is up-to-date with target branch
- [X] Lint has passed locally
- [X] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

A field has been added on the api for a few weeks to display the outbound proxy used by the sip account, this change adds it to the manager