### PR TITLE
fix(otb-ipv6): improving the error message display on IPv6 activation failure

### DIFF
--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.controller.js
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.controller.js
@@ -62,6 +62,10 @@ export default class OverTheBoxDetailsCtrl {
       ipv6Update: false,
     };
 
+    this.errorMsg = {
+      ipv6Update: undefined,
+    };
+
     this.nameEditable = false;
 
     this.deviceIds = [];
@@ -943,6 +947,7 @@ export default class OverTheBoxDetailsCtrl {
       this.$scope.$apply(() => {
         this.loaders.ipv6Update = false;
         this.error.ipv6Update = true;
+        this.errorMsg.ipv6Update = e.data.message;
         this.service.ipv6Enabled = previousValue;
       });
       this.$timeout(() => {
@@ -959,5 +964,6 @@ export default class OverTheBoxDetailsCtrl {
 
   onIpv6UpdateErrorMessageDismiss() {
     this.error.ipv6Update = false;
+    this.errorMsg.ipv6Update = undefined;
   }
 }

--- a/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
+++ b/packages/manager/modules/overthebox/src/overthebox/details/overTheBox-details.html
@@ -14,7 +14,8 @@
         dismissable
         class="m-2"
     >
-        <span data-translate="overTheBox_enabled_ipv6_error"></span>
+        <div data-translate="overTheBox_enabled_ipv6_error" class="mb-2"></div>
+        <div>{{$ctrl.errorMsg.ipv6Update}}</div>
     </oui-message>
 
     <tuc-toast-message></tuc-toast-message>

--- a/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/overthebox/src/overthebox/details/translations/Messages_fr_FR.json
@@ -100,5 +100,5 @@
   "overTheBox_release_channel_deprecated": "Version dépréciée {{version}}",
   "overTheBox_detail_ips": "IPs",
   "overTheBox_model_ips_unknown": "IPs non trouvées",
-  "overTheBox_enabled_ipv6_error": "Une erreur a eu lieu pendant l'activation de l'IPv6. Si l'erreur persiste, veuillez contacter le support."
+  "overTheBox_enabled_ipv6_error": "Une erreur a eu lieu pendant l'activation de l'IPv6: "
 }


### PR DESCRIPTION

ref: #CONN-5834

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In the current behavior, failing to activate or deactivate the IPv6 on the OTB page would display a generic error message with no clue to solve it.
The expected behavior is to display the raw API error message in order to help the user reach to conditions to properly active its v6 IP.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #CONN-5834

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
