### PR TITLE
fix(container): concurrency issue on default public cloud project selection

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -70,7 +70,7 @@ export const PublicCloudPanel: React.FC<ComponentProps<
     },
   });
 
-  const { data: defaultPciProject } = useDefaultPublicCloudProject({
+  const { data: defaultPciProject, isFetched: isDefaultProjectFetched } = useDefaultPublicCloudProject({
     select: (defaultProjectId: string | null): PciProject | null => {
       return defaultProjectId !== null
         ? pciProjects?.find(
@@ -111,13 +111,13 @@ export const PublicCloudPanel: React.FC<ComponentProps<
       }
       if (project) {
         setSelectedPciProject(project);
-      } else if (defaultPciProject !== null) {
+      } else if (defaultPciProject) {
         setSelectedPciProject(defaultPciProject);
-      } else {
+      } else if (isDefaultProjectFetched) {
         setSelectedPciProject(pciProjects[0]);
       }
     }
-  }, [rootNode, containerURL, pciProjects]);
+  }, [rootNode, containerURL, pciProjects, defaultPciProject]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Description

Ensure the default public cloud project has been fetched to avoid selection of undefined project 


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18374

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
