### PR TITLE
feat(ola-nics): adding aggregation/desaggregation buttons to nics lists

### DIFF
--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/clusters/nodes/interfaces/interfaces.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/clusters/nodes/interfaces/interfaces.html
@@ -33,6 +33,7 @@
             data-server="$ctrl.server"
             data-server-name="$ctrl.serverName"
             data-interfaces="$ctrl.interfaces"
+            data-ola="$ctrl.ola"
             data-specifications="$ctrl.specifications"
             data-urls="$ctrl.urls"
             data-failover-ips="$ctrl.failoverIps"

--- a/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
+++ b/packages/manager/apps/dedicated/client/app/dedicated/dedicated-server/servers/interfaces/interfaces.html
@@ -33,6 +33,7 @@
             data-server="$ctrl.server"
             data-server-name="$ctrl.serverName"
             data-interfaces="$ctrl.interfaces"
+            data-ola="$ctrl.ola"
             data-specifications="$ctrl.specifications"
             data-urls="$ctrl.urls"
             data-failover-ips="$ctrl.failoverIps"

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/component.js
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/component.js
@@ -6,6 +6,7 @@ export default {
     server: '<',
     serverName: '<',
     interfaces: '<',
+    ola: '<',
     specifications: '<',
     urls: '<',
     failoverIps: '<',

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/controller.js
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/controller.js
@@ -1,15 +1,20 @@
+import { OLA_MODES } from '../ola/ola.constants';
 import { LABELS } from './interfaces.constants';
 
 export default class BMNetworkInterfaceController {
   /* @ngInject */
-  constructor() {
+  constructor($state) {
+    this.$state = $state;
     this.LABELS = LABELS;
   }
 
-  $onChanges({ interfaces }) {
+  $onChanges({ interfaces, ola }) {
     this.displayedInterfaces = interfaces.currentValue.map((nic) => ({
       ...nic,
       displayedMacAdresses: nic.mac ? nic.mac.split(', ') : [],
     }));
+
+    this.isFullyAggregated =
+      ola.currentValue.getCurrentMode() === OLA_MODES.FULL_LAG;
   }
 }

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/template.html
@@ -27,6 +27,24 @@
             ></span>
         </a>
     </div>
+    <oui-button
+        data-ng-if="$ctrl.isFullyAggregated"
+        data-variant="primary"
+        data-ui-sref=".ola-reset({ola: $ctrl.ola})"
+    >
+        <span
+            data-translate="dedicated_server_interfaces_disaggregate_button"
+        ></span>
+    </oui-button>
+    <oui-button
+        data-ng-if="!$ctrl.isFullyAggregated"
+        data-variant="primary"
+        data-ui-sref=".ola-configuration"
+    >
+        <span
+            data-translate="dedicated_server_interfaces_aggregate_button"
+        ></span>
+    </oui-button>
     <oui-datagrid
         data-rows="$ctrl.displayedInterfaces"
         class="oui-tile__body table-striped "

--- a/packages/manager/modules/bm-server-components/src/network-interfaces/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/network-interfaces/translations/Messages_fr_FR.json
@@ -1,5 +1,7 @@
 {
   "dedicated_server_interfaces": "Contrôleurs d'interfaces réseau (NICs)",
+  "dedicated_server_interfaces_aggregate_button": "Agrégation réseaux",
+  "dedicated_server_interfaces_disaggregate_button": "Désaggréger les réseaux",
   "dedicated_server_interfaces_breadcrumb": "Interfaces réseau",
   "dedicated_server_interfaces_vrack_information": "Veuillez noter que par défaut aucune IP n’existe pour le réseau privé (vRack). En effet vous devez au préalable créer un réseau privé (vRack), y ajouter votre serveur, puis configurez vos IP.",
   "dedicated_server_interfaces_vrack_information_link_label": "En savoir plus sur le vRack.",

--- a/packages/manager/modules/bm-server-components/src/ola/ola-configuration/ola-configuration.html
+++ b/packages/manager/modules/bm-server-components/src/ola/ola-configuration/ola-configuration.html
@@ -55,7 +55,7 @@
             type="text"
             autocomplete="off"
             placeholder="{{:: 'dedicated_server_interfaces_ola_field_name_placeholder' | translate }}"
-            data-ng-model="$ctrl.configuration.name"
+            data-ng-model="$ctrl.configurationName"
             data-required
         />
     </oui-field>
@@ -99,17 +99,32 @@
         data-selectable-rows
     >
         <oui-datagrid-column
-            data-title=":: 'dedicated_server_interfaces_ola_column_name' | translate"
-            data-property="mac"
-        >
-        </oui-datagrid-column>
-        <oui-datagrid-column
             data-title=":: 'dedicated_server_interfaces_ola_column_current_type' | translate"
             data-property="type"
         >
-            <span
+            <div
                 data-translate="{{ 'dedicated_server_interfaces_type_' + $value + '_label' }}"
-            ></span>
+            ></div>
+            <div
+                data-ng-if="$row.displayedMacAdresses.length > 1"
+                class="oui-badge oui-badge_success"
+                data-translate="{{ 'dedicated_server_interfaces_type_badge_aggregated' }}"
+            ></div>
+        </oui-datagrid-column>
+        <oui-datagrid-column
+            data-title=":: 'dedicated_server_interfaces_ola_column_mac_address' | translate"
+            data-property="displayedMacAdresses"
+        >
+            <div data-ng-if="$row.displayedMacAdresses.length > 1">
+                <ul class="mb-0">
+                    <li data-ng-repeat="mac in $row.displayedMacAdresses">
+                        <p class="mb-0" data-ng-bind="mac"></p>
+                    </li>
+                </ul>
+            </div>
+            <div data-ng-if="$row.displayedMacAdresses.length <= 1">
+                <span data-ng-bind="$row.mac"></span>
+            </div>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title=":: 'dedicated_server_interfaces_ola_column_bandwidth_outgoing' | translate"
@@ -143,61 +158,66 @@
         </oui-datagrid-column>
     </oui-datagrid>
 
-    <strong
-        data-translate="dedicated_server_interfaces_ola_network_interfaces_after"
-    ></strong>
-    <table data-ng-if="$ctrl.isInterfaceSelectionValid()" class="oui-table">
-        <thead class="oui-table__headers">
-            <tr>
-                <th
-                    class="oui-table__header"
-                    data-translate="dedicated_server_interfaces_ola_column_mode"
-                ></th>
-                <th
-                    class="oui-table__header"
-                    data-translate="dedicated_server_interfaces_ola_column_name"
-                ></th>
-                <th
-                    class="oui-table__header"
-                    data-translate="dedicated_server_interfaces_ola_column_bandwidth_outgoing"
-                ></th>
-                <th
-                    class="oui-table__header"
-                    data-translate="dedicated_server_interfaces_ola_column_bandwidth_incoming"
-                ></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr
-                class="oui-table__row"
-                data-ng-repeat="interface in $ctrl.selectedInterfaces track by interface.name"
-            >
-                <td
-                    class="oui-table__cell"
-                    data-ng-if="!$index"
-                    data-ng-bind="'dedicated_server_interfaces_ola_field_mode_choice_' + $ctrl.configuration.mode | translate"
-                    rowspan="{{ $ctrl.selectedInterfaces.length }}"
-                ></td>
-                <td class="oui-table__cell" data-ng-bind="interface.mac"></td>
-                <td class="oui-table__cell">
-                    <span
-                        class="oui-icon oui-icon-arrow-up font-inherit"
-                    ></span>
-                    <span
-                        data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
-                    ></span>
-                </td>
-                <td class="oui-table__cell">
-                    <span
-                        class="oui-icon oui-icon-arrow-down font-inherit"
-                    ></span>
-                    <span
-                        data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
-                    ></span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    <div data-ng-if="$ctrl.isInterfaceSelectionValid()">
+        <strong
+            data-translate="dedicated_server_interfaces_ola_network_interfaces_after"
+        ></strong>
+        <table class="oui-table">
+            <thead class="oui-table__headers">
+                <tr>
+                    <th
+                        class="oui-table__header"
+                        data-translate="dedicated_server_interfaces_ola_column_mode"
+                    ></th>
+                    <th
+                        class="oui-table__header"
+                        data-translate="dedicated_server_interfaces_ola_column_mac_address"
+                    ></th>
+                    <th
+                        class="oui-table__header"
+                        data-translate="dedicated_server_interfaces_ola_column_bandwidth_outgoing"
+                    ></th>
+                    <th
+                        class="oui-table__header"
+                        data-translate="dedicated_server_interfaces_ola_column_bandwidth_incoming"
+                    ></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr
+                    class="oui-table__row"
+                    data-ng-repeat="interface in $ctrl.selectedInterfaces track by interface.name"
+                >
+                    <td
+                        class="oui-table__cell"
+                        data-ng-if="!$index"
+                        data-ng-bind="'dedicated_server_interfaces_ola_field_mode_choice_' + $ctrl.targetInterfaceType | translate"
+                        rowspan="{{ $ctrl.selectedInterfaces.length }}"
+                    ></td>
+                    <td
+                        class="oui-table__cell"
+                        data-ng-bind="interface.mac"
+                    ></td>
+                    <td class="oui-table__cell">
+                        <span
+                            class="oui-icon oui-icon-arrow-up font-inherit"
+                        ></span>
+                        <span
+                            data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
+                        ></span>
+                    </td>
+                    <td class="oui-table__cell">
+                        <span
+                            class="oui-icon oui-icon-arrow-down font-inherit"
+                        ></span>
+                        <span
+                            data-ng-bind="$ctrl.specifications.vrack.bandwidth | serverBandwidth"
+                        ></span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
     <oui-button data-size="l" data-on-click="$ctrl.cancel()">
         <span data-translate="common_cancel"></span>
     </oui-button>

--- a/packages/manager/modules/bm-server-components/src/ola/ola-configuration/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/ola/ola-configuration/translations/Messages_fr_FR.json
@@ -8,7 +8,7 @@
   "dedicated_server_interfaces_ola_alert_obsolete_option": "Dans le cadre d'une configuration Agrégation privée, votre option de bande passante sortante publique ne sera pas utilisée.",
 
   "dedicated_server_interfaces_ola_column_mode": "Mode",
-  "dedicated_server_interfaces_ola_column_name": "Interface",
+  "dedicated_server_interfaces_ola_column_mac_address": "Adresse MAC",
   "dedicated_server_interfaces_ola_column_current_type": "Type",
   "dedicated_server_interfaces_ola_column_network_offer": "Offre réseau",
   "dedicated_server_interfaces_ola_column_bandwidth_outgoing": "Bande passante sortante",

--- a/packages/manager/modules/bm-server-components/src/ola/ola-reset/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/bm-server-components/src/ola/ola-reset/translations/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
-  "dedicated_server_interfaces_ola_reset_title": "Déconfigurer l'agrégation privée",
-  "dedicated_server_interfaces_ola_reset_text": "Êtes-vous sûr de vouloir déconfigurer l'agrégation privée sur ce serveur?",
-  "dedicated_server_interfaces_ola_reset_error": "Une erreur est survenue lors de la déconfiguration de l'agrégation privée."
+  "dedicated_server_interfaces_ola_reset_title": "Détacher le réseau agrégé",
+  "dedicated_server_interfaces_ola_reset_text": "Vous sûr de vouloir détacher ce réseau agrégé ? Les interfaces réseau fonctionneront indépendamment après cette action.",
+  "dedicated_server_interfaces_ola_reset_error": "Une erreur est survenue lors du détachement du réseau agrégé."
 }


### PR DESCRIPTION
ref: #MANAGER-17106

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR introduces a new button to navigate to the ola-configuration screen or to trigger a disaggragation of the current aggregation.
In additon to that, this PR improves slightly the to-be-reworked ola-configuration screen

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17106

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
