### PR TITLE
feat(pci-instances): use regionalised call for dashboard instead aggregation

### DIFF
--- a/packages/manager/apps/pci-instances/src/data/api/instance.spec.ts
+++ b/packages/manager/apps/pci-instances/src/data/api/instance.spec.ts
@@ -1,12 +1,14 @@
 import { describe, it, vi } from 'vitest';
 import { v6 } from '@ovh-ux/manager-core-api';
-import { editInstanceName } from './instance';
+import { editInstanceName, getRegionInstance } from './instance';
 
 const projectId = 'projectId-test';
 const instanceId = 'instanceId-test';
 const instanceName = 'instanceName-test';
+const region = 'REGION-STN';
 
 vi.mock('@ovh-ux/manager-core-api');
+vi.mocked(v6.get).mockImplementation(() => Promise.resolve({ data: null }));
 
 describe('editInstanceName', () => {
   it('should call the good endpoint with the instance name params body', () => {
@@ -17,6 +19,16 @@ describe('editInstanceName', () => {
     ).toHaveBeenCalledWith(
       `/cloud/project/${projectId}/instance/${instanceId}`,
       { instanceName },
+    );
+  });
+});
+
+describe('getRegionInstance', () => {
+  it('should call the instance regionalized endpoint', () => {
+    getRegionInstance({ projectId, region, instanceId });
+
+    expect(v6.get).toHaveBeenCalledWith(
+      `/cloud/project/${projectId}/region/${region}/instance/${instanceId}`,
     );
   });
 });

--- a/packages/manager/apps/pci-instances/src/data/api/instance.ts
+++ b/packages/manager/apps/pci-instances/src/data/api/instance.ts
@@ -1,5 +1,6 @@
 import { v6 } from '@ovh-ux/manager-core-api';
 import {
+  TInstanceDetailDto,
   TInstanceDto,
   TRetrieveInstancesQueryParams,
 } from '@/types/instance/api.type';
@@ -140,6 +141,7 @@ export const activateMonthlyBilling = (
     serviceName: projectId,
   });
 
+/** @deprecated use regionalized getRegionInstance call instead */
 export const getInstance = ({
   projectId,
   instanceId,
@@ -149,6 +151,19 @@ export const getInstance = ({
 }): Promise<TInstanceDto> =>
   v6
     .get(`/cloud/project/${projectId}/aggregated/instance/${instanceId}`)
+    .then((response) => response.data);
+
+export const getRegionInstance = ({
+  projectId,
+  region,
+  instanceId,
+}: {
+  projectId: string;
+  region: string;
+  instanceId: string;
+}): Promise<TInstanceDetailDto> =>
+  v6
+    .get(`/cloud/project/${projectId}/region/${region}/instance/${instanceId}`)
     .then((response) => response.data);
 
 export const editInstanceName = ({

--- a/packages/manager/apps/pci-instances/src/data/api/instance.ts
+++ b/packages/manager/apps/pci-instances/src/data/api/instance.ts
@@ -153,6 +153,99 @@ export const getInstance = ({
     .get(`/cloud/project/${projectId}/aggregated/instance/${instanceId}`)
     .then((response) => response.data);
 
+// TODO: remove this mock function when api is ready
+export const getRegionInstanceMock = ({
+  projectId,
+  region,
+  instanceId,
+}: {
+  projectId: string;
+  region: string;
+  instanceId: string;
+}): Promise<TInstanceDetailDto> =>
+  v6
+    .get(`/cloud/project/${projectId}/region/${region}/instance/${instanceId}`)
+    .then(({ data }) => ({
+      ...data,
+      regionType: 'region',
+      image: {
+        id: data.imageId,
+        name: 'image-name',
+        deprecated: false,
+      },
+      flavor: {
+        id: data.flavorId,
+        name: data.flavorName,
+        specs: {
+          cpu: 32,
+          ram: 128000,
+          storage: 400,
+          bandwidth: {
+            public: 20000,
+            private: 20000,
+          },
+        },
+      },
+      actions: [
+        {
+          name: 'details',
+          group: 'details',
+        },
+        {
+          name: 'edit',
+          group: 'details',
+        },
+        {
+          name: 'assign_floating_ip',
+          group: 'details',
+        },
+        {
+          name: 'create_backup',
+          group: 'details',
+        },
+        {
+          name: 'create_autobackup',
+          group: 'details',
+        },
+        {
+          name: 'stop',
+          group: 'lifecycle',
+        },
+        {
+          name: 'rescue',
+          group: 'boot',
+        },
+        {
+          name: 'soft_reboot',
+          group: 'boot',
+        },
+        {
+          name: 'hard_reboot',
+          group: 'boot',
+        },
+        {
+          name: 'shelve',
+          group: 'shelve',
+        },
+        {
+          name: 'reinstall',
+          group: 'delete',
+        },
+        {
+          name: 'delete',
+          group: 'delete',
+        },
+      ],
+      prices: [
+        {
+          type: 'hour',
+          value: 297561000,
+          status: 'enabled',
+        },
+      ],
+      login: 'ssh almalinux@51.161.81.152',
+    }));
+
 export const getRegionInstance = ({
   projectId,
   region,

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.ts
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.ts
@@ -1,10 +1,13 @@
-import { TInstanceDto, TPartialInstanceDto } from '@/types/instance/api.type';
+import { TInstanceDto } from '@/types/instance/api.type';
 
-export const buildPartialInstanceDto = (initial: TPartialInstanceDto) => ({
-  with<K extends keyof TInstanceDto>(
-    key: keyof TInstanceDto,
-    value: TPartialInstanceDto[K],
-  ) {
+export const buildPartialInstanceDto = <
+  TData extends { id: string } = TInstanceDto,
+  T extends Pick<TData, 'id'> & Partial<TData> = Pick<TInstanceDto, 'id'> &
+    Partial<TData>
+>(
+  initial: T,
+) => ({
+  with<K extends keyof TData>(key: K, value: TData[K]) {
     return buildPartialInstanceDto({ ...initial, [key]: value });
   },
   build() {

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/selectors/instances.selector.ts
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/selectors/instances.selector.ts
@@ -1,11 +1,17 @@
 import { InfiniteData } from '@tanstack/react-query';
-import { TInstanceDto, TInstanceStatusDto } from '@/types/instance/api.type';
+import {
+  TInstanceActionDto,
+  TInstanceDetailDto,
+  TInstanceDto,
+  TInstanceStatusDto,
+} from '@/types/instance/api.type';
 import {
   TAddress,
   TInstance,
   TInstanceAction,
   TInstanceActions,
   TInstanceAddressType,
+  TInstanceDetail,
   TInstanceStatus,
   TInstanceStatusSeverity,
 } from '@/types/instance/entity.type';
@@ -65,7 +71,7 @@ const getActionHrefByName = (
   { region, id }: Pick<TInstance, 'id' | 'region'>,
 ): TInstanceAction['link'] => {
   if (name === 'details') {
-    return { path: id, isExternal: false };
+    return { path: `${id}/region/${region}`, isExternal: false };
   }
 
   if (name === 'edit') {
@@ -194,3 +200,14 @@ export const instancesSelector = (
       actions: mapInstanceActions(instanceDto, projectUrl),
       taskState: getInstanceTaskState(instanceDto.taskState),
     }));
+
+const isEditionEnabled = (actions: TInstanceActionDto[]) =>
+  actions.some(({ name }) => name === 'edit');
+
+export const getInstanceDetail = (
+  instanceDto: TInstanceDetailDto,
+): TInstanceDetail => ({
+  ...instanceDto,
+  status: getInstanceStatus(instanceDto.status),
+  isEditionEnabled: isEditionEnabled(instanceDto.actions),
+});

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.spec.tsx
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.spec.tsx
@@ -3,7 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, Mock, vi } from 'vitest';
 import { useEditInstanceName, useRegionInstance } from './useInstance';
-import { editInstanceName, getRegionInstance } from '@/data/api/instance';
+import { editInstanceName, getRegionInstanceMock } from '@/data/api/instance';
 import queryClient from '@/queryClient';
 import { buildPartialInstanceDto } from './builder/instanceDto.builder';
 import { TInstanceDetailDto } from '@/types/instance/api.type';
@@ -18,7 +18,7 @@ const fakeInstanceDto = buildPartialInstanceDto<TInstanceDetailDto>({
 const editInstanceNameMock = vi.fn();
 
 vi.mock('@/data/api/instance');
-vi.mocked(getRegionInstance as Mock).mockResolvedValue(fakeInstanceDto);
+vi.mocked(getRegionInstanceMock as Mock).mockResolvedValue(fakeInstanceDto);
 vi.mocked(editInstanceName).mockImplementation(editInstanceNameMock);
 
 const wrapper: FC<PropsWithChildren> = ({ children }) => (
@@ -32,7 +32,8 @@ describe('useRegionInstance', () => {
       { wrapper },
     );
 
-    expect(getRegionInstance).toHaveBeenCalledWith({
+    // TODO: expect with the good function
+    expect(getRegionInstanceMock).toHaveBeenCalledWith({
       projectId,
       instanceId,
       region,

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.ts
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.ts
@@ -4,9 +4,13 @@ import {
   UseQueryOptions,
   QueryKey,
 } from '@tanstack/react-query';
-import { editInstanceName, getInstance } from '@/data/api/instance';
+import {
+  editInstanceName,
+  getInstance,
+  getRegionInstance,
+} from '@/data/api/instance';
 import { useProjectId } from '@/hooks/project/useProjectId';
-import { TInstanceDto } from '@/types/instance/api.type';
+import { TInstanceDetailDto, TInstanceDto } from '@/types/instance/api.type';
 import { instancesQueryKey } from '@/utils';
 import { DeepReadonly } from '@/types/utils.type';
 import queryClient from '@/queryClient';
@@ -52,20 +56,50 @@ export const useInstance = <TData = TInstanceDto>(
 export const updateInstanceCache = ({
   projectId,
   instanceId,
+  region,
   payload,
 }: {
   projectId: string;
   instanceId: string;
-  payload: Partial<Omit<TInstanceDto, 'id'>>;
+  region: string;
+  payload: Partial<Omit<TInstanceDetailDto, 'id'>>;
 }) => {
-  queryClient.setQueryData<TInstanceDto>(
-    instancesQueryKey(projectId, ['instance', instanceId]),
+  queryClient.setQueryData<TInstanceDetailDto>(
+    instancesQueryKey(projectId, ['instance', instanceId, 'region', region]),
     (prevData) => {
       if (!prevData) return undefined;
       return { ...prevData, ...payload };
     },
   );
 };
+
+export const getRegionInstanceQuery = <T = TInstanceDetailDto>(
+  projectId: string,
+  region: string,
+  instanceId: string,
+): UseQueryOptions<TInstanceDetailDto, Error, T, QueryKey> => ({
+  queryKey: instancesQueryKey(projectId, [
+    'instance',
+    instanceId,
+    'region',
+    region,
+  ]),
+  queryFn: () => getRegionInstance({ projectId, region, instanceId }),
+});
+
+export const useRegionInstance = <TData = TInstanceDetailDto>(
+  projectId: string,
+  instance: string,
+  region: string,
+  options?: Omit<
+    UseQueryOptions<TInstanceDetailDto, Error, TData>,
+    'queryKey' | 'queryFn'
+  >,
+) =>
+  useQuery<TInstanceDetailDto, Error, TData>({
+    ...getRegionInstanceQuery(projectId, region, instance),
+    ...options,
+  });
 
 export const useEditInstanceName = ({
   projectId,

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.ts
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/useInstance.ts
@@ -7,7 +7,7 @@ import {
 import {
   editInstanceName,
   getInstance,
-  getRegionInstance,
+  getRegionInstanceMock,
 } from '@/data/api/instance';
 import { useProjectId } from '@/hooks/project/useProjectId';
 import { TInstanceDetailDto, TInstanceDto } from '@/types/instance/api.type';
@@ -84,7 +84,7 @@ export const getRegionInstanceQuery = <T = TInstanceDetailDto>(
     'region',
     region,
   ]),
-  queryFn: () => getRegionInstance({ projectId, region, instanceId }),
+  queryFn: () => getRegionInstanceMock({ projectId, region, instanceId }),
 });
 
 export const useRegionInstance = <TData = TInstanceDetailDto>(

--- a/packages/manager/apps/pci-instances/src/pages/instances/datagrid/cell/NameIdCell.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/datagrid/cell/NameIdCell.component.tsx
@@ -11,15 +11,19 @@ type TNameIdCellProps = {
   isLoading: boolean;
 };
 
-export const NameIdCell: FC<TNameIdCellProps> = ({ isLoading, instance }) => (
-  <LoadingCell isLoading={isLoading}>
-    <OsdsLink
-      color={ODS_THEME_COLOR_INTENT.primary}
-      className={'block'}
-      href={useHref(instance.id)}
-    >
-      {instance.name}
-    </OsdsLink>
-    <BaseTextCell>{instance.id}</BaseTextCell>
-  </LoadingCell>
-);
+export const NameIdCell: FC<TNameIdCellProps> = ({ isLoading, instance }) => {
+  const detailHref = useHref(`${instance.id}/region/${instance.region}`);
+
+  return (
+    <LoadingCell isLoading={isLoading}>
+      <OsdsLink
+        color={ODS_THEME_COLOR_INTENT.primary}
+        className={'block'}
+        href={detailHref}
+      >
+        {instance.name}
+      </OsdsLink>
+      <BaseTextCell>{instance.id}</BaseTextCell>
+    </LoadingCell>
+  );
+};

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/Instance.page.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/Instance.page.tsx
@@ -7,25 +7,31 @@ import {
   PageLayout,
   PciGuidesHeader,
   Notifications,
-  useProjectUrl,
 } from '@ovh-ux/manager-react-components';
 import { TProject } from '@ovh-ux/manager-pci-common';
 import { GoBack } from '@/components/navigation/GoBack.component';
 import InstanceWrapper from './InstanceWrapper.page';
 import { Breadcrumb } from '@/components/breadcrumb/Breadcrumb.component';
 import { CHANGELOG_LINKS } from '@/constants';
-import { useInstance } from '@/data/hooks/instance/useInstance';
+import { useRegionInstance } from '@/data/hooks/instance/useInstance';
 import InstanceName from './component/InstanceName.component';
-import { mapInstanceDto } from '@/data/hooks/instance/mapper/instance.mapper';
+import { getInstanceDetail } from '@/data/hooks/instance/selectors/instances.selector';
 
 const Instance: FC = () => {
   const project = useRouteLoaderData('root') as TProject;
-  const { instanceId } = useParams() as { instanceId: string };
-  const projectUrl = useProjectUrl('public-cloud');
+  const { instanceId, regionId } = useParams() as {
+    instanceId: string;
+    regionId: string;
+  };
 
-  const { data: instance, isLoading } = useInstance(instanceId, {
-    select: (dto) => mapInstanceDto(dto, projectUrl),
-  });
+  const { data: instance, isLoading } = useRegionInstance(
+    project.project_id,
+    instanceId,
+    regionId,
+    {
+      select: (dto) => getInstanceDetail(dto),
+    },
+  );
 
   return (
     <InstanceWrapper>
@@ -45,6 +51,7 @@ const Instance: FC = () => {
                   instanceId={instance.id}
                   isEditable={instance.isEditionEnabled}
                   name={instance.name}
+                  region={regionId}
                 />
               )}
             </div>

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/component/InstanceName.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/component/InstanceName.component.tsx
@@ -12,7 +12,8 @@ const InstanceName: FC<{
   instanceId: string;
   isEditable: boolean;
   name: string;
-}> = ({ instanceId, isEditable, name }) => {
+  region: string;
+}> = ({ instanceId, isEditable, name, region }) => {
   const { t } = useTranslation('dashboard');
   const { addError } = useNotifications();
   const projectId = useProjectId();
@@ -22,6 +23,7 @@ const InstanceName: FC<{
       updateInstanceCache({
         projectId,
         instanceId,
+        region,
         payload: { name: value },
       });
     },

--- a/packages/manager/apps/pci-instances/src/routes/routes.tsx
+++ b/packages/manager/apps/pci-instances/src/routes/routes.tsx
@@ -51,7 +51,7 @@ export const INSTANCE_PATH = 'instance/:instanceId';
 export const SECTIONS = {
   onboarding: 'onboarding',
   new: 'new',
-  instance: ':instanceId',
+  instance: ':instanceId/region/:regionId',
   delete: 'delete',
   stop: 'stop',
   start: 'start',

--- a/packages/manager/apps/pci-instances/src/types/instance/api.type.ts
+++ b/packages/manager/apps/pci-instances/src/types/instance/api.type.ts
@@ -1,12 +1,31 @@
+import { TRegionType } from '@ovh-ux/manager-pci-common';
 import { DeepReadonly } from '../utils.type';
 import {
   TActionName,
   TAddressType,
   TInstanceActionGroup,
+  TInstancePrice,
   TStatus,
 } from './common.type';
 
 export type TInstanceAddressTypeDto = TAddressType;
+
+export type TSubnetDto = {
+  id: string;
+  name: string;
+  gatewayIp: string;
+  network: {
+    id: string;
+    name: string;
+  };
+};
+
+export type TInstanceNetworkAddressDto = {
+  ip: string;
+  version: number;
+  type: TInstanceAddressTypeDto;
+  subnet: TSubnetDto;
+};
 
 export type TInstanceAddressDto = {
   ip: string;
@@ -24,6 +43,28 @@ export type TInstanceActionDto = {
   name: TInstanceActionNameDto;
   group: TInstanceActionGroup;
 };
+
+export type TFlavorDto = {
+  id: string;
+  name: string;
+  specs: {
+    cpu: number;
+    ram: number;
+    storage: number;
+    bandwidth: {
+      public: number;
+      private: number;
+    };
+  };
+};
+
+export type TImageDto = {
+  id: string;
+  name: string;
+  deprecated: boolean;
+};
+
+export type TPriceDto = TInstancePrice;
 
 export type TInstanceActionNameDto = TActionName;
 export type TInstanceStatusDto = TStatus;
@@ -57,3 +98,23 @@ export type TRetrieveInstancesQueryParams = DeepReadonly<{
   searchField?: string;
   searchValue?: string;
 }>;
+
+export type TInstanceDetailDto = {
+  addresses: TInstanceNetworkAddressDto[];
+  flavor: TFlavorDto;
+  id: string;
+  image: TImageDto;
+  name: string;
+  region: string;
+  regionType: TRegionType;
+  status: TInstanceStatusDto;
+  volumes: TInstanceVolumeDto[];
+  actions: TInstanceActionDto[];
+  pendingTask: boolean;
+  prices: TPriceDto[];
+  availabilityZone: string | null;
+  taskState: string;
+  isImageDeprecated: boolean;
+  sshKey: string;
+  login: string;
+};

--- a/packages/manager/apps/pci-instances/src/types/instance/common.type.ts
+++ b/packages/manager/apps/pci-instances/src/types/instance/common.type.ts
@@ -57,3 +57,9 @@ export type TInstanceActionGroup =
   | 'details'
   | 'lifecycle'
   | 'shelve';
+
+export type TInstancePrice = {
+  type: 'hour' | 'month' | 'licence' | 'savingplans';
+  value: number;
+  status: 'enabled' | 'available' | 'eligible';
+};

--- a/packages/manager/apps/pci-instances/src/types/instance/entity.type.ts
+++ b/packages/manager/apps/pci-instances/src/types/instance/entity.type.ts
@@ -55,5 +55,14 @@ export type TInstance = DeepReadonly<{
   availabilityZone: string | null;
   taskState: string | null;
   isImageDeprecated: boolean;
+}>;
+
+export type TInstanceDetail = DeepReadonly<{
+  id: string;
+  name: string;
+  status: TInstanceStatus;
+  pendingTask: boolean;
+  availabilityZone: string | null;
+  taskState: string | null;
   isEditionEnabled: boolean;
 }>;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
This PR will implement the regionalised called instance for dashboard since the getInstance will be deprecated.
<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference:  #TAPC-4006

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
