### PR TITLE
feat(billing): simplify sshkey truncate filter and switch

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/sshkeySwitch/sshkeySwitch.js
+++ b/packages/manager/apps/dedicated/client/app/components/sshkeySwitch/sshkeySwitch.js
@@ -3,15 +3,15 @@ import './sshkeySwitch.css';
 const SSH_REGEX = [
   {
     name: 'RSA',
-    regex: /\b(ssh-rsa)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ssh-rsa)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
   {
     name: 'ECDSA',
-    regex: /\b(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
   {
     name: 'ED25519',
-    regex: /\b(ssh-ed25519)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ssh-ed25519)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
 ];
 

--- a/packages/manager/modules/billing/src/autoRenew/ssh/sshkeyMin.js
+++ b/packages/manager/modules/billing/src/autoRenew/ssh/sshkeyMin.js
@@ -1,86 +1,20 @@
-const SSHKEY_REGEX = [
-  {
-    name: 'RSA',
-    regex: /^(ssh-rsa)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-  {
-    name: 'ECDSA',
-    regex: /^(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-  {
-    name: 'ED25519',
-    regex: /^(ssh-ed25519)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-];
-
 export default /* @ngInject */ function sshkeyMinFilter() {
-  let splitted;
-  let minLength;
-  let innerkeyLength;
-  let subLength;
   const toLength = 50;
   const dots = '...';
-  let type = false;
-  let i;
 
   return function sshkeyMin(keyParam) {
-    let key = keyParam;
+    const [sshType, encodedKey, comment = ''] = keyParam.trim().split(' ');
 
-    key = key.trim().replace(/\n/, '');
-    type = false;
-
-    /* eslint-disable */
-    for (i = SSHKEY_REGEX.length; i--; ) {
-      if (SSHKEY_REGEX[i].regex.test(key)) {
-        type = SSHKEY_REGEX[i];
-        splitted = key.match(SSHKEY_REGEX[i].regex);
-        break;
-      }
+    const initialFormat = `${sshType} ${dots} ${comment}`;
+    if (initialFormat.length > toLength) {
+      return initialFormat.substring(0, toLength - dots.length) + dots;
     }
-    /* eslint-enable */
-
-    if (type && type.name === 'RSA1' && splitted.length === 5) {
-      // special rule...
-
-      // '3' = 3 spaces
-      minLength =
-        splitted[1].length + splitted[2].length + splitted[4].length + 3;
-
-      if (minLength < toLength - dots.length - 2) {
-        //  ('2' = min 2 chars each side of dots)
-        innerkeyLength = splitted[3].length;
-        subLength = (toLength - minLength - dots.length) / 2;
-        return `${splitted[1]} ${splitted[2]} ${splitted[3].substr(
-          0,
-          subLength,
-        )}${dots}${splitted[3].substr(
-          innerkeyLength - subLength,
-          innerkeyLength,
-        )} ${splitted[4]}`;
-      }
-    } else if (type && splitted.length === 4) {
-      minLength = splitted[1].length + splitted[3].length + 2; // '2' = 2 spaces
-
-      if (minLength < toLength - dots.length - 2) {
-        //  ('2' = min 2 chars each side of dots)
-        innerkeyLength = splitted[2].length;
-        subLength = (toLength - minLength - dots.length) / 2;
-        return `${splitted[1]} ${splitted[2].substr(
-          0,
-          subLength,
-        )}${dots}${splitted[2].substr(
-          innerkeyLength - subLength,
-          innerkeyLength,
-        )} ${splitted[3]}`;
-      }
-    }
-
-    // else...Split /2
-    /* eslint-disable no-mixed-operators */
-    return (
-      key.substr(0, toLength / 2 - dots.length) +
-      dots +
-      key.substr(key.length - toLength / 2 + dots.length, key.length)
-    );
+    const remainingLength = toLength - initialFormat.length;
+    const halfLength = Math.floor(remainingLength / 2);
+    const truncatedKey = `${encodedKey.substring(
+      0,
+      halfLength,
+    )}${dots}${encodedKey.substring(encodedKey.length - halfLength)}`;
+    return `${sshType} ${truncatedKey} ${comment}`.trim();
   };
 }

--- a/packages/manager/modules/new-billing/src/autoRenew/ssh/sshkeyMin.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/ssh/sshkeyMin.js
@@ -1,86 +1,20 @@
-const SSHKEY_REGEX = [
-  {
-    name: 'RSA',
-    regex: /^(ssh-rsa)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-  {
-    name: 'ECDSA',
-    regex: /^(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-  {
-    name: 'ED25519',
-    regex: /^(ssh-ed25519)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
-  },
-];
-
 export default /* @ngInject */ function sshkeyMinFilter() {
-  let splitted;
-  let minLength;
-  let innerkeyLength;
-  let subLength;
   const toLength = 50;
   const dots = '...';
-  let type = false;
-  let i;
 
   return function sshkeyMin(keyParam) {
-    let key = keyParam;
+    const [sshType, encodedKey, comment = ''] = keyParam.trim().split(' ');
 
-    key = key.trim().replace(/\n/, '');
-    type = false;
-
-    /* eslint-disable */
-    for (i = SSHKEY_REGEX.length; i--; ) {
-      if (SSHKEY_REGEX[i].regex.test(key)) {
-        type = SSHKEY_REGEX[i];
-        splitted = key.match(SSHKEY_REGEX[i].regex);
-        break;
-      }
+    const initialFormat = `${sshType} ${dots} ${comment}`;
+    if (initialFormat.length > toLength) {
+      return initialFormat.substring(0, toLength - dots.length) + dots;
     }
-    /* eslint-enable */
-
-    if (type && type.name === 'RSA1' && splitted.length === 5) {
-      // special rule...
-
-      // '3' = 3 spaces
-      minLength =
-        splitted[1].length + splitted[2].length + splitted[4].length + 3;
-
-      if (minLength < toLength - dots.length - 2) {
-        //  ('2' = min 2 chars each side of dots)
-        innerkeyLength = splitted[3].length;
-        subLength = (toLength - minLength - dots.length) / 2;
-        return `${splitted[1]} ${splitted[2]} ${splitted[3].substr(
-          0,
-          subLength,
-        )}${dots}${splitted[3].substr(
-          innerkeyLength - subLength,
-          innerkeyLength,
-        )} ${splitted[4]}`;
-      }
-    } else if (type && splitted.length === 4) {
-      minLength = splitted[1].length + splitted[3].length + 2; // '2' = 2 spaces
-
-      if (minLength < toLength - dots.length - 2) {
-        //  ('2' = min 2 chars each side of dots)
-        innerkeyLength = splitted[2].length;
-        subLength = (toLength - minLength - dots.length) / 2;
-        return `${splitted[1]} ${splitted[2].substr(
-          0,
-          subLength,
-        )}${dots}${splitted[2].substr(
-          innerkeyLength - subLength,
-          innerkeyLength,
-        )} ${splitted[3]}`;
-      }
-    }
-
-    // else...Split /2
-    /* eslint-disable no-mixed-operators */
-    return (
-      key.substr(0, toLength / 2 - dots.length) +
-      dots +
-      key.substr(key.length - toLength / 2 + dots.length, key.length)
-    );
+    const remainingLength = toLength - initialFormat.length;
+    const halfLength = Math.floor(remainingLength / 2);
+    const truncatedKey = `${encodedKey.substring(
+      0,
+      halfLength,
+    )}${dots}${encodedKey.substring(encodedKey.length - halfLength)}`;
+    return `${sshType} ${truncatedKey} ${comment}`.trim();
   };
 }

--- a/packages/manager/modules/new-billing/src/autoRenew/ssh/sshkeySwitch/sshkeySwitch.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/ssh/sshkeySwitch/sshkeySwitch.js
@@ -3,15 +3,15 @@ import './sshkeySwitch.css';
 const SSH_REGEX = [
   {
     name: 'RSA',
-    regex: /\b(ssh-rsa)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ssh-rsa)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
   {
     name: 'ECDSA',
-    regex: /\b(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ecdsa-sha2-nistp[0-9]+)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
   {
     name: 'ED25519',
-    regex: /\b(ssh-ed25519)\s+(A{4}[0-9A-Za-z +/]+[=]{0,3})(\s+.*)?$/,
+    regex: /\b(ssh-ed25519)\s+(A{4}[0-9A-Za-z+/]+[=]{0,3})/,
   },
 ];
 


### PR DESCRIPTION
## Description

Opting for a simpler mechanism for the sshkey filter since the key is validated on creation.
We don't check the comment on a new sshkey in the switch component (since the comment regex is set to `.*` and don't use it after, so we can drop it from the switch.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17511

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
