### PR TITLE
fix(manager-react-components): target property

### DIFF
--- a/packages/manager-react-components/src/components/navigation/menus/action/action.component.tsx
+++ b/packages/manager-react-components/src/components/navigation/menus/action/action.component.tsx
@@ -58,7 +58,7 @@ const MenuItem = ({
 
   if (item.href) {
     return (
-      <a href={item.href} download={item.download}>
+      <a href={item.href} download={item.download} target={item.target}>
         <OdsButton {...buttonProps} />
       </a>
     );


### PR DESCRIPTION
ref: #MANAGER-17877

## Description
In the action menu, the target is missing in the link, so you can't do a target="_blank"

Ticket Reference: #MANAGER-17877
