### PR TITLE
fix(container): center chevron in button on public cloud sidebar

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/public-cloud/pci-sidebar.module.scss
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/public-cloud/pci-sidebar.module.scss
@@ -19,6 +19,10 @@
   border-radius: 1rem;
   line-height: 2rem;
   margin-top: 0.5rem;
+
+  span {
+    height: 100%;
+  }
 }
 
 .menuToggle {


### PR DESCRIPTION
## Description

Set chevron icon height to match its parents in order for the centering rule to work properly


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18358

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
