### PR TITLE
feat(dedicated.pcc): decommission 2API private cloud catalog

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/backup/backup.service.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/backup/backup.service.js
@@ -22,12 +22,14 @@ export default class BackupService {
     OvhApiDedicatedCloudDatacenter,
     OvhApiOrder,
     WucOrderCartService,
+    DedicatedCloud,
   ) {
     this.$http = $http;
     this.$q = $q;
     this.backupApi = OvhApiDedicatedCloudDatacenter.Backup().v6();
     this.cartApi = OvhApiOrder.Cart().v6();
     this.WucOrderCartService = WucOrderCartService;
+    this.DedicatedCloud = DedicatedCloud;
   }
 
   addConfigToCart(cartItem, datacenterId, offerType) {
@@ -117,22 +119,11 @@ export default class BackupService {
       .$promise;
   }
 
-  getCatalog(ovhSubsidiary) {
-    return this.$http
-      .get('/sws/dedicatedcloud/catalog', {
-        serviceType: 'aapi',
-        params: {
-          ovhSubsidiary,
-        },
-      })
-      .then((data) => get(data, 'data'));
-  }
-
-  getBackupOffers(serviceName, datacenterId, ovhSubsidiary, backup) {
+  getBackupOffers(serviceName, datacenterId, backup) {
     return this.$q
       .all([
         this.getOfferCapabilities(serviceName, datacenterId),
-        this.getCatalog(ovhSubsidiary),
+        this.DedicatedCloud.getCatalog(),
       ])
       .then(([backupOffers, catalog]) =>
         sortBy(

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/upgrade.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/resource/upgrade/upgrade.controller.js
@@ -7,13 +7,22 @@ import { ORDER_PARAMETERS, RESOURCE_UPGRADE_TYPES } from './upgrade.constants';
 
 export default class {
   /* @ngInject */
-  constructor($http, $q, $translate, $window, OvhApiDedicatedCloud, User) {
+  constructor(
+    $http,
+    $q,
+    $translate,
+    $window,
+    OvhApiDedicatedCloud,
+    User,
+    DedicatedCloud,
+  ) {
     this.$q = $q;
     this.$http = $http;
     this.$translate = $translate;
     this.$window = $window;
     this.OvhApiDedicatedCloud = OvhApiDedicatedCloud;
     this.User = User;
+    this.DedicatedCloud = DedicatedCloud;
   }
 
   $onInit() {
@@ -33,14 +42,7 @@ export default class {
   fetchCatalog() {
     return this.$q
       .all({
-        catalog: this.$http
-          .get('/sws/dedicatedcloud/catalog', {
-            serviceType: 'aapi',
-            params: {
-              ovhSubsidiary: this.ovhSubsidiary,
-            },
-          })
-          .then((data) => get(data, 'data')),
+        catalog: this.DedicatedCloud.getCatalog(),
         expressURL: this.User.getUrlOf('express_order'),
         service: this.OvhApiDedicatedCloud.v6().get({
           serviceName: this.productId,

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/service-pack/service-pack.service.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/service-pack/service-pack.service.js
@@ -154,17 +154,6 @@ const ServicePackService = class ServicePack {
     );
   }
 
-  getCatalog(ovhSubsidiary) {
-    return this.$http
-      .get('/sws/dedicatedcloud/catalog', {
-        serviceType: 'aapi',
-        params: {
-          ovhSubsidiary,
-        },
-      })
-      .then((catalog) => catalog.data);
-  }
-
   static getAddonsFromCatalogForFamilyName(catalog, family) {
     return find(catalog.plans[0].addonsFamily, { family }).addons;
   }
@@ -204,8 +193,8 @@ const ServicePackService = class ServicePack {
     );
   }
 
-  getPrices(ovhSubsidiary, hosts, servicePacks) {
-    return this.getCatalog(ovhSubsidiary).then((catalog) => {
+  getPrices(hosts, servicePacks) {
+    return this.DedicatedCloud.getCatalog().then((catalog) => {
       const addons = {
         hourly: ServicePack.getAddonsFromCatalogForFamilyName(
           catalog,

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/service-pack/upgrade/steps/selection/selection.state.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/service-pack/upgrade/steps/selection/selection.state.js
@@ -31,16 +31,10 @@ const resolveServicePacks = /* @ngInject */ (
   );
 
 const resolveServicePacksWithPrices = /* @ngInject */ (
-  currentUser,
   ovhManagerPccServicePackService,
   hosts,
   servicePacks,
-) =>
-  ovhManagerPccServicePackService.getPrices(
-    currentUser.ovhSubsidiary,
-    hosts,
-    servicePacks,
-  );
+) => ovhManagerPccServicePackService.getPrices(hosts, servicePacks);
 
 const resolveServicePackToOrder = /* @ngInject */ ($transition$) =>
   $transition$.params().servicePackToOrder;

--- a/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.routing.js
+++ b/packages/manager/apps/dedicated/client/app/dedicatedCloud/datacenter/backup/backup.routing.js
@@ -104,13 +104,11 @@ export default /* @ngInject */ ($stateProvider) => {
         dedicatedCloudDatacenterBackupService,
         productId,
         datacenterId,
-        currentUser,
         backup,
       ) =>
         dedicatedCloudDatacenterBackupService.getBackupOffers(
           productId,
           datacenterId,
-          currentUser.ovhSubsidiary,
           backup,
         ),
       backupConditionsUrl: /* @ngInject */ (currentUser) =>

--- a/packages/manager/apps/dedicated/client/app/managedBaremetal/datacenter/backup/backup.routing.js
+++ b/packages/manager/apps/dedicated/client/app/managedBaremetal/datacenter/backup/backup.routing.js
@@ -109,12 +109,10 @@ export default /* @ngInject */ ($stateProvider) => {
           dedicatedCloudDatacenterBackupService,
           productId,
           datacenterId,
-          currentUser,
         ) =>
           dedicatedCloudDatacenterBackupService.getBackupOffers(
             productId,
             datacenterId,
-            currentUser.ovhSubsidiary,
           ),
         backupConditionsUrl: /* @ngInject */ (currentUser) =>
           get(


### PR DESCRIPTION
2API private cloud catalog is decommissioned and replaced by feature flipping + direct API catalog use

resolves: #MANAGER-17151 #INC0117252

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
