### PR TITLE
feat(zimbra): account POST requests in sequence

### DIFF
--- a/packages/manager/apps/zimbra/src/utils/index.ts
+++ b/packages/manager/apps/zimbra/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './dnsconfig.constants';
 export * from './form';
 export * from './url';
 export * from './string';
+export * from './promise';
 
 export const DATAGRID_REFRESH_INTERVAL = 5_000;
 export const DATAGRID_REFRESH_ON_MOUNT = 'always';

--- a/packages/manager/apps/zimbra/src/utils/promise.spec.ts
+++ b/packages/manager/apps/zimbra/src/utils/promise.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from 'vitest';
+import { allSettledSequential } from './promise';
+
+describe('promise utils', () => {
+  describe('allSettledSequential', () => {
+    it('should execute all functions sequentially and collect results', async () => {
+      const func1 = () => Promise.resolve(1);
+      const func2 = () => Promise.resolve(2);
+      const func3 = () => Promise.resolve(3);
+
+      const result = await allSettledSequential([func1, func2, func3]);
+
+      expect(result).toEqual([
+        { status: 'fulfilled', value: 1 },
+        { status: 'fulfilled', value: 2 },
+        { status: 'fulfilled', value: 3 },
+      ]);
+    });
+
+    it('should continue executing even if a function throws an error', async () => {
+      const func1 = () => Promise.resolve(1);
+      const func2 = () => Promise.reject(new Error('Test error'));
+      const func3 = () => Promise.resolve(3);
+
+      const result = await allSettledSequential([func1, func2, func3]);
+
+      expect(result).toEqual([
+        { status: 'fulfilled', value: 1 },
+        { status: 'rejected', reason: new Error('Test error') },
+        { status: 'fulfilled', value: 3 },
+      ]);
+    });
+
+    it('should return an empty array when given an empty array', async () => {
+      const result = await allSettledSequential([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/manager/apps/zimbra/src/utils/promise.ts
+++ b/packages/manager/apps/zimbra/src/utils/promise.ts
@@ -1,0 +1,10 @@
+export const allSettledSequential = (funcs: Array<() => Promise<unknown>>) =>
+  funcs.reduce(
+    (promise, func) =>
+      promise.then((result) =>
+        func()
+          .then((value) => result.concat([{ status: 'fulfilled', value }]))
+          .catch((reason) => result.concat([{ status: 'rejected', reason }])),
+      ),
+    Promise.resolve([]),
+  );


### PR DESCRIPTION
ref: #MANAGER-18180

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18180  <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->


Currently there's an issue on backend side that when you send multiple account POST request in parallel, it can happen that some accounts will not show in the list of accounts and it requires manual action on backend side to fix it.

Sending the requests sequentially seems to avoid this issue in most cases, so it will be needed until a solution on backend side is found
