### PR TITLE
fix(nasha-listing): defining translations for the headers of the nas-ha's listing

### DIFF
--- a/packages/manager/modules/nasha/src/directory/directory.routing.js
+++ b/packages/manager/modules/nasha/src/directory/directory.routing.js
@@ -15,6 +15,82 @@ export default /* @ngInject */ ($stateProvider) => {
       header: () => NASHA_TITLE,
       changelog: () => 'nasha',
       customizableColumns: () => true,
+      columnConfig: /* @ngInject */ ($translate) => ({
+        data: [
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_serviceName',
+            ),
+            property: 'serviceName',
+            serviceLink: true,
+            hidden: false,
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_canCreatePartition',
+            ),
+            property: 'canCreatePartition',
+            serviceLink: false,
+            hidden: false,
+            format: ({ canCreatePartition }) =>
+              $translate.instant(
+                `nasha_directory_columns_header_canCreatePartition_${canCreatePartition}`,
+              ),
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_customName',
+            ),
+            property: 'customName',
+            serviceLink: false,
+            hidden: false,
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_datacenter',
+            ),
+            property: 'datacenter',
+            serviceLink: false,
+            hidden: false,
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_diskType',
+            ),
+            property: 'diskType',
+            serviceLink: false,
+            hidden: false,
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_monitored',
+            ),
+            property: 'monitored',
+            serviceLink: false,
+            hidden: true,
+            format: ({ monitored }) =>
+              $translate.instant(
+                `nasha_directory_columns_header_monitored_${monitored}`,
+              ),
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_zpoolCapacity',
+            ),
+            property: 'zpoolCapacity',
+            serviceLink: false,
+            hidden: true,
+          },
+          {
+            label: $translate.instant(
+              'nasha_directory_columns_header_zpoolSize',
+            ),
+            property: 'zpoolSize',
+            serviceLink: false,
+            hidden: true,
+          },
+        ],
+      }),
       getServiceNameLink: /* @ngInject */ ($state) => ({ serviceName }) =>
         $state.href('nasha.dashboard', { serviceName }),
       topbarOptions: /* @ngInject */ ($translate, $state, atInternet) => ({

--- a/packages/manager/modules/nasha/src/directory/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/nasha/src/directory/translations/Messages_fr_FR.json
@@ -1,4 +1,16 @@
 {
   "nasha_directory_order_label": "Commander un NAS-HA",
-  "nasha_directory_order_value": "Commander un NAS-HA"
+  "nasha_directory_order_value": "Commander un NAS-HA",
+  "nasha_directory_columns_header_serviceName": "ID Service",
+  "nasha_directory_columns_header_canCreatePartition": "Création de partition",
+  "nasha_directory_columns_header_canCreatePartition_true": "Autorisée",
+  "nasha_directory_columns_header_canCreatePartition_false": "Non autorisée",
+  "nasha_directory_columns_header_customName": "Nom",
+  "nasha_directory_columns_header_datacenter": "Localisation du datacenter",
+  "nasha_directory_columns_header_diskType": "Type de disque",
+  "nasha_directory_columns_header_monitored": "Monitoré",
+  "nasha_directory_columns_header_monitored_true": "Oui",
+  "nasha_directory_columns_header_monitored_false": "Non",
+  "nasha_directory_columns_header_zpoolCapacity": "capacité de ZPool",
+  "nasha_directory_columns_header_zpoolSize": "Taille de ZPool"
 }


### PR DESCRIPTION

ref: #MANAGER-18178

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In order to enable header and values translations for the NAS-HA table, we have set "columnConfig" properties to the table layout definition.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18178

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
