### PR TITLE
fix(billing): fix redirection to autorenew activation modal

### DIFF
--- a/packages/manager/modules/new-billing/src/autoRenew/autorenew.html
+++ b/packages/manager/modules/new-billing/src/autoRenew/autorenew.html
@@ -55,7 +55,7 @@
             data-ng-if="!$ctrl.defaultPaymentMean"
             data-translate="billing_autorenew_service_renew_requires_mean_and_date"
         ></p>
-        <p data-ng-if="$ctrl.defaultPaymentMean && !nicRenew.active">
+        <p data-ng-if="$ctrl.defaultPaymentMean && !$ctrl.nicRenew.active">
             <span data-ng-if="$ctrl.choiceRenewDayTooltipAvailable">
                 <span
                     data-translate="billing_autorenew_service_activate_alert_renew2016"
@@ -69,7 +69,6 @@
                 data-ng-href="{{:: $ctrl.activationLink }}"
                 class="oui-link"
                 data-translate="billing_autorenew_service_enable_autorenew"
-                target="_top"
             >
             </a>
         </p>


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-16764
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Removed target on automatic renewal activation modal link, in order to be redirected to the correct page
Fixed the condition to display the invitation to activate the automatic renewal

## Related

<!-- Link dependencies of this PR -->
