### PR TITLE
feat(mrc): improve datagrid in datagrid with col size

### DIFF
--- a/packages/manager-react-components/src/components/datagrid/datagrid-cursor.stories.tsx
+++ b/packages/manager-react-components/src/components/datagrid/datagrid-cursor.stories.tsx
@@ -5,7 +5,7 @@ import { ODS_BUTTON_VARIANT, ODS_ICON_NAME } from '@ovhcloud/ods-components';
 import { FilterComparator, applyFilters } from '@ovh-ux/manager-core-api';
 import { withRouter } from 'storybook-addon-react-router-v6';
 import { useSearchParams } from 'react-router-dom';
-import { Datagrid } from './datagrid.component';
+import { Datagrid, DatagridColumn } from './datagrid.component';
 import { useColumnFilters } from '../filters';
 import {
   columns,
@@ -233,6 +233,63 @@ WithSubComponent.args = {
   renderSubComponent: (row) => (
     <DataGridTextCell>{JSON.stringify(row.original)}</DataGridTextCell>
   ),
+};
+
+export const WithDatagridSubComponent = DatagridStory.bind({});
+
+WithDatagridSubComponent.args = {
+  columns,
+  items: [...Array(10).keys()].map((_, i) => ({
+    label: `Item #${i}`,
+    price: Math.floor(1 + Math.random() * 100),
+  })),
+  getRowCanExpand: () => true,
+  renderSubComponent: (row, headerRefs) => {
+    const subComponentColumns = columns.map((col) => ({
+      ...col,
+      size: headerRefs.current[col.id].clientWidth,
+    }));
+    const css = `
+      .sub-row > td {
+        padding: 0 0 0 var(--expander-column-width) !important;
+      }
+      .sub-row table, .sub-row tr {
+        border: none;
+      }
+      .sub-row table td {
+        border-left: none !important;
+        border-right: none !important;
+      }
+      .sub-row table tr:first-child td {
+        border-top: none;
+      }
+      .sub-row table tr:last-child td {
+        border-bottom: none;
+      }
+      .sub-row table tr td:first-child {
+        border-left: none;
+      }
+      .sub-row table tr td:last-child {
+        border-right: none;
+      }
+    `;
+
+    return (
+      <>
+        <style>{css}</style>
+        <Datagrid
+          columns={subComponentColumns}
+          items={[
+            { label: 'sub component label', price: 10 },
+            { label: 'sub component label #2', price: 100 },
+          ]}
+          totalItems={2}
+          hideHeader={true}
+          tableLayoutFixed={true}
+        ></Datagrid>
+      </>
+    );
+  },
 };
 
 export default {

--- a/packages/manager-react-components/src/components/datagrid/datagrid.spec.tsx
+++ b/packages/manager-react-components/src/components/datagrid/datagrid.spec.tsx
@@ -1,6 +1,12 @@
 import { vitest } from 'vitest';
 import React, { useState } from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { FilterCategories } from '@ovh-ux/manager-core-api';
 import { Row } from '@tanstack/react-table';
 import {
@@ -71,6 +77,7 @@ const DatagridTest = ({
   filters,
   getRowCanExpand,
   renderSubComponent,
+  tableLayoutFixed,
 }: {
   columns: any;
   items: string[];
@@ -80,6 +87,7 @@ const DatagridTest = ({
   filters?: FilterProps;
   getRowCanExpand?: (props: Row<any>) => boolean;
   renderSubComponent?: (row: Row<any>) => JSX.Element;
+  tableLayoutFixed?: boolean;
 }) => {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex,
@@ -101,6 +109,7 @@ const DatagridTest = ({
       filters={filters}
       getRowCanExpand={getRowCanExpand}
       renderSubComponent={renderSubComponent}
+      tableLayoutFixed={tableLayoutFixed}
     />
   );
 };
@@ -354,4 +363,20 @@ it('should display new column to expand a row sub component', async () => {
   ).toBe(1);
 
   expect(container.querySelector('#sub-foo')).toBeDefined();
+});
+
+it('should use fixed column width', async () => {
+  const sizedColumns = sampleColumns.map((column) => ({ ...column, size: 50 }));
+  const { getByText } = render(
+    <DatagridTest
+      columns={sizedColumns}
+      items={['foo', 'bar', 'hello']}
+      pageIndex={0}
+      className={'overflow-hidden'}
+      tableLayoutFixed={true}
+    />,
+  );
+
+  const td = getByText('foo').closest('td');
+  expect(td.style.width).toBe('50px');
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

add some improvement to handle datagrid inside datagrid with sub component by giving size of parent datagrid headers to child datagrid in order to define sub-datagrid columns sizes:

![image](https://github.com/user-attachments/assets/190d2706-6b17-476d-8866-38e50c590ac1)

Why not use expanding instead of subcomponents ?

-> To be able to use expanding feature from tanstack table. The cell definition from sub rows should be the same as for main rows. But in some cases, even if column names are same, the way the data is retrieve is different between parent and sub row. For that use case, we are not able to use expanding feature from tanstack table.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
