### PR TITLE
fix(zimbra): fix password update in account edit form

### DIFF
--- a/packages/manager/apps/zimbra/src/data/api/account/utils.ts
+++ b/packages/manager/apps/zimbra/src/data/api/account/utils.ts
@@ -5,7 +5,7 @@ export const formatAccountPayload = (
   data: AddEmailAccountSchema,
   isEdit = false,
 ): AccountBodyParamsType => {
-  const { account, domain, slotId } = data;
+  const { account, domain, slotId, password } = data;
 
   const payload: Record<string, unknown> = {
     email: `${account}@${domain}`.toLowerCase(),
@@ -16,7 +16,7 @@ export const formatAccountPayload = (
       ![
         'account',
         'domain',
-        isEdit ? 'password' : '',
+        isEdit && !password ? 'password' : '',
         isEdit || !slotId ? 'slotId' : '',
         isEdit ? 'offer' : '', // @TODO: remove when backend make this optional
       ].includes(key)


### PR DESCRIPTION
ref: #MANAGER-18755

## Description
The goal is to fix an issue with password not being updated on account edit. We need to ensure the password field is not ignored when a new password is provided in the edit form.

Ticket Reference: #MANAGER-18755

## Additional Information

