### PR TITLE
fix(manager-pci-common): rclone download modal named export

### DIFF
--- a/packages/manager/modules/manager-pci-common/src/components/rclone-download/RCloneDownloadModal.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/rclone-download/RCloneDownloadModal.tsx
@@ -35,7 +35,7 @@ import '../../index.css';
 
 type RCloneDownloadModalProps = { userId: string };
 
-export default function RCloneDownloadModal({
+export function RCloneDownloadModal({
   userId,
 }: Readonly<RCloneDownloadModalProps>) {
   const { t } = useTranslation('pci-rclone-download');

--- a/packages/manager/modules/manager-pci-common/src/components/rclone-download/index.ts
+++ b/packages/manager/modules/manager-pci-common/src/components/rclone-download/index.ts
@@ -1,1 +1,1 @@
-export * from './RCloneDownload';
+export * from './RCloneDownloadModal';


### PR DESCRIPTION
## Description

fix missing named export for rclone download modal 

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: DTCORE-3108

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
