### PR TITLE
feat(catalog): migrate from jest to vitest

### DIFF
--- a/packages/manager/apps/catalog/jest.config.js
+++ b/packages/manager/apps/catalog/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/packages/manager/apps/catalog/package.json
+++ b/packages/manager/apps/catalog/package.json
@@ -18,7 +18,8 @@
     "start": "lerna exec --stream --scope='@ovh-ux/manager-catalog-app' --include-dependencies -- npm run build --if-present",
     "start:dev": "lerna exec --stream --scope='@ovh-ux/manager-catalog-app' --include-dependencies -- npm run dev --if-present",
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-catalog-app' --include-dependencies -- npm run dev:watch --if-present",
-    "test": "jest"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@cucumber/cucumber": "^10.3.1",
@@ -49,8 +50,10 @@
     "@ovh-ux/manager-vite-config": "^0.9.3",
     "@playwright/test": "^1.49.1",
     "@tanstack/react-query-devtools": "^5.51.21",
-    "@types/jest": "^29.5.5",
-    "ts-jest": "^29.1.1"
+    "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^2.1.9",
+    "vite": "^5.4.12",
+    "vitest": "^2.1.9"
   },
   "regions": [
     "CA",

--- a/packages/manager/apps/catalog/src/utils/utils.spec.ts
+++ b/packages/manager/apps/catalog/src/utils/utils.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { products as productsData } from './mocks/test-products.mock.json';
 import {
   getUniverses,

--- a/packages/manager/apps/catalog/tsconfig.json
+++ b/packages/manager/apps/catalog/tsconfig.json
@@ -3,7 +3,7 @@
     "lib": ["dom", "es2021"],
     "noEmit": true,
     "target": "es2021",
-    "types": ["vite/client", "node", "jest"],
+    "types": ["vite/client", "node"],
     "module": "ES2020",
     "moduleResolution": "node",
     "removeComments": true,

--- a/packages/manager/apps/catalog/vitest.config.js
+++ b/packages/manager/apps/catalog/vitest.config.js
@@ -1,0 +1,21 @@
+import path from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    coverage: {
+      include: ['src'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+    mainFields: ['module'],
+  },
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

This change replaces `jest` with `vitest` to harmonize our tech stack

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-16306

## Additional Information

Base for #16160 to minimize merge conflicts, #16160 should be merged after this one

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
