### PR TITLE
feat(okms): add new secret-management-service entry and create first routes

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/securityIdentityOperation.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/securityIdentityOperation.ts
@@ -89,6 +89,17 @@ sioUniverse.children = [
           hash: '#/',
         },
       },
+      {
+        id: 'security-identity-operations-sms',
+        idAttr: 'security-identity-operations-sms-link',
+        translation: 'sidebar_security_identity_operations_sms',
+        universe: sioUniverse.id,
+        features: ['key-management-service:secret-management-service'],
+        routing: {
+          application: 'key-management-service',
+          hash: '#/secret-management-service',
+        },
+      },
     ],
   },
   {

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
@@ -175,6 +175,7 @@
   "sidebar_security_identity_operations_iam_api-keys": "Clés API",
   "sidebar_security_identity_operations_iam_logs": "Logs du compte",
   "sidebar_security_identity_operations_kms": "Key Management Service",
+  "sidebar_security_identity_operations_sms": "Secret Management Service",
   "sidebar_security_identity_operations_logs": "Logs Data Platform",
   "sidebar_marketplace": "Marketplace",
   "sidebar_roadmap_changelog": "Roadmap & Changelog",

--- a/packages/manager/apps/key-management-service/src/App.tsx
+++ b/packages/manager/apps/key-management-service/src/App.tsx
@@ -7,7 +7,8 @@ import {
   createHashRouter,
   createRoutesFromElements,
 } from 'react-router-dom';
-import routes from '@/routes/routes';
+import smsRoutes from '@sms/routes/routes';
+import kmsRoutes from '@/routes/routes';
 import Loading from '@/components/Loading/Loading';
 
 const queryClient = new QueryClient({
@@ -20,7 +21,9 @@ const queryClient = new QueryClient({
 
 function App() {
   const { shell } = useContext(ShellContext);
-  const router = createHashRouter(createRoutesFromElements(routes));
+  const router = createHashRouter(
+    createRoutesFromElements([kmsRoutes, smsRoutes]),
+  );
 
   useEffect(() => {
     shell.ux.hidePreloader();

--- a/packages/manager/apps/key-management-service/src/modules/sms/pages/detail.page.tsx
+++ b/packages/manager/apps/key-management-service/src/modules/sms/pages/detail.page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export default function SecretDetailPage() {
+  const { domainId, secretId } = useParams();
+
+  return (
+    <div>
+      <h1>Secret Detail</h1>
+      <p>This page shows the details of a specific secret.</p>
+      <p>Domain id: {domainId}</p>
+      <p>Secret id: {secretId}</p>
+    </div>
+  );
+}

--- a/packages/manager/apps/key-management-service/src/modules/sms/pages/listing.page.tsx
+++ b/packages/manager/apps/key-management-service/src/modules/sms/pages/listing.page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { OdsButton } from '@ovhcloud/ods-components/react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { SMS_ROUTES_URLS } from '@sms/routes/routes.constants';
+
+export default function SecretListingPage() {
+  const navigate = useNavigate();
+  const { domainId } = useParams();
+
+  return (
+    <div>
+      <h1>Secrets Listing</h1>
+      <p>This is the secrets listing page</p>
+      <p>Domain id: {domainId}</p>
+      <OdsButton
+        label="Go to secret Detail"
+        onClick={() => navigate(SMS_ROUTES_URLS.secretDashboard('1234', 'xyz'))}
+      />
+    </div>
+  );
+}

--- a/packages/manager/apps/key-management-service/src/modules/sms/pages/onboarding.page.tsx
+++ b/packages/manager/apps/key-management-service/src/modules/sms/pages/onboarding.page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { OdsButton } from '@ovhcloud/ods-components/react';
+import { useNavigate } from 'react-router-dom';
+import { SMS_ROUTES_URLS } from '@sms/routes/routes.constants';
+
+export default function SmsOnboardingPage() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <h1>SMS Onboarding</h1>
+      <p>This page helps you onboard on Secret Management Service.</p>
+      <OdsButton
+        label="Go to Secrets List"
+        onClick={() => navigate(SMS_ROUTES_URLS.secretListing('1234'))}
+      />
+    </div>
+  );
+}

--- a/packages/manager/apps/key-management-service/src/modules/sms/routes/routes.constants.ts
+++ b/packages/manager/apps/key-management-service/src/modules/sms/routes/routes.constants.ts
@@ -1,0 +1,23 @@
+const URIS = {
+  root: 'secret-management-service',
+  versions: 'versions',
+  secrets: 'secrets',
+  create: 'create',
+};
+
+const URLS = {
+  smsRoot: `/${URIS.root}`,
+  secretCreate: `/${URIS.root}/${URIS.create}`,
+  secretListing: (domainId: string) =>
+    `/${URIS.root}/${domainId}/${URIS.secrets}`,
+  secretDashboard: (domainId: string, secretId: string) =>
+    `/${URIS.root}/${domainId}/${URIS.secrets}/${secretId}`,
+};
+
+export const SMS_URL_PARAMS = {
+  domainId: ':domainId',
+  secretId: ':secretId',
+};
+
+export const SMS_ROUTES_URIS = URIS;
+export const SMS_ROUTES_URLS = URLS;

--- a/packages/manager/apps/key-management-service/src/modules/sms/routes/routes.tsx
+++ b/packages/manager/apps/key-management-service/src/modules/sms/routes/routes.tsx
@@ -1,0 +1,42 @@
+import { ErrorBoundary } from '@ovh-ux/manager-react-components';
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { SMS_ROUTES_URIS, SMS_URL_PARAMS } from './routes.constants';
+import NotFound from '@/pages/404';
+
+const KmsLayout = React.lazy(() => import('@/pages/layout'));
+const SmsOnboarding = React.lazy(() =>
+  import('@/modules/sms/pages/onboarding.page'),
+);
+const SecretListing = React.lazy(() =>
+  import('@/modules/sms/pages/listing.page'),
+);
+const SecretDetail = React.lazy(() =>
+  import('@/modules/sms/pages/detail.page'),
+);
+
+export default (
+  <Route
+    path={SMS_ROUTES_URIS.root}
+    Component={KmsLayout}
+    id={'sms-root'}
+    errorElement={
+      <ErrorBoundary
+        redirectionApp="key-management-service"
+        isPreloaderHide={true}
+        isRouteShellSync={true}
+      />
+    }
+  >
+    <Route path={''} Component={SmsOnboarding} />
+    <Route
+      path={`${SMS_URL_PARAMS.domainId}/${SMS_ROUTES_URIS.secrets}`}
+      Component={SecretListing}
+    />
+    <Route
+      path={`${SMS_URL_PARAMS.domainId}/${SMS_ROUTES_URIS.secrets}/${SMS_URL_PARAMS.secretId}`}
+      Component={SecretDetail}
+    />
+    <Route path={'*'} element={<NotFound />} />
+  </Route>
+);

--- a/packages/manager/apps/key-management-service/src/routes/routes.tsx
+++ b/packages/manager/apps/key-management-service/src/routes/routes.tsx
@@ -92,7 +92,7 @@ export default (
   <Route
     path={KMS_ROUTES_URIS.root}
     Component={KmsLayout}
-    id={'root'}
+    id={'kms-root'}
     errorElement={
       <ErrorBoundary
         redirectionApp="key-management-service"

--- a/packages/manager/apps/key-management-service/tsconfig.json
+++ b/packages/manager/apps/key-management-service/tsconfig.json
@@ -19,7 +19,8 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sms/*": ["./src/modules/sms/*"]
     }
   },
   "include": ["src"],

--- a/packages/manager/apps/key-management-service/vite.config.mjs
+++ b/packages/manager/apps/key-management-service/vite.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import { getBaseConfig } from '@ovh-ux/manager-vite-config';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 
 export default defineConfig({
   ...getBaseConfig(),
+  resolve: {
+    alias: {
+      '@': resolve(join(process.cwd(), 'src')),
+      '@sms': resolve(join(process.cwd(), 'src/modules/sms')),
+    },
+  },
   root: resolve(process.cwd()),
 });

--- a/packages/manager/apps/key-management-service/vitest.config.js
+++ b/packages/manager/apps/key-management-service/vitest.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      '@sms': path.resolve(__dirname, 'src/modules/sms'),
     },
     mainFields: ['module'],
   },


### PR DESCRIPTION
## Description

- add new secret-management-service menu entry
- declare first secrets routes

Ticket Reference: #MANAGER-17869

## Additionnal Informations

The "secret-management-service" features will be added in a folder called modules/sms.
Files related to "key-management-service" won't be moved for now, but the final goal is to move them to modules/kms to get a clear separation between the two modules, with a DDD strategy in mind.

For urls, this is a first step where we declare a secret-management-service/ path to host all secrets related pages. At some point we will move kms pages to a key-management-service/ path.

## Demo

_With corresponding feature-flipping for the menu entry_



https://github.com/user-attachments/assets/b948d89a-3cd0-4a47-978a-792bb86e1c3a



