### PR TITLE
fix(pci-object-storage): sticky discovery banner

### DIFF
--- a/packages/manager/apps/pci-object-storage/src/pages/objects/container/new/New.page.tsx
+++ b/packages/manager/apps/pci-object-storage/src/pages/objects/container/new/New.page.tsx
@@ -138,7 +138,7 @@ export default function ContainerNewPage() {
         />
       </div>
 
-      <div className="my-6">
+      <div className="mb-5 sticky top-0 z-50">
         <PciDiscoveryBanner project={project} />
       </div>
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-object-storage
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-2992
| License          | BSD 3-Clause

## Description

make discovery banner sticky