### PR TITLE
feat(procedures): add exitguard to prevent closing on pending rgdp form

### DIFF
--- a/packages/manager/apps/procedures/src/components/modals/confirmModal/ConfirmModal.component.tsx
+++ b/packages/manager/apps/procedures/src/components/modals/confirmModal/ConfirmModal.component.tsx
@@ -15,7 +15,6 @@ import {
   OsdsSpinner,
   OsdsText,
 } from '@ovhcloud/ods-components/react';
-import { useTranslation } from 'react-i18next';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 
 type Props = {
@@ -87,7 +86,6 @@ export const ConfirmModal: FunctionComponent<Props> = ({
           <OsdsButton
             slot="actions"
             onClick={onValidate}
-            disabled={isPending || undefined}
             variant={ODS_BUTTON_VARIANT.flat}
             color={ODS_THEME_COLOR_INTENT.primary}
           >

--- a/packages/manager/apps/procedures/src/pages/rgdp/rgdpForm/RGDPForm.component.tsx
+++ b/packages/manager/apps/procedures/src/pages/rgdp/rgdpForm/RGDPForm.component.tsx
@@ -15,6 +15,7 @@ import { FinalizeValues, GDPRFormValues, GDPRValues } from '@/types/gdpr.type';
 import { TextField } from './TextField/TextField.component';
 import { SelectField } from './SelectField/SelectField.component';
 import { TextAreaField } from './TextAreaField/TextAreaField.component';
+import ExitGuard from '@/components/ExitGuard/ExitGuard.component';
 import {
   EmailRegex,
   GDPRSubjectValues,
@@ -111,6 +112,7 @@ export const RGDPForm: FunctionComponent = () => {
 
   return (
     <form onSubmit={handleSubmit(() => setShowConfirmModal(true))} noValidate>
+      {(isPending || isError) && <ExitGuard />}
       <div className="my-10">
         <TextField
           label={t('rgdp_form_field_label_firstname')}
@@ -252,7 +254,9 @@ export const RGDPForm: FunctionComponent = () => {
           maxFiles={OtherDocumentsMaxFiles}
           multiple
           maxSize={MaxFileSize}
-          helper={t('rgdp_form_field_helper_other_documents', { maxFiles: 8 })}
+          helper={t('rgdp_form_field_helper_other_documents', {
+            maxFiles: 8,
+          })}
         />
       </div>
       {isError && (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

Adding the ExitGuard component to the RGDP form to prevent the user from closing the window before the files are uploaded and form is sent.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: MANAGER-16927

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
