### PR TITLE
feat(netapp-volume): preventing volume creation with oversized snapshots

### DIFF
--- a/packages/manager/modules/netapp/src/dashboard/volumes/create/controller.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/create/controller.js
@@ -46,9 +46,15 @@ export default class VolumeCreateCtrl {
     this.NetAppDashboardService.getManualsnapshots(
       this.eligibleVolumes,
       this.storage,
-    ).then((result) => {
+    ).then((results) => {
       this.isLoading = false;
-      this.manualSnaphost = [...this.manualSnaphost, ...result.flat()];
+      this.manualSnaphost = [
+        ...this.manualSnaphost,
+        ...results.flat().filter((snapshot) => {
+          const newVolumeSize = snapshot?.size;
+          return (newVolumeSize ?? 0) < this.availableVolumeSize;
+        }),
+      ];
     });
   }
 

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/component.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/component.js
@@ -19,7 +19,7 @@ export default {
     trackCreate: '<',
     goToRestoreSnapshot: '<',
     goToSnapshots: '<',
-    isCreateVolumeAvailable: '<',
+    canCreateVolumeFromSnapshot: '<',
   },
   controller,
   template,

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/routing.js
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/routing.js
@@ -73,6 +73,11 @@ export default /* @ngInject */ ($stateProvider) => {
           snapshotId,
         });
       },
+      canCreateVolumeFromSnapshot: (
+        volume,
+        isCreateVolumeAvailable,
+        availableVolumeSize,
+      ) => isCreateVolumeAvailable && volume.size < availableVolumeSize,
       /* @ngInject */
       createVolumeFromSnapshot: ($state, serviceName, volumeId) => (
         snapshotId,

--- a/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
+++ b/packages/manager/modules/netapp/src/dashboard/volumes/dashboard/snapshots/template.html
@@ -96,7 +96,7 @@
                 <oui-action-menu-item
                     data-ng-if="$row.type !== $ctrl.SNAPSHOT_TYPE.AUTOMATIC"
                     data-on-click="$ctrl.createVolumeFromSnapshot($row.id)"
-                    data-disabled="!$ctrl.isCreateVolumeAvailable"
+                    data-disabled="!$ctrl.canCreateVolumeFromSnapshot"
                 >
                     <span
                         data-translate="netapp_volumes_snapshots_actions_create_volume"


### PR DESCRIPTION
ref: #MANAGER-17046

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In order to prevent a volume creation from an oversized snapshot, We have added these changes:
  - The available snapshots of the volume creation modal are filtered by their size. Only the snapshots that may fit the remaining space will be displayed.
  - The "create volume" action in the list of snapshots is disabled when the size of the current volume is greater than the available size.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17046

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Screenshots to better explain the change
 -->
