### PR TITLE
fix(pack.access-list): call sort list function on not empty list

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.controller.js
@@ -69,11 +69,21 @@ export default class XdslAccessListCtrl {
         : ELIGIBILITY.not_eligible;
     });
 
-    // Order each group and add them to the sorted services list
-    const sortedServicesList = [
-      ...this.sortList(accessTypeGroupBy.eligible),
-      ...this.sortList(accessTypeGroupBy.not_eligible),
-    ];
+    let sortedServicesList = [];
+
+    if (accessTypeGroupBy.eligible && accessTypeGroupBy.not_eligible) {
+      // Order each group and add them to the sorted services list
+      sortedServicesList = [
+        ...this.sortList(accessTypeGroupBy.eligible),
+        ...this.sortList(accessTypeGroupBy.not_eligible),
+      ];
+    } else if (accessTypeGroupBy.eligible && !accessTypeGroupBy.not_eligible) {
+      // Order eligible group and add to the sorted services list
+      sortedServicesList = [...this.sortList(accessTypeGroupBy.eligible)];
+    } else {
+      // Order not eligible group and add to the sorted services list
+      sortedServicesList = [...this.sortList(accessTypeGroupBy.not_eligible)];
+    }
     return sortedServicesList;
   }
 


### PR DESCRIPTION
ref: UXCT-692

| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | yes/no
| Tickets          | Fix #UXCT-692
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] ~Only FR translations have been updated~
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Call sortList function only for not empty list

## Related

<!-- Link dependencies of this PR -->
