### PR TITLE
fix(ola-nics): fixing the display of unavailable OLA in the network panel

### DIFF
--- a/packages/manager/modules/bm-server-components/src/network-tile/template.html
+++ b/packages/manager/modules/bm-server-components/src/network-tile/template.html
@@ -180,16 +180,11 @@
                 ></span>
             </oui-tile-description>
             <oui-action-menu
+                data-ng-if="$ctrl.ola.isAvailable()"
                 aria-label="{{:: 'menu_action_label' | translate:{ t0: ('server_network_ola' | translate) } }}"
                 data-compact
                 data-placement="end"
             >
-                <oui-action-menu-item
-                    data-ng-if="!$ctrl.ola.isActivated()"
-                    data-ui-sref="{{ $ctrl.statePrefix }}.interfaces"
-                >
-                    <span data-translate="server_network_ola_activate"></span>
-                </oui-action-menu-item>
                 <oui-action-menu-item
                     data-ng-if="$ctrl.ola.isConfigured()"
                     data-ui-sref="{{ $ctrl.statePrefix }}.interfaces.ola-reset"


### PR DESCRIPTION

ref: #MANAGER-17110

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR fixes the display of the network panel.
No aggregation action should be displayed when OLA is unavailable.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17110

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
