### PR TITLE
fix(pci-object-storage): hide user creation password

### DIFF
--- a/packages/manager/apps/pci-object-storage/src/pages/objects/container/users/create/Create.page.tsx
+++ b/packages/manager/apps/pci-object-storage/src/pages/objects/container/users/create/Create.page.tsx
@@ -12,6 +12,7 @@ import {
   OdsFormField,
   OdsInput,
   OdsMessage,
+  OdsPassword,
   OdsRadio,
   OdsSelect,
   OdsText,
@@ -144,7 +145,19 @@ export default function UserCreatePage(): JSX.Element {
                 'pci_projects_project_storages_containers_add_create_or_linked_user_create_user_success_secret-key_label',
               )}
             />
-            <Clipboard className="w-[100%]" value={secret} />
+            {/* Ods clipboard doesn't currently allows input of type password */}
+            {/* @TODO refactor when clipboard allows password input types */}
+            <div className="flex">
+              <div className="flex-1">
+                <OdsPassword
+                  className="w-[100%]"
+                  name="secret"
+                  value={secret}
+                  isReadonly
+                />
+              </div>
+              <Clipboard className="w-[2rem]" value={secret} />
+            </div>
           </OdsFormField>
         </div>
       </div>


### PR DESCRIPTION
## Description

hide user password in creation success message

this is a **temporary** fix since the current ods clipboard (https://ovh.github.io/design-system/latest/?path=/docs/ods-components-form-elements-clipboard--technical-information) does not allow for an input of type password, it should be refactored once ods supports this

Ticket Reference: DTCORE-3072