### PR TITLE
feat(pci-private-registry): update IAM modal confirm handling

### DIFF
--- a/packages/manager/apps/pci-private-registry/src/pages/IAM/IAMModal/IAMModal.tsx
+++ b/packages/manager/apps/pci-private-registry/src/pages/IAM/IAMModal/IAMModal.tsx
@@ -91,9 +91,16 @@ export const IAMModal = ({
 
   const handleQuit = (action: TRegistryAction) => () => onQuit(action);
 
-  const { handleSubmit, control } = useForm<IAMchemaType>({
+  const {
+    handleSubmit,
+    control,
+    formState: { isValid },
+  } = useForm<IAMchemaType>({
     resolver: zodResolver(confirmIAMSchema()),
-    mode: 'onSubmit',
+    mode: 'onChange',
+    defaultValues: {
+      confirmIAM: '',
+    },
   });
 
   useEffect(() => {
@@ -113,6 +120,7 @@ export const IAMModal = ({
           : t('private_registry_common_status_ENABLE'),
       })}
       isPending={loading}
+      isDisabled={!isValid}
       onConfirm={handleSubmit(onManageIAM)}
       onClose={handleQuit('CLOSE')}
       onCancel={handleQuit('CANCEL')}

--- a/packages/manager/apps/pci-private-registry/src/types/index.ts
+++ b/packages/manager/apps/pci-private-registry/src/types/index.ts
@@ -37,7 +37,7 @@ export type TIPRestrictionsData = TIPRestrictions &
 
 export type ConfirmCIDRSchemaType = z.infer<ReturnType<typeof schemaAddCidr>>;
 
-export type IAMchemaType = z.infer<ReturnType<typeof confirmIAMSchema>>;
+export type IAMchemaType = { confirmIAM: string };
 
 export type TRegistryAction =
   | 'CLOSE'


### PR DESCRIPTION
ref: #TAPC-4339

This ticket improves the behavior of the confirm button to enable/disable IAM authentication.
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: [#TAPC-4339](https://jira.ovhcloud.tools/browse/TAPC-4339)   <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
