### PR TITLE
feat(xdsl.move): remove useless portline cost label on pack move

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/address/current/move-address-current.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/address/current/move-address-current.html
@@ -96,12 +96,6 @@
         </div>
 
         <p
-            data-ng-if="$ctrl.portLineNumber"
-            class="mt-2"
-            data-translate="pack_move_portLine_cost"
-        ></p>
-
-        <p
             data-translate="pack_move_keepLine_disabled"
             class="mt-2"
             data-ng-if="!$ctrl.portability"

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/translations/Messages_fr_FR.json
@@ -39,7 +39,6 @@
   "pack_move_cannot_validate_move": "Il nous est impossible de déménager votre pack: {{message}}",
   "pack_move_line_current_address": "Adresse actuelle",
   "pack_move_line_future_address": "Adresse future",
-  "pack_move_portLine_cost": "La conservation vous sera facturée <span class=\"font-weight-bold text-price\">50€</span>",
   "pack_move_eligibility_error": "Une erreur est survenue durant le test d’éligibilité:",
   "pack_move_eligibility_no_offers": "La ligne {{ number }} n'est éligible à aucune de nos offres.",
   "pack_move_portLine_disabled": "Vous ne pouvez pas porter votre numéro.",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #UXCT-684
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Remove useless portline cost label on pack move on keeping phone number page

## Related

<!-- Link dependencies of this PR -->
