### PR TITLE
feat(container): limit pnr switch to non-US customers and pnr featureAvailibility

### DIFF
--- a/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
+++ b/packages/manager/apps/container/src/container/common/nav-reshuffle-switch-back/index.tsx
@@ -13,13 +13,9 @@ import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 
 function NavReshuffleSwitchBack(): JSX.Element {
   const { t } = useTranslation('beta-modal');
-  const { updateBetaChoice, betaVersion, useBeta } = useContainer();
+  const { updateBetaChoice, useBeta } = useContainer();
   const shell = useShell();
   const trackingPlugin = shell.getPlugin('tracking');
-
-  if (!betaVersion) {
-    return <></>;
-  }
 
   const toggleVersion = (value: 'classic' | 'beta') => {
     const versionName = value === 'beta' ? 'new' : 'old';

--- a/packages/manager/apps/container/src/container/legacy/index.tsx
+++ b/packages/manager/apps/container/src/container/legacy/index.tsx
@@ -10,7 +10,7 @@ import { IFrameMessageBus } from '@ovh-ux/shell';
 import { IFrameAppRouter } from '@/core/routing';
 
 import NavReshuffleBetaAccessModal from '@/container/common/pnr-beta-modal';
-import ApplicationContext from '@/context';
+import { useApplication } from '@/context';
 import { useProgress } from '@/context/progress';
 import { LegacyContainerProvider } from './context';
 import LegacyHeader from './Header';
@@ -29,13 +29,13 @@ function LegacyContainer(): JSX.Element {
   const [iframe, setIframe] = useState<HTMLIFrameElement>(null);
   const { betaVersion } = useContainer();
 
-  const { shell } = useContext(ApplicationContext);
+  const { shell, environment } = useApplication();
   const { isStarted: isProgressAnimating } = useProgress();
   const preloaderVisible = usePreloader(shell, iframe);
-  const applications = shell
-    .getPlugin('environment')
-    .getEnvironment()
-    .getApplications();
+  const applications = environment.getApplications();
+
+  const { ovhSubsidiary } = environment.getUser();
+  const canUseBeta = ovhSubsidiary !== 'US' || betaVersion;
 
   const {
     isMfaEnrollmentForced,
@@ -67,9 +67,11 @@ function LegacyContainer(): JSX.Element {
         <Progress isAnimating={isProgressAnimating}></Progress>
 
         <div className={style.managerShell}>
-          <Suspense fallback="">
-            <NavReshuffleBetaAccessModal />
-          </Suspense>
+          {canUseBeta && (
+            <Suspense fallback="">
+              <NavReshuffleBetaAccessModal />
+            </Suspense>
+          )}
           <div>
             <LegacyHeader />
           </div>

--- a/packages/manager/apps/container/src/container/legacy/navbar/Navbar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/navbar/Navbar.tsx
@@ -14,15 +14,16 @@ import Universes from './Universes';
 import useContainer from '@/core/container';
 import LanguageMenu from '@/container/common/language';
 import modalStyle from '@/container/common/modal.module.scss';
-import NavReshuffleSwitchBack from '@/container/common/nav-reshuffle-switch-back';
 import Notifications from '@/container/common/notifications-sidebar/NotificationsButton';
 import { useShell } from '@/context';
 import { useHeader } from '@/context/header';
 import { useUniverses } from '@/hooks/useUniverses';
 import { useMediaQuery } from 'react-responsive';
 import { SMALL_DEVICE_MAX_SIZE, MOBILE_WIDTH_RESOLUTION } from '@/container/common/constants';
+import useUser from '@/hooks/user/useUser';
 
 const HamburgerMenu = React.lazy(() => import('./HamburgerMenu'));
+const NavReshuffleSwitchBack = React.lazy(() => import('@/container/common/nav-reshuffle-switch-back'))
 
 type Props = {
   environment: Environment;
@@ -30,15 +31,17 @@ type Props = {
 
 function Navbar({ environment }: Props): JSX.Element {
   const shell = useShell();
-  const { universe, setUniverse } = useContainer();
+  const { universe, setUniverse, betaVersion } = useContainer();
   const { getUniverses, getHubUniverse } = useUniverses();
   const [userLocale, setUserLocale] = useState(
     shell.getPlugin('i18n').getLocale(),
   );
+  const { ovhSubsidiary } = useUser();
+  const canUseBeta = ovhSubsidiary !== 'US' || betaVersion;
+
   const isSmallDevice = useMediaQuery({
     query: `(max-width: ${SMALL_DEVICE_MAX_SIZE})`,
   });
-
   const isMobile = useMediaQuery({
     query: `(max-width: ${MOBILE_WIDTH_RESOLUTION}px)`,
   });
@@ -104,11 +107,13 @@ function Navbar({ environment }: Props): JSX.Element {
               <Search targetURL={searchURL} />
             </div>
           )}
-          {!isSmallDevice &&
+          {!isSmallDevice && canUseBeta && (
             <div className="oui-navbar-list__item">
-              <NavReshuffleSwitchBack />
+              <Suspense fallback={<></>}>
+                <NavReshuffleSwitchBack />
+              </Suspense>
             </div>
-          }
+          )}
           <div className="oui-navbar-list__item">
             <LanguageMenu
               setUserLocale={setUserLocale}
@@ -125,11 +130,13 @@ function Navbar({ environment }: Props): JSX.Element {
           <Account />
         </div>
       </div>
-      {isSmallDevice &&
+      {isSmallDevice && canUseBeta && (
         <div className={style['small-device-pnr-switch']}>
-          <NavReshuffleSwitchBack />
+          <Suspense fallback={<></>}>
+            <NavReshuffleSwitchBack />
+          </Suspense>
         </div>
-      }
+      )}
     </>
   );
 }

--- a/packages/manager/apps/container/src/container/nav-reshuffle/header/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/header/index.tsx
@@ -1,11 +1,10 @@
-import { useState, Suspense } from 'react';
+import React, { useState, Suspense } from 'react';
 
 import HamburgerMenu from './HamburgerMenu';
 import UserAccountMenu from './user-account-menu';
 
 import LanguageMenu from '@/container/common/language';
 import modalStyle from '@/container/common/modal.module.scss';
-import NavReshuffleSwitchBack from '@/container/common/nav-reshuffle-switch-back';
 import NotificationsSidebar from '@/container/common/notifications-sidebar';
 import Notifications from '@/container/common/notifications-sidebar/NotificationsButton';
 import ApplicationContext, { useShell } from '@/context';
@@ -16,6 +15,10 @@ import { Logo } from '@/container/common/Logo';
 import style from './style.module.scss';
 import { useMediaQuery } from 'react-responsive';
 import { SMALL_DEVICE_MAX_SIZE } from '@/container/common/constants';
+import useContainer from '@/core/container';
+import useUser from '@/hooks/user/useUser';
+
+const NavReshuffleSwitchBack = React.lazy(() => import('@/container/common/nav-reshuffle-switch-back'));
 
 type Props = {
   isSidebarExpanded?: boolean;
@@ -29,6 +32,12 @@ function Header({
   onUserAccountMenuToggle = () => {},
 }: Props): JSX.Element {
   const shell = useShell();
+
+  // PNR SwitchBack check //
+  const { betaVersion } = useContainer();
+  const { ovhSubsidiary } = useUser();
+  const canUseBeta = ovhSubsidiary !== 'US' || betaVersion;
+
   const [userLocale, setUserLocale] = useState<string>(
     shell.getPlugin('i18n').getLocale(),
   );
@@ -68,11 +77,13 @@ function Header({
             <div
               className={`oui-navbar-list oui-navbar-list_aside oui-navbar-list_end ${style.navbarList}`}
             >
-              {!isSmallDevice &&
+              {!isSmallDevice && canUseBeta && (
                 <div className={`oui-navbar-list__item ${style.navbarListItem}`}>
-                  <NavReshuffleSwitchBack />
+                  <Suspense fallback={<></>}>
+                    <NavReshuffleSwitchBack />
+                  </Suspense>
                 </div>
-              }
+              )}
               <div className={`oui-navbar-list__item ${style.navbarListItem}`}>
                 <LanguageMenu
                   setUserLocale={setUserLocale}
@@ -96,11 +107,13 @@ function Header({
               </div>
             </div>
           </div>
-          {isSmallDevice &&
+          {isSmallDevice && canUseBeta && (
             <div className={style['small-device-pnr-switch']}>
-              <NavReshuffleSwitchBack />
+              <Suspense fallback={<></>}>
+                <NavReshuffleSwitchBack />
+              </Suspense>
             </div>
-          }
+          )}
           <NotificationsSidebar />
         </Suspense>
       )}


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
This change adds a check in legacy and pnr container if the SwitchBack component should be shown, allowing the user to switch between legacy and new navigation.

The new condition is: 
- User is not customer of US subsidary **or**
- User has the 'pnr' feature flag enabled (beta tester)

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: MANAGER-17185

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
