### PR TITLE
fix(pci): do not open external links in new tabs

### DIFF
--- a/packages/manager/modules/pci/src/projects/projects.routing.js
+++ b/packages/manager/modules/pci/src/projects/projects.routing.js
@@ -141,7 +141,7 @@ export default /* @ngInject */ ($stateProvider) => {
               state = [targetedState.url, url.searchParams].join('?');
             }
             if (targetedState.isExternal) {
-              window.open(state);
+              window.top.location = state;
             } else {
               window.location = state;
             }


### PR DESCRIPTION
ref: #DATATR-2078

## Description

Directly open external links in current tab to avoid opening infinite tabs after project creation
