### PR TITLE
fix(container): prevent auth token refresh on reduced chat

### DIFF
--- a/packages/manager/apps/container/src/container/livechat/LiveChat.component.tsx
+++ b/packages/manager/apps/container/src/container/livechat/LiveChat.component.tsx
@@ -127,6 +127,7 @@ export default function LiveChat({
      */
     if (chatbotOpen && chatType === null) {
       setChatType('Adrielly');
+      setChatState('open'); // initialize chat state to open
     }
 
     const livechatMessageEventHandler = async (
@@ -164,13 +165,14 @@ export default function LiveChat({
     }
   }, []);
 
+  // refetch auth token if the chat is open and the session_id is not set (on refresh)
   useEffect(() => {
-    if (chatType === 'SNOW' && !snowContext.session_id) {
+    if (chatType === 'SNOW' && !snowContext.session_id && chatState === 'open') {
       fetchAuthToken().then((token) => {
         setSnowContext((prev) => ({ ...prev, session_id: token }));
       });
     }
-  }, [chatType]);
+  }, [chatType, chatState]);
 
   if (region === 'US') return null;
 
@@ -181,6 +183,7 @@ export default function LiveChat({
       data-testid="live-chat-wrapper"
       className="absolute w-full h-full xl:h-fit xl:w-auto bottom-0 xl:bottom-2 right-0 xl:right-2 z-[960] flex flex-col justify-end pointer-events-none"
     >
+      {/* We don't check for chatState here, otherwise the sessions would be reset instead of shown again */}
       {chatType === 'Adrielly' && (
         <ChatDialog
           title="OVHcloud Chat"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Prevent auth token refresh on reduced chat

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18788
Incident: INC0137469

## Considerations

- We can not return `null` instead of the iFrame on reduce, since this would reset currently running chat instances instead of hiding them
- We need to keep the `useEffect` to refetch the token, to re-initialize the token for SNOW-chat, otherwise it would create guest sessions instead of authenticated ones.
- Main part of the change was to set the `chatState` to `open` on initial chat opening, which was necessary for the check, before it was enough to set the state on reduce (to save session storage)

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
