### PR TITLE
build(config): remove unused lodash dependency

### DIFF
--- a/packages/manager/modules/config/package.json
+++ b/packages/manager/modules/config/package.json
@@ -30,8 +30,7 @@
     "start:watch": "lerna exec --stream --parallel --scope='@ovh-ux/manager-config' --include-dependencies -- yarn run dev:watch"
   },
   "dependencies": {
-    "@ovh-ux/ovh-reket": "^2.1.7",
-    "lodash-es": "^4.17.15"
+    "@ovh-ux/ovh-reket": "^2.1.7"
   },
   "devDependencies": {
     "@ovh-ux/request-tagger": "^0.4.0"


### PR DESCRIPTION
ref: #MANAGER-16634

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-16634    <!-- prefix each issue number with "#", if any  -->

## Additional Information

In an effort to reduce bundle size I'm trying to strip lodash dependency from microapps that doesn't use it, and after removing lodash from `ovh-at-internet` package, this should do the trick

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
