### PR TITLE
refactor(zimbra): fix circular dependencies

### DIFF
--- a/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/ActionButton.component.tsx
@@ -11,7 +11,6 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { AutoReplyItem } from './AutoReplies.page';
 import { usePlatform } from '@/data/hooks';
 import { useGenerateUrl } from '@/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
@@ -20,6 +19,7 @@ import {
   DELETE_AUTO_REPLY,
   EMAIL_ACCOUNT_DELETE_AUTO_REPLY,
 } from '@/tracking.constants';
+import { AutoReplyItem } from './AutoReplies.types';
 
 export interface ActionButtonAutoReplyProps {
   item: AutoReplyItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/AutoReplies.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/AutoReplies.page.tsx
@@ -33,15 +33,7 @@ import {
   ADD_AUTO_REPLY,
   EMAIL_ACCOUNT_ADD_AUTO_REPLY,
 } from '@/tracking.constants';
-
-export type AutoReplyItem = {
-  id: string;
-  name: string;
-  from: string;
-  until: string;
-  copyTo: string;
-  status: keyof typeof ResourceStatus;
-};
+import { AutoReplyItem } from './AutoReplies.types';
 
 const items: AutoReplyItem[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/AutoReplies.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/autoReplies/AutoReplies.types.ts
@@ -1,0 +1,10 @@
+import { ResourceStatus } from '@/data/api';
+
+export type AutoReplyItem = {
+  id: string;
+  name: string;
+  from: string;
+  until: string;
+  copyTo: string;
+  status: keyof typeof ResourceStatus;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/domains/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/domains/ActionButton.component.tsx
@@ -8,7 +8,6 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { DomainItem } from './Domains.page';
 import { usePlatform } from '@/data/hooks';
 import { useGenerateUrl } from '@/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
@@ -18,6 +17,7 @@ import {
   DOMAIN_DIAGNOSTICS,
   EDIT_DOMAIN,
 } from '@/tracking.constants';
+import { DomainItem } from './Domains.types';
 
 interface ActionButtonDomainProps {
   item: DomainItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/domains/CnameBadge.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/domains/CnameBadge.component.tsx
@@ -12,9 +12,9 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { DomainItem } from './Domains.page';
 import { useGenerateUrl } from '@/hooks';
 import { VERIFY_DOMAIN } from '@/tracking.constants';
+import { DomainItem } from './Domains.types';
 
 export type CnameBadgeProps = {
   item: DomainItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/domains/Domains.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/domains/Domains.page.tsx
@@ -27,16 +27,7 @@ import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { DATAGRID_REFRESH_INTERVAL, DATAGRID_REFRESH_ON_MOUNT } from '@/utils';
 import { AccountStatistics, ResourceStatus, DomainType } from '@/data/api';
 import { ADD_DOMAIN } from '@/tracking.constants';
-
-export type DomainItem = {
-  id: string;
-  name: string;
-  organizationId: string;
-  organizationLabel: string;
-  account: number;
-  status: keyof typeof ResourceStatus;
-  cnameToCheck?: string;
-};
+import { DomainItem } from './Domains.types';
 
 const columns: DatagridColumn<DomainItem>[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/domains/Domains.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/domains/Domains.types.ts
@@ -1,0 +1,11 @@
+import { ResourceStatus } from '@/data/api';
+
+export type DomainItem = {
+  id: string;
+  name: string;
+  organizationId: string;
+  organizationLabel: string;
+  account: number;
+  status: keyof typeof ResourceStatus;
+  cnameToCheck?: string;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/ActionButton.component.tsx
@@ -11,7 +11,6 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { EmailAccountItem } from './EmailAccountsDatagrid.component';
 import { usePlatform } from '@/data/hooks';
 import { useAccountsStatistics, useGenerateUrl } from '@/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
@@ -29,6 +28,7 @@ import {
   UPGRADE_SLOT,
 } from '@/tracking.constants';
 import { FEATURE_AVAILABILITY, MAX_PRO_ACCOUNTS } from '@/constants';
+import { EmailAccountItem } from './EmailAccounts.types';
 
 interface ActionButtonEmailAccountProps {
   item: EmailAccountItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccounts.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccounts.types.ts
@@ -1,0 +1,14 @@
+import { ResourceStatus, SlotService } from '@/data/api';
+
+export type EmailAccountItem = {
+  id: string;
+  email: string;
+  offer: string;
+  organizationId: string;
+  organizationLabel: string;
+  used: number;
+  available: number;
+  status: keyof typeof ResourceStatus;
+  slotId: string;
+  service?: SlotService;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccountsDatagrid.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccountsDatagrid.component.tsx
@@ -17,22 +17,9 @@ import {
   getZimbraPlatformListQueryKey,
   ResourceStatus,
   AccountType,
-  SlotService,
 } from '@/data/api';
 import queryClient from '@/queryClient';
-
-export type EmailAccountItem = {
-  id: string;
-  email: string;
-  offer: string;
-  organizationId: string;
-  organizationLabel: string;
-  used: number;
-  available: number;
-  status: keyof typeof ResourceStatus;
-  slotId: string;
-  service?: SlotService;
-};
+import { EmailAccountItem } from './EmailAccounts.types';
 
 const columns: DatagridColumn<EmailAccountItem>[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/ActionButton.component.tsx
@@ -11,12 +11,12 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { AliasItem } from './Aliases.page';
 import { usePlatform } from '@/data/hooks';
 import { useGenerateUrl } from '@/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { ResourceStatus } from '@/data/api';
 import { EMAIL_ACCOUNT_DELETE_ALIAS } from '@/tracking.constants';
+import { AliasItem } from './Aliases.types';
 
 interface ActionButtonAliasAccountProps {
   item: AliasItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/Aliases.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/Aliases.page.tsx
@@ -19,7 +19,7 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { AliasType, ResourceStatus } from '@/data/api';
+import { AliasType } from '@/data/api';
 import { usePlatform, useAliases } from '@/data/hooks';
 import { useDebouncedValue, useGenerateUrl } from '@/hooks';
 import ActionButtonAlias from './ActionButton.component';
@@ -27,12 +27,7 @@ import { BadgeStatus } from '@/components';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { EMAIL_ACCOUNT_ADD_ALIAS } from '@/tracking.constants';
 import { DATAGRID_REFRESH_INTERVAL, DATAGRID_REFRESH_ON_MOUNT } from '@/utils';
-
-export type AliasItem = {
-  id: string;
-  alias: string;
-  status: keyof typeof ResourceStatus;
-};
+import { AliasItem } from './Aliases.types';
 
 const columns: DatagridColumn<AliasItem>[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/Aliases.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/settings/aliases/Aliases.types.ts
@@ -1,0 +1,7 @@
+import { ResourceStatus } from '@/data/api';
+
+export type AliasItem = {
+  id: string;
+  alias: string;
+  status: keyof typeof ResourceStatus;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/ActionButton.component.tsx
@@ -11,7 +11,6 @@ import {
 import { usePlatform } from '@/data/hooks';
 import { useGenerateUrl } from '@/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
-import { MailingListItem } from './MailingLists.page';
 import { ResourceStatus } from '@/data/api';
 import {
   CONFIGURE_DELEGATION_MAILING_LIST,
@@ -19,6 +18,7 @@ import {
   DELETE_MAILING_LIST,
   EDIT_MAILING_LIST,
 } from '@/tracking.constants';
+import { MailingListItem } from './MailingLists.types';
 
 interface ActionButtonMailingListProps {
   item: MailingListItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/MailingLists.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/MailingLists.page.tsx
@@ -22,22 +22,11 @@ import { usePlatform, useMailingLists } from '@/data/hooks';
 import { useGenerateUrl, useOverridePage } from '@/hooks';
 import ActionButtonMailingList from './ActionButton.component';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
-import { MailingListType, ResourceStatus } from '@/data/api';
+import { MailingListType } from '@/data/api';
 import { DATAGRID_REFRESH_INTERVAL, DATAGRID_REFRESH_ON_MOUNT } from '@/utils';
 import { BadgeStatus, LabelChip } from '@/components';
 import { ADD_MAILING_LIST } from '@/tracking.constants';
-
-export type MailingListItem = {
-  id: string;
-  name: string;
-  organizationLabel: string;
-  organizationId: string;
-  owner: string;
-  aliases: number;
-  moderators: number;
-  subscribers: number;
-  status: keyof typeof ResourceStatus;
-};
+import { MailingListItem } from './MailingLists.types';
 
 const columns: DatagridColumn<MailingListItem>[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/MailingLists.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/mailingLists/MailingLists.types.ts
@@ -1,0 +1,13 @@
+import { ResourceStatus } from '@/data/api';
+
+export type MailingListItem = {
+  id: string;
+  name: string;
+  organizationLabel: string;
+  organizationId: string;
+  owner: string;
+  aliases: number;
+  moderators: number;
+  subscribers: number;
+  status: keyof typeof ResourceStatus;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/organizations/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/organizations/ActionButton.component.tsx
@@ -8,12 +8,12 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { OrganizationItem } from './Organizations.page';
 import { useGenerateUrl } from '@/hooks';
 import { usePlatform } from '@/data/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { ResourceStatus } from '@/data/api';
 import { DELETE_ORGANIZATION, EDIT_ORGANIZATION } from '@/tracking.constants';
+import { OrganizationItem } from './Organizations.types';
 
 interface ActionButtonOrganizationProps {
   item: OrganizationItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/organizations/Organizations.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/organizations/Organizations.page.tsx
@@ -18,7 +18,6 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { ResourceStatus } from '@/data/api';
 import { useGenerateUrl, useDebouncedValue, useOverridePage } from '@/hooks';
 import { useOrganizations, usePlatform } from '@/data/hooks';
 import ActionButton from './ActionButton.component';
@@ -26,14 +25,7 @@ import { BadgeStatus, LabelChip, IdLink } from '@/components';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { DATAGRID_REFRESH_INTERVAL, DATAGRID_REFRESH_ON_MOUNT } from '@/utils';
 import { ADD_ORGANIZATION } from '@/tracking.constants';
-
-export type OrganizationItem = {
-  id: string;
-  name: string;
-  label: string;
-  account: number;
-  status: keyof typeof ResourceStatus;
-};
+import { OrganizationItem } from './Organizations.types';
 
 const columns: DatagridColumn<OrganizationItem>[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/organizations/Organizations.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/organizations/Organizations.types.ts
@@ -1,0 +1,9 @@
+import { ResourceStatus } from '@/data/api';
+
+export type OrganizationItem = {
+  id: string;
+  name: string;
+  label: string;
+  account: number;
+  status: keyof typeof ResourceStatus;
+};

--- a/packages/manager/apps/zimbra/src/pages/dashboard/redirections/ActionButton.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/redirections/ActionButton.component.tsx
@@ -8,7 +8,6 @@ import {
   PageLocation,
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
-import { RedirectionItem } from './Redirections.page';
 import { useGenerateUrl } from '@/hooks';
 import { usePlatform } from '@/data/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
@@ -20,6 +19,7 @@ import {
   EMAIL_ACCOUNT_DELETE_REDIRECTION,
   EMAIL_ACCOUNT_EDIT_REDIRECTION,
 } from '@/tracking.constants';
+import { RedirectionItem } from './Redirections.types';
 
 interface ActionButtonRedirectionAccountProps {
   item: RedirectionItem;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.page.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.page.tsx
@@ -18,14 +18,7 @@ import { usePlatform } from '@/data/hooks';
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 import { ResourceStatus } from '@/data/api';
 import { BadgeStatus } from '@/components';
-
-export type RedirectionItem = {
-  id: string;
-  from: string;
-  to: string;
-  organization: string;
-  status: keyof typeof ResourceStatus;
-};
+import { RedirectionItem } from './Redirections.types';
 
 const items: RedirectionItem[] = [
   {

--- a/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.types.ts
@@ -1,0 +1,9 @@
+import { ResourceStatus } from '@/data/api';
+
+export type RedirectionItem = {
+  id: string;
+  from: string;
+  to: string;
+  organization: string;
+  status: keyof typeof ResourceStatus;
+};


### PR DESCRIPTION
ref: #MANAGER-18467

## Description

Ticket Reference: #MANAGER-18467

## Additional Information
This PR aims to fix all circular dependencies issues in the project by using the 'madge' CLI. Using this tool, we identified six circular dependencies, primarily caused by the import of types from the pages components.

<img width="773" alt="Capture d’écran 2025-06-24 à 14 57 19" src="https://github.com/user-attachments/assets/ca48dbac-a262-47a2-9dae-a3e04ce09cde" />

