### PR TITLE
fix(vrack-listing): defining translations for the headers of the vrack's listing

### DIFF
--- a/packages/manager/modules/vrack/src/listing/listing.route.js
+++ b/packages/manager/modules/vrack/src/listing/listing.route.js
@@ -26,18 +26,30 @@ export default /* @ngInject */ ($stateProvider) => {
           });
       },
       defaultFilterColumn: () => 'serviceName',
-      columnConfig: /* @ngInject */ () => ({
+      columnConfig: /* @ngInject */ ($translate) => ({
         data: [
           {
-            label: 'Service Name',
+            label: $translate.instant(
+              `vrack_listing_columns_header_serviceName`,
+            ),
             serviceLink: true,
             property: 'serviceName',
             hidden: false,
           },
-          { label: 'Description', property: 'description', hidden: false },
-          { label: 'Name', property: 'name', hidden: false },
           {
-            label: 'Status',
+            label: $translate.instant(
+              `vrack_listing_columns_header_description`,
+            ),
+            property: 'description',
+            hidden: false,
+          },
+          {
+            label: $translate.instant(`vrack_listing_columns_header_name`),
+            property: 'name',
+            hidden: false,
+          },
+          {
+            label: $translate.instant(`vrack_listing_columns_header_state`),
             property: 'state',
             sortable: false,
             filterable: false,

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_de_DE.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_de_DE.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Meinen Dienst kündigen"
+  "vrack_listing_action_delete": "Meinen Dienst kündigen",
+  "vrack_listing_columns_header_serviceName": "Dienst",
+  "vrack_listing_columns_header_description": "Beschreibung",
+  "vrack_listing_columns_header_name": "Name",
+  "vrack_listing_columns_header_state": "Status"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_en_GB.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_en_GB.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Cancel my subscription"
+  "vrack_listing_action_delete": "Cancel my subscription",
+  "vrack_listing_columns_header_serviceName": "Service",
+  "vrack_listing_columns_header_description": "Description",
+  "vrack_listing_columns_header_name": "Name",
+  "vrack_listing_columns_header_state": "State"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_es_ES.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_es_ES.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Dar de baja mi servicio"
+  "vrack_listing_action_delete": "Dar de baja mi servicio",
+  "vrack_listing_columns_header_serviceName": "Servicio",
+  "vrack_listing_columns_header_description": "Descripción",
+  "vrack_listing_columns_header_name": "Nombre",
+  "vrack_listing_columns_header_state": "Estado"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_fr_CA.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Résilier mon service"
+  "vrack_listing_action_delete": "Résilier mon service",
+  "vrack_listing_columns_header_serviceName": "Service",
+  "vrack_listing_columns_header_description": "Description",
+  "vrack_listing_columns_header_name": "Nom",
+  "vrack_listing_columns_header_state": "État"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_fr_FR.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Résilier mon service"
+  "vrack_listing_action_delete": "Résilier mon service",
+  "vrack_listing_columns_header_serviceName": "Service",
+  "vrack_listing_columns_header_description": "Description",
+  "vrack_listing_columns_header_name": "Nom",
+  "vrack_listing_columns_header_state": "État"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_it_IT.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_it_IT.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Disattivare il servizio"
+  "vrack_listing_action_delete": "Disattivare il servizio",
+  "vrack_listing_columns_header_serviceName": "Servizio",
+  "vrack_listing_columns_header_description": "Descrizione",
+  "vrack_listing_columns_header_name": "Cognome",
+  "vrack_listing_columns_header_state": "Stato"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_pl_PL.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Rezygnuję z usługi"
+  "vrack_listing_action_delete": "Rezygnuję z usługi",
+  "vrack_listing_columns_header_serviceName": "Usługa",
+  "vrack_listing_columns_header_description": "Opis",
+  "vrack_listing_columns_header_name": "Nazwa",
+  "vrack_listing_columns_header_state": "Status"
 }

--- a/packages/manager/modules/vrack/src/listing/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/vrack/src/listing/translations/Messages_pt_PT.json
@@ -1,3 +1,7 @@
 {
-  "vrack_listing_action_delete": "Rescindir o meu serviço"
+  "vrack_listing_action_delete": "Rescindir o meu serviço",
+  "vrack_listing_columns_header_serviceName": "Serviço",
+  "vrack_listing_columns_header_description": "Descrição",
+  "vrack_listing_columns_header_name": "Nome",
+  "vrack_listing_columns_header_state": "Estado"
 }


### PR DESCRIPTION

ref: #MANAGER-18167

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In order to enable header translations for the VRACK table, we have set "columnConfig" properties to the table layout definition.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18167

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
