### PR TITLE
feat(common-api): add services delete hook

### DIFF
--- a/packages/manager/modules/common-api/package.json
+++ b/packages/manager/modules/common-api/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@ovh-ux/manager-core-api": "^0.11.1",
     "@ovh-ux/manager-core-test-utils": "^0.4.4",
+    "@ovh-ux/manager-react-shell-client": "^0.8.7",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@vitejs/plugin-react": "^4.3.3",
@@ -37,6 +38,7 @@
   },
   "peerDependencies": {
     "@ovh-ux/manager-core-api": "^0.9.0",
+    "@ovh-ux/manager-react-shell-client": "^0.8.7",
     "@tanstack/react-query": "5.x",
     "react": "18.x"
   }

--- a/packages/manager/modules/common-api/src/services/api/post.spec.ts
+++ b/packages/manager/modules/common-api/src/services/api/post.spec.ts
@@ -1,0 +1,40 @@
+import { vi } from 'vitest';
+import { v6 } from '@ovh-ux/manager-core-api';
+import { deleteService } from './post';
+
+const mockId = 123123;
+
+vi.mock('@ovh-ux/manager-core-api', () => ({
+  v6: {
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+describe('delete service test suite', () => {
+  const useCases: {
+    ovhSubsidiary: string;
+    apiEndpoint: string;
+    httpMethod: keyof typeof v6;
+  }[] = [
+    {
+      ovhSubsidiary: 'FR',
+      apiEndpoint: `/services/${mockId}/terminate`,
+      httpMethod: 'post',
+    },
+    {
+      ovhSubsidiary: 'US',
+      apiEndpoint: `/services/${mockId}`,
+      httpMethod: 'delete',
+    },
+  ];
+
+  test.each(useCases)(
+    'should use the correct API endpoint for subsidiary: $ovhSubsidiary',
+    async ({ ovhSubsidiary, apiEndpoint: apiEnpoint, httpMethod }) => {
+      await deleteService({ serviceId: mockId }, ovhSubsidiary);
+
+      expect(v6[httpMethod]).toHaveBeenCalledWith(apiEnpoint);
+    },
+  );
+});

--- a/packages/manager/modules/common-api/src/services/api/post.ts
+++ b/packages/manager/modules/common-api/src/services/api/post.ts
@@ -1,11 +1,22 @@
-import { apiClient } from '@ovh-ux/manager-core-api';
+import { v6 } from '@ovh-ux/manager-core-api';
 
 export type DeleteServiceParams = {
   serviceId: number;
 };
 
+const US_SUBSIDIARY = 'US';
 /**
- * Terminiate a service
+ * Delete service
  */
-export const deleteService = async ({ serviceId }: DeleteServiceParams) =>
-  apiClient.v6.post<{ message: string }>(`/services/${serviceId}/terminate`);
+export type DeleteServiceResponse = {
+  message: string;
+};
+
+export const deleteService = async (
+  { serviceId }: DeleteServiceParams,
+  ovhSubsidiary?: string,
+) => {
+  return ovhSubsidiary === US_SUBSIDIARY
+    ? v6.delete<DeleteServiceResponse>(`/services/${serviceId}`)
+    : v6.post<DeleteServiceResponse>(`/services/${serviceId}/terminate`);
+};

--- a/packages/manager/modules/common-api/src/services/hooks/useDeleteService.ts
+++ b/packages/manager/modules/common-api/src/services/hooks/useDeleteService.ts
@@ -1,9 +1,12 @@
 import { ApiError, ApiResponse } from '@ovh-ux/manager-core-api';
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
 import {
   MutationOptions,
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
+import { useContext } from 'react';
+
 import {
   getResourceServiceId,
   getResourceServiceIdQueryKey,
@@ -27,6 +30,9 @@ export const useDeleteService = ({
   ...options
 }: UseDeleteServiceParams) => {
   const queryClient = useQueryClient();
+  const { ovhSubsidiary } =
+    useContext(ShellContext)?.environment?.getUser() || {};
+
   const { mutate: terminateService, ...mutation } = useMutation({
     mutationKey,
     mutationFn: async ({ resourceName }) => {
@@ -37,7 +43,7 @@ export const useDeleteService = ({
         queryKey: getResourceServiceIdQueryKey({ resourceName }),
         queryFn: () => getResourceServiceId({ resourceName }),
       });
-      return deleteService({ serviceId: data[0] });
+      return deleteService({ serviceId: data[0] }, ovhSubsidiary);
     },
     ...options,
   });


### PR DESCRIPTION
ref: #MANAGER-18300
## Description



Update the hook deleteService to be able to call diffrents routes depending of the ovhSubsidiary

**common-api** needs now  the dependency **ovh-ux/manager-react-shell-client** 
