### PR TITLE
fix(zimbra): fix typo in guide description

### DIFF
--- a/packages/manager/apps/zimbra/public/translations/onboarding/Messages_fr_CA.json
+++ b/packages/manager/apps/zimbra/public/translations/onboarding/Messages_fr_CA.json
@@ -13,6 +13,6 @@
   "card_guide_title_2": "Configurer son compte Zimbra",
   "card_guide_title_3": "Maitriser le webmail Zimbra",
   "card_guide_description_1": "Découvrez comment créer vos premières boites mail et administrer votre service",
-  "card_guide_description_2": "Apprenez à configurer et utiliser votre compre Zimbra sur un terminal externe (PC ou smartphone)",
+  "card_guide_description_2": "Apprenez à configurer et utiliser votre compte Zimbra sur un terminal externe (PC ou smartphone)",
   "card_guide_description_3": "Découvrez les fonctionnalités de l'interface web Zimbra"
 }

--- a/packages/manager/apps/zimbra/public/translations/onboarding/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/onboarding/Messages_fr_FR.json
@@ -13,6 +13,6 @@
   "card_guide_title_2": "Configurer son compte Zimbra",
   "card_guide_title_3": "Maitriser le webmail Zimbra",
   "card_guide_description_1": "Découvrez comment créer vos premières boites mail et administrer votre service",
-  "card_guide_description_2": "Apprenez à configurer et utiliser votre compre Zimbra sur un terminal externe (PC ou smartphone)",
+  "card_guide_description_2": "Apprenez à configurer et utiliser votre compte Zimbra sur un terminal externe (PC ou smartphone)",
   "card_guide_description_3": "Découvrez les fonctionnalités de l'interface web Zimbra"
 }


### PR DESCRIPTION
ref: MANAGER-18333
## Description

Ticket Reference: #18333

- [x] [CMT-25309](https://jira.ovhcloud.tools/browse/CMT-25309)

## Additional Information
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/e3cf80d0-36a7-4d7d-85e3-3c1a1ca5d367" />

