### PR TITLE
feat(billing): rename zimbra service name on services page

### DIFF
--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_de_DE.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_de_DE.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "Alle 6 Monate",
   "billing_autorenew_service_every_12_month": "Jedes Jahr",
   "billing_autorenew_engagement_none": "Ohne Vertragsbindung",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra E-Mail-Account"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_en_GB.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_en_GB.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "Every 6 months",
   "billing_autorenew_service_every_12_month": "Every year",
   "billing_autorenew_engagement_none": "No commitment",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Email Account"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_es_ES.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_es_ES.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "Cada 6 meses",
   "billing_autorenew_service_every_12_month": "Todos los años",
   "billing_autorenew_engagement_none": "Sin compromiso",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Cuenta Email Zimbra"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_CA.json
@@ -157,7 +157,7 @@
   "billing_autorenew_service_type_VRACK_SERVICES_RESOURCE": "vRack Services",
   "billing_autorenew_service_type_NUTANIX": "Nutanix",
   "billing_autorenew_service_type_OKMS_RESOURCE": "OVHcloud KMS",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter",
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Compte Email Zimbra",
   "billing_export_csv": "Exporter en CSV",
   "billing_common_link_new_window": "(nouvelle fenêtre)",
   "billing_autorenew_renew_action": "Renouveler",

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_fr_FR.json
@@ -157,7 +157,7 @@
   "billing_autorenew_service_type_VRACK_SERVICES_RESOURCE": "vRack Services",
   "billing_autorenew_service_type_NUTANIX": "Nutanix",
   "billing_autorenew_service_type_OKMS_RESOURCE": "OVHcloud KMS",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter",
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Compte Email Zimbra",
   "billing_export_csv": "Exporter en CSV",
   "billing_common_link_new_window": "(nouvelle fenêtre)",
   "billing_autorenew_renew_action": "Renouveler",

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_it_IT.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_it_IT.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "Ogni 6 mesi",
   "billing_autorenew_service_every_12_month": "Ogni anno",
   "billing_autorenew_engagement_none": "Senza impegno contrattuale",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Account Email Zimbra"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_pl_PL.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "Co 6 miesięcy",
   "billing_autorenew_service_every_12_month": "Co rok",
   "billing_autorenew_engagement_none": "Bez umowy terminowej",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Konto Email Zimbra"
 }

--- a/packages/manager/modules/billing/src/autoRenew/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/billing/src/autoRenew/translations/Messages_pt_PT.json
@@ -164,5 +164,5 @@
   "billing_autorenew_service_every_6_month": "A cada 6 meses",
   "billing_autorenew_service_every_12_month": "Todos os anos",
   "billing_autorenew_engagement_none": "Sem compromisso",
-  "billing_autorenew_service_type_ZIMBRA_SLOT": "Zimbra Starter"
+  "billing_autorenew_service_type_ZIMBRA_SLOT": "Conta Email Zimbra"
 }


### PR DESCRIPTION
ref: #MANAGER-17342

## Description

Ticket Reference: #MANAGER-17342

## Additional Information

Since now we have Zimbra plans : Starter/ Pro, this PR aims to simply rename the service from 'Zimbra Starter' to 'Zimbra Email Account'.

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/38eb7249-c6eb-473e-8cbd-1167728726cb" />
