### PR TITLE
feat(container): add lazy loading to hamburger menu on mobile devices

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/navbar/Navbar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import React, { Suspense, useCallback, useState } from 'react';
 
 import { Environment } from '@ovh-ux/manager-config';
 
@@ -7,7 +7,6 @@ import { TRANSLATE_NAMESPACE } from './constants';
 
 import Account from './Account';
 import Brand from './Brand';
-import Hamburger from './HamburgerMenu';
 import style from './navbar.module.scss';
 import Search from './Search';
 import Universes from './Universes';
@@ -21,7 +20,9 @@ import { useShell } from '@/context';
 import { useHeader } from '@/context/header';
 import { useUniverses } from '@/hooks/useUniverses';
 import { useMediaQuery } from 'react-responsive';
-import { SMALL_DEVICE_MAX_SIZE } from '@/container/common/constants';
+import { SMALL_DEVICE_MAX_SIZE, MOBILE_WIDTH_RESOLUTION } from '@/container/common/constants';
+
+const HamburgerMenu = React.lazy(() => import('./HamburgerMenu'));
 
 type Props = {
   environment: Environment;
@@ -36,6 +37,10 @@ function Navbar({ environment }: Props): JSX.Element {
   );
   const isSmallDevice = useMediaQuery({
     query: `(max-width: ${SMALL_DEVICE_MAX_SIZE})`,
+  });
+
+  const isMobile = useMediaQuery({
+    query: `(max-width: ${MOBILE_WIDTH_RESOLUTION}px)`,
   });
 
   const [searchURL] = useState<string>();
@@ -74,7 +79,14 @@ function Navbar({ environment }: Props): JSX.Element {
         role="navigation"
         aria-label={t('navbar_menu_name')}
       >
-        <Hamburger universe={universe} universes={getUniverses()} />
+        {isMobile && (
+          <Suspense fallback={<></>}>
+            <HamburgerMenu
+              universe={universe}
+              universes={getUniverses()}
+            />
+          </Suspense>
+        )}
         <Brand
           targetURL={getHubUniverse()?.url || '#'}
           onClick={brandClickHandler}


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Tickets          | MANAGER-15633
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~

## Description

Lazy load the hamburger component and only render on mobile devices.
Media-query in the Hamburger-Nav is set to display at a max-width of `1023px`, here we're re-using the constant for mobile devices of `1024px` which is close enough to prevent *magic numbers*.

## Related

<!-- Link dependencies of this PR -->
