### PR TITLE
fix(billing): display API error message on unsuccessful termination

### DIFF
--- a/packages/manager/modules/billing-components/src/components/cancellation-form/billing-confirmTerminate.controller.js
+++ b/packages/manager/modules/billing-components/src/components/cancellation-form/billing-confirmTerminate.controller.js
@@ -30,7 +30,7 @@ export default class TerminateServiceCtrl {
       .catch((error) =>
         this.Alerter.error(
           this.$translate.instant('billing_confirm_termination_error', {
-            message: error.message,
+            message: error?.data?.message || error?.message,
           }),
         ),
       )


### PR DESCRIPTION
## Description

Use alternative error message path in order to display the API error when the resiliation is unsuccessful


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #PRB0041386, #MANAGER-18445

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
