### PR TITLE
feat(dedicated): clean type & mode params for template following finished migration

### DIFF
--- a/packages/manager/modules/bm-server-components/src/server/server.service.js
+++ b/packages/manager/modules/bm-server-components/src/server/server.service.js
@@ -806,10 +806,6 @@ export default class Server {
         urlParams: {
           serviceName,
         },
-        params: {
-          type: 'ovh',
-          mode: 'new',
-        },
       },
     );
   }


### PR DESCRIPTION
## Description

Remove useless type=ovh & mode=new/legacy when listing partitions in the dedicated server OS reinstallation since personal template types have been removed and new format of that route has been adopted everywhere.

Ticket Reference: MANAGER-17980

## Additional Information

2API sws-dedicated-server-installation-ovhTemplate dependency must be deployed first
