### PR TITLE
fix(pci-public-ip): use regionalize call for subnets

### DIFF
--- a/packages/manager/apps/pci-public-ip/src/api/data/subnets.ts
+++ b/packages/manager/apps/pci-public-ip/src/api/data/subnets.ts
@@ -6,13 +6,19 @@ export type TSubnet = {
   id: string;
 };
 
-export const getSubnetsUrl = (projectId: string, networkId: string) =>
-  `/cloud/project/${projectId}/network/private/${networkId}/subnet`;
+export const getSubnetsUrl = (
+  projectId: string,
+  region: string,
+  networkId: string,
+) => `/cloud/project/${projectId}/region/${region}/network/${networkId}/subnet`;
 
 export const getSubnets = async (
   projectId: string,
+  region: string,
   networkId: string,
 ): Promise<TSubnet[]> => {
-  const { data } = await v6.get<TSubnet[]>(getSubnetsUrl(projectId, networkId));
+  const { data } = await v6.get<TSubnet[]>(
+    getSubnetsUrl(projectId, region, networkId),
+  );
   return data;
 };

--- a/packages/manager/apps/pci-public-ip/src/api/hooks/useSubnets.ts
+++ b/packages/manager/apps/pci-public-ip/src/api/hooks/useSubnets.ts
@@ -1,14 +1,23 @@
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { getSubnets, getSubnetsUrl } from '@/api/data/subnets';
 
-export const getSubnetsQuery = (projectId: string, networkId: string) => ({
-  queryKey: [getSubnetsUrl(projectId, networkId)],
-  queryFn: () => getSubnets(projectId, networkId),
-});
+const getSubnetsQuery = (
+  projectId: string,
+  region: string,
+  networkId: string,
+) =>
+  queryOptions({
+    queryKey: [getSubnetsUrl(projectId, region, networkId)],
+    queryFn: () => getSubnets(projectId, region, networkId),
+    enabled: !!projectId && !!region && !!networkId,
+  });
 
-export const useSubnets = (projectId: string, networkId: string) => {
+export const useSubnets = (
+  projectId: string,
+  region: string,
+  networkId: string,
+) => {
   return useQuery({
-    ...getSubnetsQuery(projectId, networkId),
-    enabled: !!projectId && !!networkId,
+    ...getSubnetsQuery(projectId, region, networkId),
   });
 };

--- a/packages/manager/apps/pci-public-ip/src/pages/order/steps/FloatingIpSummary.tsx
+++ b/packages/manager/apps/pci-public-ip/src/pages/order/steps/FloatingIpSummary.tsx
@@ -39,6 +39,7 @@ export const FloatingIpSummary = ({
   );
   const { data: rawSubnets, isPending: isSubnetsPending } = useSubnets(
     projectId,
+    ipRegion,
     networkId,
   );
   const { state: selectedGateway } = useSelectedGateway();


### PR DESCRIPTION
ref: TAPC-2713

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-2713
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

To find subnet the api endpoint is `/region/{regionName}/network/{networkId}/subnet` instead of 
`/cloud/project/{serviceName}/network/private/{networkId}/subnet`
Otherwise this will return a 404 error and user can't create floating IP 


<!-- Write a brief description of the changes introduced by this PR -->

## Related

<!-- Link dependencies of this PR -->
