### PR TITLE
feat(agora-order-ipv4): adding an bandwidth limit explanation message when service is in APAC

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.constant.js
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ip-ip-agoraOrder.constant.js
@@ -19,6 +19,31 @@ export const IP_FAILOVER_PLANCODE = {
   US: 'ip-failover-arin',
 };
 
+export const PRODUCT_TYPES = {
+  dedicatedServer: {
+    apiTypeName: 'SERVER',
+    typeName: 'DEDICATED',
+  },
+  privateCloud: {
+    apiTypeName: 'DEDICATED_CLOUD',
+    typeName: 'PRIVATE_CLOUD',
+  },
+  vps: {
+    apiTypeName: 'VPS',
+    typeName: 'VPS',
+  },
+  parking: {
+    apiTypeName: 'parking',
+    typeName: 'parking',
+  },
+  vrack: {
+    apiTypeName: 'VRACK',
+    typeName: 'VRACK',
+  },
+};
+
+export const ASIAN_PACIFIC_DATACENTERS = ['SYD', 'YNM', 'SGP'];
+
 export default {
   ADDITIONAL_IP,
   TRACKING_PREFIX,
@@ -28,4 +53,6 @@ export default {
   DASHBOARD_STATE_NAME,
   IP_TYPE,
   ALERT_ID,
+  PRODUCT_TYPES,
+  ASIAN_PACIFIC_DATACENTERS,
 };

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv4/ipv4.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv4/ipv4.controller.js
@@ -16,12 +16,13 @@ import {
   IP_TYPE_TITLE,
   TRACKING_PREFIX,
   FUNNEL_TRACKING_PREFIX,
+  ASIAN_PACIFIC_DATACENTERS,
+  PRODUCT_TYPES,
 } from '../ip-ip-agoraOrder.constant';
 
 import {
   IP_LOCATION_GROUPS,
   IP_SERVICETYPE__PARK,
-  PRODUCT_TYPES,
   VPS_MAX_QUANTITY,
   IP_AGORA,
   ADDITIONAL_IP,
@@ -70,6 +71,7 @@ export default class AgoraIpV4OrderController {
     this.ADDITIONAL_IP = ADDITIONAL_IP;
     this.BLOCK_ADDITIONAL_IP = BLOCK_ADDITIONAL_IP;
     this.ALERT_ID = ALERT_ID;
+    this.ASIAN_PACIFIC_DATACENTERS = ASIAN_PACIFIC_DATACENTERS;
     this.region = coreConfig.getRegion();
     this.type = IP_TYPE_TITLE.IPv4;
     this.ovhManagerRegionService = ovhManagerRegionService;
@@ -122,6 +124,26 @@ export default class AgoraIpV4OrderController {
       ['renew', 'installation'].every((capacity) =>
         price.capacities.includes(capacity),
       ),
+    );
+  }
+
+  isVrackAndAPACRegion(region) {
+    const isVrack =
+      this.model?.selectedService?.type === PRODUCT_TYPES.vrack.typeName;
+    return (
+      isVrack && this.ASIAN_PACIFIC_DATACENTERS.includes(region.datacenter)
+    );
+  }
+
+  getRegionLabelDisplay(region) {
+    return this.isVrackAndAPACRegion(region)
+      ? `${region.location} *`
+      : region.location;
+  }
+
+  hasAPACRegionInCatalog() {
+    return this.catalogByLocation?.some((region) =>
+      this.isVrackAndAPACRegion(region),
     );
   }
 

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv4/ipv4.html
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv4/ipv4.html
@@ -80,7 +80,7 @@
                     class="d-inline-block col-md-6 col-xl-3 my-3"
                     data-name="region"
                     data-ng-repeat="region in $ctrl.catalogByLocation track by region.regionName"
-                    data-label="{{ region.location }}"
+                    data-label="{{ $ctrl.getRegionLabelDisplay(region)}}"
                     data-description="{{ region.regionName }}"
                     data-variant="light"
                     data-picture="{{ ::region.icon }}"
@@ -89,6 +89,10 @@
                 >
                 </oui-select-picker>
             </div>
+            <div
+                data-ng-if="$ctrl.hasAPACRegionInCatalog()"
+                data-translate="ip_agora_ip_region_apac_bandwidth_limit_explaination"
+            ></div>
         </oui-step-form>
 
         <!-- Choice your solution -->

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv6/ipv6.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv6/ipv6.controller.js
@@ -6,6 +6,8 @@ import {
   IP_TYPE_TITLE,
   TRACKING_PREFIX,
   FUNNEL_TRACKING_PREFIX,
+  ASIAN_PACIFIC_DATACENTERS,
+  PRODUCT_TYPES,
 } from '../ip-ip-agoraOrder.constant';
 
 import { FLAGS, ACTIONS_SUFFIX } from './ipv6.constant';
@@ -39,6 +41,7 @@ export default class AgoraIpV6OrderController {
     this.ovhSubsidiary = coreConfig.getUser().ovhSubsidiary;
     this.loading = {};
     this.ADDITIONAL_IP = ADDITIONAL_IP;
+    this.ASIAN_PACIFIC_DATACENTERS = ASIAN_PACIFIC_DATACENTERS;
     this.type = IP_TYPE_TITLE.IPv6;
     this.ovhManagerRegionService = ovhManagerRegionService;
   }
@@ -145,7 +148,9 @@ export default class AgoraIpV6OrderController {
   }
 
   loadRegions() {
-    this.trackClick(`select_service::next_${this.model.selectedService}`);
+    this.trackClick(
+      `select_service::next_${this.model.selectedService?.serviceName}`,
+    );
 
     this.catalogByLocation = this.ipv6RegionsWithPlan.map(
       ({ regionId, plan }) => {
@@ -168,6 +173,22 @@ export default class AgoraIpV6OrderController {
     );
   }
 
+  isAPACRegion(region) {
+    const isVrack =
+      this.model?.selectedService?.type === PRODUCT_TYPES.vrack.typeName;
+    return (
+      isVrack && this.ASIAN_PACIFIC_DATACENTERS.includes(region.datacenter)
+    );
+  }
+
+  getRegionLabelDisplay(region) {
+    return this.isAPACRegion(region) ? `${region.location} *` : region.location;
+  }
+
+  hasAPACRegionInCatalog() {
+    return this.catalogByLocation?.some((region) => this.isAPACRegion(region));
+  }
+
   redirectToPaymentPage() {
     this.trackSelectRegion(
       this.model.selectedPlan.location.replaceAll(' ', '-'),
@@ -181,12 +202,12 @@ export default class AgoraIpV6OrderController {
       duration: 'P1M',
       planCode,
       quantity: 1,
-      destination: this.model.selectedService,
+      destination: this.model.selectedService?.serviceName,
     });
 
     this.atInternet.trackClick({
       name: `${FUNNEL_TRACKING_PREFIX}button::add_additional_ip::confirm::ipv6_${
-        this.model.selectedService
+        this.model.selectedService?.serviceName
       }_${this.model.selectedPlan.location.replaceAll(' ', '-')}__free`,
       type: 'action',
       level2: 57,
@@ -229,7 +250,7 @@ export default class AgoraIpV6OrderController {
     );
     this.atInternet.trackClick({
       name: `${FUNNEL_TRACKING_PREFIX}button::add_additional_ip::cancel::ipv6_${
-        this.model.selectedService
+        this.model.selectedService?.serviceName
       }_${this.model.selectedPlan.location.replaceAll(' ', '-')}_free`,
       type: 'action',
       level2: 57,

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv6/ipv6.html
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/ipv6/ipv6.html
@@ -67,7 +67,6 @@
                             data-items="$ctrl.services"
                             data-match="displayName"
                             data-model="$ctrl.model.selectedService"
-                            data-value-property="serviceName"
                             data-name="service"
                             data-placeholder="{{:: 'global_select' | translate}}"
                             data-searchable
@@ -121,7 +120,7 @@
                         class="d-inline-block col-md-6 col-xl-3 my-3"
                         data-name="plan"
                         data-ng-repeat="plan in $ctrl.catalogByLocation track by plan.regionId"
-                        data-label="{{ plan.location }}"
+                        data-label="{{ $ctrl.getRegionLabelDisplay(plan) }}"
                         data-description="{{ plan.regionId }}"
                         data-variant="light"
                         data-picture="{{ ::plan.icon }}"
@@ -132,6 +131,10 @@
                     >
                     </oui-select-picker>
                 </div>
+                <div
+                    data-ng-if="$ctrl.hasAPACRegionInCatalog()"
+                    data-translate="ip_agora_ip_region_apac_bandwidth_limit_explaination"
+                ></div>
             </div>
         </oui-step-form>
     </oui-stepper>

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_de_DE.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " vRack erstellen",
   "ip_agora_ipv4_localisation_not_available": "Die Geolokalisierungsinformationen können für eine einzelne IP-Adresse nicht geändert werden.",
   "ip_agora_ipv6_location_eu-south-mil": "Europa (Italien – Mailand)",
-  "ip_region_eu-south-mil": "Europa (Italien – Mailand)"
+  "ip_region_eu-south-mil": "Europa (Italien – Mailand)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "( * ) Die standardmäßige (kostenlose) Option für die öffentliche Bandbreite, die das Leiten des Netzwerkverkehrs zum vRack in den Regionen des asiatisch-pazifischen Raums ermöglicht, ist auf 100 Mbit/s beschränkt."
 }

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_en_GB.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " Create a vRack ",
   "ip_agora_ipv4_localisation_not_available": "Geolocation information cannot be changed for only one IP address.",
   "ip_agora_ipv6_location_eu-south-mil": "Europe (Italy - Milan)",
-  "ip_region_eu-south-mil": "Europe (Italy - Milan)"
+  "ip_region_eu-south-mil": "Europe (Italy - Milan)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "(*) The default public bandwidth (free) for routing network traffic to vRack in Asia-Pacific regions is capped at 100 Mbps."
 }

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_es_ES.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " Crear un vRack",
   "ip_agora_ipv4_localisation_not_available": "No es posible modificar los datos de geolocalización para una única dirección IP.",
   "ip_agora_ipv6_location_eu-south-mil": "Europa (Italia - Milán)",
-  "ip_region_eu-south-mil": "Europa (Italia - Milán)"
+  "ip_region_eu-south-mil": "Europa (Italia - Milán)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "(*) La opción de ancho de banda público por defecto (gratuito) que permite dirigir el tráfico de red hacia el vRack en las regiones de Asia-Pacífico está limitada a 100 Mb/s."
 }

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_fr_CA.json
@@ -7,6 +7,7 @@
   "ip_agora_select_quantity_title": "Choisissez votre quantité",
   "ip_agora_ip_localisation_title": "Localisation de l'adresse IP",
   "ip_agora_ip_localisation_description": "Veuillez choisir l'un des emplacements disponibles pour votre nouveau bloc d'adresses {{ ipType }} supplémentaire.",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "( * ) L'option de bande passante publique par défaut (gratuite) qui permet d'acheminer le trafic réseau vers le vRack dans les régions Asie-Pacifique est limitée à 100 Mbit/s.",
   "ip_agora_ipv4_localisation_not_available": "Les informations de géolocalisation ne peuvent être modifiées pour une seule adresse IP.",
   "ip_agora_ipv4_localisation_title": "Géolocalisation de l'adresse IP",
   "ip_agora_ipv4_localisation_description": "Pour modifier la géolocalisation de votre adresse IP, merci de choisir un pays dans la liste déroulante.",

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_fr_FR.json
@@ -7,6 +7,7 @@
   "ip_agora_select_quantity_title": "Choisissez votre quantité",
   "ip_agora_ip_localisation_title": "Localisation de l'adresse IP",
   "ip_agora_ip_localisation_description": "Veuillez choisir l'un des emplacements disponibles pour votre nouveau bloc d'adresses {{ ipType }} supplémentaire.",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "( * ) L'option de bande passante publique par défaut (gratuite) qui permet d'acheminer le trafic réseau vers le vRack dans les régions Asie-Pacifique est limitée à 100 Mbit/s.",
   "ip_agora_ipv4_localisation_not_available": "Les informations de géolocalisation ne peuvent être modifiées pour une seule adresse IP.",
   "ip_agora_ipv4_localisation_title": "Géolocalisation de l'adresse IP",
   "ip_agora_ipv4_localisation_description": "Pour modifier la géolocalisation de votre adresse IP, merci de choisir un pays dans la liste déroulante.",

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_it_IT.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " Creare una vRack",
   "ip_agora_ipv4_localisation_not_available": "Le informazioni di geolocalizzazione non possono essere modificate per un solo indirizzo IP.",
   "ip_agora_ipv6_location_eu-south-mil": "Europa (Italia - Milano)",
-  "ip_region_eu-south-mil": "Europa (Italia - Milano)"
+  "ip_region_eu-south-mil": "Europa (Italia - Milano)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "(*) L'opzione di banda passante pubblica predefinita (gratuita) che permette l'instradamento del traffico di rete verso la vRack nelle Region in Asia Pacifica è limitata a 100 Mbps."
 }

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_pl_PL.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " Utwórz vRack",
   "ip_agora_ipv4_localisation_not_available": "Informacje geolokalizacyjne nie mogą być modyfikowane dla pojedynczego adresu IP.",
   "ip_agora_ipv6_location_eu-south-mil": "Europa (Włochy - Mediolan)",
-  "ip_region_eu-south-mil": "Europa (Włochy - Mediolan)"
+  "ip_region_eu-south-mil": "Europa (Włochy - Mediolan)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "(*) Domyślna (bezpłatna) opcja przepustowości do sieci publicznej, która umożliwia kierowanie ruchu do sieci vRack w regionach Azja-Pacyfik jest ograniczona do 100 Mbps."
 }

--- a/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/ip/agoraOrder/translations/Messages_pt_PT.json
@@ -91,5 +91,6 @@
   "ip_agora_ipv6_no_services_link": " Criar uma vRack",
   "ip_agora_ipv4_localisation_not_available": "As informações de geolocalização não podem ser alteradas para um único endereço IP.",
   "ip_agora_ipv6_location_eu-south-mil": "Europa (Itália - Milão)",
-  "ip_region_eu-south-mil": "Europa (Itália - Milão)"
+  "ip_region_eu-south-mil": "Europa (Itália - Milão)",
+  "ip_agora_ip_region_apac_bandwidth_limit_explaination": "(*) A opção de largura de banda pública predefinida (gratuita) que permite encaminhar o tráfego de rede para o vRack nas regiões Ásia-Pacífico está limitada a 100 Mbps."
 }


### PR DESCRIPTION

ref: #MANAGER-18535

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR displays a message and a star (*) on the displayed datacenter catalogs when choosing an additionnal IPv4

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18535

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
