### PR TITLE
feat(pci.savings-plan): loading skeleton

### DIFF
--- a/packages/manager/apps/pci-savings-plan/src/components/Dashboard/ConsumptionDatagrid/ConsumptionDatagrid.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Dashboard/ConsumptionDatagrid/ConsumptionDatagrid.tsx
@@ -1,39 +1,53 @@
-import {
-  Datagrid,
-  DataGridTextCell,
-  Title,
-} from '@ovh-ux/manager-react-components';
+import { Datagrid, DataGridTextCell } from '@ovh-ux/manager-react-components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { OdsText } from '@ovhcloud/ods-components/react';
+import { OdsSkeleton, OdsText } from '@ovhcloud/ods-components/react';
 import { savingsPlanConsumptionMocked } from '@/_mock_/savingsPlanConsumption';
 
-const ConsumptionDatagrid = () => {
+const ConsumptionDatagrid = ({
+  isLoading,
+}: Readonly<{ isLoading: boolean }>) => {
   const { t } = useTranslation('dashboard');
   const columns = [
     {
       label: t('dashboard_columns_start'),
       id: 'begin',
-      cell: (props: any) => <DataGridTextCell>{props.begin}</DataGridTextCell>,
+      cell: (props: any) =>
+        isLoading ? (
+          <OdsSkeleton />
+        ) : (
+          <DataGridTextCell>{props.begin}</DataGridTextCell>
+        ),
     },
     {
       label: t('dashboard_columns_end'),
       id: 'end',
-      cell: (props: any) => <DataGridTextCell>{props.end}</DataGridTextCell>,
+      cell: (props: any) =>
+        isLoading ? (
+          <OdsSkeleton />
+        ) : (
+          <DataGridTextCell>{props.end}</DataGridTextCell>
+        ),
     },
     {
       label: t('dashboard_columns_consumption_size'),
       id: 'consumption_size',
-      cell: (props: any) => (
-        <DataGridTextCell>{props.consumption_size}</DataGridTextCell>
-      ),
+      cell: (props: any) =>
+        isLoading ? (
+          <OdsSkeleton />
+        ) : (
+          <DataGridTextCell>{props.consumption_size}</DataGridTextCell>
+        ),
     },
     {
       label: t('dashboard_columns_cumul_plan_size'),
       id: 'cumul_plan_size',
-      cell: (props: any) => (
-        <DataGridTextCell>{props.cumul_plan_size}</DataGridTextCell>
-      ),
+      cell: (props: any) =>
+        isLoading ? (
+          <OdsSkeleton />
+        ) : (
+          <DataGridTextCell>{props.cumul_plan_size}</DataGridTextCell>
+        ),
     },
   ];
 

--- a/packages/manager/apps/pci-savings-plan/src/components/Dashboard/Filters/Filters.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Dashboard/Filters/Filters.tsx
@@ -2,7 +2,7 @@ import {
   OdsSelectChangeEventDetail,
   OdsSelectCustomEvent,
 } from '@ovhcloud/ods-components';
-import { OdsSelect } from '@ovhcloud/ods-components/react';
+import { OdsSelect, OdsSkeleton } from '@ovhcloud/ods-components/react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getInstancesInformation, isInstanceFlavor } from '@/utils/savingsPlan';
@@ -17,6 +17,7 @@ const SelectWithLabel = <T extends string>({
   name,
   onChange,
   value,
+  isLoading,
 }: {
   label: string;
   options: { label: string; value: T }[];
@@ -24,12 +25,20 @@ const SelectWithLabel = <T extends string>({
   name: string;
   onChange: (value: T) => void;
   value: T;
+  isLoading: boolean;
 }) => {
   const onChangeEvent = (
     event: OdsSelectCustomEvent<OdsSelectChangeEventDetail>,
   ) => {
     onChange(event.target.value as T);
   };
+  if (isLoading) {
+    return (
+      <div className="flex flex-col w-64">
+        <OdsSkeleton />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col w-64">
@@ -61,9 +70,15 @@ interface FiltersProps {
   defaultFilter: SavingsPlanService;
   savingsPlan: SavingsPlanService[];
   locale: string;
+  isLoading: boolean;
 }
 
-const Filters = ({ defaultFilter, savingsPlan, locale }: FiltersProps) => {
+const Filters = ({
+  defaultFilter,
+  savingsPlan,
+  locale,
+  isLoading,
+}: FiltersProps) => {
   const lastTwelveMonths = useMemo(() => getLastTwelveMonths(locale), [locale]);
 
   const [resource, setResource] = useState<ResourceType>(ResourceType.instance);
@@ -143,6 +158,7 @@ const Filters = ({ defaultFilter, savingsPlan, locale }: FiltersProps) => {
   return (
     <div className="flex flex-row gap-4">
       <SelectWithLabel
+        isLoading={isLoading}
         label={t('dashboard_select_label_resource')}
         value={resource}
         onChange={(value) => {
@@ -154,6 +170,7 @@ const Filters = ({ defaultFilter, savingsPlan, locale }: FiltersProps) => {
         name="resource"
       />
       <SelectWithLabel
+        isLoading={isLoading}
         label={t('dashboard_select_label_flavor')}
         options={instanceRangeOptions}
         placeholder={t('dashboard_select_placeholder_flavor')}
@@ -163,6 +180,7 @@ const Filters = ({ defaultFilter, savingsPlan, locale }: FiltersProps) => {
         onChange={(value) => setFlavor(value)}
       />
       <SelectWithLabel
+        isLoading={isLoading}
         label={t('dashboard_select_label_model')}
         options={modelOptions}
         placeholder={t('dashboard_select_placeholder_model')}
@@ -171,6 +189,7 @@ const Filters = ({ defaultFilter, savingsPlan, locale }: FiltersProps) => {
         onChange={setModel}
       />
       <SelectWithLabel
+        isLoading={isLoading}
         label={t('dashboard_select_label_period')}
         options={lastTwelveMonths.map((month) => ({
           label: month,

--- a/packages/manager/apps/pci-savings-plan/src/components/Dashboard/Kpis/Kpis.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Dashboard/Kpis/Kpis.tsx
@@ -1,5 +1,10 @@
 import { ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
-import { OdsText, OdsTooltip, OdsIcon } from '@ovhcloud/ods-components/react';
+import {
+  OdsText,
+  OdsTooltip,
+  OdsIcon,
+  OdsSkeleton,
+} from '@ovhcloud/ods-components/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,12 +13,20 @@ const Kpi = ({
   value,
   tooltip,
   index,
+  isLoading,
 }: {
   title: string;
   value: number;
   tooltip: string;
   index: number;
+  isLoading: boolean;
 }) => {
+  if (isLoading)
+    return (
+      <div className="h-16 w-[200px] mx-2 flex flex-col justify-center">
+        <OdsSkeleton />
+      </div>
+    );
   return (
     <div className="flex flex-col gap-2 w-[200px]">
       <OdsText preset="heading-5" className="max-w-lg">
@@ -38,7 +51,7 @@ const Kpi = ({
   );
 };
 
-const Kpis = () => {
+const Kpis = ({ isLoading }: Readonly<{ isLoading: boolean }>) => {
   const { t } = useTranslation('dashboard');
   const data = [
     {
@@ -62,17 +75,16 @@ const Kpis = () => {
     <div className="flex flex-row gap-4 items-center mt-7">
       {data.map((item, index) => (
         <React.Fragment key={item.title}>
-          <div key={item.title}>
-            <Kpi
-              title={item.title}
-              value={item.value}
-              tooltip={item.tooltip}
-              index={index}
-            />
-            {index < data.length - 1 && (
-              <div className="h-16 w-px bg-gray-300 mx-2"></div>
-            )}
-          </div>
+          <Kpi
+            title={item.title}
+            value={item.value}
+            tooltip={item.tooltip}
+            index={index}
+            isLoading={isLoading}
+          />
+          {index < data.length - 1 && (
+            <div className="h-16 w-px bg-gray-300 mx-2"></div>
+          )}
         </React.Fragment>
       ))}
     </div>

--- a/packages/manager/apps/pci-savings-plan/src/pages/dashboard/index.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/pages/dashboard/index.tsx
@@ -43,9 +43,10 @@ const Dashboard: React.FC = () => {
         defaultFilter={currentPlan}
         savingsPlan={savingsPlan}
         locale={locale}
+        isLoading={isLoading}
       />
-      <Kpis />
-      <ConsumptionDatagrid />
+      <Kpis isLoading={isLoading} />
+      <ConsumptionDatagrid isLoading={isLoading} />
     </>
   );
 };


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `feat/TAPC-2358-svp-dashboard` 
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | Fix #TAPC-2358
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [ ] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

This PR adds a loading skeleton through a fake loading while waiting for the actual API to be ready.

## Related

<!-- Link dependencies of this PR -->
