### PR TITLE
fix(kms): manage users with no permissions to services

### DIFF
--- a/packages/manager/apps/key-management-service/src/components/Listing/ListingCells.tsx
+++ b/packages/manager/apps/key-management-service/src/components/Listing/ListingCells.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   ActionMenu,
   Clipboard,
@@ -24,10 +24,8 @@ import { OkmsAllServiceKeys } from '@/types/okmsServiceKey.type';
 import { useServiceKeyTypeTranslations } from '@/hooks/serviceKey/useServiceKeyTypeTranslations';
 import { ServiceKeyStatus } from '../serviceKey/serviceKeyStatus/serviceKeyStatus.component';
 import useServiceKeyActionsList from '@/hooks/serviceKey/useServiceKeyActionsList';
-import { useOkmsServiceKeyById } from '@/data/hooks/useOkmsServiceKeys';
 import { useFormattedDate } from '@/hooks/useFormattedDate';
 import { OkmsServiceState } from '../layout-helpers/Dashboard/okmsServiceState/OkmsServiceState.component';
-import { OkmsContext } from '@/pages/dashboard';
 import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
 
 export const DatagridCellId = (props: OKMS | OkmsAllServiceKeys) => {
@@ -66,16 +64,19 @@ export const DatagridCellRegion = (kms: OKMS) => {
 };
 
 export const DatagridCellStatus = (kms: OKMS) => {
-  const { data: OkmsServiceInfos, isLoading, isError } = useServiceDetails({
+  const { data: okmsService, isPending, isError } = useServiceDetails({
     resourceName: kms.id,
   });
-  if (isLoading) {
+
+  if (isPending) {
     return <OdsSpinner size={ODS_SPINNER_SIZE.sm} />;
   }
-  if (isError) {
+
+  if (!isError) {
     return <></>;
   }
-  return <OkmsServiceState state={OkmsServiceInfos.data.resource.state} />;
+
+  return <OkmsServiceState state={okmsService?.data?.resource?.state} />;
 };
 
 export const DatagridResourceKmipCountCell = (kms: OKMS) => {
@@ -139,18 +140,14 @@ export const DatagridStatus = (props: OkmsAllServiceKeys) => {
   return <ServiceKeyStatus state={props.state} />;
 };
 
-export const DatagridServiceKeyActionMenu = (props: OkmsAllServiceKeys) => {
-  const okms = useContext(OkmsContext);
-  const { data: serviceKey, isPending } = useOkmsServiceKeyById({
-    okmsId: okms.id,
-    keyId: props.id,
-  });
-  const actionList = useServiceKeyActionsList(okms, serviceKey?.data, true);
-
+export const DatagridServiceKeyActionMenu = (
+  serviceKey: OkmsAllServiceKeys,
+  okms: OKMS,
+) => {
+  const actionList = useServiceKeyActionsList(okms, serviceKey, true);
   return (
     <ActionMenu
-      id={`service-key-actions-${props.id}`}
-      isLoading={isPending}
+      id={`service-key-actions-${serviceKey.id}`}
       isCompact
       variant={ODS_BUTTON_VARIANT.ghost}
       icon={ODS_ICON_NAME.ellipsisVertical}

--- a/packages/manager/apps/key-management-service/src/components/credential/credentialDatagrid/CredentialDatagrid.tsx
+++ b/packages/manager/apps/key-management-service/src/components/credential/credentialDatagrid/CredentialDatagrid.tsx
@@ -6,7 +6,7 @@ import {
 import { queryClient } from '@ovh-ux/manager-react-core-application';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
 import {
   getOkmsCredentialsQueryKey,
@@ -23,11 +23,15 @@ import {
 } from '@/components/credential/credentialDatagrid/CredentialDatagridCells';
 import Loading from '@/components/Loading/Loading';
 import { OkmsCredential } from '@/types/okmsCredential.type';
+import { OKMS } from '@/types/okms.type';
 
-const CredentialDatagrid = () => {
+type CredentialDatagridProps = {
+  okms: OKMS;
+};
+
+const CredentialDatagrid = ({ okms }: CredentialDatagridProps) => {
   const { t } = useTranslation('key-management-service/credential');
   const navigate = useNavigate();
-  const { okmsId } = useParams();
   const { state } = useLocation();
 
   const {
@@ -35,7 +39,7 @@ const CredentialDatagrid = () => {
     isLoading: isLoadingCredentials,
     error: credentialsError,
   } = useOkmsCredentials({
-    okmsId,
+    okmsId: okms.id,
     deletingCredentialId: state?.deletingCredentialId,
   });
 
@@ -48,7 +52,7 @@ const CredentialDatagrid = () => {
         onRedirectHome={() => navigate(KMS_ROUTES_URLS.kmsListing)}
         onReloadPage={() =>
           queryClient.refetchQueries({
-            queryKey: getOkmsCredentialsQueryKey(okmsId),
+            queryKey: getOkmsCredentialsQueryKey(okms.id),
           })
         }
       />
@@ -93,7 +97,8 @@ const CredentialDatagrid = () => {
     },
     {
       id: 'actions',
-      cell: DatagridCredentialCellActions,
+      cell: (credential: OkmsCredential) =>
+        DatagridCredentialCellActions(credential, okms),
       label: '',
       isSortable: false,
     },

--- a/packages/manager/apps/key-management-service/src/components/credential/credentialDatagrid/CredentialDatagridCells.tsx
+++ b/packages/manager/apps/key-management-service/src/components/credential/credentialDatagrid/CredentialDatagridCells.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -18,9 +18,9 @@ import { OkmsCredential } from '@/types/okmsCredential.type';
 import { useFormattedDate } from '@/hooks/useFormattedDate';
 import { CredentialStatus } from '../credentialStatus/CredentialStatus.component';
 import { getDownloadCredentialParameters } from '@/utils/credential/credentialDownload';
-import { OkmsContext } from '@/pages/dashboard';
 import { KMS_ROUTES_URIS } from '@/routes/routes.constants';
 import { kmsIamActions } from '@/utils/iam/iam.constants';
+import { OKMS } from '@/types/okms.type';
 
 export const DatagridCredentialCellName = (credential: OkmsCredential) => {
   const navigate = useNavigate();
@@ -94,9 +94,11 @@ export const DatagridCredentialCellStatus = (credential: OkmsCredential) => {
   return <CredentialStatus state={credential.status} />;
 };
 
-export const DatagridCredentialCellActions = (credential: OkmsCredential) => {
+export const DatagridCredentialCellActions = (
+  credential: OkmsCredential,
+  okms: OKMS,
+) => {
   const { t } = useTranslation('key-management-service/credential');
-  const okms = useContext(OkmsContext);
   const navigate = useNavigate();
   const { trackClick } = useOvhTracking();
   const { filename, href, isDisabled } = getDownloadCredentialParameters(

--- a/packages/manager/apps/key-management-service/src/components/layout-helpers/Dashboard/GeneralInformationsTiles/InformationsTile.spec.tsx
+++ b/packages/manager/apps/key-management-service/src/components/layout-helpers/Dashboard/GeneralInformationsTiles/InformationsTile.spec.tsx
@@ -51,17 +51,20 @@ describe('InformationsTile component tests suite', () => {
     tags: null,
   };
 
-  const renderComponent = (okms: OKMS) =>
-    render(<InformationsTile okmsData={okms} okmsServiceInfos={serviceInfo} />);
-
   test('Should display information tile with only all mandatory data', async () => {
-    const { container } = renderComponent(kms);
+    const { container } = render(
+      <InformationsTile
+        okmsData={kms}
+        okmsDisplayName={serviceInfo.resource.displayName}
+      />,
+    );
 
     await waitFor(() => {
       expect(
         screen.getByText('key_management_service_dashboard_field_label_name'),
       ).toBeVisible();
       expect(screen.getByText(serviceInfo.resource.displayName)).toBeVisible();
+      expect(screen.getByLabelText('edit')).toBeVisible();
 
       expect(
         screen.getByText('key_management_service_dashboard_field_label_id'),

--- a/packages/manager/apps/key-management-service/src/components/layout-helpers/Dashboard/GeneralInformationsTiles/InformationsTile.tsx
+++ b/packages/manager/apps/key-management-service/src/components/layout-helpers/Dashboard/GeneralInformationsTiles/InformationsTile.tsx
@@ -4,7 +4,6 @@ import {
   DashboardTile,
   DashboardTileBlockItem,
   Region,
-  ServiceDetails,
 } from '@ovh-ux/manager-react-components';
 import { OdsButton, OdsText } from '@ovhcloud/ods-components/react';
 import {
@@ -20,13 +19,13 @@ import { OKMS } from '@/types/okms.type';
 import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
 
 type InformationTileProps = {
-  okmsData?: OKMS;
-  okmsServiceInfos?: ServiceDetails;
+  okmsData: OKMS;
+  okmsDisplayName: string;
 };
 
 const InformationsTile = ({
   okmsData,
-  okmsServiceInfos,
+  okmsDisplayName,
 }: InformationTileProps) => {
   const { t } = useTranslation('key-management-service/dashboard');
   const navigate = useNavigate();
@@ -38,7 +37,7 @@ const InformationsTile = ({
       value: (
         <div className="flex justify-between items-center gap-2">
           <OdsText preset={ODS_TEXT_PRESET.paragraph} className="break-all">
-            {okmsServiceInfos?.resource.displayName}
+            {okmsDisplayName}
           </OdsText>
           <div className="min-w-fit">
             <OdsButton

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/KmsDashboard.page.spec.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/KmsDashboard.page.spec.tsx
@@ -4,6 +4,7 @@ import {
   WAIT_FOR_DEFAULT_OPTIONS,
   assertTextVisibility,
   getOdsButtonByLabel,
+  assertOdsModalVisibility,
 } from '@ovh-ux/manager-core-test-utils';
 import { renderTestApp } from '@/utils/tests/renderTestApp';
 import { labels } from '@/utils/tests/init.i18n';
@@ -114,7 +115,7 @@ describe('KMS dashboard test suite', () => {
   });
 
   it('should navigate to the rename modal on click on rename button', async () => {
-    await renderTestApp(mockPageUrl);
+    const { container } = await renderTestApp(mockPageUrl);
 
     await waitFor(
       () => expect(screen.getByLabelText('edit')).toBeEnabled(),
@@ -123,16 +124,13 @@ describe('KMS dashboard test suite', () => {
 
     await waitFor(() => userEvent.click(screen.getByLabelText('edit')));
 
-    await waitFor(
-      () =>
-        expect(
-          screen.getAllByText(
-            labels.serviceKeys[
-              'key_management_service_service-keys_dashboard_field_name'
-            ],
-          ),
-        ).toHaveLength(2),
-      WAIT_FOR_DEFAULT_OPTIONS,
-    );
+    // Wait for modal to open
+    await assertOdsModalVisibility({ container, isVisible: true });
+
+    expect(
+      await screen.findByText(
+        labels.credentials.key_management_service_credential_dashboard_name,
+      ),
+    ).toBeVisible();
   });
 });

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/KmsDashboard.type.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/KmsDashboard.type.tsx
@@ -1,0 +1,8 @@
+import { ServiceDetails } from '@ovh-ux/manager-react-components';
+import { OKMS } from '@/types/okms.type';
+
+export type KmsDashboardOutletContext = {
+  okms: OKMS;
+  okmsDisplayName: string;
+  okmsService: ServiceDetails | undefined;
+};

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/credentialList/CredentialList.page.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/credentialList/CredentialList.page.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react';
-import { Outlet, useNavigate } from 'react-router-dom';
+import React from 'react';
+import { Outlet, useNavigate, useOutletContext } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { OdsText } from '@ovhcloud/ods-components/react';
 import {
@@ -16,15 +16,15 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import CredentialDatagrid from '../../../components/credential/credentialDatagrid/CredentialDatagrid';
+import CredentialDatagrid from '@/components/credential/credentialDatagrid/CredentialDatagrid';
 import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
-import { OkmsContext } from '..';
 import { kmsIamActions } from '@/utils/iam/iam.constants';
+import { KmsDashboardOutletContext } from '@/pages/dashboard/KmsDashboard.type';
 
 const CredentialList = () => {
   const { t } = useTranslation('key-management-service/credential');
   const navigate = useNavigate();
-  const okms = useContext(OkmsContext);
+  const { okms } = useOutletContext<KmsDashboardOutletContext>();
   const { trackClick } = useOvhTracking();
 
   const { isAuthorized, isLoading: isLoadingIam } = useAuthorizationIam(
@@ -58,7 +58,7 @@ const CredentialList = () => {
       />
       {!isLoadingIam &&
         (isAuthorized ? (
-          <CredentialDatagrid />
+          <CredentialDatagrid okms={okms} />
         ) : (
           <OdsText preset={ODS_TEXT_PRESET.paragraph}>
             {t('key_management_service_credential_not_authorized')}

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/generalInformations/GeneralInformations.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/generalInformations/GeneralInformations.tsx
@@ -1,50 +1,25 @@
 import React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import {
-  DashboardGridLayout,
-  useServiceDetails,
-} from '@ovh-ux/manager-react-components';
-import { useOkmsById } from '@/data/hooks/useOkms';
-import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
+import { Outlet, useOutletContext } from 'react-router-dom';
+import { DashboardGridLayout } from '@ovh-ux/manager-react-components';
 import InformationsTile from '@/components/layout-helpers/Dashboard/GeneralInformationsTiles/InformationsTile';
-import Loading from '@/components/Loading/Loading';
 import KmipTile from '@/components/layout-helpers/Dashboard/GeneralInformationsTiles/KmipTile';
 import RestApiTile from '@/components/layout-helpers/Dashboard/GeneralInformationsTiles/RestApiTile';
 import BillingInformationsTile from '@/components/layout-helpers/Dashboard/GeneralInformationsTiles/BillingInformationsTile';
+import { KmsDashboardOutletContext } from '@/pages/dashboard/KmsDashboard.type';
 
 function GeneralInformationsTab() {
-  const { okmsId } = useParams();
-  const { data: okms, error, isLoading: isOkmsLoading } = useOkmsById(okmsId);
-  const {
-    data: okmsService,
-    isLoading: isOkmsServiceLoading,
-  } = useServiceDetails({ resourceName: okms?.data.id });
-
-  const navigate = useNavigate();
-
-  if (error) {
-    navigate(KMS_ROUTES_URLS.kmsListing);
-  }
-
-  if (isOkmsLoading || isOkmsServiceLoading || !okms || !okmsService) {
-    return (
-      <div>
-        <Loading />
-      </div>
-    );
-  }
+  const contextValue = useOutletContext<KmsDashboardOutletContext>();
+  const { okmsService, okms, okmsDisplayName } = contextValue;
 
   return (
     <DashboardGridLayout>
-      <InformationsTile
-        okmsData={okms.data}
-        okmsServiceInfos={okmsService.data}
-      />
+      <InformationsTile okmsData={okms} okmsDisplayName={okmsDisplayName} />
       <div className="flex flex-col gap-4 md:gap-6">
-        <KmipTile okmsData={okms.data} />
-        <RestApiTile okmsData={okms.data} />
+        <KmipTile okmsData={okms} />
+        <RestApiTile okmsData={okms} />
       </div>
-      <BillingInformationsTile okmsService={okmsService.data} />
+      {okmsService && <BillingInformationsTile okmsService={okmsService} />}
+      <Outlet context={contextValue} />
     </DashboardGridLayout>
   );
 }

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/generalInformations/updateName/OkmsNameUpdateModal.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/generalInformations/updateName/OkmsNameUpdateModal.tsx
@@ -1,28 +1,28 @@
-import {
-  UpdateNameModal,
-  useServiceDetails,
-} from '@ovh-ux/manager-react-components';
 import React from 'react';
+import { UpdateNameModal } from '@ovh-ux/manager-react-components';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { useUpdateOkmsName } from '@/data/hooks/useUpdateOkmsName';
+import { KmsDashboardOutletContext } from '../../KmsDashboard.type';
 
 const OkmsNameUpdateModal = () => {
   const { t: tDashboard } = useTranslation('key-management-service/dashboard');
   const { t: tCredential } = useTranslation(
     'key-management-service/credential',
   );
-  const { okmsId } = useParams();
-  const { data: okmsServiceInfos, isLoading } = useServiceDetails({
-    resourceName: okmsId,
-  });
   const navigate = useNavigate();
+  const { okmsId } = useParams();
+  const contextValue = useOutletContext<KmsDashboardOutletContext>();
   const { updateKmsName, isPending, error } = useUpdateOkmsName({
     okmsId,
     onSuccess: () => {
       navigate('..');
     },
   });
+
+  if (!contextValue) {
+    return null;
+  }
 
   return (
     <UpdateNameModal
@@ -31,8 +31,8 @@ const OkmsNameUpdateModal = () => {
       inputLabel={tCredential(
         'key_management_service_credential_dashboard_name',
       )}
-      defaultValue={okmsServiceInfos?.data.resource.displayName}
-      isLoading={isLoading || isPending}
+      defaultValue={contextValue.okmsService?.resource?.displayName}
+      isLoading={isPending}
       error={error?.message}
       closeModal={() => {
         navigate('..');

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/index.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Suspense, useMemo } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import {
@@ -6,9 +6,9 @@ import {
   BaseLayout,
   HeadersProps,
   ErrorBanner,
-  useServiceDetails,
   ChangelogButton,
   useFeatureAvailability,
+  useServiceDetails,
 } from '@ovh-ux/manager-react-components';
 import { OdsBadge } from '@ovhcloud/ods-components/react';
 import { queryClient } from '@ovh-ux/manager-react-core-application';
@@ -18,15 +18,13 @@ import Breadcrumb from '@/components/Breadcrumb/Breadcrumb';
 import { KMS_ROUTES_URIS, KMS_ROUTES_URLS } from '@/routes/routes.constants';
 import { BreadcrumbItem } from '@/hooks/breadcrumb/useBreadcrumb';
 import { getOkmsResourceQueryKey } from '@/data/api/okms';
-import { OKMS } from '@/types/okms.type';
 import { useOkmsById } from '@/data/hooks/useOkms';
 import { CHANGELOG_LINKS, SERVICE_KEYS_LABEL } from '@/constants';
 import KmsTabs, {
   KmsTabProps,
 } from '@/components/layout-helpers/Dashboard/KmsTabs';
 import { KMS_FEATURES } from '@/utils/feature-availability/feature-availability.constants';
-
-export const OkmsContext = createContext<OKMS>(null);
+import { KmsDashboardOutletContext } from './KmsDashboard.type';
 
 export default function DashboardPage() {
   const { t } = useTranslation([
@@ -45,17 +43,14 @@ export default function DashboardPage() {
   } = useOkmsById(okmsId);
 
   const {
-    data: okmsServiceInfos,
-    isLoading: isOkmsServiceInfosLoading,
-    isError: isOkmsServiceInfosError,
-    error: okmsServiceInfoError,
+    data: okmsService,
+    isPending: isOkmsServiceLoading,
   } = useServiceDetails({ resourceName: okmsId });
 
-  const { data: features, isLoading } = useFeatureAvailability([
-    KMS_FEATURES.LOGS,
-  ]);
-
-  const displayName = okmsServiceInfos?.data?.resource.displayName;
+  const {
+    data: features,
+    isLoading: isFeatureAvailabilityLoading,
+  } = useFeatureAvailability([KMS_FEATURES.LOGS]);
 
   const tabsList: KmsTabProps[] = useMemo(
     () =>
@@ -94,6 +89,29 @@ export default function DashboardPage() {
     [features, t],
   );
 
+  if (isOkmsServiceLoading || isOkmsLoading || isFeatureAvailabilityLoading) {
+    return <Loading />;
+  }
+
+  if (isOkmsError) {
+    return (
+      <ErrorBanner
+        error={okmsError.response}
+        onRedirectHome={() => navigate(KMS_ROUTES_URLS.kmsListing)}
+        onReloadPage={() =>
+          queryClient.refetchQueries({
+            queryKey: getOkmsResourceQueryKey(okmsId),
+          })
+        }
+      />
+    );
+  }
+
+  // If the service information is not accessible, we fallback to the okms id
+  const displayName = okmsService
+    ? okmsService?.data?.resource.displayName
+    : okms?.data?.id;
+
   const breadcrumbItems: BreadcrumbItem[] = [
     {
       id: okmsId,
@@ -126,51 +144,34 @@ export default function DashboardPage() {
     },
   ];
 
-  if (isOkmsServiceInfosLoading || isOkmsLoading || isLoading)
-    return <Loading />;
-
-  if (isOkmsServiceInfosError || isOkmsError) {
-    return (
-      <ErrorBanner
-        error={
-          okmsServiceInfoError
-            ? okmsServiceInfoError.response
-            : okmsError.response
-        }
-        onRedirectHome={() => navigate(KMS_ROUTES_URLS.kmsListing)}
-        onReloadPage={() =>
-          queryClient.refetchQueries({
-            queryKey: getOkmsResourceQueryKey(okmsId),
-          })
-        }
-      />
-    );
-  }
-
   const headerProps: HeadersProps = {
     title: displayName,
     headerButton: <KmsGuidesHeader />,
     changelogButton: <ChangelogButton links={CHANGELOG_LINKS} />,
   };
 
+  const contextValue: KmsDashboardOutletContext = {
+    okms: okms.data,
+    okmsDisplayName: displayName,
+    okmsService: okmsService?.data,
+  };
+
   return (
     <Suspense fallback={<Loading />}>
-      <OkmsContext.Provider value={okms?.data}>
-        <BaseLayout
-          header={headerProps}
-          onClickReturn={() => {
-            navigate(KMS_ROUTES_URLS.kmsListing);
-          }}
-          backLinkLabel={t(
-            'key-management-service/dashboard:key_management_service_dashboard_back_link',
-          )}
-          breadcrumb={<Breadcrumb items={breadcrumbItems} />}
-          message={<Notifications />}
-          tabs={<KmsTabs tabs={tabsList} />}
-        >
-          <Outlet />
-        </BaseLayout>
-      </OkmsContext.Provider>
+      <BaseLayout
+        header={headerProps}
+        onClickReturn={() => {
+          navigate(KMS_ROUTES_URLS.kmsListing);
+        }}
+        backLinkLabel={t(
+          'key-management-service/dashboard:key_management_service_dashboard_back_link',
+        )}
+        breadcrumb={<Breadcrumb items={breadcrumbItems} />}
+        message={<Notifications />}
+        tabs={<KmsTabs tabs={tabsList} />}
+      >
+        <Outlet context={contextValue} />
+      </BaseLayout>
     </Suspense>
   );
 }

--- a/packages/manager/apps/key-management-service/src/pages/dashboard/serviceKeyList/ServiceKeyList.page.tsx
+++ b/packages/manager/apps/key-management-service/src/pages/dashboard/serviceKeyList/ServiceKeyList.page.tsx
@@ -1,5 +1,10 @@
-import React, { useContext } from 'react';
-import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import React from 'react';
+import {
+  Outlet,
+  useNavigate,
+  useParams,
+  useOutletContext,
+} from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { queryClient } from '@ovh-ux/manager-react-core-application';
 import {
@@ -30,17 +35,26 @@ import {
 } from '@/components/Listing/ListingCells';
 import { useOkmsServiceKeys } from '@/data/hooks/useOkmsServiceKeys';
 import { KMS_ROUTES_URLS } from '@/routes/routes.constants';
-import { OkmsContext } from '..';
 import Loading from '@/components/Loading/Loading';
 import { getOkmsServiceKeyResourceListQueryKey } from '@/data/api/okmsServiceKey';
 import { kmsIamActions } from '@/utils/iam/iam.constants';
 import { SERVICE_KEY_LIST_TEST_IDS } from './ServiceKeyList.constants';
+import { KmsDashboardOutletContext } from '@/pages/dashboard/KmsDashboard.type';
+import { OkmsAllServiceKeys } from '@/types/okmsServiceKey.type';
 
 export default function Keys() {
   const { t } = useTranslation('key-management-service/serviceKeys');
   const { t: tError } = useTranslation('error');
   const navigate = useNavigate();
   const { trackClick } = useOvhTracking();
+
+  const { sorting, setSorting } = useDatagridSearchParams();
+  const { okmsId } = useParams();
+  const { error, data: okmsServiceKey, isLoading } = useOkmsServiceKeys({
+    sorting,
+    okmsId,
+  });
+  const { okms } = useOutletContext<KmsDashboardOutletContext>();
 
   const columns = [
     {
@@ -70,19 +84,12 @@ export default function Keys() {
     },
     {
       id: 'action',
-      cell: DatagridServiceKeyActionMenu,
+      cell: (serviceKey: OkmsAllServiceKeys) =>
+        DatagridServiceKeyActionMenu(serviceKey, okms),
       isSortable: false,
       label: '',
     },
   ];
-
-  const { sorting, setSorting } = useDatagridSearchParams();
-  const okms = useContext(OkmsContext);
-  const { okmsId } = useParams();
-  const { error, data: okmsServiceKey, isLoading } = useOkmsServiceKeys({
-    sorting,
-    okmsId,
-  });
 
   if (isLoading) return <Loading />;
 


### PR DESCRIPTION
## Description

When connected with NONE role (even with all the right permissions on KMS), the KMS dashboard page fails and displays an error.

Ticket Reference: #MANAGER-18260

## Fix Details

- Since there is no way to check for IAM permissions on services endpoint, the error is on the endpoint call is handle and considered as a lack of permissions.

### Use of `OutletContext` to pass data to tabs 

The `useServiceDetails` was called 1st in the `dashboard/index.tsx` file, then a 2nd time in the tab file.
The call on the tab file was conditional to the first one, when the fetch returns an error this setup triggers infinite loop calls in errors.
This can be solved by disabling the `retryOnMount` option, [but this is looks like a patch on a design flaw,](https://github.com/TanStack/query/discussions/2755) so I removed the call on the inner component, and passed the `okmsService` data via the `OutletContext` feature of react-router, which feels a lot cleaner.

Then I saw that the Okms data was also called from the top page component AND the tab component, so I used also `OutletContext`.
Then I saw that for other tabs the Okms data was passed from a ReactContext, so I used `OutletContext` everywhere and remove the use of ReactContext.

- `react-query` allows to call queries in sub-components and queries are deduplicated, but it seems to be a lot better to just use props to pass down dependencies than abuse of queries everywhere
- I could have chosen to pass `OkmsService` from `React.Context` with the `Okms` data but `OutletContext` is here out of the box, it seems better to me to use it and pass some props down to subcomponents

