### PR TITLE
feat(mrc): add order config/summary component

### DIFF
--- a/packages/manager-react-components/src/components/index.ts
+++ b/packages/manager-react-components/src/components/index.ts
@@ -28,3 +28,4 @@ export * from './ManagerText/ManagerText';
 
 export * from './pci-maintenance-banner';
 export * from './region/region.component';
+export * from './order';

--- a/packages/manager-react-components/src/components/order/Order.component.spec.tsx
+++ b/packages/manager-react-components/src/components/order/Order.component.spec.tsx
@@ -1,0 +1,130 @@
+import React, { fireEvent } from '@testing-library/react';
+import { vi, vitest } from 'vitest';
+import { Order } from './Order.component';
+import { render } from '../../utils/test.provider';
+
+describe('<Order> tests suite', () => {
+  // Mock global window.open
+  vi.stubGlobal('open', vi.fn());
+
+  const onCancelSpy = vi.fn();
+  const onValidateSpy = vi.fn();
+  const onFinishSpy = vi.fn();
+  const onClickLinkSpy = vi.fn();
+  const orderLink = 'https://order-link';
+
+  afterEach(() => {
+    vitest.resetAllMocks();
+  });
+
+  const renderComponent = (
+    isValid: boolean,
+    link: string,
+    productName: string,
+  ) =>
+    render(
+      <Order>
+        <Order.Configuration
+          isValid={isValid}
+          onCancel={onCancelSpy}
+          onConfirm={onValidateSpy}
+        >
+          <p>Order steps</p>
+        </Order.Configuration>
+        <Order.Summary
+          onFinish={onFinishSpy}
+          orderLink={link}
+          onClickLink={onClickLinkSpy}
+          productName={productName}
+        ></Order.Summary>
+      </Order>,
+    );
+
+  it.each([{ valid: true }, { valid: false }])(
+    'when order configuration validity is $valid confirm button disabled attribute should be $valid',
+    ({ valid }) => {
+      const { getByTestId, getByText } = renderComponent(valid, null, null);
+
+      expect(getByText('Order steps')).toBeVisible();
+
+      const orderButton = getByTestId('cta-order-configuration-order');
+      expect(orderButton).toHaveAttribute('label', 'Commander');
+      expect(orderButton).toHaveAttribute('is-disabled', `${!valid}`);
+    },
+  );
+
+  it('confirm button should be enabled and clickable when order configuration is valid', () => {
+    const { getByTestId } = renderComponent(true, null, null);
+
+    fireEvent.click(getByTestId('cta-order-configuration-order'));
+
+    expect(onValidateSpy).toHaveBeenCalled();
+  });
+
+  it('should cancel order configuration when cancel button is clicked', () => {
+    const { getByTestId } = renderComponent(false, null, null);
+
+    fireEvent.click(getByTestId('cta-order-configuration-cancel'));
+
+    expect(onCancelSpy).toHaveBeenCalled();
+  });
+
+  it('should open order link and display order summary when order configuration is confirmed ', () => {
+    vi.spyOn(window, 'open');
+    const { getByTestId, queryByText } = renderComponent(true, orderLink, null);
+
+    fireEvent.click(getByTestId('cta-order-configuration-order'));
+
+    // order configuration is hidden
+    expect(queryByText('Order steps')).not.toBeInTheDocument();
+
+    expect(getByTestId('order-summary-title')).toBeVisible();
+    expect(getByTestId('order-summary-link')).toBeVisible();
+
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(
+      orderLink,
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('should open order link when order link is clicked', () => {
+    vi.spyOn(window, 'open');
+    const { getByTestId } = renderComponent(true, orderLink, null);
+
+    fireEvent.click(getByTestId('cta-order-configuration-order'));
+    fireEvent.click(getByTestId('order-summary-link'));
+
+    expect(onClickLinkSpy).toHaveBeenCalled();
+  });
+
+  it('should close order summary when finish button is clicked', () => {
+    vi.spyOn(window, 'open');
+    const { getByTestId } = renderComponent(true, orderLink, null);
+
+    fireEvent.click(getByTestId('cta-order-configuration-order'));
+    fireEvent.click(getByTestId('cta-order-summary-finish'));
+
+    expect(onFinishSpy).toHaveBeenCalled();
+    expect(getByTestId('cta-order-configuration-order')).toBeVisible();
+  });
+
+  it.each([{ productName: '' }, { productName: 'OVHcloud product' }])(
+    'should display given product name with value $productName',
+    ({ productName }) => {
+      vi.spyOn(window, 'open');
+      const { getByTestId, getByText } = renderComponent(
+        true,
+        orderLink,
+        productName,
+      );
+
+      fireEvent.click(getByTestId('cta-order-configuration-order'));
+      fireEvent.click(getByTestId('order-summary-link'));
+
+      const product = productName || 'service';
+      expect(getByText(`Commande de votre ${product} initiée`)).toBeVisible();
+    },
+  );
+});

--- a/packages/manager-react-components/src/components/order/Order.component.tsx
+++ b/packages/manager-react-components/src/components/order/Order.component.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+import { OrderContextProvider } from './Order.context';
+import { OrderConfiguration } from './OrderConfiguration.component';
+import { OrderSummary } from './OrderSummary.component';
+import './translations';
+
+export const Order = ({ children }: PropsWithChildren) => {
+  return <OrderContextProvider>{children}</OrderContextProvider>;
+};
+
+Order.Configuration = OrderConfiguration;
+Order.Summary = OrderSummary;

--- a/packages/manager-react-components/src/components/order/Order.context.tsx
+++ b/packages/manager-react-components/src/components/order/Order.context.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+export type TOrderContext = {
+  setIsOrderInitialized: (isOrderInitialized: boolean) => void;
+  isOrderInitialized: boolean;
+};
+
+const OrderContext = createContext<TOrderContext>({} as TOrderContext);
+
+export const OrderContextProvider = ({ children }: React.PropsWithChildren) => {
+  const [isOrderInitialized, setIsOrderInitialized] = useState<boolean>(false);
+
+  const context = useMemo<TOrderContext>(
+    () => ({
+      isOrderInitialized,
+      setIsOrderInitialized,
+    }),
+    [isOrderInitialized],
+  );
+
+  return (
+    <OrderContext.Provider value={context}>{children}</OrderContext.Provider>
+  );
+};
+
+export const useOrderContext = (): TOrderContext => {
+  const context = useContext(OrderContext);
+  if (context === undefined) {
+    throw new Error('Order-related components must be used within <Order>');
+  }
+  return context;
+};

--- a/packages/manager-react-components/src/components/order/Order.stories.tsx
+++ b/packages/manager-react-components/src/components/order/Order.stories.tsx
@@ -1,0 +1,57 @@
+import React, { ComponentType } from 'react';
+
+import { OdsText } from '@ovhcloud/ods-components/react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Order } from './Order.component';
+
+function renderComponent(args) {
+  return (
+    <Order>
+      <Order.Configuration
+        onCancel={args.onCancel}
+        onConfirm={args.onConfirm}
+        isValid={args.isValid}
+      >
+        <p>
+          <OdsText preset="code" className="italic">
+            ...|order configuration steps| ...
+          </OdsText>
+        </p>
+      </Order.Configuration>
+      <Order.Summary
+        onFinish={args.onFinish}
+        orderLink={args.orderLink}
+        onClickLink={args.onClickLink}
+        productName={args.productName}
+      ></Order.Summary>
+    </Order>
+  );
+}
+
+type Story = StoryObj<typeof Order> &
+  StoryObj<typeof Order.Configuration> &
+  StoryObj<typeof Order.Summary>;
+
+export const DemoOrder: Story = {
+  args: {
+    isValid: true,
+    orderLink: 'https://www.ovh.com',
+    productName: '',
+    onCancel: () => {},
+    onConfirm: () => {},
+    onFinish: () => {},
+    onClickLink: () => {},
+  },
+  render: renderComponent,
+};
+
+const meta: Meta = {
+  title: 'Components/Order',
+  component: Order,
+  subcomponents: {
+    'Order.Summary': Order.Summary as ComponentType<unknown>,
+    'Order.Configuration': Order.Configuration as ComponentType<unknown>,
+  },
+};
+
+export default meta;

--- a/packages/manager-react-components/src/components/order/OrderConfiguration.component.tsx
+++ b/packages/manager-react-components/src/components/order/OrderConfiguration.component.tsx
@@ -1,0 +1,61 @@
+import {
+  ODS_BUTTON_COLOR,
+  ODS_BUTTON_ICON_ALIGNMENT,
+  ODS_BUTTON_SIZE,
+  ODS_BUTTON_VARIANT,
+  ODS_ICON_NAME,
+} from '@ovhcloud/ods-components';
+import { OdsButton } from '@ovhcloud/ods-components/react';
+import React, { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useOrderContext } from './Order.context';
+
+export type TOrderConfiguration = {
+  children: ReactNode;
+  onCancel: () => void;
+  onConfirm: () => void;
+  isValid: boolean;
+};
+
+export const OrderConfiguration: React.FC<TOrderConfiguration> = ({
+  children,
+  onCancel,
+  onConfirm,
+  isValid,
+}: TOrderConfiguration): JSX.Element => {
+  const { isOrderInitialized, setIsOrderInitialized } = useOrderContext();
+  const { t } = useTranslation('order');
+
+  if (isOrderInitialized) {
+    return <></>;
+  }
+
+  return (
+    <>
+      {children}
+      <div className="flex flex-row gap-4">
+        <OdsButton
+          size={ODS_BUTTON_SIZE.md}
+          variant={ODS_BUTTON_VARIANT.ghost}
+          color={ODS_BUTTON_COLOR.primary}
+          onClick={onCancel}
+          label={t('order_configuration_cancel')}
+          data-testid="cta-order-configuration-cancel"
+        />
+        <OdsButton
+          size={ODS_BUTTON_SIZE.md}
+          color={ODS_BUTTON_COLOR.primary}
+          isDisabled={!isValid}
+          onClick={() => {
+            onConfirm();
+            setIsOrderInitialized(true);
+          }}
+          icon={ODS_ICON_NAME.externalLink}
+          iconAlignment={ODS_BUTTON_ICON_ALIGNMENT.left}
+          label={t('order_configuration_order')}
+          data-testid="cta-order-configuration-order"
+        />
+      </div>
+    </>
+  );
+};

--- a/packages/manager-react-components/src/components/order/OrderSummary.component.tsx
+++ b/packages/manager-react-components/src/components/order/OrderSummary.component.tsx
@@ -1,0 +1,83 @@
+import {
+  ODS_BUTTON_COLOR,
+  ODS_BUTTON_SIZE,
+  ODS_TEXT_PRESET,
+} from '@ovhcloud/ods-components';
+import { OdsButton, OdsText } from '@ovhcloud/ods-components/react';
+import { Trans, useTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { Links, LinkType } from '../typography';
+import { useOrderContext } from './Order.context';
+
+export type TOrderSummary = {
+  onFinish: () => void;
+  onClickLink?: () => void;
+  orderLink: string;
+  productName?: string;
+};
+
+export const OrderSummary: React.FC<TOrderSummary> = ({
+  onFinish,
+  onClickLink,
+  orderLink,
+  productName,
+}: TOrderSummary): JSX.Element => {
+  const { t } = useTranslation('order');
+  const { isOrderInitialized, setIsOrderInitialized } = useOrderContext();
+
+  useEffect(() => {
+    if (orderLink && isOrderInitialized) {
+      window.open(orderLink, '_blank', 'noopener,noreferrer');
+    }
+  }, [orderLink, isOrderInitialized]);
+
+  if (!isOrderInitialized) {
+    return <></>;
+  }
+
+  // set default label if no product name provided
+  const product = productName || t('order_summary_product_default_label');
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        <OdsText
+          preset={ODS_TEXT_PRESET.heading2}
+          data-testid="order-summary-title"
+        >
+          {t('order_summary_order_initiated_title', { product })}
+        </OdsText>
+        <OdsText preset={ODS_TEXT_PRESET.paragraph}>
+          <Trans
+            t={t}
+            i18nKey="order_summary_order_initiated_subtitle"
+            components={{
+              OrderLink: (
+                <Links
+                  type={LinkType.external}
+                  target="_blank"
+                  href={orderLink}
+                  data-testid="order-summary-link"
+                  onClickReturn={onClickLink}
+                />
+              ),
+            }}
+          ></Trans>
+        </OdsText>
+        <OdsText preset={ODS_TEXT_PRESET.paragraph}>
+          {t('order_summary_order_initiated_info', { product })}
+        </OdsText>
+      </div>
+      <OdsButton
+        size={ODS_BUTTON_SIZE.md}
+        color={ODS_BUTTON_COLOR.primary}
+        data-testid="cta-order-summary-finish"
+        onClick={() => {
+          onFinish();
+          setIsOrderInitialized(false);
+        }}
+        label={t('order_summary_finish')}
+      />
+    </div>
+  );
+};

--- a/packages/manager-react-components/src/components/order/index.ts
+++ b/packages/manager-react-components/src/components/order/index.ts
@@ -1,0 +1,2 @@
+export * from './Order.component';
+export { useOrderContext } from './Order.context';

--- a/packages/manager-react-components/src/components/order/translations/Messages_de_DE.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_de_DE.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Abbrechen",
+  "order_configuration_order": "Bestellen",
+  "order_summary_finish": "Beenden",
+  "order_summary_product_default_label": "Dienst",
+  "order_summary_order_initiated_title": "Bestellung Ihres {{product}} initiiert",
+  "order_summary_order_initiated_subtitle": "Wenn Sie Ihre Bestellung nicht abschließen konnten, füllen Sie bitte diese aus, indem Sie auf den <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Wir werden Sie per E-Mail über die Verfügbarkeit Ihres {{product}} informieren."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_en_GB.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_en_GB.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Cancel",
+  "order_configuration_order": "Order now",
+  "order_summary_finish": "Finish",
+  "order_summary_product_default_label": "service",
+  "order_summary_order_initiated_title": "Order for your {{product}} initiated",
+  "order_summary_order_initiated_subtitle": "If you were unable to complete your order, please complete it by clicking on the <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "We will notify you of the availability of your {{product}} by email."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_es_ES.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_es_ES.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Cancelar",
+  "order_configuration_order": "Contratar",
+  "order_summary_finish": "Finalizar",
+  "order_summary_product_default_label": "servicio",
+  "order_summary_order_initiated_title": "Contratación de su {{product}} iniciada",
+  "order_summary_order_initiated_subtitle": "Si no ha podido finalizar el pedido, cumplimente los campos haciendo clic en el <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Le informaremos de la disponibilidad de su {{product}} por correo electrónico."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_fr_CA.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_fr_CA.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Annuler",
+  "order_configuration_order": "Commander",
+  "order_summary_finish": "Terminer",
+  "order_summary_product_default_label": "service",
+  "order_summary_order_initiated_title": "Commande de votre {{product}} initiée",
+  "order_summary_order_initiated_subtitle": "Si vous n'avez pas pu finaliser votre commande, merci de la compléter en cliquant sur le <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Nous vous informerons de la disponibilité de votre {{product}} par e-mail."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_fr_FR.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_fr_FR.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Annuler",
+  "order_configuration_order": "Commander",
+  "order_summary_finish": "Terminer",
+  "order_summary_product_default_label": "service",
+  "order_summary_order_initiated_title": "Commande de votre {{product}} initiée",
+  "order_summary_order_initiated_subtitle": "Si vous n'avez pas pu finaliser votre commande, merci de la compléter en cliquant sur le <OrderLink label=\"lien suivant\">{{label}}</OrderLink>",
+  "order_summary_order_initiated_info": "Nous vous informerons de la disponibilité de votre {{product}} par e-mail."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_it_IT.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_it_IT.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Annulla",
+  "order_configuration_order": "Ordina",
+  "order_summary_finish": "Termina",
+  "order_summary_product_default_label": "servizio",
+  "order_summary_order_initiated_title": "Ordine del {{product}} avviato",
+  "order_summary_order_initiated_subtitle": "Se non sei riuscito a completare l'ordine, clicca sul <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Ti informeremo della disponibilità del tuo {{product}} via email."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_pl_PL.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_pl_PL.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Anuluj",
+  "order_configuration_order": "Zamów",
+  "order_summary_finish": "Zakończ",
+  "order_summary_product_default_label": "usługa",
+  "order_summary_order_initiated_title": "Zamówienie dla {{product}} zostało zainicjowane",
+  "order_summary_order_initiated_subtitle": "Jeśli nie jesteś w stanie sfinalizować zamówienia, uzupełnij je, klikając na <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Powiadomimy Cię e-mailem o dostępności {{product}}."
+}

--- a/packages/manager-react-components/src/components/order/translations/Messages_pt_PT.json
+++ b/packages/manager-react-components/src/components/order/translations/Messages_pt_PT.json
@@ -1,0 +1,9 @@
+{
+  "order_configuration_cancel": "Anular",
+  "order_configuration_order": "Encomendar",
+  "order_summary_finish": "Terminer",
+  "order_summary_product_default_label": "serviço",
+  "order_summary_order_initiated_title": "Encomenda do seu {{product}} iniciada",
+  "order_summary_order_initiated_subtitle": "Se não conseguiu finalizar a sua encomenda, agradecemos que a complete clicando no <OrderLink label='lien suivant' />",
+  "order_summary_order_initiated_info": "Receberá por e-mail a informação da disponibilidade do seu {{product}}."
+}

--- a/packages/manager-react-components/src/components/order/translations/index.ts
+++ b/packages/manager-react-components/src/components/order/translations/index.ts
@@ -1,0 +1,27 @@
+import i18next from 'i18next';
+
+import de_DE from './Messages_de_DE.json';
+import en_GB from './Messages_en_GB.json';
+import es_ES from './Messages_es_ES.json';
+import fr_CA from './Messages_fr_CA.json';
+import fr_FR from './Messages_fr_FR.json';
+import it_IT from './Messages_it_IT.json';
+import pl_PL from './Messages_pl_PL.json';
+import pt_PT from './Messages_pt_PT.json';
+
+function addTranslations() {
+  i18next.addResources('de_DE', 'order', de_DE);
+  i18next.addResources('en_GB', 'order', en_GB);
+  i18next.addResources('es_ES', 'order', es_ES);
+  i18next.addResources('fr_CA', 'order', fr_CA);
+  i18next.addResources('fr_FR', 'order', fr_FR);
+  i18next.addResources('it_IT', 'order', it_IT);
+  i18next.addResources('pl_PL', 'order', pl_PL);
+  i18next.addResources('pt_PT', 'order', pt_PT);
+}
+
+if (i18next.isInitialized) {
+  addTranslations();
+} else {
+  i18next.on('initialized', addTranslations);
+}


### PR DESCRIPTION
ref: MANAGER-16647

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          |`develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-16647
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Add a component to wrap the order of a new product when it uses express order

![image](https://github.com/user-attachments/assets/101a65de-334c-450f-b28f-93e756a30ff6)

Firt of all, the order configuration part should be provided as a children of `<Order.Configuration>`

![image](https://github.com/user-attachments/assets/05a7c1a1-7e8b-49e9-8b28-3564fcf34b1c)

Once order configuration is OK, by clicking on order button, a summary is displayed while opening a new tab with the express order (provided by the given link)

![image](https://github.com/user-attachments/assets/c00f28a7-90b8-4a76-88d0-4c6ad962eab2)

`Product label` can be overridden otherwise it will be `service` by default

Tracking and navigation routing could be provided  by all the event button props 

## Related

<!-- Link dependencies of this PR -->

Github issue : https://github.com/ovh/manager/issues/15068
