### PR TITLE
fix(pci-instances): rework loading states for initial fetch & refetch

### DIFF
--- a/packages/manager/apps/pci-instances/src/pages/instances/Instances.page.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/Instances.page.tsx
@@ -15,6 +15,7 @@ import {
   ODS_BUTTON_VARIANT,
   ODS_ICON_NAME,
   ODS_ICON_SIZE,
+  ODS_SPINNER_SIZE,
   OsdsSearchBarCustomEvent,
 } from '@ovhcloud/ods-components';
 import {
@@ -24,6 +25,7 @@ import {
   OsdsPopover,
   OsdsPopoverContent,
   OsdsSearchBar,
+  OsdsSpinner,
 } from '@ovhcloud/ods-components/react';
 import { FC, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -60,7 +62,13 @@ const Instances: FC = () => {
   const location = useLocation();
   const notFoundAction: boolean = location.state?.notFoundAction;
 
-  const { data, isFetchingNextPage, refresh, isFetching } = useInstances({
+  const {
+    data,
+    isFetchingNextPage,
+    refresh,
+    isFetching,
+    isRefetching,
+  } = useInstances({
     limit: 20,
     sort: sorting.id,
     sortOrder: sorting.desc ? 'desc' : 'asc',
@@ -139,7 +147,7 @@ const Instances: FC = () => {
           <Notifications />
           <SearchNotifications />
           <OsdsDivider />
-          <div className={'sm:flex items-center justify-between mt-4'}>
+          <div className="sm:flex items-center justify-between mt-4 min-h-[40px]">
             <OsdsButton
               size={ODS_BUTTON_SIZE.sm}
               variant={ODS_BUTTON_VARIANT.stroked}
@@ -157,24 +165,28 @@ const Instances: FC = () => {
                 <span>{t('common:pci_instances_common_create_instance')}</span>
               </span>
             </OsdsButton>
-            <div className="justify-between flex gap-5">
-              <div>
-                <OsdsButton
-                  slot="reset-trigger"
-                  size={ODS_BUTTON_SIZE.sm}
-                  color={ODS_THEME_COLOR_INTENT.primary}
-                  variant={ODS_BUTTON_VARIANT.stroked}
-                  onClick={handleRefresh}
-                  {...(isFetching && { disabled: true })}
-                >
-                  <span slot="start" className="flex items-center mr-0">
-                    <OsdsIcon
-                      name={ODS_ICON_NAME.REFRESH}
-                      size={ODS_ICON_SIZE.sm}
-                      color={ODS_THEME_COLOR_INTENT.primary}
-                    />
-                  </span>
-                </OsdsButton>
+            <div className="justify-between flex gap-5 min-h-[40px] items-center">
+              <div className="flex items-center">
+                {isRefetching ? (
+                  <OsdsSpinner inline={true} size={ODS_SPINNER_SIZE.md} />
+                ) : (
+                  <OsdsButton
+                    slot="reset-trigger"
+                    size={ODS_BUTTON_SIZE.sm}
+                    color={ODS_THEME_COLOR_INTENT.primary}
+                    variant={ODS_BUTTON_VARIANT.stroked}
+                    onClick={handleRefresh}
+                    {...(isFetching && { disabled: true })}
+                  >
+                    <span slot="start" className="flex items-center mr-0">
+                      <OsdsIcon
+                        name={ODS_ICON_NAME.REFRESH}
+                        size={ODS_ICON_SIZE.sm}
+                        color={ODS_THEME_COLOR_INTENT.primary}
+                      />
+                    </span>
+                  </OsdsButton>
+                )}
               </div>
               <OsdsSearchBar
                 className={'w-auto'}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

This PR adds a overhaul rework for loading states.

At initial mount, we have now 10 skeletons displayed in the DataGrid:
![437022498-1074be9c-67dd-4136-bba2-c03621721ba2](https://github.com/user-attachments/assets/b8b1d899-ff0b-4b6a-b4d9-ab0e82008503)


When user do a manual refetch, changes sort, searches for a keyword, or when there is a background refetch, there is a loader that indicates the loading state, to prevent from the datagrid to shift:

 
![Capture d’écran 2025-04-24 à 14 42 29](https://github.com/user-attachments/assets/0ed86f01-808c-46f1-84b0-7bf9e380f16b)



<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
