### PR TITLE
feat(ongoing-operation): add button to redirect to DNS update form

### DIFF
--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_de_DE.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_de_DE.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "Allgemeine Informationen",
   "domain_operations_upload_file_template_1": "Nur Dateien, die diesem ",
   "domain_operations_upload_file_template_link": "Dokumentvorlage",
-  "domain_operations_upload_file_template_2": " werden angenommen."
+  "domain_operations_upload_file_template_2": " werden angenommen.",
+  "domain_operations_update_dns_click": "Klicken Sie hier, um die Konfiguration Ihrer DNS-Server zu korrigieren."
 }

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_en_GB.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_en_GB.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "General information",
   "domain_operations_upload_file_template_1": "Only files following this ",
   "domain_operations_upload_file_template_link": "document template",
-  "domain_operations_upload_file_template_2": " will be accepted."
+  "domain_operations_upload_file_template_2": " will be accepted.",
+  "domain_operations_update_dns_click": "Click here to correct the configuration of your DNS servers"
 }

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_es_ES.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_es_ES.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "Información general",
   "domain_operations_upload_file_template_1": "Solo los archivos siguientes a este ",
   "domain_operations_upload_file_template_link": "plantilla de documento",
-  "domain_operations_upload_file_template_2": " serán aceptados."
+  "domain_operations_upload_file_template_2": " serán aceptados.",
+  "domain_operations_update_dns_click": "Haga clic aquí para corregir la configuración de sus servidores DNS"
 }

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_CA.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_CA.json
@@ -74,6 +74,7 @@
   "domain_operations_update_nicowner_click_whoisContactBilling": "Changez les informations du contact facturation en cliquant ici",
   "domain_operations_update_nicowner_click_whoisContactTech": "Changez les informations du contact technique en cliquant ici",
   "domain_operations_update_nicowner_click_identityEvidence": "Fournir une copie de la carte d'identité, du permis de conduire ou du passeport de la personne inscrite.",
+  "domain_operations_update_dns_click": "Cliquez ici pour corriger la configuration de vos serveurs DNS",
   "domain_operations_update_contact_administrator": "Contactez votre administrateur pour corriger ce problème.",
   "tracking_transfert_domain_title": "Suivi du transfert pour le domaine \"{{t0}}\"",
   "tracking_transfert_last_update": "Dernière mise à jour : {{t0}}",

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_FR.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_FR.json
@@ -74,6 +74,7 @@
   "domain_operations_update_nicowner_click_whoisContactBilling": "Changez les informations du contact facturation en cliquant ici",
   "domain_operations_update_nicowner_click_whoisContactTech": "Changez les informations du contact technique en cliquant ici",
   "domain_operations_update_nicowner_click_identityEvidence": "Fournir une copie de la carte d'identité, du permis de conduire ou du passeport de la personne inscrite.",
+  "domain_operations_update_dns_click": "Cliquez ici pour corriger la configuration de vos serveurs DNS",
   "domain_operations_update_contact_administrator": "Contactez votre administrateur pour corriger ce problème.",
   "tracking_transfert_domain_title": "Suivi du transfert pour le domaine \"{{t0}}\"",
   "tracking_transfert_last_update": "Dernière mise à jour : {{t0}}",

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_it_IT.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_it_IT.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "Informazioni generali",
   "domain_operations_upload_file_template_1": "Solo i file seguenti ",
   "domain_operations_upload_file_template_link": "modello di documento",
-  "domain_operations_upload_file_template_2": " saranno accettati."
+  "domain_operations_upload_file_template_2": " saranno accettati.",
+  "domain_operations_update_dns_click": "Clicca qui per correggere la configurazione dei tuoi server DNS"
 }

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_pl_PL.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_pl_PL.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "Informacje ogólne",
   "domain_operations_upload_file_template_1": "Tylko następujące pliki ",
   "domain_operations_upload_file_template_link": "szablon dokumentu",
-  "domain_operations_upload_file_template_2": " zostaną zaakceptowane."
+  "domain_operations_upload_file_template_2": " zostaną zaakceptowane.",
+  "domain_operations_update_dns_click": "Kliknij tutaj, aby skorygować konfigurację serwerów DNS"
 }

--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_pt_PT.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_pt_PT.json
@@ -143,5 +143,6 @@
   "domain_operations_guides": "Informações gerais",
   "domain_operations_upload_file_template_1": "Apenas os ficheiros que seguem este ",
   "domain_operations_upload_file_template_link": "modelo de documento",
-  "domain_operations_upload_file_template_2": " serão aceites."
+  "domain_operations_upload_file_template_2": " serão aceites.",
+  "domain_operations_update_dns_click": "Clique aqui para corrigir a configuração dos seus servidores DNS"
 }

--- a/packages/manager/apps/web-ongoing-operations/src/components/Update/Content/Update.Me.Dns.component.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/components/Update/Content/Update.Me.Dns.component.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { OdsLink } from '@ovhcloud/ods-components/react';
+import { useNavigationGetUrl } from '@ovh-ux/manager-react-shell-client';
+
+interface ActionMeDnsComponentProps {
+  readonly domainName: string;
+}
+
+export default function ActionMeDnsComponent({
+  domainName,
+}: ActionMeDnsComponentProps) {
+  const { t } = useTranslation('dashboard');
+  const { data: webUrl } = useNavigationGetUrl(['web', '', {}]);
+
+  const url = `${webUrl}/domain/${domainName}/dns-modify`;
+  return (
+    <OdsLink
+      href={url}
+      color="primary"
+      label={t('domain_operations_update_dns_click')}
+      className="block"
+      icon="external-link"
+      isDisabled={!url}
+    />
+  );
+}

--- a/packages/manager/apps/web-ongoing-operations/src/constants.ts
+++ b/packages/manager/apps/web-ongoing-operations/src/constants.ts
@@ -4,6 +4,7 @@ export const taskMeDns = ['me', 'task', 'dns'];
 export const domainCreate = 'DomainCreate';
 export const domainIncomingTransfer = 'DomainIncomingTransfer';
 export const domainResourceDelete = 'DomainResourceDelete';
+export const domainDnsUpdate = 'DomainDnsUpdate';
 
 export const DOMAIN_OPERATIONS = [
   'ContactControlAcknowledge',

--- a/packages/manager/apps/web-ongoing-operations/src/pages/update/Update.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/pages/update/Update.tsx
@@ -6,7 +6,8 @@ import {
 import React, { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import { OdsText } from '@ovhcloud/ods-components/react';
+import { useNavigationGetUrl } from '@ovh-ux/manager-react-shell-client';
+import { OdsLink, OdsText } from '@ovhcloud/ods-components/react';
 import { ODS_TEXT_PRESET, OdsFile } from '@ovhcloud/ods-components';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import pLimit from 'p-limit';
@@ -24,6 +25,8 @@ import UpdateContentComponent from '@/components/Update/UpdateContent.component'
 import UpdateActions from '@/components/Update/Content/UpdateActions.component';
 import { TFiles } from '@/types';
 import { urls } from '@/routes/routes.constant';
+import { domainDnsUpdate } from '@/constants';
+import ActionMeDnsComponent from '@/components/Update/Content/Update.Me.Dns.component';
 
 export default function Update() {
   const { t } = useTranslation('dashboard');
@@ -232,6 +235,12 @@ export default function Update() {
             />
           </OdsText>
         </div>
+
+        {domain.function === domainDnsUpdate && (
+          <div className="flex flex-col gap-y-4">
+            <ActionMeDnsComponent domainName={domain.domain} />
+          </div>
+        )}
 
         {operationArguments?.data?.length > 0 && (
           <div className="flex flex-col gap-y-4">


### PR DESCRIPTION
## Description

Add a link to redirect to the DNS update form directly linked to the service. Allow the customer to recreate a new DNSUpdate with the corrected value. Instead of letting the customer cancel the current update and go to the dashboard to launch a new update.

Ticket Reference: #MANAGER-18582