### PR TITLE
feat(billing): display banner after successful default payment method creation

### DIFF
--- a/packages/manager/modules/new-billing/src/payment/method/add/controller.js
+++ b/packages/manager/modules/new-billing/src/payment/method/add/controller.js
@@ -103,9 +103,12 @@ export default class BillingPaymentMethodAddCtrl {
     this.onPaymentMethodAddError(error);
   }
 
-  onPaymentMethodIntegrationSuccess(paymentMethod, selectedPaymentMethodType) {
+  onPaymentMethodIntegrationSuccess(selectedPaymentMethodType) {
     this.loading.redirecting = true;
-    this.onPaymentMethodAdded(paymentMethod, selectedPaymentMethodType);
+    this.onPaymentMethodAdded(
+      selectedPaymentMethodType,
+      this.model.setAsDefault,
+    );
   }
 
   /* ----------  OuiStepper callbacks  ---------- */

--- a/packages/manager/modules/new-billing/src/payment/method/add/routing.js
+++ b/packages/manager/modules/new-billing/src/payment/method/add/routing.js
@@ -129,25 +129,37 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
       onPaymentMethodAdded: /* @ngInject */ (
         $transition$,
         $translate,
+        $state,
         goPaymentList,
         RedirectionService,
         OVH_PAYMENT_METHOD_TYPE,
-      ) => (paymentMethod, selectedPaymentMethodType) => {
+      ) => (selectedPaymentMethodType, isDefault) => {
         const { callbackUrl } = $transition$.params();
         if (callbackUrl && RedirectionService.validate(callbackUrl)) {
           window.location.href = callbackUrl;
           return callbackUrl;
         }
 
+        let message = $translate.instant(
+          selectedPaymentMethodType?.paymentType ===
+            OVH_PAYMENT_METHOD_TYPE.BANK_ACCOUNT
+            ? 'billing_payment_method_add_sepa_success'
+            : 'billing_payment_method_add_status_success',
+        );
+        if (isDefault) {
+          const autorenewLink = $state.href('billing.autorenew', {
+            filters: JSON.stringify({ status: 'manual' }),
+          });
+          message = `${message}<br>${$translate.instant(
+            'billing_payment_method_add_default_info_auto_renew',
+            { autorenewLink },
+          )}`;
+        }
+
         return goPaymentList(
           {
             type: 'success',
-            text: $translate.instant(
-              selectedPaymentMethodType?.paymentType ===
-                OVH_PAYMENT_METHOD_TYPE.BANK_ACCOUNT
-                ? 'billing_payment_method_add_sepa_success'
-                : 'billing_payment_method_add_status_success',
-            ),
+            text: message,
           },
           get($transition$.params(), 'from', null),
         );

--- a/packages/manager/modules/new-billing/src/payment/method/add/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/new-billing/src/payment/method/add/translations/Messages_fr_FR.json
@@ -38,5 +38,6 @@
   "billing_payment_method_add_sepa_direct_debit_warning_owner_identity": "Attention, le propriétaire du compte bancaire doit être identique au propriétaire du compte OVHcloud.",
   "billing_payment_method_add_sepa_direct_debit_data_processing_info": "Les données collectées sont traitées par OVHcloud en qualité de responsable de traitement afin de mettre en place votre prélèvement SEPA.",
   "billing_payment_method_add_sepa_direct_debit_digital_signature_info": "La mise en place d'un prélèvement SEPA nécessite un mandat qu'il vous sera demandé de signer électroniquement en utilisant une solution fournie par Worldline, un prestataire habilité à délivrer les services de confiance définies par le règlement \"eDIAS\" n° 910/2014 du 23 juillet 2014. Dans ce cadre, ces données lui sont communiquées.",
-  "billing_payment_method_add_credit_card_registration_charges_info": "Un paiement de {{ registrationCharges }} maximum sera réalisé afin de valider le bon fonctionnement de votre carte. Il vous sera intégralement remboursé dans un délai de 48 heures."
+  "billing_payment_method_add_credit_card_registration_charges_info": "Un paiement de {{ registrationCharges }} maximum sera réalisé afin de valider le bon fonctionnement de votre carte. Il vous sera intégralement remboursé dans un délai de 48 heures.",
+  "billing_payment_method_add_default_info_auto_renew": "Si vous aviez des services en renouvellement automatique, il est peut être nécessaire que vous réactiviez leur renouvellement automatique via <a href=\"{{autorenewLink}}\">cette page</a>."
 }


### PR DESCRIPTION
## Description

Added a banner after a successfull default payment addition in order to inform customer they might have to switch their services renewal in automatic.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-16775

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
