### PR TITLE
fix(mrc): add default sorting to state in useResourcesV6

### DIFF
--- a/packages/manager-react-components/src/hooks/datagrid/useResourcesV6.tsx
+++ b/packages/manager-react-components/src/hooks/datagrid/useResourcesV6.tsx
@@ -100,7 +100,9 @@ export function useResourcesV6<T extends Record<string, unknown>>({
     retry: false,
   });
 
-  const [sorting, setSorting] = useState<ColumnSort>();
+  const [sorting, setSorting] = useState<ColumnSort | undefined>(
+    defaultSorting,
+  );
   const [pageIndex, setPageIndex] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
   const [flattenData, setFlattenData] = useState<T[]>([]);
@@ -115,17 +117,16 @@ export function useResourcesV6<T extends Record<string, unknown>>({
   }, [searchFilters, data?.data, filters]);
 
   const filteredAndSortedData = useMemo(() => {
-    const currSorting = sorting || defaultSorting;
-    if (currSorting) {
+    if (sorting) {
       const columnType =
-        columns.find((col) => col.id === currSorting.id)?.type ||
+        columns.find((col) => col.id === sorting.id)?.type ||
         FilterTypeCategories.String;
       return [...filteredData].sort((a, b) =>
         sortColumn(
           columnType,
-          `${a?.[currSorting.id]}`,
-          `${b?.[currSorting.id]}`,
-          currSorting.desc,
+          `${a?.[sorting.id]}`,
+          `${b?.[sorting.id]}`,
+          sorting.desc,
         ),
       );
     }


### PR DESCRIPTION
ref: #17251

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
We can set a default sorting for useResourcesV6.
This default sorting is used for data sorting.
However, this default sorting is not added to the state, and thus, not sent to the datagrid that does know there is a current sorting.

The fix adds this default sorting to the state, so that it's then passed to the datagrid that displays the correct sorting arrow

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #17251

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
