### PR TITLE
fix(manager-pci-common): pci modal cancel button

### DIFF
--- a/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/modal/PciModal.component.tsx
@@ -60,7 +60,7 @@ export function PciModal({
           color="primary"
           variant="ghost"
           onClick={onCancel}
-          isDisabled={isDisabled}
+          isDisabled={isPending}
           slot="actions"
           data-testid="pciModal-button_cancel"
         />
@@ -68,7 +68,7 @@ export function PciModal({
           label={submitText || t('common_confirm')}
           color="primary"
           onClick={onConfirm}
-          isDisabled={isDisabled}
+          isDisabled={isDisabled || isPending}
           slot="actions"
           data-testid="pciModal-button_submit"
         />

--- a/packages/manager/modules/manager-pci-common/src/components/modal/deletion-modal/DeletionModal.component.spec.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/modal/deletion-modal/DeletionModal.component.spec.tsx
@@ -61,8 +61,9 @@ describe('DeletionModal', () => {
         value: 'CONFIRM',
       } as OdsInputChangeEventDetail);
     });
-    expect(getByTestId('pciModal-button_submit')).not.toHaveAttribute(
+    expect(getByTestId('pciModal-button_submit')).toHaveAttribute(
       'is-disabled',
+      'false',
     );
   });
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-object-storage
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-3000
| License          | BSD 3-Clause

## Description

fix pci modal disabled buttons