### PR TITLE
fix(dedicated): number of disks in os reinstallation

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -2207,8 +2207,8 @@ export default class ServerInstallationOvhCtrl {
       hardwareRaid: [],
       partitioning: {
         disks:
-          this.$scope.informations.nbDisk > 2 &&
-          this.$scope.installation.nbDiskUse > 1
+          this.$scope.informations.nbDisk > 1 &&
+          this.$scope.installation.nbDiskUse
             ? this.$scope.installation.nbDiskUse
             : 0,
       },


### PR DESCRIPTION
## Description

Number of disks parameter is not taken into account in the API payload to reinstall the OS on the dedicated servers.
It is quasi always set to 0, meaning all disks.
This is this issue that this PR will fix.

Ticket Reference: MANAGER-18029

## Additional Information

No dependencies, no translation, ready to be deployed once acked