### PR TITLE
feat(telephony): adding voicemail transcript ui

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/index.js
@@ -6,6 +6,7 @@ import 'ovh-api-services';
 
 import controller from './management.controller';
 import template from './management.html';
+import service from './management.service';
 
 const moduleName = 'ovhManagerTelecomTelephonyServiceVoicemailManagement';
 
@@ -15,8 +16,10 @@ angular
     'ngTranslateAsyncLoader',
     'pascalprecht.translate',
     'ovh-api-services',
+    'oui',
   ])
   .controller('TelecomTelephonyServiceVoicemailManagementCtrl', controller)
+  .service('VoicemailManagmentService', service)
   .run(
     /* @ngInject */ ($templateCache) => {
       $templateCache.put(

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.controller.js
@@ -15,8 +15,20 @@ export default /* @ngInject */ function TelecomTelephonyServiceVoicemailManageme
   $window,
   TucToastError,
   OvhApiTelephony,
+  VoicemailManagmentService,
 ) {
   const self = this;
+  this.VoicemailManagmentService = VoicemailManagmentService;
+
+  this.isOpenModal = false;
+  this.activeTranscript = '';
+  this.activeDownloadUrl = '';
+
+  this.resetModalInfo = function resetModalInfo() {
+    this.isOpenModal = false;
+    this.activeTranscript = '';
+    this.activeDownloadUrl = '';
+  };
 
   function fetchMessageList() {
     return OvhApiTelephony.Voicemail()
@@ -169,6 +181,86 @@ export default /* @ngInject */ function TelecomTelephonyServiceVoicemailManageme
         });
     }
     return $q.when(null);
+  };
+
+  this.downloadMessage = function downloadMessage(message) {
+    set(message, 'pendingDownload', true);
+    return self
+      .fetchMessageFile(message)
+      .then((info) => {
+        // eslint-disable-next-line no-param-reassign
+        $window.location.href = info.url;
+      })
+      .catch((err) => new TucToastError(err))
+      .finally(() => {
+        set(message, 'pendingDownload', false);
+      });
+  };
+
+  this.getTranscript = function getTranscript(message) {
+    /**
+     * Fetching a transcript is a little bit tricky because if file state
+     * is not "done" the url will return doing.
+     * So we have to poll the query until the file state is "done"
+     * or until the call fails.
+     * Then we have to download the transcript and return it.
+     */
+    const tryDownload = function tryDownload() {
+      return VoicemailManagmentService.getTranscriptURL(
+        $stateParams.billingAccount,
+        $stateParams.serviceName,
+        message.id,
+      ).then((info) => {
+        if (info.status === 'error') {
+          return $q.reject({
+            statusText: 'Unable to download message',
+          });
+        }
+        if (info.status === 'done') {
+          return VoicemailManagmentService.getTranscriptText(info.url)
+            .then((txt) => {
+              return $q.when({
+                transcriptUrl: info.url,
+                transcriptText: txt,
+              });
+            })
+            .catch(() => {
+              return $q.reject({
+                statusText: 'Unable to download message',
+              });
+            });
+        }
+
+        // file is not ready to download, just retry
+        return $timeout(() => {
+          return tryDownload();
+        }, 1000);
+      });
+    };
+    return tryDownload();
+  };
+
+  this.downloadActiveTranscript = function downloadActiveTranscript() {
+    if (this.activeDownloadUrl === '') return;
+    // eslint-disable-next-line no-param-reassign
+    $window.location.href = this.activeDownloadUrl;
+    this.resetModalInfo();
+  };
+
+  this.openTranscriptModal = function openTranscriptModal(message) {
+    set(message, 'pendingTranscript', true);
+
+    return this.getTranscript(message)
+      .then((data) => {
+        // Now we should download the text from S3 and display it in the modal
+        this.isOpenModal = true;
+        this.activeTranscript = data.transcriptText.replace(/^[\r\n]+/, '');
+        this.activeDownloadUrl = data.transcriptUrl;
+      })
+      .catch((err) => new TucToastError(err))
+      .finally(() => {
+        set(message, 'pendingTranscript', false);
+      });
   };
 
   this.downloadMessage = function downloadMessage(message) {

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.html
@@ -189,6 +189,24 @@
                             <button
                                 class="btn btn-link mr-2"
                                 type="button"
+                                title="{{:: 'telephony_line_answer_voicemail_directories_transcript' | translate }}"
+                                data-ng-disabled="VoicemailManagementCtrl.messages.isDeleting"
+                                data-ng-click="VoicemailManagementCtrl.openTranscriptModal(message)"
+                            >
+                                <i
+                                    class="fa fa-eye"
+                                    data-ng-if="!message.pendingTranscript"
+                                ></i>
+                                <oui-spinner
+                                    class="ml-2"
+                                    data-ng-if="message.pendingTranscript"
+                                    data-size="s"
+                                >
+                                </oui-spinner>
+                            </button>
+                            <button
+                                class="btn btn-link mr-2"
+                                type="button"
                                 title="{{:: 'telephony_line_answer_voicemail_directories_download_message' | translate }}"
                                 data-ng-disabled="VoicemailManagementCtrl.messages.isDeleting"
                                 data-ng-click="VoicemailManagementCtrl.downloadMessage(message)"
@@ -260,5 +278,31 @@
         ></div>
     </div>
     <!-- /.widget-presentation -->
+    <div data-ng-if="VoicemailManagementCtrl.isOpenModal">
+        <div class="modal d-block">
+            <div
+                class="modal-dialog modal-dialog-centered modal-dialog-scrollable"
+            >
+                <div class="modal-content">
+                    <form>
+                        <oui-modal
+                            heading="{{:: 'telephony_line_answer_voicemail_directories_transcript_modal_title' | translate }}"
+                            primary-action="VoicemailManagementCtrl.downloadActiveTranscript()"
+                            primary-label="{{ :: 'telephony_line_answer_voicemail_directories_transcript_modal_download' | translate }}"
+                            secondary-action="VoicemailManagementCtrl.resetModalInfo()"
+                            secondary-label="{{ :: 'telephony_line_answer_voicemail_directories_transcript_modal_close' | translate }}"
+                            on-dismiss="VoicemailManagementCtrl.resetModalInfo()"
+                        >
+                            <pre
+                                style="white-space: pre-wrap !important;  max-height: 400px; overflow-y: auto;"
+                            ><p>{{:: VoicemailManagementCtrl.activeTranscript}}</p></pre>
+                        </oui-modal>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="oui-modal-backdrop"></div>
+    </div>
+    <!-- /.oui.modal -->
 </section>
 <!-- /.telephony-group-service-voicemail-management -->

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.service.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/management.service.js
@@ -1,0 +1,25 @@
+export default class VoicemailManagmentService {
+  /* @ngInject */
+  constructor($http) {
+    this.$http = $http;
+  }
+
+  getTranscriptURL(billingAccount, serviceName, id) {
+    return this.$http
+      .get(
+        `/telephony/${billingAccount}/voicemail/${serviceName}/directories/${id}/transcript?format=text`,
+      )
+      .then(({ data }) => data);
+  }
+
+  getTranscriptText(url) {
+    return this.$http
+      .get(url, { responseType: 'text' })
+      .then((text) => {
+        return text.data;
+      })
+      .catch((error) => {
+        throw error;
+      });
+  }
+}

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/translations/Messages_en_GB.json
@@ -9,5 +9,9 @@
   "telephony_line_answer_voicemail_directories_empty": "You have no messages.",
   "telephony_line_answer_voicemail_directories_caller": "Caller",
   "telephony_line_answer_voicemail_directories_date": "Date",
-  "telephony_line_answer_voicemail_directories_duration": "Duration"
+  "telephony_line_answer_voicemail_directories_duration": "Duration",
+  "telephony_line_answer_voicemail_directories_transcript": "Transcript",
+  "telephony_line_answer_voicemail_directories_transcript_modal_title": "AI Transcript",
+  "telephony_line_answer_voicemail_directories_transcript_modal_download": "Download  the transcript",
+  "telephony_line_answer_voicemail_directories_transcript_modal_close": "Close"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/management/translations/Messages_fr_FR.json
@@ -9,5 +9,9 @@
   "telephony_line_answer_voicemail_directories_empty": "Vous n'avez aucun message.",
   "telephony_line_answer_voicemail_directories_caller": "Appelant",
   "telephony_line_answer_voicemail_directories_date": "Date",
-  "telephony_line_answer_voicemail_directories_duration": "Durée"
+  "telephony_line_answer_voicemail_directories_duration": "Durée",
+  "telephony_line_answer_voicemail_directories_transcript": "Voir la transcription",
+  "telephony_line_answer_voicemail_directories_transcript_modal_title": "Transcription assisté par IA",
+  "telephony_line_answer_voicemail_directories_transcript_modal_download": "Télécharger la transcription",
+  "telephony_line_answer_voicemail_directories_transcript_modal_close": "Fermer"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/options/translations/Messages_en_GB.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/options/translations/Messages_en_GB.json
@@ -29,5 +29,7 @@
   "telephony_line_answer_voicemail_options_mail_empty": "You have not yet configured an email address to notify.",
   "telephony_line_answer_voicemail_options_mail_limit": "You can notify a maximum of 5 email addresses.",
   "telephony_line_answer_voicemail_options_mail_type_attachment": "Attached message",
-  "telephony_line_answer_voicemail_options_mail_type_simple": "Notification only"
+  "telephony_line_answer_voicemail_options_mail_type_simple": "Notification only",
+  "telephony_line_answer_voicemail_options_mail_type_transcript": "Transcript attached",
+  "telephony_line_answer_voicemail_options_mail_type_attachment+transcript": "Transcript + message attached"
 }

--- a/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/options/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/service/voicemail/options/translations/Messages_fr_FR.json
@@ -29,5 +29,7 @@
   "telephony_line_answer_voicemail_options_mail_empty": "Vous n'avez pas encore configuré d'adresse e-mail à notifier.",
   "telephony_line_answer_voicemail_options_mail_limit": "Vous pouvez notifier un maximum de 5 adresses e-mail.",
   "telephony_line_answer_voicemail_options_mail_type_attachment": "Message joint en attachement",
-  "telephony_line_answer_voicemail_options_mail_type_simple": "Notification uniquement"
+  "telephony_line_answer_voicemail_options_mail_type_simple": "Notification uniquement",
+  "telephony_line_answer_voicemail_options_mail_type_transcript": "Transcription en attachement",
+  "telephony_line_answer_voicemail_options_mail_type_attachment+transcript": "Transcription et message joint en attachement"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


Hello,

In this PR we're adding a new UI for the AI Transcription in Voicemails for telephony.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: TEL-5376   <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->

Here the API We're using : https://eu.api.ovh.com/console/?section=%2Ftelephony&branch=v1#get-/telephony/-billingAccount-/voicemail/-serviceName-/directories/-id-/transcript

Fetching a transcript is a little bit tricky because if file is not "done" the url will return doing and no url. So we have to poll the query until the file state is "done" or until the call fails. Then we have to download the transcript and return it.

AS OvhApiServices is an archive, we created a service to wrap the HTTP call.

For the moment it's an internal route, still waiting for internal approval before Beta.
