### PR TITLE
feat(dedicated.vps): hide error message on listing page when a vps is expired

### DIFF
--- a/packages/manager/modules/vps/src/list/vps-list.controller.js
+++ b/packages/manager/modules/vps/src/list/vps-list.controller.js
@@ -43,6 +43,9 @@ export default class extends ListLayoutHelper.ListLayoutCtrl {
       })
       .catch((error) => {
         const errorMessage = error.data?.message || error.data || error;
+        if (errorMessage === 'This service is expired') {
+          return this.buildRow($row);
+        }
         this.Alerter.error(
           [
             this.$translate.instant('vps_list_loadLocation_error'),


### PR DESCRIPTION

## Description
### VPS Listing page :
Hide error message related to location when a VPS is expired, as this error is not relevant.

Error message that will be hidden when service is expired : 

<img src="https://github.com/user-attachments/assets/b1869338-16e4-436a-ab03-6971c6ea17d7" height="120" />

## Additional Information
Ticket Reference: MANAGER-18613
