### PR TITLE
fix(billing): put defaultPaymentMean back to autorenew resolve

### DIFF
--- a/packages/manager/modules/new-billing/src/autoRenew/autorenew.routing.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/autorenew.routing.js
@@ -118,6 +118,9 @@ export default /* @ngInject */ ($stateProvider, coreConfigProvider) => {
                     data.models['services.billing.engagement.EndStrategyEnum']
                       ?.enum,
                 ),
+            /* @ngInject */
+            defaultPaymentMean: (ovhPaymentMethod) =>
+              ovhPaymentMethod.getDefaultPaymentMethod(),
           }
         : {},
     ),

--- a/packages/manager/modules/new-billing/src/autoRenew/services/services.routing.js
+++ b/packages/manager/modules/new-billing/src/autoRenew/services/services.routing.js
@@ -26,9 +26,6 @@ export default /* @ngInject */ ($stateProvider) => {
       billingServices: /* @ngInject */ (services) =>
         map(services.list.results, (service) => new BillingService(service)),
       canDisableAllDomains: /* @ngInject */ (services) => services.bulkDomains,
-      /* @ngInject */
-      defaultPaymentMean: (ovhPaymentMethod) =>
-        ovhPaymentMethod.getDefaultPaymentMethod(),
       disableAutorenewForDomains: /* @ngInject */ ($state) => () =>
         $state.go('billing.autorenew.services.disableDomainsBulk'),
       disableBulkAutorenew: /* @ngInject */ ($state) => (services) =>


### PR DESCRIPTION
## Description

Put back `defaultPaymentMean` into `autorenew` resolve list to avoid displaying user a wrong message regarding their payment method


<!-- Provide Jira ticket or Github issue -->
Ticket Reference:  #MANAGER-18574, #INC0133696

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
