### PR TITLE
feat(overthebox.detail): display ipv4 and ipv6 if available

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.constant.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.constant.js
@@ -76,4 +76,8 @@ export default {
   pattern: /[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/,
   deprecated: '_deprecated',
   version: 'v',
+  ip: {
+    v4: 'v4',
+    v6: 'v6',
+  },
 };

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.controller.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.controller.js
@@ -92,6 +92,7 @@ export default class OverTheBoxDetailsCtrl {
             return otb;
           }),
         this.getDeviceHardware(),
+        this.getIps(),
       ])
       .finally(() => {
         if (this.allDevices.length === 1 && !this.device) {
@@ -883,6 +884,21 @@ export default class OverTheBoxDetailsCtrl {
             errorMessage: err.data.message,
           }),
         );
+      });
+  }
+
+  getIps() {
+    this.ips = [];
+    this.noIps = '';
+    return this.OverTheBoxDetailsService.getIps(this.serviceName)
+      .then((ips) => {
+        this.ips = ips;
+      })
+      .catch((error) => {
+        if (error.status === 404) {
+          this.noIps = this.$translate.instant('overTheBox_model_ips_unknown');
+        }
+        return this.$q.reject(error);
       });
   }
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -135,6 +135,39 @@
                         </div>
                         <div class="oui-tile__item">
                             <div class="oui-tile__definition">
+                                <h4
+                                    class="oui-heading_5"
+                                    data-translate="overTheBox_detail_ips"
+                                ></h4>
+                                <div
+                                    data-ng-repeat="ip in $ctrl.ips | orderBy:'version' track by ip.ip"
+                                    data-ng-if="$ctrl.ips.length > 0"
+                                >
+                                    <div
+                                        class="oui-tile__term"
+                                        data-translate="overTheBox_detail_ip_v4"
+                                        data-ng-if="ip.version === $ctrl.OVERTHEBOX_DETAILS.ip.v4"
+                                    ></div>
+                                    <div
+                                        class="oui-tile__term"
+                                        data-translate="overTheBox_detail_ip_v6"
+                                        data-ng-if="ip.version === $ctrl.OVERTHEBOX_DETAILS.ip.v6"
+                                    ></div>
+                                    <div class="oui-tile__description">
+                                        <div
+                                            class="d-inline-block my-2"
+                                            data-ng-bind="ip.ip + '&nbsp;/&nbsp;' + ip.range"
+                                        ></div>
+                                    </div>
+                                </div>
+                                <div
+                                    data-ng-if="$ctrl.ips.length == 0"
+                                    data-ng-bind="$ctrl.noIps"
+                                ></div>
+                            </div>
+                        </div>
+                        <div class="oui-tile__item">
+                            <div class="oui-tile__definition">
                                 <strong
                                     class="oui-tile__term d-block"
                                     data-translate="overTheBox_detail_bandwidth"

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.service.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.service.js
@@ -2,8 +2,9 @@ import 'moment';
 
 export default class OverTheBoxDetailsService {
   /* @ngInject */
-  constructor($http) {
+  constructor($http, iceberg) {
     this.$http = $http;
+    this.iceberg = iceberg;
   }
 
   loadStatistics(serviceName, metricsType, period) {
@@ -29,5 +30,13 @@ export default class OverTheBoxDetailsService {
 
   unlinkDevice(serviceName) {
     return this.$http.delete(`/overTheBox/${serviceName}/device`);
+  }
+
+  getIps(serviceName) {
+    return this.iceberg(`/overTheBox/${serviceName}/ips`)
+      .query()
+      .expand('CachedObjectList-Pages')
+      .execute()
+      .$promise.then(({ data: result }) => result);
   }
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_de_DE.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_de_DE.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Das Gerät konnte nicht getrennt werden: {{errorMessage}}",
   "overTheBox_unlink_device_success": "Die Zuordnung des Geräts wurde erfolgreich aufgehoben.",
   "overTheBox_change_offer": "Angebot wechseln",
-  "overTheBox_release_channel_deprecated": "Veraltete Version {{version}}"
+  "overTheBox_release_channel_deprecated": "Veraltete Version {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IPs nicht gefunden"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Unable to unlink the device: {{errorMessage}}",
   "overTheBox_unlink_device_success": "Your device has been successfully detached.",
   "overTheBox_change_offer": "Change plan",
-  "overTheBox_release_channel_deprecated": "Deprecated version {{version}}"
+  "overTheBox_release_channel_deprecated": "Deprecated version {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IPs not found"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
@@ -87,7 +87,7 @@
   "overTheBox_change_auto_upgrade_success": "The automatic updates have been changed overnight.",
   "overTheBox_change_auto_upgrade_error": "Unable to change automatic updates at night: {{errorMessage}}",
   "overTheBox_offer_name": "Service offer",
-  "overthebox_caracteristics": "Nodes sizing",
+  "overthebox_caracteristics": "Specifications",
   "overTheBox_model_device": "Device model",
   "overTheBox_detail_bandwidth": "Maximum bandwidth",
   "overTheBox_model_device_unknown": "Unknown",

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_es_ES.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_es_ES.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "No se pudo desasociar el dispositivo: {{errorMessage}}",
   "overTheBox_unlink_device_success": "El dispositivo se ha desvinculado correctamente.",
   "overTheBox_change_offer": "Cambiar de plan",
-  "overTheBox_release_channel_deprecated": "Versión obsoleta {{version}}"
+  "overTheBox_release_channel_deprecated": "Versión obsoleta {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IP no encontradas"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_CA.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Nous n'avons pas pu dissocier le périphérique : {{errorMessage}}",
   "overTheBox_unlink_device_success": "Votre périphérique a été dissocié avec succès.",
   "overTheBox_change_offer": "Changer d'offre",
-  "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}"
+  "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IPs non trouvées"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Nous n'avons pas pu dissocier le périphérique : {{errorMessage}}",
   "overTheBox_unlink_device_success": "Votre périphérique a été dissocié avec succès.",
   "overTheBox_change_offer": "Changer d'offre",
-  "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}"
+  "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IPs non trouvées"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_it_IT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_it_IT.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Impossibile dissociare la periferica: {{errorMessage}}",
   "overTheBox_unlink_device_success": "Il dispositivo è stato scollegato correttamente.",
   "overTheBox_change_offer": "Modificare soluzione",
-  "overTheBox_release_channel_deprecated": "Versione obsoleta {{version}}"
+  "overTheBox_release_channel_deprecated": "Versione obsoleta {{version}}",
+  "overTheBox_detail_ips": "IP",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IP non trovati"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pl_PL.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Nie można odłączyć urządzenia: {{errorMessage}}",
   "overTheBox_unlink_device_success": "Urządzenie zostało pomyślnie odłączone.",
   "overTheBox_change_offer": "Zmień ofertę",
-  "overTheBox_release_channel_deprecated": "Wersja przestarzała {{version}}"
+  "overTheBox_release_channel_deprecated": "Wersja przestarzała {{version}}",
+  "overTheBox_detail_ips": "IP",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "Nie znaleziono adresów IP"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pt_PT.json
@@ -97,5 +97,9 @@
   "overTheBox_unlink_device_error": "Não foi possível desassociar o dispositivo: {{errorMessage}}",
   "overTheBox_unlink_device_success": "O dispositivo foi dissociado com sucesso.",
   "overTheBox_change_offer": "Mudar de oferta",
-  "overTheBox_release_channel_deprecated": "Versão obsoleta {{version}}"
+  "overTheBox_release_channel_deprecated": "Versão obsoleta {{version}}",
+  "overTheBox_detail_ips": "IPs",
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_model_ips_unknown": "IP não encontrados"
 }


### PR DESCRIPTION
## Description

On OverTheBox detail page, display section with all IPs: IPv4 and IPv6 (if available)

Ticket Reference: #UXCT-712

