### PR TITLE
feat(manager-web): add the ability to force field display on Contact Edit domains pages

### DIFF
--- a/packages/manager/apps/web/client/app/domain/contact/edit/edit.constants.js
+++ b/packages/manager/apps/web/client/app/domain/contact/edit/edit.constants.js
@@ -47,6 +47,11 @@ export const SECTIONS = {
   ],
 };
 
+export const FORCED_FIELDS = {
+  firstName: 'firstName',
+  lastName: 'lastName',
+}
+
 export const FIELD_NAME_LIST = {
   legalform: 'legalForm',
   legalFormCategory: 'legalFormCategory',

--- a/packages/manager/apps/web/client/app/domain/contact/edit/field/edit-form-field-component.controller.js
+++ b/packages/manager/apps/web/client/app/domain/contact/edit/field/edit-form-field-component.controller.js
@@ -10,6 +10,7 @@ import {
   OVH_FIELD_PREFIX,
   REGEX,
   OTHER_KEY,
+  FORCED_FIELDS,
 } from '../edit.constants';
 
 export default class EditOwnerFormFieldController {
@@ -182,8 +183,10 @@ export default class EditOwnerFormFieldController {
     return true;
   }
 
+  // Returns a list of fields that are required to pass the validation rules.
+  // In some cases we need to return a list of fields even though the rule says otherwise.
   isRequired() {
-    return !!this.rule?.constraints
+    return Object.values(FORCED_FIELDS).includes(this.rule?.label) || !!this.rule?.constraints
       .filter((constraint) => constraint.operator === 'required')
       .find((rules) => {
         if (rules?.conditions) {


### PR DESCRIPTION
## Description

Add the ability to force field display on Contact Edit domains pages

These fields must be displayed even if the rule says otherwise.

Fields :

- lastName
- firstName

Ticket Reference: #MANAGER-17225

## Additional Information
