### PR TITLE
fix(pci-load-balancer): fix wrong price for floating IP at LB creation

### DIFF
--- a/packages/manager/apps/pci-load-balancer/src/constants.ts
+++ b/packages/manager/apps/pci-load-balancer/src/constants.ts
@@ -56,7 +56,6 @@ export const ACTION_LABELS = {
 
 export const AGORA_ADDON_FAMILY = 'octavia-loadbalancer';
 export const SIZE_FLAVOUR_REGEX = /octavia-loadbalancer.loadbalancer-([23]?xl|[sml]).hour.consumption/;
-export const AGORA_FLOATING_IP_REGEX = /floatingip.floatingip.hour.consumption/;
 export const NETWORK_PRIVATE_VISIBILITY = 'private';
 export const FLOATING_IP_TYPE = {
   NO_IP: 'none',

--- a/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStep.spec.tsx
+++ b/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStep.spec.tsx
@@ -1,9 +1,5 @@
 import { describe, Mock, vi } from 'vitest';
-import {
-  StepComponent,
-  TStepProps,
-  useCatalogPrice,
-} from '@ovh-ux/manager-react-components';
+import { StepComponent, TStepProps } from '@ovh-ux/manager-react-components';
 import { render, renderHook, within } from '@testing-library/react';
 import {
   OsdsSelect,
@@ -20,6 +16,7 @@ import { StepsEnum, useCreateStore } from '@/pages/create/store';
 import { TFloatingIp } from '@/api/data/floating-ips';
 import { FLOATING_IP_TYPE } from '@/constants';
 import { IpStepMessages } from '@/pages/create/steps/ip/IpStepMessages';
+import { TRegion } from '@/api/hook/useRegions';
 
 vi.mock('./IpStepMessages', async () => ({
   IpStepMessages: vi
@@ -370,9 +367,10 @@ describe('IpStep', () => {
           it("should display IpMessages if the selected ip is 'create'", () => {
             const { result } = renderStore();
 
-            act(() =>
-              result.current.set.publicIp({ type: 'create' } as TFloatingIp),
-            );
+            act(() => {
+              result.current.set.publicIp({ type: 'create' } as TFloatingIp);
+              result.current.set.region({ type: 'region' } as TRegion);
+            });
 
             const catalog = ({
               addons: [
@@ -405,7 +403,7 @@ describe('IpStep', () => {
 
             const call = (IpStepMessages as Mock).mock.lastCall[0];
 
-            expect(call).toEqual({ type: 'none', price: undefined });
+            expect(call).toEqual({ type: 'none', price: '' });
           });
         });
       });

--- a/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStepMessages.spec.tsx
+++ b/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStepMessages.spec.tsx
@@ -1,11 +1,7 @@
 import { describe, vi } from 'vitest';
-import { act } from 'react-dom/test-utils';
-import { TCatalog } from '@ovh-ux/manager-pci-common';
-import { render, renderHook, within } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import React from 'react';
-import { TFloatingIp } from '@/api/data/floating-ips';
 import { IpStepMessages } from '@/pages/create/steps/ip/IpStepMessages';
-import { TCreateStore, useCreateStore } from '@/pages/create/store';
 import { FLOATING_IP_TYPES } from '@/constants';
 
 vi.mock('react-i18next', async () => {
@@ -59,11 +55,6 @@ describe('IpStepMessages', () => {
       expect(
         within(message).queryByText(
           'load-balancer/create | octavia_load_balancer_create_floating_ip_new_price',
-        ),
-      ).toBeInTheDocument();
-      expect(
-        within(message).queryByText(
-          'load-balancer/create | octavia_load_balancer_create_floating_ip_new_price_interval',
         ),
       ).toBeInTheDocument();
     });

--- a/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStepMessages.tsx
+++ b/packages/manager/apps/pci-load-balancer/src/pages/create/steps/ip/IpStepMessages.tsx
@@ -58,9 +58,6 @@ export const IpStepMessages = ({
                     ),
                   }}
                 ></span>
-                {tCreate(
-                  'octavia_load_balancer_create_floating_ip_new_price_interval',
-                )}
               </OsdsText>
             </div>
           </div>


### PR DESCRIPTION
ref: TAPC-2759

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop`
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-2759
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Display the good Floating IP price for selected region

![image-2025-01-31-17-31-51-647](https://github.com/user-attachments/assets/2749de9b-2131-49ff-a96f-471c08f1a946)


## Related

<!-- Link dependencies of this PR -->
