### PR TITLE
fix(pnr): change universe is broken on mobile

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/index.tsx
@@ -15,7 +15,6 @@ import useProductNavReshuffle from '@/core/product-nav-reshuffle/useProductNavRe
 
 interface SubTreeProps {
   rootNode: Node;
-  handleBackNavigation(): void;
   handleCloseSideBar(): void;
   handleOnSubMenuClick(node: Node): void;
   selectedNode: Node;
@@ -23,7 +22,6 @@ interface SubTreeProps {
 
 const SubTree = ({
   rootNode,
-  handleBackNavigation,
   handleOnSubMenuClick,
   selectedNode,
   handleCloseSideBar,
@@ -49,7 +47,7 @@ const SubTree = ({
             setFocusOnLast(false);
             return;
           }
-          handleBackNavigation();
+          handleCloseSideBar();
         }
       }}
     >
@@ -73,7 +71,7 @@ const SubTree = ({
 
       <button
         className={style.subtree_back_btn}
-        onClick={handleBackNavigation}
+        onClick={handleCloseSideBar}
         title={t('sidebar_back_menu')}
         role="button"
       >
@@ -83,38 +81,38 @@ const SubTree = ({
         ></span>
         {t('sidebar_back_menu')}
       </button>
-      {rootNode.illustration && (
+      {rootNode?.illustration && (
         <div
-          aria-label={t(rootNode.translation)}
+          aria-label={t(rootNode?.translation)}
           className={`d-block py-3 ${style.subtree_illustration}`}
           role="img"
         >
           <img
-            src={rootNode.illustration}
-            alt={t(rootNode.translation)}
+            src={rootNode?.illustration}
+            alt={t(rootNode?.translation)}
             aria-hidden="true"
           />
         </div>
       )}
 
-      <div className={rootNode.illustration ? '' : 'pt-4'}>
+      <div className={rootNode?.illustration ? '' : 'pt-4'}>
         <ul
           className={`${style.subtree_list}`}
           role="menu"
-          aria-label={t(rootNode.translation)}
+          aria-label={t(rootNode?.translation)}
         >
           <li className="mb-4 px-3">
-            <h2>{t(rootNode.translation)}</h2>
+            <h2>{t(rootNode?.translation)}</h2>
           </li>
 
-          {rootNode.id.startsWith('pci') ? (
+          {rootNode?.id.startsWith('pci') ? (
             <PublicCloudPanel
               rootNode={rootNode}
               selectedNode={selectedNode}
               handleOnSubMenuClick={handleOnSubMenuClick}
             />
           ) : (
-            rootNode.children
+            rootNode?.children
               ?.filter((childNode) => !shouldHideElement(childNode, 1))
               .map((node) => (
                 <li

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -237,6 +237,7 @@ const Sidebar = (): JSX.Element => {
   const closeSubMenu = () => {
     setShowSubTree(false);
     setIsManuallyClosed(true);
+    if (isMobile) setSelectedNode(null);
   };
 
   const menuClickHandler = (node: Node) => {
@@ -385,9 +386,6 @@ const Sidebar = (): JSX.Element => {
       </div>
       {showSubTree && !isManuallyClosed && (
         <SubTree
-          handleBackNavigation={() => {
-            if (isMobile) setSelectedNode(null);
-          }}
           selectedNode={selectedSubMenu}
           handleCloseSideBar={closeSubMenu}
           handleOnSubMenuClick={selectSubMenu}


### PR DESCRIPTION
ref: MANAGER-16895

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | MANAGER-16895
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

There is a regression on the mobile navigation, we can't change of universe on PNR

## Related

<!-- Link dependencies of this PR -->
