### PR TITLE
fix(xdsl.move): set buildingReference from api result endpoint

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.constants.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.constants.js
@@ -1,5 +1,8 @@
 export const AUTHORIZED_ABBREVIATIONS = ['RN'];
 
+export const BUILDING = 'building';
+
 export default {
   AUTHORIZED_ABBREVIATIONS,
+  BUILDING,
 };

--- a/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/move/eligibility/address/move-eligibility-address.controller.js
@@ -1,6 +1,9 @@
 import assign from 'lodash/assign';
 
-import { AUTHORIZED_ABBREVIATIONS } from './move-eligibility-address.constants';
+import {
+  AUTHORIZED_ABBREVIATIONS,
+  BUILDING,
+} from './move-eligibility-address.constants';
 import { ELIGIBILITY_LINE_STATUS } from '../../pack-move.constant';
 
 export default class {
@@ -397,7 +400,10 @@ export default class {
           address: copper.result.endpoint.address,
         });
       }
-      offer.buildingReference = fiber.fiberInfo.buildingReference;
+      offer.buildingReference =
+        fiber.referenceTypeFiber === BUILDING
+          ? fiber.referenceFiber
+          : fiber.fiberInfo.buildingReference;
     } else {
       assign(offer.endpoint, {
         address: copper.result.endpoint.address,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | `master`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #UXCT-691
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [x] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] ~Breaking change is mentioned in relevant commits~

## Description

Set buildingReference from API result endpoint if referenceType is 'building'.

## Related

<!-- Link dependencies of this PR -->
