### PR TITLE
feat(manager-react-component): export formatted date component

### DIFF
--- a/packages/manager-react-components/package.json
+++ b/packages/manager-react-components/package.json
@@ -25,9 +25,9 @@
     "prepare": "tsc && vite build",
     "prettier": "prettier --write \"src/**/*.{ts,tsx,js,mdx}\"",
     "start": "rm -rf dist/.cache/storybook && storybook dev -p 6006",
-    "test": "vitest run",
-    "test:cov": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test": "TZ=UTC vitest run",
+    "test:cov": "TZ=UTC vitest run --coverage",
+    "test:watch": "TZ=UTC vitest"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css,md}": [

--- a/packages/manager-react-components/src/components/formatted-date/FormattedDate.spec.tsx
+++ b/packages/manager-react-components/src/components/formatted-date/FormattedDate.spec.tsx
@@ -1,0 +1,21 @@
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FormattedDate } from './FormattedDate';
+import * as useFormattedDateHook from '../../hooks/date/useFormattedDate';
+
+describe('FormattedDate', () => {
+  it('renders formatted date', () => {
+    vi.spyOn(useFormattedDateHook, 'useFormattedDate').mockReturnValue(
+      'Janv 1, 1970',
+    );
+
+    render(
+      <FormattedDate
+        dateString="01/01/1970"
+        format={useFormattedDateHook.DateFormat.display}
+      />,
+    );
+
+    expect(screen.getByText('Janv 1, 1970')).toBeInTheDocument();
+  });
+});

--- a/packages/manager-react-components/src/components/formatted-date/FormattedDate.tsx
+++ b/packages/manager-react-components/src/components/formatted-date/FormattedDate.tsx
@@ -3,6 +3,9 @@ import {
   useFormattedDate,
 } from '../../hooks/date/useFormattedDate';
 
+//
+// @deprecated This component is deprecated. Use `useFormatDate` hook instead.
+//
 export const FormattedDate = (props: FormattedDateProps) => {
   const formattedDate = useFormattedDate(props);
 

--- a/packages/manager-react-components/src/hooks/date/use-formatted-date.stories.mdx
+++ b/packages/manager-react-components/src/hooks/date/use-formatted-date.stories.mdx
@@ -1,0 +1,137 @@
+import { Meta, Source, ArgTypes, ArgsTable } from '@storybook/blocks';
+
+<Meta title="Hooks/useFormatDate"
+  argTypes={{
+    defaultLocale: {
+      control: 'text',
+      type: 'string',
+      default: 'FR-fr',
+      description: 'Fallback locale if i18n is not available.',
+      table: {
+        defaultValue: { summary: 'FR-fr' },
+        type: { summary: 'string' }
+      }
+    },
+    unknownDateLabelDefault: {
+      control: 'text',
+      value: 'N/A',
+      description: 'Label used when the date is invalid or missing.',
+      table: {
+        defaultValue: { summary: 'N/A' },
+        type: { summary: 'string' }
+      }
+    },
+    date: {
+      control: 'date',
+      description: 'Date to format',
+      table: {
+        defaultValue: { summary: 'undefined' },
+        type: { summary: 'date | string' }
+      }
+    },
+    unknownDateLabel: {
+      control: 'text',
+      description: 'Label used when the date is invalid or missing. (Overwrite `unknownDateLabelDefault`)',
+      table: {
+        defaultValue: { summary: 'undefined' },
+        type: { summary: 'string' }
+      }
+    },
+    format: {
+      control: 'select',
+      options: ['DateFormat.compact', 'DateFormat.display', 'DateFormat.fullDisplay'],
+      description: 'Format of date expected',
+      table: {
+        defaultValue: { summary: 'DateFormat.display' },
+        type: { summary: 'enum' }
+      }
+    },
+    timeFormat: {
+      control: 'select',
+      options: ['TimeFormat.hidden', 'TimeFormat.hourAndMinute', 'TimeFormat.fullDisplay'],
+      description: 'Format of time expected',
+      table: {
+        defaultValue: { summary: 'TimeFormat.hidden' },
+        type: { summary: 'enum' }
+      }
+    },
+  }}
+/>
+
+# useFormatDate
+
+The `useFormatDate` hook is a utility that provides a `formatDate` function to format date strings or `Date` objects into localized human-readable strings.
+
+## Usage
+
+<Source
+  code={`const { formatDate } = useFormatDate();
+
+formatDate({ date: '2024-09-14T09:21:21.943Z' });
+// → "14 Sept 2024" (default format)`}
+  language="ts"
+/>
+
+## Parameters
+
+### Parameters of hook
+
+<ArgTypes include={['defaultLocale', 'unknownDateLabelDefault']} />
+
+### Parameters of formatDate
+
+<ArgTypes include={['date', 'format', 'timeFormat', 'unknownDateLabel']} />
+
+## Output examples
+
+<Source
+  code={`
+const { formatDate } = useFormatDate();
+
+// Default formatting
+formatDate({ date: '2024-09-14T09:21:21.943Z' });
+// → "14 Sept 2024"
+
+// With full month name
+formatDate({ date: '2024-09-14T09:21:21.943Z', format: DateFormat.fullDisplay });
+// → "14 September 2024"
+
+// Compact date format
+formatDate({ date: '2024-06-14T09:21:21.943Z', format: DateFormat.compact });
+// → "14/06/2024"
+
+// With time included
+formatDate({
+  date: '2024-01-14T09:21:21.943Z',
+  format: DateFormat.display,
+  timeFormat: TimeFormat.hourAndMinute,
+});
+// → "14 Jan 2024, 10:21"
+
+// Full display with time
+formatDate({
+  date: '2024-01-14T09:21:21.943Z',
+  format: DateFormat.fullDisplay,
+  timeFormat: TimeFormat.fullDisplay,
+});
+// → "14 January 2024 at 10:21:21"`}
+  language="ts"
+/>
+
+## Handling invalid or missing dates
+
+<Source
+  code={`formatDate({ date: undefined });
+// → "N/A"
+
+formatDate({ date: null });
+// → "N/A"
+
+formatDate({ date: '', unknownDateLabel: 'Unknown' });
+// → "Unknown"`}
+  language="ts"
+/>
+
+## Localization
+
+The locale is automatically inferred from `i18n.language`. If not available, it falls back to `'FR-fr'`

--- a/packages/manager-react-components/src/hooks/date/useFormattedDate.spec.tsx
+++ b/packages/manager-react-components/src/hooks/date/useFormattedDate.spec.tsx
@@ -4,6 +4,8 @@ import {
   useFormattedDate,
   defaultUnknownDateLabel,
   DateFormat,
+  useFormatDate,
+  TimeFormat,
 } from './useFormattedDate';
 
 vitest.mock('react-i18next', () => ({
@@ -73,6 +75,100 @@ describe('useFormattedDate', () => {
         useFormattedDate({ dateString, format }),
       );
       expect(result.current).toBe(expected);
+    },
+  );
+});
+
+describe('useFormatDate', () => {
+  it.each([
+    {
+      case: 'label for no date',
+      input: 'invalid',
+      dateString: undefined,
+      format: undefined,
+      expected: defaultUnknownDateLabel,
+    },
+    {
+      case: 'label for no date',
+      input: 'empty',
+      dateString: '',
+      format: undefined,
+      expected: defaultUnknownDateLabel,
+    },
+    {
+      case: 'a valid date',
+      input: 'null',
+      dateString: null,
+      format: undefined,
+      expected: 'N/A',
+    },
+    {
+      case: 'a valid date with abbreviated month',
+      input: 'valid',
+      dateString: '2024-09-14T09:21:21.943Z',
+      format: undefined,
+      expected: '14 sept. 2024',
+    },
+    {
+      case: 'a valid date with abbreviated month',
+      input: 'valid',
+      dateString: '2024-10-14T09:21:21.943Z',
+      format: DateFormat.display,
+      expected: '14 oct. 2024',
+    },
+    {
+      case: 'a valid date with non-abbreviated month',
+      input: 'valid',
+      dateString: '2024-09-14T09:21:21.943Z',
+      format: DateFormat.fullDisplay,
+      expected: '14 septembre 2024',
+    },
+    {
+      case: 'a valid date with compact format',
+      input: 'valid and format is compact',
+      dateString: '2024-06-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      expected: '14/06/2024',
+    },
+    {
+      case: 'a valid date with compact format and time format (CEST)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-06-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14/06/2024 09:21',
+    },
+    {
+      case: 'a valid date with compact format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14/01/2024 09:21',
+    },
+    {
+      case: 'a valid date with display format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.display,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14 janv. 2024, 09:21',
+    },
+    {
+      case: 'a valid date with full display format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.fullDisplay,
+      timeFormat: TimeFormat.fullDisplay,
+      expected: '14 janvier 2024 à 09:21:21',
+    },
+  ])(
+    'displays %s if the date is %s',
+    async ({ dateString, format, timeFormat, expected }) => {
+      const { result } = renderHook(() => useFormatDate({}));
+      expect(
+        result.current.formatDate({ date: dateString, format, timeFormat }),
+      ).toBe(expected);
     },
   );
 });

--- a/packages/manager-react-components/src/hooks/date/useFormattedDate.ts
+++ b/packages/manager-react-components/src/hooks/date/useFormattedDate.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const defaultUnknownDateLabel = 'N/A';
@@ -17,6 +18,21 @@ export enum DateFormat {
   fullDisplay = 'fullDisplay',
 }
 
+export enum TimeFormat {
+  /**
+   * No time
+   */
+  hidden = 'hidden',
+  /**
+   * HH:MM
+   */
+  hourAndMinute = 'hourAndMinute',
+  /**
+   * HH:MM:ss
+   */
+  fullDisplay = 'fullDisplay',
+}
+
 export type FormattedDateProps = {
   dateString: string;
   unknownDateLabel?: string;
@@ -24,6 +40,10 @@ export type FormattedDateProps = {
   format?: DateFormat;
 };
 
+//
+// @deprecated This hook is deprecated and will be removed in the next major version.
+// Use directly the component useFormatDate instead to be more readable
+//
 export const useFormattedDate = ({
   dateString,
   defaultLocale = 'FR-fr',
@@ -45,4 +65,96 @@ export const useFormattedDate = ({
         month: format === DateFormat.fullDisplay ? 'long' : 'short',
         year: 'numeric',
       });
+};
+
+const DATE_FORMAT_LIST = {
+  [DateFormat.compact]: {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+  },
+  [DateFormat.display]: {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  },
+  [DateFormat.fullDisplay]: {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  },
+} as const;
+
+const TIME_FORMAT_LIST = {
+  [TimeFormat.hidden]: {},
+  [TimeFormat.hourAndMinute]: {
+    hour: '2-digit',
+    minute: '2-digit',
+  },
+  [TimeFormat.fullDisplay]: {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  },
+} as const;
+
+class ManagerDateFormatter {
+  constructor(
+    private readonly locale: string,
+    private readonly unknownDateLabelDefault: string,
+  ) {
+    this.locale = locale;
+    this.unknownDateLabelDefault = unknownDateLabelDefault;
+  }
+
+  formatDate({
+    date,
+    format = DateFormat.display,
+    timeFormat = TimeFormat.hidden,
+    unknownDateLabel = this.unknownDateLabelDefault,
+  }: {
+    date?: Date | string;
+    format?: DateFormat;
+    timeFormat?: TimeFormat;
+    unknownDateLabel?: string;
+  }) {
+    const newDate = typeof date === 'string' ? new Date(date) : date;
+
+    if (!newDate || newDate?.toString() === 'Invalid Date') {
+      return unknownDateLabel;
+    }
+
+    return newDate.toLocaleString(this.locale, {
+      ...ManagerDateFormatter.formatDateParams(format),
+      ...ManagerDateFormatter.formatTimeParams(timeFormat),
+    });
+  }
+
+  static formatDateParams(dateFormat: DateFormat) {
+    return DATE_FORMAT_LIST[dateFormat] ?? DATE_FORMAT_LIST[DateFormat.display];
+  }
+
+  static formatTimeParams(timeFormat: TimeFormat) {
+    return TIME_FORMAT_LIST[timeFormat] ?? TIME_FORMAT_LIST[TimeFormat.hidden];
+  }
+}
+
+export type FormatDateProps = {
+  unknownDateLabelDefault?: string;
+  defaultLocale?: string;
+};
+
+export const useFormatDate = ({
+  defaultLocale = 'FR-fr',
+  unknownDateLabelDefault = defaultUnknownDateLabel,
+}: FormatDateProps = {}) => {
+  const { i18n } = useTranslation();
+  const locale = i18n?.language?.replace('_', '-') || defaultLocale;
+
+  const managerDateFormatter = useMemo(
+    () => new ManagerDateFormatter(locale, unknownDateLabelDefault),
+    [locale, unknownDateLabelDefault],
+  );
+
+  return managerDateFormatter;
 };

--- a/packages/manager-react-components/src/hooks/date/useFormattedDateEnglish.spec.tsx
+++ b/packages/manager-react-components/src/hooks/date/useFormattedDateEnglish.spec.tsx
@@ -4,6 +4,8 @@ import {
   useFormattedDate,
   defaultUnknownDateLabel,
   DateFormat,
+  TimeFormat,
+  useFormatDate,
 } from './useFormattedDate';
 
 vitest.mock('react-i18next', () => ({
@@ -73,6 +75,100 @@ describe('useFormattedDate', () => {
         useFormattedDate({ dateString, format }),
       );
       expect(result.current).toBe(expected);
+    },
+  );
+});
+
+describe('useFormatDate', () => {
+  it.each([
+    {
+      case: 'label for no date',
+      input: 'invalid',
+      dateString: undefined,
+      format: undefined,
+      expected: defaultUnknownDateLabel,
+    },
+    {
+      case: 'label for no date',
+      input: 'empty',
+      dateString: '',
+      format: undefined,
+      expected: defaultUnknownDateLabel,
+    },
+    {
+      case: 'a valid date',
+      input: 'null',
+      dateString: null,
+      format: undefined,
+      expected: 'N/A',
+    },
+    {
+      case: 'a valid date with abbreviated month',
+      input: 'valid',
+      dateString: '2024-09-14T09:21:21.943Z',
+      format: undefined,
+      expected: '14 Sept 2024',
+    },
+    {
+      case: 'a valid date with abbreviated month',
+      input: 'valid',
+      dateString: '2024-10-14T09:21:21.943Z',
+      format: DateFormat.display,
+      expected: '14 Oct 2024',
+    },
+    {
+      case: 'a valid date with non-abbreviated month',
+      input: 'valid',
+      dateString: '2024-09-14T09:21:21.943Z',
+      format: DateFormat.fullDisplay,
+      expected: '14 September 2024',
+    },
+    {
+      case: 'a valid date with compact format',
+      input: 'valid and format is compact',
+      dateString: '2024-06-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      expected: '14/06/2024',
+    },
+    {
+      case: 'a valid date with compact format and time format (CEST)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-06-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14/06/2024, 09:21',
+    },
+    {
+      case: 'a valid date with compact format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.compact,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14/01/2024, 09:21',
+    },
+    {
+      case: 'a valid date with display format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.display,
+      timeFormat: TimeFormat.hourAndMinute,
+      expected: '14 Jan 2024, 09:21',
+    },
+    {
+      case: 'a valid date with full display format and time format (CET)',
+      input: 'valid and format is compact with time',
+      dateString: '2024-01-14T09:21:21.943Z',
+      format: DateFormat.fullDisplay,
+      timeFormat: TimeFormat.fullDisplay,
+      expected: '14 January 2024 at 09:21:21',
+    },
+  ])(
+    'displays %s if the date is %s',
+    async ({ dateString, format, timeFormat, expected }) => {
+      const { result } = renderHook(() => useFormatDate({}));
+      expect(
+        result.current.formatDate({ date: dateString, format, timeFormat }),
+      ).toBe(expected);
     },
   );
 });


### PR DESCRIPTION


BREAKING CHANGE: Render useFormattedDate deprecated

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->

Ticket Reference: Resolve #16372
## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
![Pasted Graphic](https://github.com/user-attachments/assets/78e2926d-d0db-4239-bffb-46dd7d90a0b4)

