### PR TITLE
fix(billing): hide autorenew links for us

### DIFF
--- a/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
+++ b/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
@@ -11,6 +11,7 @@ export default class BillingLinksService {
 
   generateAutorenewLinks(service, options) {
     const {
+      billingManagementAvailability,
       getCommitmentLink,
       getCancelCommitmentLink,
       getCancelResiliationLink,
@@ -20,7 +21,9 @@ export default class BillingLinksService {
     const links = {};
     const fetchAutoRenewLink = this.$q.defer();
 
-    if (this.$injector.has('shellClient')) {
+    if (!billingManagementAvailability) {
+      fetchAutoRenewLink.resolve(null);
+    } else if (this.$injector.has('shellClient')) {
       this.$injector
         .get('shellClient')
         .navigation.getURL('dedicated', '#/billing/autorenew')
@@ -109,7 +112,8 @@ export default class BillingLinksService {
         default:
           links.resiliateLink = service.canResiliateByEndRule()
             ? resiliationByEndRuleLink
-            : `${links.autorenewLink}/delete?serviceId=${service.serviceId}${serviceTypeParam}`;
+            : autorenewLink &&
+              `${autorenewLink}/delete?serviceId=${service.serviceId}${serviceTypeParam}`;
           break;
       }
 


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master` 
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #MANAGER-16906
| License          | BSD 3-Clause

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~~Only FR translations have been updated~~ (n/a)
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~~Breaking change is mentioned in relevant commits~~ (n/a)

## Description

Reinstated the use of FF to hide autorenew links for US customers

## Related

<!-- Link dependencies of this PR -->
