### PR TITLE
fix(account): remove error message on vat number when it is empty

### DIFF
--- a/packages/manager/modules/sign-up/src/components/siret/siret.controller.js
+++ b/packages/manager/modules/sign-up/src/components/siret/siret.controller.js
@@ -18,7 +18,6 @@ export default class SiretCtrl {
     this.displayManualForm = false;
     this.activeSelectSuggest = null;
     this.user = coreConfig.getUser();
-    this.vatFieldTouched = false;
   }
 
   $onInit() {
@@ -123,13 +122,5 @@ export default class SiretCtrl {
       name: `${this.trackingPrefix}${hit}`,
       type: 'navigation',
     });
-  }
-
-  displayVatError() {
-    if (!this.vatFieldTouched) {
-      const regex = new RegExp(this.rules?.vat?.regularExpression);
-      return !regex.test(this.model.vat);
-    }
-    return false;
   }
 }

--- a/packages/manager/modules/sign-up/src/components/siret/siret.html
+++ b/packages/manager/modules/sign-up/src/components/siret/siret.html
@@ -231,11 +231,6 @@
                         data-ng-disabled="$ctrl.disableField"
                     />
                 </oui-field>
-                <p
-                    class="mb-0 text-danger siret-vat-field-error"
-                    data-ng-if="$ctrl.displayVatError($ctrl.vatFieldTouched)"
-                    data-translate="common_field_error_pattern"
-                ></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

Remove format error message on vat number when it is empty and untouched


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #PRB0042259 #MANAGER-17414

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
