### PR TITLE
feat(config): extend error response to general unavailability

### DIFF
--- a/packages/manager/modules/config/src/index.ts
+++ b/packages/manager/modules/config/src/index.ts
@@ -81,6 +81,15 @@ export const fetchConfiguration = async (
         };
         throw errorObj;
       }
+      if (err?.status >= 500) {
+        const errorObj = {
+          error: {
+            message: err?.response?.data || err?.response?.statusText,
+          },
+          environment,
+        };
+        throw errorObj;
+      }
       return environment;
     });
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
Goal is to show an error message on general unavailability of the /configuration api.

Here we catch reason for unavailability instead of showing generic message.
Alternative would have been to check in the container if the returned `environment` has the `universe` with the value `null` or an empty `user` object.

This way, we can re-use the implementation for the Maintenance error display and show the HTTP status text instead of no explanation at all.

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18615

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
