### PR TITLE
feat: add product names translation for LDP integrations

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
@@ -796,5 +796,14 @@
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
   "streams_subscriptions_resource_products_account-api": "Espace client OVHcloud & OVHcloud API",
   "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_account-iam": "IAM",
+  "streams_subscriptions_resource_products_email-exchange": "Hosted Exchange",
+  "streams_subscriptions_resource_products_hosting-private-database": "Web Cloud Databases",
+  "streams_subscriptions_resource_products_cloud-project-database-mongodb": "Managed MongoDB",
+  "streams_subscriptions_resource_products_cloud-project-database": "Managed Databases",
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "streams_subscriptions_resource_products_cloud-project-octavia": "OVHcloud Load Balancer",
+  "streams_subscriptions_resource_products_ovh-cloud-connect": "OVHcloud Connect",
+  "streams_subscriptions_resource_products_okms": "Key Management Service",
+  "streams_subscriptions_resource_products_dedicated-cloud": "VMware on OVHcloud"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

With a feature named "Logs to Customers", we are integrating Logs Data Platform inside each OVHcloud product. Somewhere in the LDP Manager, we display products for which customers have subscribed to logs forwarding (between a product & LDP).

We need to nicely display product names, and some are missing. This PR add the needed translations.

(I don't know if this needs to go to the translation team or if I can update all languages files, as these trads are about products names)