### PR TITLE
feat(vrack-services): add iam checks on dashboard and listing

### DIFF
--- a/packages/manager/apps/vrack-services/mocks/iam/iam.mock.ts
+++ b/packages/manager/apps/vrack-services/mocks/iam/iam.mock.ts
@@ -1,0 +1,21 @@
+import { IAM_ACTION } from '../../src/utils/iamActions.constants';
+
+const defaultUrn = 'urn:v1:eu:resource:vrackServices:vrs-ar7-72w-poh-3qe';
+
+export const configureIamResponse = ({
+  unauthorizedActions = [],
+  urn,
+}: {
+  unauthorizedActions?: string[];
+  urn?: string;
+}) => {
+  const allActions = Object.values(IAM_ACTION);
+  const authorizedActions = allActions.filter(
+    (action) => !unauthorizedActions.includes(action),
+  );
+  return {
+    urn: urn || defaultUrn,
+    authorizedActions,
+    unauthorizedActions,
+  };
+};

--- a/packages/manager/apps/vrack-services/mocks/iam/iam.ts
+++ b/packages/manager/apps/vrack-services/mocks/iam/iam.ts
@@ -1,4 +1,5 @@
 import { Handler } from '@ovh-ux/manager-core-test-utils';
+import { configureIamResponse } from './iam.mock';
 
 export const iamResources = [
   {
@@ -44,9 +45,22 @@ export const iamResources = [
 
 export type GetIamMocksParams = {
   iamKo?: boolean;
+  unauthorizedActions?: string[];
+  urn?: string;
 };
 
-export const getIamMocks = ({ iamKo }: GetIamMocksParams): Handler[] => [
+export const getIamMocks = ({
+  iamKo,
+  unauthorizedActions,
+  urn,
+}: GetIamMocksParams): Handler[] => [
+  {
+    url: '/iam/resource/:urn/authorization/check',
+    response: () => configureIamResponse({ urn, unauthorizedActions }),
+    api: 'v2',
+    method: 'post',
+    status: 200,
+  },
   {
     url: '/iam/resource',
     response: () => {

--- a/packages/manager/apps/vrack-services/src/components/display-name/DisplayName.component.tsx
+++ b/packages/manager/apps/vrack-services/src/components/display-name/DisplayName.component.tsx
@@ -11,6 +11,7 @@ import { EditButton } from './EditButton.component';
 import { VrackServicesWithIAM, getDisplayName, isEditable } from '@/data';
 import { urls } from '@/routes/routes.constants';
 import { InfoIcon } from './InfoIcon.component';
+import { IAM_ACTION } from '@/utils/iamActions.constants';
 
 export type DisplayNameProps = {
   isListing?: boolean;
@@ -57,6 +58,8 @@ export const DisplayName: React.FC<DisplayNameProps> = ({
         navigate(urls.overviewEdit.replace(':id', vs.id));
       }}
       data-testid="display-name-edit-button"
+      iamActions={[IAM_ACTION.VRACK_SERVICES_RESOURCE_EDIT]}
+      urn={vs.iam?.urn}
     >
       {name}
     </EditButton>

--- a/packages/manager/apps/vrack-services/src/components/display-name/EditButton.component.tsx
+++ b/packages/manager/apps/vrack-services/src/components/display-name/EditButton.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { OsdsButton, OsdsIcon, OsdsText } from '@ovhcloud/ods-components/react';
+import { OsdsIcon, OsdsText } from '@ovhcloud/ods-components/react';
 import {
   ODS_BUTTON_SIZE,
   ODS_BUTTON_TYPE,
@@ -10,17 +10,21 @@ import {
   ODS_TEXT_LEVEL,
 } from '@ovhcloud/ods-components';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-import { handleClick } from '@ovh-ux/manager-react-components';
+import { handleClick, ManagerButton } from '@ovh-ux/manager-react-components';
 
 export type EditButtonProps = React.PropsWithChildren<{
   disabled?: boolean;
   onClick: () => void;
+  iamActions?: string[];
+  urn?: string;
 }>;
 
 export const EditButton: React.FC<EditButtonProps> = ({
   children,
   disabled,
   onClick,
+  iamActions,
+  urn,
 }) => (
   <div className="flex items-center">
     <div className="grow">
@@ -33,7 +37,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
       </OsdsText>
     </div>
     <div className="flex-none">
-      <OsdsButton
+      <ManagerButton
         className="ml-2"
         inline
         circle
@@ -44,13 +48,15 @@ export const EditButton: React.FC<EditButtonProps> = ({
         {...handleClick(onClick)}
         disabled={disabled || undefined}
         data-testid="edit-button"
+        iamActions={iamActions}
+        urn={urn}
       >
         <OsdsIcon
           color={ODS_THEME_COLOR_INTENT.primary}
           name={ODS_ICON_NAME.PEN}
           size={ODS_ICON_SIZE.xs}
         />
-      </OsdsButton>
+      </ManagerButton>
     </div>
   </div>
 );

--- a/packages/manager/apps/vrack-services/src/components/vrack-id/useVrackMenuItems.hook.ts
+++ b/packages/manager/apps/vrack-services/src/components/vrack-id/useVrackMenuItems.hook.ts
@@ -8,6 +8,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { VrackServicesWithIAM, isEditable } from '@/data';
 import { urls } from '@/routes/routes.constants';
+import { IAM_ACTION } from '@/utils/iamActions.constants';
 
 export type UseVrackMenuItemsParams = {
   vs: VrackServicesWithIAM;
@@ -44,6 +45,8 @@ export const useVrackMenuItems = ({
           ),
         );
       },
+      iamActions: [IAM_ACTION.VRACK_SERVICES_VRACK_ATTACH],
+      urn: vs.iam?.urn,
     },
     vrackId && {
       id: 5,
@@ -65,6 +68,8 @@ export const useVrackMenuItems = ({
             .replace(':vrackId', vs.currentState.vrackId),
         );
       },
+      iamActions: [IAM_ACTION.VRACK_SERVICES_VRACK_ATTACH],
+      urn: vs.iam?.urn,
     },
     vrackId && {
       id: 6,

--- a/packages/manager/apps/vrack-services/src/pages/associate/AssociateVrack.spec.tsx
+++ b/packages/manager/apps/vrack-services/src/pages/associate/AssociateVrack.spec.tsx
@@ -18,6 +18,7 @@ import {
 import vrackServicesList from '../../../mocks/vrack-services/get-vrack-services.json';
 import { urls } from '@/routes/routes.constants';
 import { vrackList } from '../../../mocks/vrack/vrack';
+import { IAM_ACTION } from '@/utils/iamActions.constants';
 
 describe('Vrack Services associate vrack test suite', () => {
   it('from dashboard should associate vrack using vrack modal', async () => {
@@ -64,6 +65,27 @@ describe('Vrack Services associate vrack test suite', () => {
     await waitFor(() => userEvent.click(associateButton));
 
     await assertModalVisibility({ container, isVisible: false });
+  });
+
+  it('from dashboard should disable vrack association if user have not the iam right to do it', async () => {
+    const { container } = await renderTest({
+      initialRoute: urls.overview.replace(':id', vrackServicesList[0].id),
+      nbVs: 1,
+      unauthorizedActions: [IAM_ACTION.VRACK_SERVICES_VRACK_ATTACH],
+    });
+
+    const actionMenuButton = await getButtonByIcon({
+      container,
+      iconName: ODS_ICON_NAME.ELLIPSIS,
+    });
+
+    await waitFor(() => fireEvent.click(actionMenuButton));
+
+    await getButtonByLabel({
+      container,
+      label: labels.common.associateVrackButtonLabel,
+      disabled: true,
+    });
   });
 
   it('from dashboard, should propose user to create vrack if no eligible vrack', async () => {

--- a/packages/manager/apps/vrack-services/src/pages/listing/ActionCell.component.tsx
+++ b/packages/manager/apps/vrack-services/src/pages/listing/ActionCell.component.tsx
@@ -11,6 +11,7 @@ import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { isEditable, VrackServicesWithIAM } from '@/data';
 import { urls } from '@/routes/routes.constants';
 import { useVrackMenuItems } from '@/components/vrack-id/useVrackMenuItems.hook';
+import { IAM_ACTION } from '@/utils/iamActions.constants';
 
 export const ActionCell: React.FC<VrackServicesWithIAM> = (vs) => {
   const navigate = useNavigate();
@@ -58,6 +59,8 @@ export const ActionCell: React.FC<VrackServicesWithIAM> = (vs) => {
             });
             navigate(urls.listingEdit.replace(':id', vs.id));
           },
+          iamActions: [IAM_ACTION.VRACK_SERVICES_RESOURCE_EDIT],
+          urn: vs.iam?.urn,
         },
         ...vrackActionsMenuItems,
         {

--- a/packages/manager/apps/vrack-services/src/pages/listing/Listing.spec.tsx
+++ b/packages/manager/apps/vrack-services/src/pages/listing/Listing.spec.tsx
@@ -13,6 +13,7 @@ import {
   labels,
   renderTest,
 } from '../../test-utils';
+import { IAM_ACTION } from '@/utils/iamActions.constants';
 
 describe('Vrack Services listing test suite', () => {
   it('should redirect to the onboarding page when the VRS list is empty', async () => {
@@ -99,5 +100,36 @@ describe('Vrack Services listing test suite', () => {
     await waitFor(() => fireEvent.click(goToDEtailButton));
 
     await assertTextVisibility(labels.dashboard.dashboardPageDescription);
+  });
+
+  it('should disable iam actions', async () => {
+    const { container } = await renderTest({
+      nbVs: 1,
+      unauthorizedActions: [
+        IAM_ACTION.VRACK_SERVICES_RESOURCE_EDIT,
+        IAM_ACTION.VRACK_SERVICES_VRACK_ATTACH,
+      ],
+    });
+
+    await assertTextVisibility(labels.listing.createVrackServicesButtonLabel);
+
+    const actionMenu = await getButtonByIcon({
+      container,
+      iconName: ODS_ICON_NAME.ELLIPSIS,
+    });
+
+    await waitFor(() => fireEvent.click(actionMenu));
+
+    await getButtonByLabel({
+      container,
+      label: labels.common['action-editDisplayName'],
+      disabled: true,
+    });
+
+    await getButtonByLabel({
+      container,
+      label: labels.common.associateVrackButtonLabel,
+      disabled: true,
+    });
   });
 });

--- a/packages/manager/apps/vrack-services/src/test-utils/setupTests.tsx
+++ b/packages/manager/apps/vrack-services/src/test-utils/setupTests.tsx
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import React from 'react';
 import '@testing-library/jest-dom';
 import { NavLinkProps } from 'react-router-dom';
+import { configureIamResponse } from '../../mocks/iam/iam.mock';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -28,5 +29,13 @@ vi.mock('react-router-dom', async (importOriginal) => {
       pathname: 'pathname',
     }),
     NavLink: ({ ...params }: NavLinkProps) => <>{params.children}</>,
+  };
+});
+
+vi.mock('@ovh-ux/manager-react-components', async (importOriginal) => {
+  const original: typeof import('@ovh-ux/manager-react-components') = await importOriginal();
+  return {
+    ...original,
+    useAuthorizationIam: vi.fn().mockReturnValue(configureIamResponse({})),
   };
 });

--- a/packages/manager/apps/vrack-services/src/utils/iamActions.constants.ts
+++ b/packages/manager/apps/vrack-services/src/utils/iamActions.constants.ts
@@ -1,0 +1,5 @@
+export const IAM_ACTION = {
+  VRACK_SERVICES_RESOURCE_EDIT: 'vrackServices:apiovh:resource/edit',
+  VRACK_SERVICES_VRACK_ATTACH: 'vrackServices:apiovh:vrack/attach',
+  VRACK_SERVICES_RESOURCE_GET: 'vrackServices:apiovh:resource/get',
+};


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #MANAGER-16523
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- ~~[ ] Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- ~~[ ] Breaking change is mentioned in relevant commits~~

## Description

Add feature to disable vrack services name edit and vrack attach on dashboard and listing when user don't have the iam rights to do it.

## Related

<!-- Link dependencies of this PR -->
