### PR TITLE
fix(container): fix livechat reduce button

### DIFF
--- a/packages/manager/apps/container/src/container/livechat/LiveChat.component.tsx
+++ b/packages/manager/apps/container/src/container/livechat/LiveChat.component.tsx
@@ -215,7 +215,7 @@ export default function LiveChat({
               onClick={() => handleReduceChat(true)}
             >
               <OsdsIcon
-                name={ODS_ICON_NAME.SPEECH_BUBBLE_CONCEPT}
+                name={ODS_ICON_NAME.CLOSE}
                 size={ODS_ICON_SIZE.md}
                 className="m-2"
                 contrasted


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

This fix replaces the speech bubble icon with the X icon when the chat is not reduced, to trigger the reduce.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18560

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
