### PR TITLE
feat(pci-private-registry): display IAM authentication status in regi…

### DIFF
--- a/packages/manager/apps/pci-private-registry/src/components/listing/Action.component.tsx
+++ b/packages/manager/apps/pci-private-registry/src/components/listing/Action.component.tsx
@@ -33,6 +33,16 @@ export default function ActionComponent({
   const items = [
     {
       id: 0,
+      label: t('private_registry_rename'),
+      href: hrefRename,
+      onClick: () =>
+        tracking?.trackClick({
+          name: 'PCI_PROJECTS_PRIVATEREGISTRY_UPDATE',
+          type: 'action',
+        }),
+    },
+    {
+      id: 1,
       label: t('private_registry_upgrade_plan'),
       href: hrefUpgradePlan,
       disabled:
@@ -46,7 +56,7 @@ export default function ActionComponent({
         }),
     },
     {
-      id: 1,
+      id: 2,
       label: t('private_registry_harbor_ui'),
       href: hrefHarborUI,
       disabled: registry.status !== PRIVATE_REGISTRY_STATUS.READY,
@@ -58,7 +68,7 @@ export default function ActionComponent({
         }),
     },
     {
-      id: 2,
+      id: 3,
       label: t('private_registry_harbor_api'),
       href: hrefHarborAPI,
       disabled: registry.status !== PRIVATE_REGISTRY_STATUS.READY,
@@ -69,7 +79,7 @@ export default function ActionComponent({
         }),
     },
     {
-      id: 3,
+      id: 4,
       label: t('private_registry_regenerate_creds'),
       href: hrefRegenerateCredentials,
       disabled:
@@ -82,30 +92,7 @@ export default function ActionComponent({
         }),
     },
     {
-      id: 4,
-      label: t('private_registry_rename'),
-      href: hrefRename,
-      onClick: () =>
-        tracking?.trackClick({
-          name: 'PCI_PROJECTS_PRIVATEREGISTRY_UPDATE',
-          type: 'action',
-        }),
-    },
-    {
       id: 5,
-      label: t('ip-restrictions:private_registry_cidr_manage_title'),
-      href: hrefManageCIDR,
-      disabled:
-        registry.status !== PRIVATE_REGISTRY_STATUS.READY &&
-        registry.status !== PRIVATE_REGISTRY_STATUS.ERROR,
-      onClick: () =>
-        tracking?.trackClick({
-          name: 'PCI_PROJECTS_PRIVATEREGISTRY_MANAGE_CIDR',
-          type: 'action',
-        }),
-    },
-    {
-      id: 6,
       label: t('private_registry_iam_authentication_manage', {
         manage: registry.iamEnabled
           ? t('private_registry_common_status_DISABLE')
@@ -118,6 +105,19 @@ export default function ActionComponent({
           name: `PCI_PROJECTS_PRIVATEREGISTRY_${
             registry.iamEnabled ? 'DISABLE' : 'ENABLE'
           }_IAM_AUTHENTICATION`,
+          type: 'action',
+        }),
+    },
+    {
+      id: 6,
+      label: t('ip-restrictions:private_registry_cidr_manage_title'),
+      href: hrefManageCIDR,
+      disabled:
+        registry.status !== PRIVATE_REGISTRY_STATUS.READY &&
+        registry.status !== PRIVATE_REGISTRY_STATUS.ERROR,
+      onClick: () =>
+        tracking?.trackClick({
+          name: 'PCI_PROJECTS_PRIVATEREGISTRY_MANAGE_CIDR',
           type: 'action',
         }),
     },

--- a/packages/manager/apps/pci-private-registry/src/components/listing/RegistryIAMStatus.component.tsx
+++ b/packages/manager/apps/pci-private-registry/src/components/listing/RegistryIAMStatus.component.tsx
@@ -1,0 +1,27 @@
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+import { OsdsChip } from '@ovhcloud/ods-components/react';
+import { useTranslation } from 'react-i18next';
+
+const RegistryIAMStatus = ({ enabled }: Readonly<{ enabled: boolean }>) => {
+  const { t } = useTranslation();
+
+  return (
+    <OsdsChip
+      color={
+        enabled
+          ? ODS_THEME_COLOR_INTENT.success
+          : ODS_THEME_COLOR_INTENT.default
+      }
+      className="w-fit"
+      data-testid="registryIamAthenticationStatus_chip"
+    >
+      <span className="whitespace-nowrap">
+        {t(
+          `private_registry_common_status_${enabled ? 'ENABLED' : 'DISABLED'}`,
+        )}
+      </span>
+    </OsdsChip>
+  );
+};
+
+export default RegistryIAMStatus;

--- a/packages/manager/apps/pci-private-registry/src/pages/list/useDatagridColumn.spec.tsx
+++ b/packages/manager/apps/pci-private-registry/src/pages/list/useDatagridColumn.spec.tsx
@@ -1,13 +1,44 @@
-import { renderHook } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
+import { Datagrid } from '@ovh-ux/manager-react-components';
 import { useDatagridColumn } from './useDatagridColumn';
+import { wrapper } from '@/wrapperRenders';
+import { TRegistry } from '@/api/data/registry';
 
 describe('useDatagridColumn', () => {
+  const mockedPartialRegistry: Omit<TRegistry, 'iamEnabled'> = {
+    id: 'registryId',
+    createdAt: '2024-01-01',
+    deliveredAt: '2024-01-02',
+    name: 'Test Registry',
+    notary_url: 'https://example.com/notary',
+    region: 'GRA',
+    size: 1024,
+    status: 'READY',
+    updatedAt: '2024-01-03',
+    url: 'https://example.com/registry',
+    version: '1.0',
+    plan: {
+      id: 'plan1',
+      name: 'SMALL',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-02',
+      registryLimits: {
+        imageStorage: 100,
+        parallelRequest: 10,
+      },
+      features: {
+        vulnerability: true,
+      },
+      code: 'PLAN_CODE',
+    },
+  };
+
   it('should return the correct columns', () => {
     const { result } = renderHook(() => useDatagridColumn());
 
     const columns = result.current;
 
-    expect(columns).toHaveLength(8);
+    expect(columns).toHaveLength(9);
 
     const nameColumn = columns.find((col) => col.id === 'name');
     expect(nameColumn).toBeDefined();
@@ -29,6 +60,9 @@ describe('useDatagridColumn', () => {
     expect(versionColumn).toBeDefined();
     expect(versionColumn?.label).toBe('private_registry_harbor_version');
 
+    const iamColumn = columns.find((col) => col.id === 'iam');
+    expect(iamColumn?.label).toBeDefined();
+
     const statusColumn = columns.find((col) => col.id === 'status');
     expect(statusColumn).toBeDefined();
     expect(statusColumn?.label).toBe('private_registry_status');
@@ -40,5 +74,57 @@ describe('useDatagridColumn', () => {
     const actionsColumn = columns.find((col) => col.id === 'actions');
     expect(actionsColumn).toBeDefined();
     expect(actionsColumn?.label).toBe('');
+  });
+
+  it('should display enabled IAM authentication status if registry IAM is enabled', () => {
+    const columns = useDatagridColumn();
+    const mockedRegistries: TRegistry[] = [
+      { ...mockedPartialRegistry, iamEnabled: true },
+    ];
+
+    const fakeData = {
+      rows: mockedRegistries,
+      pageCount: 1,
+      totalRows: 1,
+    };
+
+    const { getByTestId } = render(
+      <Datagrid
+        columns={columns}
+        items={fakeData.rows}
+        totalItems={fakeData.totalRows}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      getByTestId('registryIamAthenticationStatus_chip'),
+    ).toHaveTextContent('private_registry_common_status_ENABLED');
+  });
+
+  it('should display disabled IAM authentication status if registry IAM is disabled', () => {
+    const columns = useDatagridColumn();
+    const mockedRegistries: TRegistry[] = [
+      { ...mockedPartialRegistry, iamEnabled: false },
+    ];
+
+    const fakeData = {
+      rows: mockedRegistries,
+      pageCount: 1,
+      totalRows: 1,
+    };
+
+    const { getByTestId } = render(
+      <Datagrid
+        columns={columns}
+        items={fakeData.rows}
+        totalItems={fakeData.totalRows}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      getByTestId('registryIamAthenticationStatus_chip'),
+    ).toHaveTextContent('private_registry_common_status_DISABLED');
   });
 });

--- a/packages/manager/apps/pci-private-registry/src/pages/list/useDatagridColumn.tsx
+++ b/packages/manager/apps/pci-private-registry/src/pages/list/useDatagridColumn.tsx
@@ -2,12 +2,63 @@ import {
   DatagridColumn,
   DataGridTextCell,
 } from '@ovh-ux/manager-react-components';
+import {
+  OsdsIcon,
+  OsdsPopover,
+  OsdsPopoverContent,
+  OsdsText,
+} from '@ovhcloud/ods-components/react';
 import { useTranslation } from 'react-i18next';
+import {
+  ODS_TEXT_SIZE,
+  ODS_TEXT_LEVEL,
+  ODS_ICON_NAME,
+  ODS_ICON_SIZE,
+} from '@ovhcloud/ods-components';
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+
 import { TRegistry } from '@/api/data/registry';
 import ActionComponent from '@/components/listing/Action.component';
 import { RegistryPlan } from '@/components/listing/RegistryPlan.component';
 import { RegistrySpace } from '@/components/listing/RegistrySpace.component';
+import RegistryIAMStatus from '@/components/listing/RegistryIAMStatus.component';
 import RegistryStatus from '@/components/listing/RegistryStatus.component';
+
+const IAMColumnLabel = () => {
+  const { t } = useTranslation();
+
+  return (
+    <span className="inline-flex">
+      <OsdsText
+        data-testid="registryIamColumnLabel"
+        className="text-[--ods-color-primary-800] self-center"
+        size={ODS_TEXT_SIZE._500}
+      >
+        {t('private_registry_iam_authentication_status')}
+      </OsdsText>
+      <span onClick={(event) => event.stopPropagation()}>
+        <OsdsPopover className="whitespace-normal">
+          <span slot="popover-trigger">
+            <OsdsIcon
+              name={ODS_ICON_NAME.HELP}
+              size={ODS_ICON_SIZE.xs}
+              className="ml-4 cursor-help"
+              color={ODS_THEME_COLOR_INTENT.primary}
+            />
+          </span>
+          <OsdsPopoverContent>
+            <OsdsText
+              color={ODS_THEME_COLOR_INTENT.text}
+              level={ODS_TEXT_LEVEL.body}
+            >
+              {t('private_registry_iam_authentication_infos_tooltip')}
+            </OsdsText>
+          </OsdsPopoverContent>
+        </OsdsPopover>
+      </span>
+    </span>
+  );
+};
 
 export const useDatagridColumn = () => {
   const { t } = useTranslation();
@@ -38,6 +89,11 @@ export const useDatagridColumn = () => {
       id: 'version',
       label: t('private_registry_harbor_version'),
       cell: (props) => <DataGridTextCell>{props.version}</DataGridTextCell>,
+    },
+    {
+      id: 'iam',
+      label: ((<IAMColumnLabel />) as unknown) as string,
+      cell: (props) => <RegistryIAMStatus enabled={props.iamEnabled} />,
     },
     {
       id: 'status',


### PR DESCRIPTION

This PR aims to display private registry IAM authentication status in the list.

ref: #TAPC-3162

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: [#TAPC-3162](https://jira.ovhcloud.tools/browse/TAPC-3162)    <!-- prefix each issue number with "#", if any  -->

## Additional Information
🔍 IAM Disabled :
 <img width="1067" alt="Capture d’écran 2025-06-12 à 10 42 44" src="https://github.com/user-attachments/assets/536ae2d3-13de-48a1-97c3-d622ee0fc56f" />

🔎 IAM Enabled :
<img width="1064" alt="Capture d’écran 2025-06-12 à 10 43 00" src="https://github.com/user-attachments/assets/1839f6cd-1543-4358-a7f9-8a9025b724f2" />

⚠️ Actions order has been updated:
"rename" goes on top and "IAM authentication" goes under  "Generating new identification details"
<img width="397" alt="Capture d’écran 2025-06-12 à 10 31 42" src="https://github.com/user-attachments/assets/571d785b-9415-4a8e-a118-dac665b697ca" />

<!-- 
 Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
