### PR TITLE
fix(pci-volume-backup): preserve original volume type when creating from backup

### DIFF
--- a/packages/manager/apps/pci-volume-backup/src/__tests__/mocks.ts
+++ b/packages/manager/apps/pci-volume-backup/src/__tests__/mocks.ts
@@ -12,6 +12,7 @@ export const MOCKED_INSTANCE_ID = 'instance-id';
 export const MOCKED_REGION_NAME = 'region-name';
 export const MOCKED_VOLUME_BACKUP_ID = 'backup-id';
 export const MOCKED_VOLUME_NAME = 'volume-name';
+export const MOCKED_VOLUME_TYPE = 'classic';
 
 export const MOCKED_VOLUME: TVolume = {
   id: MOCKED_VOLUME_ID,

--- a/packages/manager/apps/pci-volume-backup/src/data/api/volume.spec.ts
+++ b/packages/manager/apps/pci-volume-backup/src/data/api/volume.spec.ts
@@ -9,6 +9,7 @@ import {
   MOCKED_VOLUME_BACKUP_ID,
   MOCKED_VOLUME_ID,
   MOCKED_VOLUME_NAME,
+  MOCKED_VOLUME_TYPE,
 } from '@/__tests__/mocks';
 
 describe('Volume API Service', () => {
@@ -60,14 +61,49 @@ describe('Volume API Service', () => {
         MOCKED_REGION_NAME,
         MOCKED_VOLUME_BACKUP_ID,
         MOCKED_VOLUME_NAME,
+        MOCKED_VOLUME_TYPE,
       );
 
       expect(v6.post).toHaveBeenCalledTimes(1);
-      expect(
-        v6.post,
-      ).toHaveBeenCalledWith(
-        `/cloud/project/${MOCKED_PROJECT_ID}/region/${MOCKED_REGION_NAME}/volumeBackup/${MOCKED_VOLUME_BACKUP_ID}/volume`,
-        { name: MOCKED_VOLUME_NAME },
+      expect(v6.post).toHaveBeenCalledWith(
+        `/cloud/project/${MOCKED_PROJECT_ID}/region/${MOCKED_REGION_NAME}/volume`,
+        {
+          name: MOCKED_VOLUME_NAME,
+          backupId: MOCKED_VOLUME_BACKUP_ID,
+          type: MOCKED_VOLUME_TYPE,
+        },
+      );
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should create a volume from a backup with type high-speed', async () => {
+      const mockResponse = {
+        id: 'new-volume-id',
+        name: MOCKED_VOLUME_NAME,
+        status: 'creating',
+      };
+
+      vi.mocked(v6.post).mockResolvedValueOnce({
+        data: mockResponse,
+      });
+
+      const result = await createVolumeFromBackup(
+        MOCKED_PROJECT_ID,
+        MOCKED_REGION_NAME,
+        MOCKED_VOLUME_BACKUP_ID,
+        MOCKED_VOLUME_NAME,
+        'high-speed',
+      );
+
+      expect(v6.post).toHaveBeenCalledTimes(1);
+      expect(v6.post).toHaveBeenCalledWith(
+        `/cloud/project/${MOCKED_PROJECT_ID}/region/${MOCKED_REGION_NAME}/volume`,
+        {
+          name: MOCKED_VOLUME_NAME,
+          backupId: MOCKED_VOLUME_BACKUP_ID,
+          type: 'high-speed',
+        },
       );
 
       expect(result).toEqual(mockResponse);
@@ -83,6 +119,7 @@ describe('Volume API Service', () => {
           MOCKED_REGION_NAME,
           MOCKED_VOLUME_BACKUP_ID,
           MOCKED_VOLUME_NAME,
+          MOCKED_VOLUME_TYPE,
         ),
       ).rejects.toThrow('Backup not found');
 

--- a/packages/manager/apps/pci-volume-backup/src/data/api/volume.ts
+++ b/packages/manager/apps/pci-volume-backup/src/data/api/volume.ts
@@ -1,8 +1,6 @@
 import { v6 } from '@ovh-ux/manager-core-api';
 import { TVolume } from '@ovh-ux/manager-pci-common';
 
-export type TNewVolumeData = Partial<TVolume> & { snapshotId?: string };
-
 export const getVolume = async (
   projectId: string,
   volumeId: string,
@@ -19,12 +17,15 @@ export async function createVolumeFromBackup(
   regionName: string,
   volumeBackupId: string,
   volumeName: string,
-) {
-  const {
-    data,
-  } = await v6.post(
-    `/cloud/project/${projectId}/region/${regionName}/volumeBackup/${volumeBackupId}/volume`,
-    { name: volumeName },
+  type: string,
+): Promise<TVolume> {
+  const { data } = await v6.post(
+    `/cloud/project/${projectId}/region/${regionName}/volume`,
+    {
+      name: volumeName,
+      backupId: volumeBackupId,
+      type,
+    },
   );
 
   return data;

--- a/packages/manager/apps/pci-volume-backup/src/data/hooks/useVolume.spec.tsx
+++ b/packages/manager/apps/pci-volume-backup/src/data/hooks/useVolume.spec.tsx
@@ -69,6 +69,7 @@ describe('useCreateVolumeFromBackup', () => {
     regionName: 'region-1',
     volumeBackupId: 'backup-1',
     volumeName: 'new-volume',
+    type: 'classic',
   };
 
   beforeEach(() => {
@@ -97,6 +98,7 @@ describe('useCreateVolumeFromBackup', () => {
       newVolumeData.regionName,
       newVolumeData.volumeBackupId,
       newVolumeData.volumeName,
+      newVolumeData.type,
     );
     expect(onSuccess).toHaveBeenCalledWith(MOCKED_VOLUME);
   });

--- a/packages/manager/apps/pci-volume-backup/src/data/hooks/useVolume.ts
+++ b/packages/manager/apps/pci-volume-backup/src/data/hooks/useVolume.ts
@@ -12,6 +12,7 @@ export type TNewVolumeFromBackupData = {
   regionName: string;
   volumeBackupId: string;
   volumeName: string;
+  type: string;
 };
 
 export type TCreateVolumeFromBackupArguments = {
@@ -51,6 +52,7 @@ export const useCreateVolumeFromBackup = ({
         data.regionName,
         data.volumeBackupId,
         data.volumeName,
+        data.type,
       ),
     onError,
     onSuccess: async (newVolume: TVolume) => {

--- a/packages/manager/apps/pci-volume-backup/src/pages/create-volume/CreateVolume.page.tsx
+++ b/packages/manager/apps/pci-volume-backup/src/pages/create-volume/CreateVolume.page.tsx
@@ -112,7 +112,8 @@ export default function CreateVolumePage() {
     createVolumeFromBackup({
       regionName: volume.region,
       volumeBackupId: backup.id,
-      volumeName: editedVolume.name || '',
+      volumeName: editedVolume.name ?? '',
+      type: volume.type ?? 'classic',
     });
   };
 


### PR DESCRIPTION
fix(pci-volume-backup): preserve original volume type when creating from backup

ref: #TAPC-4081
