### PR TITLE
fix(dedicated): os installation raid 0 space remaining

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -610,7 +610,7 @@ export default class ServerInstallationOvhCtrl {
         this.$scope.informations.raidController
       ) {
         realRemainingSize = remainingSize;
-      } else if (raidLevel) {
+      } else {
         switch (raidLevel) {
           case this.$scope.constants.warningRaid0:
             realRemainingSize = remainingSize;


### PR DESCRIPTION
## Description

raidLevel has been changed form a string "_0", "_1", etc. to an integer 0, 1, etc. [here](https://github.com/ovh/manager/commit/295b31e813bc8abace80b9f05a0a2a92e051ac4b#diff-aa6febc3148d280209b447e8968fa3c3810b31ac5c6a795e14d7ca7bde4114b5L576)
This has the consequence to exclude the raidLevel 0 from switch case and therefore caused the bug when clicking to fill remaining space when raidLevel is 0

Ticket Reference: #MANAGER-18173