### PR TITLE
fix(dedicated): size of partition that fills remaining size of disk(s)

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -2169,7 +2169,12 @@ export default class ServerInstallationOvhCtrl {
         const newPartition = {
           fileSystem: partition.fileSystem,
           mountPoint: partition.mountPoint,
-          size: partition.size,
+          size:
+            this.$scope.installation.options.variablePartition &&
+            this.$scope.installation.options.variablePartition.mountPoint ===
+              partition.mountPoint
+              ? 0
+              : partition.size,
           raidLevel: partition.raidLevel,
           extras: {},
         };
@@ -2226,7 +2231,7 @@ export default class ServerInstallationOvhCtrl {
     } else {
       storage.partitioning.schemeName = this.$scope.installation.selectPartitionScheme;
     }
-    this.$scope.installation.storage.push(storage);
+    this.$scope.installation.storage = [storage];
   }
 
   install() {


### PR DESCRIPTION
## Description

In OS installation wizard for dedicated servers, partitions sizes overview in UX can sometimes be a bit inaccurate. Not an issue since this overview is just for information purposes, the exact calculation is done in the backend by the worker.
Problem is when it comes to click the button to auto set the size of a partition to fill the remaining space: when size is a bit too big, it doesn't fit the available size and the worker complains that the partitioning query in the API is impossible to achieve on the hardware.
Auto fixing the worker is not a good approach. API supports up to 1 partition in a layout to be set with a size of 0 meaning filling the remaining space. This is what this PR is about: sending a size of 0 in the API payload when partition is set to fill the remaining size in the UX.

ref: MANAGER-18058

## Additional Information

No dependencies, to be deployed as soon as possible because all customers currently checking box to customize partitions are blocked, when not changing the (usually, depends on selected OS) "/" partition size: the installation task fails later in the process.