### PR TITLE
fix(procedures): extend exit guard to cover the full upload process

### DIFF
--- a/packages/manager/apps/procedures/src/pages/disableMFA/create/form/Form.page.tsx
+++ b/packages/manager/apps/procedures/src/pages/disableMFA/create/form/Form.page.tsx
@@ -44,12 +44,13 @@ const FormCreateRequest = () => {
   );
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const [showSuccessModal, setShowSuccessModal] = useState<boolean>(false);
+  const [processStarted, setProcessStarted] = useState<boolean>(false);
   const { useUploadDocuments, useUploadLinks } = useProcedures('2FA');
 
   const files = flatFiles(watch());
   const isAnyFileSelected = files.length > 0;
 
-  // We split the CTA action into two mutation, as once the first is done the API will start
+  // We split the CTA action into two mutations, as once the first one is done the API will start
   // to send us errors if we retry it
   // The following mutation cover the upload of the document as well as the finalization of the request
   const {
@@ -61,6 +62,7 @@ const FormCreateRequest = () => {
     onSuccess: () => {
       setShowSuccessModal(true);
       setShowConfirmModal(false);
+      setProcessStarted(false);
     },
     onError: () => {
       setShowConfirmModal(false);
@@ -79,6 +81,7 @@ const FormCreateRequest = () => {
     },
     onError: () => {
       setShowConfirmModal(false);
+      setProcessStarted(false);
     },
   });
 
@@ -104,7 +107,7 @@ const FormCreateRequest = () => {
 
   return (
     <form onSubmit={handleSubmit(() => setShowConfirmModal(true))}>
-      {isPending && <ExitGuard />}
+      {processStarted && <ExitGuard />}
       {isOtherLegalFormForFR && (
         <div className="my-6">
           <OsdsText
@@ -179,6 +182,7 @@ const FormCreateRequest = () => {
             if (links) {
               uploadDocuments({ files, links });
             } else {
+              setProcessStarted(true);
               getUploadLinks({ numberOfDocuments: files.length });
             }
           }}

--- a/packages/manager/apps/procedures/src/pages/disableMFA/create/form/Form.page.tsx
+++ b/packages/manager/apps/procedures/src/pages/disableMFA/create/form/Form.page.tsx
@@ -44,7 +44,6 @@ const FormCreateRequest = () => {
   );
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const [showSuccessModal, setShowSuccessModal] = useState<boolean>(false);
-  const [processStarted, setProcessStarted] = useState<boolean>(false);
   const { useUploadDocuments, useUploadLinks } = useProcedures('2FA');
 
   const files = flatFiles(watch());
@@ -62,7 +61,6 @@ const FormCreateRequest = () => {
     onSuccess: () => {
       setShowSuccessModal(true);
       setShowConfirmModal(false);
-      setProcessStarted(false);
     },
     onError: () => {
       setShowConfirmModal(false);
@@ -81,7 +79,6 @@ const FormCreateRequest = () => {
     },
     onError: () => {
       setShowConfirmModal(false);
-      setProcessStarted(false);
     },
   });
 
@@ -107,7 +104,7 @@ const FormCreateRequest = () => {
 
   return (
     <form onSubmit={handleSubmit(() => setShowConfirmModal(true))}>
-      {processStarted && <ExitGuard />}
+      {(isPending || isError) && <ExitGuard />}
       {isOtherLegalFormForFR && (
         <div className="my-6">
           <OsdsText
@@ -182,7 +179,6 @@ const FormCreateRequest = () => {
             if (links) {
               uploadDocuments({ files, links });
             } else {
-              setProcessStarted(true);
               getUploadLinks({ numberOfDocuments: files.length });
             }
           }}


### PR DESCRIPTION
## Description

Extend the exit restriction to the whole procedure creation process: from the moment the procedure creation is succesfully received by SIA to the moment we successfully called SIA's /finalize endpoint


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: PRB0042171, MANAGER-17171

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
