### PR TITLE
fix(pci-cold-archive): fix wrong width in user selection on mobile

### DIFF
--- a/packages/manager/apps/pci-cold-archive/src/pages/containers/new/steps/LinkUserSelector.component.tsx
+++ b/packages/manager/apps/pci-cold-archive/src/pages/containers/new/steps/LinkUserSelector.component.tsx
@@ -107,7 +107,7 @@ export default function LinkUserSelector({
 
         <div className="flex gap-4 items-center">
           <OdsSelect
-            className="min-w-[35rem]"
+            className="w-full max-w-[35rem]"
             key={`select-users-${validUsers?.length}`}
             defaultValue={`${selectedUser?.id}`}
             name="selectUser"


### PR DESCRIPTION
ref: DTCORE-3192

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In the archive creation screen, hen selecting "Select an existing user", the user selection input was too large for smaller screen.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: DTCORE-3192

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
