### PR TITLE
test(container): add test for tracking init in cookie policy modal

### DIFF
--- a/packages/manager/apps/container/src/cookie-policy/CookiePolicy.spec.tsx
+++ b/packages/manager/apps/container/src/cookie-policy/CookiePolicy.spec.tsx
@@ -1,0 +1,92 @@
+import { render, waitFor } from '@testing-library/react';
+import { it, vi, describe, expect } from 'vitest';
+import { initShell } from '@ovh-ux/shell';
+import CookiePolicy from './CookiePolicy';
+import { Environment, User } from '@ovh-ux/manager-config';
+import ApplicationContext from '@/context/application.context';
+import { useCookies } from 'react-cookie';
+
+const onValidate = vi.fn();
+const trackingInit = vi.fn().mockResolvedValue(undefined);
+const trackingSetEnabled = vi.fn().mockResolvedValue(undefined);
+const trackingOnConsentModalDisplay = vi.fn().mockResolvedValue(undefined);
+
+const renderCookiePolicy = async () => {
+  const shell = await initShell();
+  const environment = shell.getPlugin('environment').getEnvironment();
+  render(
+    <ApplicationContext.Provider value={{ shell, environment }}>
+      <CookiePolicy onValidate={onValidate} shell={shell} />
+    </ApplicationContext.Provider>
+  );
+};
+
+const mockedShell = (region: string) => ({
+  getPlugin: (plugin: string) => ({
+    environment: {
+      getEnvironment: () => ({
+        user: {
+          ovhSubsidiary: region,
+        } as User,
+        getRegion: () => region,
+      } as Environment),
+    },
+    tracking: {
+      setRegion: vi.fn(),
+      init: trackingInit,
+      setEnabled: trackingSetEnabled,
+      onConsentModalDisplay: trackingOnConsentModalDisplay,
+    },
+  }[plugin]),
+});
+
+vi.mock('@ovh-ux/shell');
+vi.mock('react-cookie');
+
+
+describe('CookiePolicy.component', () => {
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['EU', 'valid'],
+    ['US', 'invalid'],
+  ])('should init tracking if region is %s and cookie is %s', async (region, cookieValidity) => {
+
+    const cookieValue = cookieValidity === 'valid' ? '1' : '0';
+    vi.mocked(useCookies).mockReturnValue([{ MANAGER_TRACKING: cookieValue, }, vi.fn(), vi.fn()]);
+    (await import('@ovh-ux/shell')).initShell = vi.fn().mockResolvedValue(mockedShell(region));
+    void renderCookiePolicy();
+    await waitFor(() => {
+      expect(trackingInit).toHaveBeenCalledWith(true);
+      expect(trackingSetEnabled).not.toHaveBeenCalled();
+      expect(trackingOnConsentModalDisplay).not.toHaveBeenCalled();
+    }, { timeout: 2000 });
+  });
+
+  it('should show consent modal if cookie is null and region is not US', async () => {
+
+    vi.mocked(useCookies).mockReturnValue([{ MANAGER_TRACKING: null, }, vi.fn(), vi.fn()]);
+    (await import('@ovh-ux/shell')).initShell = vi.fn().mockResolvedValue(mockedShell('EU'));
+    void renderCookiePolicy();
+    await waitFor(() => {
+      expect(trackingInit).not.toHaveBeenCalled();
+      expect(trackingSetEnabled).not.toHaveBeenCalled();
+      expect(trackingOnConsentModalDisplay).toHaveBeenCalled();
+    }, { timeout: 2000 });
+  });
+
+  it('should disable tracking plugin if cookie is invalid and region is not US', async () => {
+
+    vi.mocked(useCookies).mockReturnValue([{ MANAGER_TRACKING: '0', }, vi.fn(), vi.fn()]);
+    (await import('@ovh-ux/shell')).initShell = vi.fn().mockResolvedValue(mockedShell('EU'));
+    void renderCookiePolicy();
+    await waitFor(() => {
+      expect(trackingInit).not.toHaveBeenCalled();
+      expect(trackingSetEnabled).toHaveBeenCalledWith(false);
+      expect(trackingOnConsentModalDisplay).not.toHaveBeenCalled();
+    }, { timeout: 2000 });
+  });
+});


### PR DESCRIPTION
ref: MANAGER-16559

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-16559
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [ ] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Testing the tracking plugins behavior (and it's initialization) depending on the customers region and tracking cookie value.

## Related

<!-- Link dependencies of this PR -->
