### PR TITLE
feat(manager-cli): add check duplicated translations script

### DIFF
--- a/packages/manager-cli/manager-cli.mjs
+++ b/packages/manager-cli/manager-cli.mjs
@@ -52,7 +52,17 @@ yarn manager-cli migrations-status --type tests --format html
 
 yarn manager-cli migrations-status --type all --format html
 yarn manager-cli migrations-status --type all --format json`
-  }
+  },
+  'duplicated-translations': {
+    script: 'check-duplicated-translations',
+    isAppRequired: true,
+    description:
+      'Check for duplicate translations that already exist in the common module.',
+    help: `
+      #Check duplicated translations on zimbra app
+      yarn manager-cli duplicated-translations --app zimbra
+    `,
+  },
 };
 
 const validMigrationTypes = ['routes', 'tests', 'swc', 'all'];

--- a/packages/manager-cli/package.json
+++ b/packages/manager-cli/package.json
@@ -15,6 +15,7 @@
   "author": "OVH SAS",
   "main": "index.js",
   "scripts": {
+    "check-duplicated-translations": "node ./translations-checker/check-duplicated-translations.mjs",
     "common-tests-config-migration": "node ./tests-migrate/common-tests-config-migration.mjs",
     "json-to-component-route-migration": "node ./routes-migrate/json-to-component-route-migration.mjs",
     "manager-cli": "node ./manager-cli.mjs",

--- a/packages/manager-cli/translations-checker/check-duplicated-translations.mjs
+++ b/packages/manager-cli/translations-checker/check-duplicated-translations.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import { runMigration } from '../utils/ScriptUtils.mjs';
+
+const appName = process.argv[2];
+
+runMigration({
+  appName,
+  commandLabel: 'translations',
+  scriptOrSteps: ['node ./translations-checker/steps/check-duplicated-cli.mjs'],
+  statusOnly: true,
+});

--- a/packages/manager-cli/translations-checker/steps/check-duplicated-cli.mjs
+++ b/packages/manager-cli/translations-checker/steps/check-duplicated-cli.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Helpers to get dirname equivalent in ESM
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+// Hardcoded common folder path (constant)
+const commonFolder = path.resolve(
+  dirname,
+  '../../../manager/modules/common-translations/public/translations/',
+);
+
+const args = process.argv.slice(2);
+const appName = args[0];
+const projectRoot = process.cwd();
+const appFolder = path.resolve(
+  dirname,
+  `../../../manager/apps/${appName}/public/translations/`,
+);
+const targetFileName = 'Messages_fr_FR.json';
+
+/**
+ * Recursively collect all target JSON files named `Messages_fr_FR.json`.
+ */
+function getAllTargetJsonFiles(folderPath) {
+  let results = [];
+
+  const entries = fs.readdirSync(folderPath, { withFileTypes: true });
+
+  entries.forEach((entry) => {
+    const fullPath = path.join(folderPath, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(getAllTargetJsonFiles(fullPath));
+    } else if (entry.isFile() && entry.name === targetFileName) {
+      results.push(fullPath);
+    }
+  });
+
+  return results;
+}
+
+/**
+ * Safely read and parse a JSON file.
+ */
+function readJSON(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (err) {
+    console.error(`Failed to read/parse JSON: ${filePath}`, err.message);
+    return null;
+  }
+}
+
+/**
+ * Load all values from matching common translation files.
+ * Maps each value to the file(s) it appears in.
+ */
+function loadCommonValueMap(folder) {
+  const valueMap = new Map();
+  const files = getAllTargetJsonFiles(folder);
+
+  files.forEach((file) => {
+    const content = readJSON(file);
+    if (!content) return;
+
+    Object.values(content).forEach((val) => {
+      if (!valueMap.has(val)) {
+        valueMap.set(val, new Set());
+      }
+      valueMap.get(val).add(path.relative(projectRoot, file));
+    });
+  });
+
+  return valueMap;
+}
+
+/**
+ * Scan source folder for duplicate values, mapped to common file locations.
+ */
+function findDuplicatesGroupedByCommonFiles(sourceDir, commonValueMap) {
+  const files = getAllTargetJsonFiles(sourceDir);
+  const report = [];
+
+  files.forEach((file) => {
+    const data = readJSON(file);
+    if (!data) return;
+
+    const grouped = new Map(); // commonFilesKey => [ { key, value } ]
+    Object.entries(data).forEach(([key, value]) => {
+      const commonFiles = commonValueMap.get(value);
+      if (commonFiles) {
+        const commonFilesKey = Array.from(commonFiles)
+          .sort()
+          .join(', ');
+        if (!grouped.has(commonFilesKey)) {
+          grouped.set(commonFilesKey, []);
+        }
+        grouped.get(commonFilesKey).push({ key, value });
+      }
+    });
+
+    if (grouped.size > 0) {
+      report.push({
+        sourceFile: path.relative(projectRoot, file),
+        groups: Array.from(grouped.entries()).map(
+          ([commonFilesKey, entries]) => ({
+            commonFilesKey,
+            entries,
+          }),
+        ),
+      });
+    }
+  });
+
+  return report;
+}
+
+// -------------------- Main Script --------------------
+const checkDuplicatedTranslations = async () => {
+  if (
+    !fs.existsSync(commonFolder) ||
+    !fs.statSync(commonFolder).isDirectory()
+  ) {
+    console.error('Common folder path is invalid or does not exist.');
+    process.exit(1);
+  }
+  if (!fs.existsSync(appFolder) || !fs.statSync(appFolder).isDirectory()) {
+    console.error('Source folder path is invalid or does not exist.');
+    process.exit(1);
+  }
+
+  const commonValueMap = loadCommonValueMap(commonFolder);
+  const report = findDuplicatesGroupedByCommonFiles(appFolder, commonValueMap);
+
+  if (report.length === 0) {
+    console.log('✅ No duplicates found.');
+  } else {
+    console.log('\n🚨 Duplicates Report:\n');
+
+    report.forEach(({ sourceFile, groups }) => {
+      console.log(`Source File: ${sourceFile}`);
+      groups.forEach(({ commonFilesKey, entries }) => {
+        console.log(`  - ${commonFilesKey}`);
+        entries.forEach(({ key, value }) => {
+          console.log(`     - Key: "${key}" => Value: "${value}"`);
+        });
+      });
+      console.log('');
+    });
+  }
+};
+
+// Start script
+checkDuplicatedTranslations().catch((err) => {
+  console.error('❌ Script failed:', err);
+  process.exit(1);
+});

--- a/packages/manager-cli/utils/ScriptUtils.mjs
+++ b/packages/manager-cli/utils/ScriptUtils.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-console */
 
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -10,17 +13,17 @@ const __dirname = dirname(__filename);
 const basePath = path.resolve('../manager/apps');
 
 export const runMigration = ({
-   appName = null,
-   commandLabel,
-   scriptOrSteps,
-   formatGlob = '*.{js,ts,tsx}',
-   framework = null,
-   testType = null,
-   testCommand = null,
-   dryRun = false,
-   docLink = null,
-   statusOnly = false,
-   onEnd = () => {}
+  appName = null,
+  commandLabel,
+  scriptOrSteps,
+  formatGlob = '*.{js,ts,tsx}',
+  framework = null,
+  testType = null,
+  testCommand = null,
+  dryRun = false,
+  docLink = null,
+  statusOnly = false,
+  onEnd = () => {},
 }) => {
   const appPath = appName ? path.join(basePath, appName) : null;
 
@@ -28,21 +31,35 @@ export const runMigration = ({
     const isValidAppName = /^[a-zA-Z0-9_-]+$/.test(appName);
 
     if (!isValidAppName || !isCodeFileExistsSync(appPath)) {
-      console.error([
-        `❌ Unable to proceed: invalid or missing application setup.`,
-        '',
-        `Possible issues:`,
-        `  - App name is missing or invalid: "${appName}"`,
-        `  - App folder not found at: ${appPath}`,
-        '',
-        `Usage: yarn manager-cli ${commandLabel} --app <app-name> ${framework ? '[--framework <name>] ' : ''}${commandLabel.includes('tests-migrate') ? '--testType <unit|integration> ' : ''}[--dry-run]`,
-      ].join('\n'));
+      console.error(
+        [
+          `❌ Unable to proceed: invalid or missing application setup.`,
+          '',
+          `Possible issues:`,
+          `  - App name is missing or invalid: "${appName}"`,
+          `  - App folder not found at: ${appPath}`,
+          '',
+          `Usage: yarn manager-cli ${commandLabel} --app <app-name> ${
+            framework ? '[--framework <name>] ' : ''
+          }${
+            commandLabel.includes('tests-migrate')
+              ? '--testType <unit|integration> '
+              : ''
+          }[--dry-run]`,
+        ].join('\n'),
+      );
       process.exit(1);
     }
 
-    console.log(`🔄 Starting ${commandLabel}${testType ? ` (${testType} tests)` : ''} for app: ${appName}${framework ? ` using ${framework}` : ''}`);
+    console.log(
+      `🔄 Starting ${commandLabel}${
+        testType ? ` (${testType} tests)` : ''
+      } for app: ${appName}${framework ? ` using ${framework}` : ''}`,
+    );
   } else {
-    console.log(`🔄 Running ${commandLabel}${dryRun ? ' in dry-run mode' : ''}`);
+    console.log(
+      `🔄 Running ${commandLabel}${dryRun ? ' in dry-run mode' : ''}`,
+    );
   }
 
   try {
@@ -50,10 +67,12 @@ export const runMigration = ({
       for (const cmd of scriptOrSteps) {
         const finalCmd = [
           cmd,
-          appName ? appName : '',
+          appName || '',
           dryRun ? '--dry-run' : '',
           testType ? `--testType ${testType}` : '',
-        ].filter(Boolean).join(' ');
+        ]
+          .filter(Boolean)
+          .join(' ');
         console.log(`📦 Running: ${finalCmd}`);
         execSync(finalCmd, { stdio: 'inherit' });
       }
@@ -62,10 +81,13 @@ export const runMigration = ({
         ? `./${commandLabel}/${testType}/migrate-${framework || 'default'}.mjs`
         : `./${commandLabel}/migrate-${framework || 'default'}.mjs`;
       const migrateCommand = [
-        'node', migrateScript,
+        'node',
+        migrateScript,
         dryRun ? '--dry-run' : '',
-        appName ? `--only ${appName}` : ''
-      ].filter(Boolean).join(' ');
+        appName ? `--only ${appName}` : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
       execSync(migrateCommand, { stdio: 'inherit' });
     }
 
@@ -74,26 +96,34 @@ export const runMigration = ({
     } else {
       console.log(`✅ ${commandLabel} completed.`);
     }
-
   } catch (error) {
-    console.error([
-      `❌ Failed during the ${commandLabel} process.`,
-      '',
-      docLink ? `See: ${docLink}` : '',
-      '',
-      'Please check the logs above for more details.',
-    ].join('\n'));
+    console.error(
+      [
+        `❌ Failed during the ${commandLabel} process.`,
+        '',
+        docLink ? `See: ${docLink}` : '',
+        '',
+        'Please check the logs above for more details.',
+      ].join('\n'),
+    );
     console.error(error);
     process.exit(1);
   }
 
-  if ((dryRun || statusOnly)  && typeof onEnd === 'function') {
+  if ((dryRun || statusOnly) && typeof onEnd === 'function') {
     onEnd();
   }
 
   if (dryRun || !appName || statusOnly) return;
 
-  const appFullPath = join('packages', 'manager', 'apps', appName, '**', formatGlob);
+  const appFullPath = join(
+    'packages',
+    'manager',
+    'apps',
+    appName,
+    '**',
+    formatGlob,
+  );
 
   try {
     console.log('📦 Running yarn install to apply dependency changes...');
@@ -130,7 +160,9 @@ export const runMigration = ({
 
   if (testCommand) {
     try {
-      console.log(`🧪 Running tests for app "${appName}" to verify migration...`);
+      console.log(
+        `🧪 Running tests for app "${appName}" to verify migration...`,
+      );
       execSync(`yarn workspace @ovh-ux/manager-${appName}-app ${testCommand}`, {
         stdio: 'inherit',
         cwd: resolve(__dirname, '../..'),
@@ -142,7 +174,7 @@ export const runMigration = ({
     }
   }
 
-  if ((dryRun || statusOnly)  && typeof onEnd === 'function') {
+  if ((dryRun || statusOnly) && typeof onEnd === 'function') {
     onEnd();
   }
 };


### PR DESCRIPTION
## Description

This PR introduces a new CLI command that helps verify all translations used in an app against the existing translations available in the `@ovh-ux/manager-common-translations` module. 

## Usage Examples

```bash
yarn manager-cli duplicated-translations --app web-office
```

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/4dd0945b-20e5-4e6f-a506-4b856c0c7368" />

