### PR TITLE
feat(pci.instances): disabled assigning floating ip when instance has public IP v6 or v4

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instances.html
+++ b/packages/manager/modules/pci/src/projects/project/instances/instances.html
@@ -207,7 +207,7 @@
             </oui-action-menu-item>
             <oui-action-menu-item
                 data-ng-if="$ctrl.isAdditionalIpsAvailable && $ctrl.PciProjectsProjectInstanceService.additionalIpsIsAvailable($row.flavor.type) && !$row.isLocalZone"
-                data-disabled="$row.hasPublicIpV4() && $row.hasPublicIpV6()"
+                data-disabled="$row.hasPublicIpV4() || $row.hasPublicIpV6()"
                 data-on-click="$ctrl.assignFloatingIp($row)"
             >
                 <span


### PR DESCRIPTION
ref: TAPC-2821

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

-->

| Question         | Answer
| ---------------- | ---
| Branch?          | `develop` <!-- target branch -->
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Tickets          | Fix #TAPC-2821
| License          | BSD 3-Clause

<!--
  Before submitting your PR, please review the following checklist:
-->

- [x] Try to keep pull requests small so they can be easily reviewed.
- [x] Commits are signed-off
- [ ] Only FR translations have been updated
- [x] Branch is up-to-date with target branch
- [x] Lint has passed locally
- [x] Standalone app was ran and tested locally
- [x] Ticket reference is mentioned in linked commits (internal only)
- [ ] Breaking change is mentioned in relevant commits

## Description

Disabled the "assign floating IP" action when instance has public IP v6 **or** public IP v4

## Related

<!-- Link dependencies of this PR -->
