### PR TITLE
feat: UXCT-713 ipv6 activation on the OTB screen

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/index.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/index.js
@@ -5,6 +5,7 @@ import angularTranslate from 'angular-translate';
 import bandwidth from '@ovh-ux/manager-filters';
 
 import ovhManagerOtbWarning from '../warning';
+import ovhManagerOtbIpDisplay from '../ip-display';
 
 import component from './overTheBox-details.component';
 import constant from './overTheBox-details.constant';
@@ -20,6 +21,7 @@ angular
     angularTranslate,
     ovhManagerOtbWarning,
     bandwidth,
+    ovhManagerOtbIpDisplay,
   ])
   .component('overTheBoxDetails', component)
   .constant('OVERTHEBOX_DETAILS', constant)

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.constant.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.constant.js
@@ -76,8 +76,4 @@ export default {
   pattern: /[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/,
   deprecated: '_deprecated',
   version: 'v',
-  ip: {
-    v4: 'v4',
-    v6: 'v6',
-  },
 };

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -6,6 +6,16 @@
     >
         <span data-translate="overTheBox_available_update"></span>
     </oui-message>
+    <oui-message
+        id="overTheBox_enabled_ipv6_error_msg"
+        type="error"
+        data-ng-if="$ctrl.error.ipv6Update"
+        data-on-dismiss="$ctrl.onIpv6UpdateErrorMessageDismiss()"
+        dismissable
+        class="m-2"
+    >
+        <span data-translate="overTheBox_enabled_ipv6_error"></span>
+    </oui-message>
 
     <tuc-toast-message></tuc-toast-message>
 
@@ -143,22 +153,13 @@
                                     data-ng-repeat="ip in $ctrl.ips | orderBy:'version' track by ip.ip"
                                     data-ng-if="$ctrl.ips.length > 0"
                                 >
-                                    <div
-                                        class="oui-tile__term"
-                                        data-translate="overTheBox_detail_ip_v4"
-                                        data-ng-if="ip.version === $ctrl.OVERTHEBOX_DETAILS.ip.v4"
-                                    ></div>
-                                    <div
-                                        class="oui-tile__term"
-                                        data-translate="overTheBox_detail_ip_v6"
-                                        data-ng-if="ip.version === $ctrl.OVERTHEBOX_DETAILS.ip.v6"
-                                    ></div>
-                                    <div class="oui-tile__description">
-                                        <div
-                                            class="d-inline-block my-2"
-                                            data-ng-bind="ip.ip + '&nbsp;/&nbsp;' + ip.range"
-                                        ></div>
-                                    </div>
+                                    <ip-display
+                                        data-ip="ip"
+                                        data-is-updating="$ctrl.loaders.ipv6Update"
+                                        data-on-ip-activation-update="$ctrl.onIpActivationUpdate(isIpEnabled)"
+                                        data-is-ipv6-enabled="$ctrl.service.ipv6Enabled"
+                                    >
+                                    </ip-display>
                                 </div>
                                 <div
                                     data-ng-if="$ctrl.ips.length == 0"

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.service.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.service.js
@@ -39,4 +39,18 @@ export default class OverTheBoxDetailsService {
       .execute()
       .$promise.then(({ data: result }) => result);
   }
+
+  async updateIpActivation(serviceName, updatedValue) {
+    const response = await this.$http.put(`/overTheBox/${serviceName}/ipv6`, {
+      enabled: updatedValue,
+    });
+    return response?.data?.taskId;
+  }
+
+  async checkIpv6UpdateTask(serviceName, taskId) {
+    const response = await this.$http.get(
+      `/overTheBox/${serviceName}/tasks/${taskId}`,
+    );
+    return response?.data?.status === 'done';
+  }
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_de_DE.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_de_DE.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Angebot wechseln",
   "overTheBox_release_channel_deprecated": "Veraltete Version {{version}}",
   "overTheBox_detail_ips": "IP-Adressen",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IPs nicht gefunden"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_en_GB.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Change plan",
   "overTheBox_release_channel_deprecated": "Deprecated version {{version}}",
   "overTheBox_detail_ips": "IPs",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IPs not found"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_es_ES.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_es_ES.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Cambiar de plan",
   "overTheBox_release_channel_deprecated": "Versión obsoleta {{version}}",
   "overTheBox_detail_ips": "IP",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IP no encontradas"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_CA.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Changer d'offre",
   "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}",
   "overTheBox_detail_ips": "IPs",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IPs non trouvées"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -99,7 +99,6 @@
   "overTheBox_change_offer": "Changer d'offre",
   "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}",
   "overTheBox_detail_ips": "IPs",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
-  "overTheBox_model_ips_unknown": "IPs non trouvées"
+  "overTheBox_model_ips_unknown": "IPs non trouvées",
+  "overTheBox_enabled_ipv6_error": "Une erreur a eu lieu pendant l'activation de l'IPv6. Si l'erreur persiste, veuillez contacter le support."
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_it_IT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_it_IT.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Modificare soluzione",
   "overTheBox_release_channel_deprecated": "Versione obsoleta {{version}}",
   "overTheBox_detail_ips": "IP",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IP non trovati"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pl_PL.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Zmień ofertę",
   "overTheBox_release_channel_deprecated": "Wersja przestarzała {{version}}",
   "overTheBox_detail_ips": "Adresy IP ",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "Nie znaleziono adresów IP"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_pt_PT.json
@@ -99,7 +99,5 @@
   "overTheBox_change_offer": "Mudar de oferta",
   "overTheBox_release_channel_deprecated": "Versão obsoleta {{version}}",
   "overTheBox_detail_ips": "IP",
-  "overTheBox_detail_ip_v4": "IPv4",
-  "overTheBox_detail_ip_v6": "IPv6",
   "overTheBox_model_ips_unknown": "IP não encontrados"
 }

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/index.js
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/index.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import ngTranslateAsyncLoader from '@ovh-ux/ng-translate-async-loader';
+import angularTranslate from 'angular-translate';
+
+import component from './ip-display.component';
+
+const moduleName = 'ovhManagerOtbDetailsIpDisplay';
+
+angular
+  .module(moduleName, [ngTranslateAsyncLoader, angularTranslate])
+  .component('ipDisplay', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.component.js
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.component.js
@@ -1,0 +1,15 @@
+import controller from './ip-display.controller';
+import template from './ip-display.html';
+
+import './ip-display.scss';
+
+export default {
+  controller,
+  template,
+  bindings: {
+    ip: '<',
+    isUpdating: '<',
+    isIpv6Enabled: '=',
+    onIpActivationUpdate: '&',
+  },
+};

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.constant.js
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.constant.js
@@ -1,0 +1,6 @@
+export default {
+  ip: {
+    v4: 'v4',
+    v6: 'v6',
+  },
+};

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.controller.js
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.controller.js
@@ -1,0 +1,28 @@
+import OVERTHEBOX_DETAILS_IP_DISPLAY from './ip-display.constant';
+
+export default class Ipv6DisplayCtrl {
+  isIpv4 = false;
+
+  isIpv6 = false;
+
+  $onInit() {
+    this.isIpv4 = this.ip.version === OVERTHEBOX_DETAILS_IP_DISPLAY.ip.v4;
+    this.isIpv6 = this.ip.version === OVERTHEBOX_DETAILS_IP_DISPLAY.ip.v6;
+  }
+
+  formatIp() {
+    return `${this.ip.ip} / ${this.ip.range}`;
+  }
+
+  loaderLabelClass() {
+    return this.isIpv6Enabled
+      ? 'overthebox-ip-display_ip-activation_from-disabled'
+      : 'overthebox-ip-display_ip-activation_from-enabled';
+  }
+
+  onIpv6ActivationChange(modelValue) {
+    this.onIpActivationUpdate({
+      isIpEnabled: modelValue,
+    });
+  }
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.html
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.html
@@ -1,0 +1,45 @@
+<div class="overthebox-ip-display">
+    <div
+        class="oui-tile__term"
+        data-translate="overTheBox_detail_ip_v4"
+        data-ng-if="$ctrl.isIpv4"
+    ></div>
+    <div
+        class="oui-tile__term"
+        data-translate="overTheBox_detail_ip_v6"
+        data-ng-if="$ctrl.isIpv6"
+    ></div>
+    <div class="oui-tile__description">
+        <div class="my-2" data-ng-if="$ctrl.isIpv6">
+            <div
+                class="overthebox-ip-display_ip-activation"
+                data-ng-hide="$ctrl.isUpdating"
+            >
+                <oui-checkbox
+                    name="ipv6_activated"
+                    data-model="$ctrl.isIpv6Enabled"
+                    data-on-change="$ctrl.onIpv6ActivationChange(modelValue)"
+                >
+                    <span
+                        data-translate="overTheBox_detail_ip_v6_activated"
+                    ></span>
+                </oui-checkbox>
+            </div>
+            <div
+                class="overthebox-ip-display_ip-activation"
+                data-ng-show="$ctrl.isUpdating"
+            >
+                <oui-spinner
+                    size="s"
+                    class="align-middle overthebox-ip-display_ip-activation"
+                />
+                <span
+                    ng-class="$ctrl.loaderLabelClass()"
+                    class="align-middle d-inline-block"
+                    data-translate="overTheBox_detail_ip_v6_activated"
+                ></span>
+            </div>
+        </div>
+        <div class="my-2" data-ng-bind="$ctrl.formatIp()"></div>
+    </div>
+</div>

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.scss
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/ip-display.scss
@@ -1,0 +1,16 @@
+.overthebox-ip-display {
+  $ip-activation-line-height: 1.5em;
+
+  &_ip-activation {
+    max-height: $ip-activation-line-height;
+    line-height: $ip-activation-line-height;
+    overflow: hidden;
+
+    &_from-enabled {
+      font-weight: bold;
+    }
+    &_from-disabled {
+      font-weight: normal;
+    }
+  }
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_de_DE.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_de_DE.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 aktiviert"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_en_GB.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_en_GB.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 enabled"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_es_ES.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_es_ES.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 activada"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_fr_CA.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 activée"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 activée"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_it_IT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_it_IT.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 attivato"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_pl_PL.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 włączone"
+}

--- a/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/overthebox/src/overthebox/ip-display/translations/Messages_pt_PT.json
@@ -1,0 +1,5 @@
+{
+  "overTheBox_detail_ip_v4": "IPv4",
+  "overTheBox_detail_ip_v6": "IPv6",
+  "overTheBox_detail_ip_v6_activated": "IPv6 ativado"
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR includes the following updates:
 - refactoring the ip display of the overTheBox detail component by managing it into a dedicated angularjs component
 - displaying the ipv6 activation state of the current service as a checkbox. Clicking on the checkbox triggers an update task for this ipv6 activation state. 


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #UXCT-713

## Additional Information
Translations has been added and may require correction.
<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
