### PR TITLE
fix(pci-cold-archive): make pagination work after filtering

### DIFF
--- a/packages/manager/apps/pci-cold-archive/src/api/hooks/useArchive.ts
+++ b/packages/manager/apps/pci-cold-archive/src/api/hooks/useArchive.ts
@@ -81,25 +81,26 @@ export const usePaginatedArchive = (
     isFetching,
   } = useArchives(projectId);
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    const sortedAndFilteredArchives = sortResults<TArchiveContainer>(
+      applyFilters<TArchiveContainer>(archives || [], filters),
+      sorting,
+    );
+    return {
       isLoading,
       isPending,
       isSuccess,
       isFetching,
       paginatedArchives: paginateResults<TArchiveContainer>(
-        sortResults<TArchiveContainer>(
-          applyFilters<TArchiveContainer>(archives || [], filters),
-          sorting,
-        ),
+        sortedAndFilteredArchives,
         pagination,
       ),
       refresh: () => invalidateGetArchivesCache(projectId, region),
       allArchives: archives,
+      allFilteredArchives: sortedAndFilteredArchives,
       error,
-    }),
-    [archives, error, isLoading, isPending, pagination, sorting, filters],
-  );
+    };
+  }, [archives, error, isLoading, isPending, pagination, sorting, filters]);
 };
 
 export const useDeleteArchive = ({

--- a/packages/manager/apps/pci-cold-archive/src/pages/containers/Listing.page.tsx
+++ b/packages/manager/apps/pci-cold-archive/src/pages/containers/Listing.page.tsx
@@ -44,6 +44,7 @@ export default function ListingPage() {
   const {
     paginatedArchives,
     allArchives,
+    allFilteredArchives,
     isPending: isContainersPending,
     isFetching,
     refresh,
@@ -217,12 +218,14 @@ export default function ListingPage() {
           </div>
         </div>
 
-        <FilterList filters={filters} onRemoveFilter={removeFilter} />
+        <div>
+          <FilterList filters={filters} onRemoveFilter={removeFilter} />
+        </div>
 
         <Datagrid
           columns={columns}
           items={paginatedArchives?.rows || []}
-          totalItems={allArchives?.length || 0}
+          totalItems={allFilteredArchives?.length || 0}
           pagination={pagination}
           onPaginationChange={setPagination}
           sorting={sorting}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Pagination was not working properly after filtering.

If the total number of archives was 12, there were 2 pages : ok.
But, if, after applying a filtering, only 2 archives remain, still 2 pages were displayed.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: DTCORE-3182

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
