### PR TITLE
feat(billing): add filter and sort on agreements listing page

### DIFF
--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/details/details.module.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/details/details.module.js
@@ -1,8 +1,12 @@
 import uiRouter from '@uirouter/angularjs';
 import routing from './details.routing';
+import component from './user-agreements-details.component';
 
 const moduleName = 'ovhManagerBillingAgreementsDetails';
 
-angular.module(moduleName, [uiRouter]).config(routing);
+angular
+  .module(moduleName, [uiRouter])
+  .config(routing)
+  .component('userAgreementsDetails', component);
 
 export default moduleName;

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/details/details.routing.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/details/details.routing.js
@@ -1,6 +1,3 @@
-import controller from './user-agreements-details.controller';
-import template from './user-agreements-details.html';
-
 export default /* @ngInject */ (
   $stateProvider,
   $urlServiceProvider,
@@ -9,9 +6,7 @@ export default /* @ngInject */ (
   if (coreConfigProvider.isRegion(['EU', 'CA'])) {
     $stateProvider.state('billing.autorenew.agreements.agreement', {
       url: '/details/{id:int}',
-      template,
-      controller,
-      controllerAs: 'ctrl',
+      component: 'userAgreementsDetails',
       resolve: {
         agreementId: /* @ngInject */ ($transition$) => $transition$.params().id,
         breadcrumb: /* @ngInject */ (agreementId) => agreementId.toString(),

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.component.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.component.js
@@ -1,0 +1,11 @@
+import controller from './user-agreements-details.controller';
+import template from './user-agreements-details.html';
+
+export default {
+  bindings: {
+    agreementId: '<',
+    goBack: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.controller.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.controller.js
@@ -1,34 +1,42 @@
 import filter from 'lodash/filter';
 import get from 'lodash/get';
-
 import {
   AGREEMENT_GENERIC_MORE_INFORMATIONS_URL,
   GDPR_AGREEMENTS_INFOS,
   SUPPORT_URL,
 } from '../user-agreements.constant';
 
-export default /* @ngInject */ function UserAccountAgreementsDtailsController(
-  $q,
-  UserAccountServicesAgreements,
-  Alerter,
-  agreementId,
-  $translate,
-  coreConfig,
-) {
-  const CGV_AGREEMENT_ID = 1635;
+const CGV_AGREEMENT_ID = 1635;
 
-  this.$ngInit = () => {
+export default class UserAccountAgreementsDetailsController {
+  /* @ngInject */
+  constructor(
+    $q,
+    UserAccountServicesAgreements,
+    Alerter,
+    $translate,
+    coreConfig,
+  ) {
+    this.$q = $q;
+    this.UserAccountServicesAgreements = UserAccountServicesAgreements;
+    this.Alerter = Alerter;
+    this.$translate = $translate;
+    this.coreConfig = coreConfig;
+  }
+
+  $onInit() {
     this.accepted = false;
     this.loading = true;
     this.confirmed = false;
     this.alreadyAccepted = false;
 
-    $q.all([
-      UserAccountServicesAgreements.getAgreement(agreementId),
-      UserAccountServicesAgreements.getContract(agreementId),
-    ])
+    this.$q
+      .all([
+        this.UserAccountServicesAgreements.getAgreement(this.agreementId),
+        this.UserAccountServicesAgreements.getContract(this.agreementId),
+      ])
       .then(([agreement, contract]) => {
-        const user = coreConfig.getUser();
+        const user = this.coreConfig.getUser();
         this.SUPPORT_URL = SUPPORT_URL + user.ovhSubsidiary;
         this.agreement = agreement;
         this.contract = contract;
@@ -48,37 +56,35 @@ export default /* @ngInject */ function UserAccountAgreementsDtailsController(
         );
       })
       .catch((err) => {
-        Alerter.error(
-          $translate.instant('user_agreements_error'),
+        this.Alerter.error(
+          this.$translate.instant('user_agreements_error'),
           'agreements_details_alerter',
         );
-        return $q.reject(err);
+        return this.$q.reject(err);
       })
       .finally(() => {
         this.loading = false;
       });
-  };
+  }
 
-  this.accept = () => {
-    UserAccountServicesAgreements.accept({
+  accept() {
+    this.UserAccountServicesAgreements.accept({
       ...this.agreement,
       ...this.contract,
     })
       .then(() => {
         this.accepted = true;
-        Alerter.success(
-          $translate.instant('user_agreement_details_success'),
+        this.Alerter.success(
+          this.$translate.instant('user_agreement_details_success'),
           'agreements_details_alerter',
         );
       })
       .catch((err) => {
-        Alerter.error(
-          $translate.instant('user_agreement_details_error'),
+        this.Alerter.error(
+          this.$translate.instant('user_agreement_details_error'),
           'agreements_details_alerter',
         );
-        $q.reject(err);
+        this.$q.reject(err);
       });
-  };
-
-  this.$ngInit();
+  }
 }

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.html
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/details/user-agreements-details.html
@@ -1,15 +1,15 @@
 <div class="module-useraccount-sections-agreements-container">
-    <oui-back-button data-href="{{ ctrl.$state.href('^') }}"
+    <oui-back-button data-href="{{ $ctrl.$state.href('^') }}"
         ><span data-translate="user_agreement_details_title"></span>
     </oui-back-button>
 
     <div data-ovh-alert="agreements_details_alerter"></div>
 
-    <div class="text-center" data-ng-if="ctrl.loading">
+    <div class="text-center" data-ng-if="$ctrl.loading">
         <oui-spinner></oui-spinner>
     </div>
 
-    <div data-ng-if="ctrl.isCGVContract">
+    <div data-ng-if="$ctrl.isCGVContract">
         <h2 data-translate="user_agreement_details_title1"></h2>
         <h3 data-translate="user_agreement_details_subtitle1"></h3>
         <p data-translate="user_agreement_details_paragraph1"></p>
@@ -33,51 +33,51 @@
         </ul>
     </div>
 
-    <div data-ng-if="!ctrl.loading">
-        <h2 data-ng-bind="ctrl.agreement.title || ctrl.contract.name"></h2>
-        <p data-ng-bind-html="ctrl.agreement.helperText"></p>
+    <div data-ng-if="!$ctrl.loading">
+        <h2 data-ng-bind="$ctrl.agreement.title || $ctrl.contract.name"></h2>
+        <p data-ng-bind-html="$ctrl.agreement.helperText"></p>
         <pre
             class="pre-scrollable contract"
-            data-ng-bind="ctrl.contract.text"
+            data-ng-bind="$ctrl.contract.text"
         ></pre>
     </div>
 
-    <div data-ng-if="ctrl.isCGVContract && ctrl.isIndividual">
+    <div data-ng-if="$ctrl.isCGVContract && $ctrl.isIndividual">
         <h2 data-translate="user_agreement_details_subtitle3"></h2>
         <p
-            data-ng-bind-html="'user_agreement_details_paragraph3' | translate:{ t0: ctrl.SUPPORT_URL }"
+            data-ng-bind-html="'user_agreement_details_paragraph3' | translate:{ t0: $ctrl.SUPPORT_URL }"
         ></p>
     </div>
 
-    <div data-ng-if="!ctrl.loading">
+    <div data-ng-if="!$ctrl.loading">
         <div class="oui-checkbox">
             <input
                 class="oui-checkbox__input"
                 id="user-agreement"
                 name="user-agreement"
                 type="checkbox"
-                data-ng-model="ctrl.confirmed"
-                data-ng-disabled="ctrl.alreadyAccepted"
+                data-ng-model="$ctrl.confirmed"
+                data-ng-disabled="$ctrl.alreadyAccepted"
             />
             <label class="oui-checkbox__label-container" for="user-agreement">
                 <span class="oui-checkbox__label">
                     <span class="oui-checkbox__icon"></span>
                     <span
                         class="oui-checkbox__text"
-                        data-ng-bind-html="'user_agreement_details_agreed' | translate:{ t0: ctrl.agreement.title || ctrl.contract.name }"
+                        data-ng-bind-html="'user_agreement_details_agreed' | translate:{ t0: $ctrl.agreement.title || $ctrl.contract.name }"
                     ></span>
                 </span>
                 <span
                     class="oui-checkbox__description"
-                    data-ng-bind-html="ctrl.appendicesLink ? ('user_agreement_appendices' | translate:{ t0: ctrl.appendicesLink }) : ''"
+                    data-ng-bind-html="$ctrl.appendicesLink ? ('user_agreement_appendices' | translate:{ t0: $ctrl.appendicesLink }) : ''"
                 ></span>
             </label>
         </div>
         <button
             type="button"
             class="oui-button oui-button_primary mt-4"
-            data-ng-disabled="!ctrl.confirmed || ctrl.accepted"
-            data-ng-click="ctrl.accept()"
+            data-ng-disabled="!$ctrl.confirmed || $ctrl.accepted"
+            data-ng-click="$ctrl.accept()"
             data-translate="user_agreement_details_accept"
         ></button>
     </div>

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.component.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.component.js
@@ -1,0 +1,15 @@
+import controller from './user-agreements.controller';
+import template from './user-agreements.html';
+
+export default {
+  bindings: {
+    gotoAcceptAllAgreements: '<',
+    onQueryParamsChange: '<',
+    page: '<',
+    itemsPerPage: '<',
+    state: '<',
+    sorting: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.constant.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.constant.js
@@ -79,8 +79,29 @@ export const GDPR_AGREEMENTS_INFOS = [
   },
 ];
 
+export const COLUMNS_CONFIG = [
+  {
+    property: 'name',
+  },
+  {
+    property: 'state',
+  },
+  {
+    property: 'date',
+  },
+];
+
+export const AGREEMENTS_STATUS = {
+  KO: 'KO',
+  OBSOLETE: 'OBSOLETE',
+  OK: 'OK',
+  TODO: 'TODO',
+};
+
 export default {
   AGREEMENT_GENERIC_MORE_INFORMATIONS_URL,
   SUPPORT_URL,
   GDPR_AGREEMENTS_INFOS,
+  COLUMNS_CONFIG,
+  AGREEMENTS_STATUS,
 };

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.controller.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.controller.js
@@ -71,7 +71,7 @@ export default class UserAccountAgreementsController {
   loadAgreementsList({ pageSize, offset }) {
     return this.UserAccountServicesAgreements.getList(
       pageSize,
-      offset,
+      offset - 1,
       this.state,
       this.sorting,
     )

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.controller.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.controller.js
@@ -130,6 +130,7 @@ export default class UserAccountAgreementsController {
 
   onSortChange({ name, order }) {
     this.onQueryParamsChange({
+      page: 1,
       sorting: JSON.stringify({ predicate: name, reverse: order === 'DESC' }),
     });
   }
@@ -139,6 +140,7 @@ export default class UserAccountAgreementsController {
       (criteria) => criteria.property === 'state',
     );
     this.onQueryParamsChange({
+      page: 1,
       state: stateCriteria?.value || null,
     });
   }

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.html
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.html
@@ -7,7 +7,7 @@
             class="close"
             data-dismiss="alert"
             aria-label="Close"
-            data-ng-click="resetMessages()"
+            data-ng-click="$ctrl.resetMessages()"
             title="{{ 'user_agreements_alert_close' | translate }}"
         >
             <span aria-hidden="true">&times;</span>
@@ -15,14 +15,16 @@
         <span data-ng-bind="message"></span>
     </div>
 
-    <div data-ng-if="toActivate.count || (loading && loaders.toActivate)">
+    <div
+        data-ng-if="$ctrl.toActivate.count || ($ctrl.loading && $ctrl.loaders.toActivate)"
+    >
         <div class="row">
             <h2 class="col" data-translate="user_agreements_to_validate"></h2>
             <div class="col">
                 <oui-button
                     class="d-block text-right"
-                    data-ng-if="!loaders.toActivate"
-                    data-on-click="gotoAcceptAllAgreements(toActivate.list.results)"
+                    data-ng-if="!$ctrl.loaders.toActivate"
+                    data-on-click="$ctrl.gotoAcceptAllAgreements(toActivate.list.results)"
                 >
                     <span data-translate="user_agreements_accept_all"></span>
                 </oui-button>
@@ -38,7 +40,7 @@
             </thead>
             <tbody>
                 <tr
-                    data-ng-repeat="agreement in toActivate.list.results track by $index"
+                    data-ng-repeat="agreement in $ctrl.toActivate.list.results track by $index"
                 >
                     <th scope="row">
                         <a
@@ -50,18 +52,18 @@
                     <td class="text-right">
                         <oui-spinner
                             data-size="s"
-                            data-ng-if="loaders['accept_' + agreement.id]"
+                            data-ng-if="$ctrl.loaders['accept_' + agreement.id]"
                         >
                         </oui-spinner>
 
                         <div
                             data-uib-dropdown
-                            data-ng-if="!loaders['accept_' + agreement.id]"
+                            data-ng-if="!$ctrl.loaders['accept_' + agreement.id]"
                         >
                             <button
                                 type="button"
                                 class="btn btn-link py-0"
-                                data-ng-disabled="loaders['accept_' + agreement.id]"
+                                data-ng-disabled="$ctrl.loaders['accept_' + agreement.id]"
                                 data-uib-dropdown-toggle
                             >
                                 <span
@@ -78,7 +80,7 @@
                                     <button
                                         type="button"
                                         class="btn btn-link"
-                                        data-ng-click="accept(agreement)"
+                                        data-ng-click="$ctrl.accept(agreement)"
                                         data-translate="user_agreements_accept"
                                         title="{{ 'user_agreements_accept_title' | translate:{ t0: agreement.name } }}"
                                     ></button>
@@ -102,7 +104,7 @@
                     </td>
                 </tr>
             </tbody>
-            <tbody data-ng-if="loaders.toActivate">
+            <tbody data-ng-if="$ctrl.loaders.toActivate">
                 <tr>
                     <td class="text-center" colspan="4">
                         <oui-spinner class="my-4" data-size="s"> </oui-spinner>
@@ -113,84 +115,71 @@
     </div>
 
     <h2 data-translate="user_agreements_list_title"></h2>
-
-    <table class="table table-hover">
-        <thead>
-            <tr>
-                <th scope="col" data-translate="user_agreements_name"></th>
-                <th scope="col" data-translate="user_agreements_status"></th>
-                <th
-                    scope="col"
-                    data-translate="user_agreements_date"
-                    colspan="2"
-                ></th>
-            </tr>
-        </thead>
-        <tbody data-ng-if="loading">
-            <tr>
-                <td colspan="3" class="text-center">
-                    <oui-spinner class="my-4" data-size="s"> </oui-spinner>
-                </td>
-            </tr>
-        </tbody>
-        <tbody data-ng-if="list.count == 0 && !loading">
-            <tr>
-                <td colspan="3" class="text-center">
-                    <span
-                        class="font-italic"
-                        data-translate="user_agreements_table_empty"
-                    >
-                    </span>
-                </td>
-            </tr>
-        </tbody>
-        <tbody data-ng-if="list.count > 0 && !loading">
-            <tr data-ng-repeat="agreement in list.list.results track by $index">
-                <th scope="row">
-                    <a
-                        data-ui-sref="billing.autorenew.agreements.agreement({ id: agreement.id })"
-                        data-ng-bind="agreement.name"
-                    >
-                    </a>
-                </th>
-                <td>
-                    <span
-                        class="label"
-                        data-ng-class="{
-                                'label-danger': agreement.state == 'KO',
-                                'label-info': agreement.state == 'OBSOLETE',
-                                'label-success': agreement.state == 'OK',
-                                'label-danger': agreement.state == 'TODO'
-                            }"
-                        data-translate="{{ 'user_agreements_status_'+agreement.state }}"
-                    ></span>
-                </td>
-                <td data-ng-bind="agreement.date | date:'short'"></td>
-                <td>
-                    <a
-                        class="oui-link"
-                        target="_blank"
-                        rel="noopener"
-                        data-ng-href="{{agreement.pdfUrl}}"
-                        data-track-on="click"
-                        data-track-type="action"
-                        data-track-name="contracts::download::download_contracts"
-                    >
-                        <span
-                            class="sr-only"
-                            data-translate="user_agreements_download_pdf_title"
-                            data-translate-values="{ t0: agreement.name }"
-                        ></span>
-                        <span class="fa fa-download" aria-hidden="true"></span>
-                    </a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <div
-        data-pagination-server-side="agreementsList"
-        data-pagination-server-side-function="loadAgreementsList"
-        data-pagination-server-side-paginated-stuff="list"
-        data-pagination-server-side-table-loading="loading"
-    ></div>
+    <oui-datagrid
+        id="agreements"
+        data-page-size="{{:: $ctrl.itemsPerPage }}"
+        data-page="{{ $ctrl.page }}"
+        data-empty-placeholder="{{:: 'user_agreements_table_empty' | translate }}"
+        data-rows-loader="$ctrl.loadAgreementsList($config)"
+        data-criteria="$ctrl.criteria"
+        data-on-criteria-change="$ctrl.onCriteriaChange($criteria)"
+        data-on-page-change="$ctrl.onPageChange($pagination)"
+        data-on-sort-change="$ctrl.onSortChange($sort)"
+        data-columns="$ctrl.columnsConfig"
+    >
+        <oui-datagrid-column
+            data-property="name"
+            data-title="::'user_agreements_name' | translate"
+        >
+            <a
+                data-ui-sref="billing.autorenew.agreements.agreement({ id: $row.id })"
+                data-ng-bind="$row.name"
+            >
+            </a>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-property="state"
+            data-title="::'user_agreements_status' | translate"
+            data-type="options"
+            data-type-options="$ctrl.filtersOptions.state"
+            data-filterable
+        >
+            <span
+                class="label"
+                data-ng-class="{
+                'label-danger': $row.state == 'KO',
+                'label-info': $row.state == 'OBSOLETE',
+                'label-success': $row.state == 'OK',
+                'label-danger': $row.state == 'TODO'
+            }"
+                data-translate="{{ 'user_agreements_status_' + $row.state }}"
+            ></span>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-property="date"
+            data-title="::'user_agreements_date' | translate"
+            data-sortable
+        >
+            <span data-ng-bind="$row.date | date:'short'"> </span>
+        </oui-datagrid-column>
+        <oui-datagrid-column>
+            <a
+                class="oui-link"
+                target="_blank"
+                rel="noopener"
+                data-ng-href="{{$row.pdfUrl}}"
+                data-track-on="click"
+                data-track-type="action"
+                data-track-name="contracts::download::download_contracts"
+            >
+                <span
+                    class="sr-only"
+                    data-translate="user_agreements_download_pdf_title"
+                    data-translate-values="{ t0: $row.name }"
+                ></span>
+                <span class="fa fa-download" aria-hidden="true"></span>
+            </a>
+        </oui-datagrid-column>
+        <!-- /Columns -->
+    </oui-datagrid>
 </div>

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.module.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.module.js
@@ -9,6 +9,7 @@ import acceptAll from './popup-agreement/popup-agreement.module';
 import details from './details/details.module';
 import routing from './user-agreements.routes';
 import service from './user-agreements.service';
+import component from './user-agreements.component';
 
 const moduleName = 'ovhManagerBillingAgreements';
 
@@ -24,6 +25,7 @@ angular
   ])
   .config(routing)
   .service('UserAccountServicesAgreements', service)
+  .component('userAgreements', component)
   .run(/* @ngTranslationsInject:json ./translations */);
 
 export default moduleName;

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.module.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.module.js
@@ -11,6 +11,8 @@ import routing from './user-agreements.routes';
 import service from './user-agreements.service';
 import component from './user-agreements.component';
 
+import './user-agreements.style.less';
+
 const moduleName = 'ovhManagerBillingAgreements';
 
 angular

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.routes.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.routes.js
@@ -70,7 +70,7 @@ export default /* @ngInject */ (
           $state.go('^', queryParams),
         page: /* @ngInject */ (queryParams) => parseInt(queryParams.page, 10),
         itemsPerPage: /* @ngInject */ (queryParams) =>
-          parseInt(queryParams.itemsPerPage, 10),
+          Math.min(parseInt(queryParams.itemsPerPage, 10), 300),
         state: /* @ngInject */ (queryParams) => queryParams.state,
         sorting: /* @ngInject */ (queryParams) =>
           !!queryParams.sorting && JSON.parse(queryParams.sorting),

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.routes.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.routes.js
@@ -1,5 +1,3 @@
-import controller from './user-agreements.controller';
-import template from './user-agreements.html';
 import {
   TRACKING_AGREEMENTS_PAGE_NAME,
   TRACKING_PAGE_CATEGORY,
@@ -12,9 +10,26 @@ export default /* @ngInject */ (
 ) => {
   if (coreConfigProvider.isRegion(['EU', 'CA'])) {
     $stateProvider.state('billing.autorenew.agreements', {
-      url: '/agreements',
-      template,
-      controller,
+      url: '/agreements?page&itemsPerPage&state&sorting',
+      component: 'userAgreements',
+      params: {
+        page: {
+          value: '1',
+          squash: true,
+        },
+        itemsPerPage: {
+          value: '10',
+          squash: true,
+        },
+        state: {
+          value: null,
+          squash: true,
+        },
+        sorting: {
+          value: JSON.stringify({ predicate: 'date', reverse: true }),
+          squash: true,
+        },
+      },
       redirectTo: (transition) =>
         transition
           .injector()
@@ -47,6 +62,18 @@ export default /* @ngInject */ (
         },
         breadcrumb: /* @ngInject */ ($translate) =>
           $translate.instant('user_agreements_list_title'),
+        queryParams: /* @ngInject */ ($transition$) => $transition$.params(),
+        onQueryParamsChange: /* @ngInject */ ($state) => (params) => {
+          $state.go('.', { ...$state.params, ...params }, { notify: false });
+        },
+        goBack: /* @ngInject */ ($state, queryParams) => () =>
+          $state.go('^', queryParams),
+        page: /* @ngInject */ (queryParams) => parseInt(queryParams.page, 10),
+        itemsPerPage: /* @ngInject */ (queryParams) =>
+          parseInt(queryParams.itemsPerPage, 10),
+        state: /* @ngInject */ (queryParams) => queryParams.state,
+        sorting: /* @ngInject */ (queryParams) =>
+          !!queryParams.sorting && JSON.parse(queryParams.sorting),
       },
     });
 

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.service.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.service.js
@@ -42,13 +42,15 @@ export default /* @ngInject */ function UserAccountAgreementsService(
     return response;
   }
 
-  this.getList = function getList(count, offset) {
+  this.getList = function getList(count, offset, state, sorting) {
     return $http
       .get('/sws/agreements', {
         cache: userAgreementsCache,
         params: {
           count,
           offset,
+          ...(state ? { agreed: state } : {}),
+          ...(sorting ? { sortOrder: sorting.reverse ? 'DESC' : 'ASC' } : {}),
         },
         serviceType: 'aapi',
       })
@@ -104,7 +106,6 @@ export default /* @ngInject */ function UserAccountAgreementsService(
       .get('/sws/agreements', {
         cache: userAgreementsCache,
         params: {
-          count: 0,
           offset: 0,
           agreed: 'todo',
         },

--- a/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.style.less
+++ b/packages/manager/modules/new-billing/src/autoRenew/agreements/user-agreements.style.less
@@ -1,0 +1,7 @@
+oui-datagrid#agreements {
+  oui-criteria {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Description

Set up default sorting to DESC date
Add filtering on status column
Fixed back to previous page behavior on agreement details page (was previously returning to the first agreements list page)


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17517

## Additional Information

Refactored agreements table to use ui-kit datagrid (with filter and sorting)