### PR TITLE
fix(dedicated): wrong size overview for software raid 10

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.constants.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.constants.js
@@ -1,16 +1,6 @@
 export const MOUNT_POINTS = 'defghijklmnopqrstuvwxyza';
 export const MAX_MOUNT_POINTS = 24;
 
-export const TEMPLATE_OS_SOFTWARE_RAID_LIST = {
-  1: [0],
-  2: [0, 1],
-  3: [0, 1, 5],
-  4: [0, 1, 5, 10],
-  5: [0, 1, 5, 6, 10],
-  6: [0, 1, 5, 6, 10],
-  7: [0, 1, 5, 6, 7, 10],
-};
-
 export const REINSTALL_API_CONSOLE_LINK = {
   EU:
     'https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&branch=v1#post-/dedicated/server/-serviceName-/reinstall',
@@ -113,7 +103,6 @@ export const EOL_PERSONAL_INSTALLATION_TEMPLATES_DOCUMENTATION_LINK = {
 export default {
   MOUNT_POINTS,
   MAX_MOUNT_POINTS,
-  TEMPLATE_OS_SOFTWARE_RAID_LIST,
   REINSTALL_API_CONSOLE_LINK,
   API_OS_INSTALLATION_DOCUMENTATION_LINK,
   EOL_PERSONAL_INSTALLATION_TEMPLATES_DOCUMENTATION_LINK,

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -668,8 +668,7 @@ export default class ServerInstallationOvhCtrl {
               (remainingSize / this.$scope.installation.nbDiskUse) * 3;
             break;
           case this.$scope.constants.warningRaid10:
-            realRemainingSize =
-              remainingSize / (this.$scope.installation.nbDiskUse / 2);
+            realRemainingSize = remainingSize / ( this.$scope.installation.nbDiskUse / ( this.$scope.installation.nbDiskUse / 2 ));
             break;
           default:
             break;
@@ -1666,7 +1665,7 @@ export default class ServerInstallationOvhCtrl {
             set(
               option,
               'partition.realSize',
-              option.partition.size * (this.$scope.installation.nbDiskUse / 2),
+              option.partition.size * (this.$scope.installation.nbDiskUse / ( this.$scope.installation.nbDiskUse / 2 ) ),
             );
             break;
           default:

--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -7,7 +7,6 @@ import { INPUTS_RULES } from '../../inputs/constants';
 import {
   MOUNT_POINTS,
   MAX_MOUNT_POINTS,
-  TEMPLATE_OS_SOFTWARE_RAID_LIST,
   REINSTALL_API_CONSOLE_LINK,
   API_OS_INSTALLATION_DOCUMENTATION_LINK,
   EOL_PERSONAL_INSTALLATION_TEMPLATES_DOCUMENTATION_LINK,
@@ -89,7 +88,6 @@ export default class ServerInstallationOvhCtrl {
 
       defaultOsCategory: 'BASIC',
 
-      raidList: TEMPLATE_OS_SOFTWARE_RAID_LIST,
       fileSystemList: null,
 
       forbiddenMountPoint: [
@@ -1522,19 +1520,26 @@ export default class ServerInstallationOvhCtrl {
 
   // return list of available raid
   getRaidList(nbDisk) {
-    if (nbDisk !== null && this.$scope.constants.raidList !== null) {
-      if (nbDisk >= 7) {
-        return this.$scope.constants.raidList[7];
-      }
-      if (nbDisk >= 6) {
-        if (nbDisk % 2 === 0) {
-          return this.$scope.constants.raidList[5] || [];
-        }
-        return this.$scope.constants.raidList[6] || [];
-      }
-      return this.$scope.constants.raidList[nbDisk] || [];
+    const raidList = [0];
+    if (nbDisk === null || this.$scope.constants.raidList === null) {
+      return raidList;
     }
-    return [];
+    if (nbDisk >= 2) {
+      raidList.push(1);
+    }
+    if (nbDisk >= 3) {
+      raidList.push(5);
+    }
+    if (nbDisk >= 5) {
+      raidList.push(6);
+    }
+    if (nbDisk >= 7) {
+      raidList.push(7);
+    }
+    if (nbDisk >= 4 && nbDisk % 2 === 0) {
+      raidList.push(10);
+    }
+    return raidList;
   }
 
   // Reture true if partition is in edit mode


### PR DESCRIPTION
## Description

* fix(dedicated): prevent choosing raid 10 when odd number of disks
* fix(dedicated): wrong size overview for software raid 10
    ref: #MANAGER-18917

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
