### PR TITLE
fix(pci-object-storage): swift container deletion

### DIFF
--- a/packages/manager/apps/pci-object-storage/src/api/hooks/useStorages.ts
+++ b/packages/manager/apps/pci-object-storage/src/api/hooks/useStorages.ts
@@ -244,8 +244,9 @@ export const useDeleteStorage = ({
           url,
         }),
       );
-
       await Promise.all(deletePromises);
+      // adding some delay to avoid api deletion error
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       return deleteSwiftContainer(projectId, storage.id);
     },
     onError,


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          | feat/pci-object-storage
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Tickets          | DTCORE-3073
| License          | BSD 3-Clause

## Description

add some delay to container swift deletion to avoid api sync errors