### PR TITLE
feat(mrc): datagrid - add sub component feature

### DIFF
--- a/packages/manager-react-components/src/components/datagrid/datagrid-cursor.stories.tsx
+++ b/packages/manager-react-components/src/components/datagrid/datagrid-cursor.stories.tsx
@@ -13,6 +13,7 @@ import {
   columnsSearchAndFilters,
 } from './datagrid.mock';
 import { ActionMenu } from '../navigation';
+import DataGridTextCell from './text-cell.component';
 
 interface Item {
   label: string;
@@ -88,6 +89,8 @@ const DatagridStory = (args) => {
               },
             }
           : {})}
+        getRowCanExpand={args.getRowCanExpand}
+        renderSubComponent={args.renderSubComponent}
         {...(args.isSortable
           ? {
               sorting,
@@ -207,6 +210,20 @@ Topbar.args = {
     onSearch: () => {},
   },
   topbar: <TopbarComponent />,
+};
+
+export const WithSubComponent = DatagridStory.bind({});
+
+WithSubComponent.args = {
+  columns,
+  items: [...Array(10).keys()].map((_, i) => ({
+    label: `Item #${i}`,
+    price: Math.floor(1 + Math.random() * 100),
+  })),
+  getRowCanExpand: () => true,
+  renderSubComponent: (row) => (
+    <DataGridTextCell>{JSON.stringify(row.original)}</DataGridTextCell>
+  ),
 };
 
 export default {

--- a/packages/manager-react-components/src/components/datagrid/datagrid.stories.tsx
+++ b/packages/manager-react-components/src/components/datagrid/datagrid.stories.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { withRouter } from 'storybook-addon-react-router-v6';
 import { useSearchParams } from 'react-router-dom';
 import { applyFilters } from '@ovh-ux/manager-core-api';
+import { Row } from '@tanstack/react-table';
 import { Datagrid } from './datagrid.component';
 import { useDatagridSearchParams } from './useDatagridSearchParams';
 import { useColumnFilters } from '../filters';
 import { columns as clm, columnsFilters, Item } from './datagrid.mock';
+import DataGridTextCell from './text-cell.component';
 
 function sortItems(
   itemList: Item[],
@@ -25,11 +27,15 @@ const DatagridStory = ({
   isPaginated,
   isSortable,
   columns = clm,
+  getRowCanExpand,
+  renderSubComponent,
 }: {
   items: Item[];
   isPaginated: boolean;
   isSortable: boolean;
   columns?: any;
+  renderSubComponent?: (props: Row<any>) => JSX.Element;
+  getRowCanExpand?: (row: Row<any>) => boolean;
 }) => {
   const [searchParams] = useSearchParams();
   const { pagination, setPagination, sorting, setSorting } =
@@ -67,6 +73,8 @@ const DatagridStory = ({
         {...paginationAttrs}
         {...sortingAttrs}
         filters={{ filters, add: addFilter, remove: removeFilter }}
+        getRowCanExpand={getRowCanExpand}
+        renderSubComponent={renderSubComponent}
       />
     </>
   );
@@ -105,6 +113,20 @@ Filters.args = {
   isPaginated: true,
   isSortable: true,
   columns: columnsFilters,
+};
+
+export const WithSubComponent = DatagridStory.bind({});
+
+WithSubComponent.args = {
+  columns: clm,
+  items: [...Array(10).keys()].map((_, i) => ({
+    label: `Item #${i}`,
+    price: Math.floor(1 + Math.random() * 100),
+  })),
+  getRowCanExpand: () => true,
+  renderSubComponent: (row) => (
+    <DataGridTextCell>{JSON.stringify(row.original)}</DataGridTextCell>
+  ),
 };
 
 export default {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
Add props on MRC Datagrid to use tanstack table sub components.

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #[14962](https://github.com/ovh/manager/issues/14962)    <!-- prefix each issue number with "#", if any  -->

## Additional Information

If nether getRowCanExpand and renderSubComponent is set, do not display the expand action column.
If getRowCanExpand and renderSubComponent are set and getRowCanExpand return true, an OdsButton is displayed to toggle the expandable row.
renderSubComponent can accept any React component and get row as param.

![image](https://github.com/user-attachments/assets/ab73c422-ec11-4854-acec-b0b60320344f)
![image](https://github.com/user-attachments/assets/981f8adf-8f94-4e90-8266-ecc54daa2e6a)
<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
