### PR TITLE
fix(pci-kubernetes): let the edit value unchanged

### DIFF
--- a/packages/manager/apps/pci-kubernetes/src/api/data/kubernetes.ts
+++ b/packages/manager/apps/pci-kubernetes/src/api/data/kubernetes.ts
@@ -30,10 +30,10 @@ export type NodePool = {
   autoscale: boolean;
   availabilityZones?: string[];
   desiredNodes: number;
-  minNodes: number;
+  minNodes?: number;
   localisation: string | null;
   flavorName: string;
-  maxNodes: number;
+  maxNodes?: number;
   monthlyBilled: boolean;
 };
 

--- a/packages/manager/apps/pci-kubernetes/src/api/data/node-pools.ts
+++ b/packages/manager/apps/pci-kubernetes/src/api/data/node-pools.ts
@@ -1,4 +1,5 @@
 import { v6 } from '@ovh-ux/manager-core-api';
+import { TCreateNodePoolParam } from '@/types';
 
 type TRawClusterNodePool = {
   id: string;
@@ -98,8 +99,8 @@ export const deleteNodePool = async (
 
 export type TUpdateNodePoolSizeParam = {
   desiredNodes: number;
-  minNodes: number;
-  maxNodes: number;
+  minNodes?: number;
+  maxNodes?: number;
   autoscale: boolean;
 };
 
@@ -113,18 +114,6 @@ export const updateNodePoolSize = async (
     `/cloud/project/${projectId}/kube/${clusterId}/nodepool/${poolId}`,
     param,
   );
-
-export type TCreateNodePoolParam = {
-  flavorName: string;
-  name: string;
-  availabilityZones?: string[];
-  antiAffinity: boolean;
-  monthlyBilled: boolean;
-  autoscale: boolean;
-  minNodes: number;
-  desiredNodes: number;
-  maxNodes: number;
-};
 
 export const createNodePool = (
   projectId: string,

--- a/packages/manager/apps/pci-kubernetes/src/components/Autoscaling.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/components/Autoscaling.component.tsx
@@ -28,15 +28,7 @@ import {
   NODE_RANGE,
   AUTOSCALING_LINK,
 } from '@/constants';
-
-export interface AutoscalingState {
-  quantity: {
-    desired: number;
-    min: number;
-    max: number;
-  };
-  isAutoscale: boolean;
-}
+import { TAutoscalingState } from '@/types';
 
 function getDesiredQuantity(
   quantity: { min: number; desired: number },
@@ -48,11 +40,11 @@ function getDesiredQuantity(
 }
 
 export interface AutoscalingProps {
-  initialScaling?: { min: number; max: number; desired: number };
+  initialScaling?: TAutoscalingState['quantity'];
   isMonthlyBilling?: boolean;
   isAntiAffinity?: boolean;
-  autoscale: boolean;
-  onChange?: (scaling: AutoscalingState) => void;
+  autoscale?: TAutoscalingState['isAutoscale'];
+  onChange?: (scaling: TAutoscalingState) => void;
 }
 
 export function Autoscaling({
@@ -63,25 +55,16 @@ export function Autoscaling({
 }: Readonly<AutoscalingProps>) {
   const { t } = useTranslation('autoscaling');
   const ovhSubsidiary = useMe()?.me?.ovhSubsidiary;
-  const infosURL = AUTOSCALING_LINK[ovhSubsidiary] || AUTOSCALING_LINK.DEFAULT;
-  const [isAutoscale, setIsAutoscale] = useState(autoscale);
+  const infosURL =
+    AUTOSCALING_LINK[ovhSubsidiary as keyof typeof AUTOSCALING_LINK] ||
+    AUTOSCALING_LINK.DEFAULT;
+  const [isAutoscale, setIsAutoscale] = useState<boolean>(!!autoscale);
   const [quantity, setQuantity] = useState({
     desired: initialScaling ? initialScaling.desired : NODE_RANGE.MIN,
     min: initialScaling ? initialScaling.min : 0,
     max: initialScaling ? initialScaling.max : NODE_RANGE.MAX,
   });
   const maxValue = isAntiAffinity ? ANTI_AFFINITY_MAX_NODES : NODE_RANGE.MAX;
-
-  // reset min node and max node if autoscaling is turned to off.
-  useEffect(() => {
-    if (!isAutoscale) {
-      setQuantity((q) => ({
-        ...q,
-        min: 0,
-        max: maxValue,
-      }));
-    }
-  }, [isAutoscale]);
 
   useEffect(() => {
     onChange?.({

--- a/packages/manager/apps/pci-kubernetes/src/components/Autoscaling.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/components/Autoscaling.component.tsx
@@ -28,7 +28,7 @@ import {
   NODE_RANGE,
   AUTOSCALING_LINK,
 } from '@/constants';
-import { TAutoscalingState } from '@/types';
+import { TScalingState } from '@/types';
 
 function getDesiredQuantity(
   quantity: { min: number; desired: number },
@@ -40,11 +40,11 @@ function getDesiredQuantity(
 }
 
 export interface AutoscalingProps {
-  initialScaling?: TAutoscalingState['quantity'];
+  initialScaling?: TScalingState['quantity'];
   isMonthlyBilling?: boolean;
   isAntiAffinity?: boolean;
-  autoscale?: TAutoscalingState['isAutoscale'];
-  onChange?: (scaling: TAutoscalingState) => void;
+  autoscale?: TScalingState['isAutoscale'];
+  onChange?: (scaling: TScalingState) => void;
 }
 
 export function Autoscaling({

--- a/packages/manager/apps/pci-kubernetes/src/helpers/node-pool.spec.ts
+++ b/packages/manager/apps/pci-kubernetes/src/helpers/node-pool.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  exceedsMaxNodes,
+  zoneAZisChecked,
+  isScalingValid,
+  hasMax5NodesAntiAffinity,
+  hasInvalidScalingOrAntiAffinityConfig,
+} from './node-pool';
+import * as deploymentUtils from '.';
+import { DeploymentMode, NodePoolState } from '@/types';
+import { TRegionInformations } from '@/types/region';
+
+vi.mock('@/constants', () => ({
+  NODE_RANGE: { MAX: 10 },
+  ANTI_AFFINITY_MAX_NODES: 5,
+}));
+
+vi.mock('.', () => ({
+  isMonoDeploymentZone: vi.fn(),
+}));
+
+describe('exceedsMaxNodes', () => {
+  it.each([
+    [11, true],
+    [10, false],
+    [0, false],
+  ])('returns %s when quantity is %i', (input, expected) => {
+    expect(exceedsMaxNodes(input)).toBe(expected);
+  });
+});
+
+describe('zoneAZisChecked', () => {
+  it('returns true if mono deployment zone', () => {
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(true);
+    expect(
+      zoneAZisChecked(
+        { type: DeploymentMode.MONO_ZONE } as TRegionInformations,
+        {} as NodePoolState,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true if availability zone is selected', () => {
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const nodePoolState = {
+      selectedAvailabilityZone: 'zone-a',
+    } as NodePoolState;
+    expect(
+      zoneAZisChecked(
+        { type: DeploymentMode.MULTI_ZONES } as TRegionInformations,
+        nodePoolState,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false otherwise', () => {
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const nodePoolState = {} as NodePoolState;
+    expect(
+      zoneAZisChecked(
+        { type: DeploymentMode.MULTI_ZONES } as TRegionInformations,
+        nodePoolState,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isScalingValid', () => {
+  it('returns true if scaling is undefined', () => {
+    expect(isScalingValid({} as NodePoolState)).toBe(true);
+  });
+
+  it.each([
+    [{ isAutoscale: false, quantity: { desired: 5 } }, true],
+    [{ isAutoscale: false, quantity: { desired: 11 } }, false],
+    [{ isAutoscale: true, quantity: { min: 1, max: 10, desired: 5 } }, true],
+    [{ isAutoscale: true, quantity: { min: 6, max: 5, desired: 5 } }, false],
+    [{ isAutoscale: true, quantity: { min: 1, max: 12, desired: 5 } }, false],
+    [{ isAutoscale: true, quantity: { min: 3, max: 6, desired: 2 } }, false],
+  ])('returns %s for config %j', (scaling, expected) => {
+    const nodePoolState = { scaling } as NodePoolState;
+    expect(isScalingValid(nodePoolState)).toBe(expected);
+  });
+});
+
+describe('hasMax5NodesAntiAffinity', () => {
+  it.each([
+    [{ antiAffinity: false }, true],
+    [{ antiAffinity: true, scaling: { quantity: { desired: 4 } } }, true],
+    [{ antiAffinity: true, scaling: { quantity: { desired: 5 } } }, true],
+    [{ antiAffinity: true, scaling: { quantity: { desired: 6 } } }, false],
+    [{ antiAffinity: true }, false],
+  ])('returns %s for state %j', (state, expected) => {
+    expect(hasMax5NodesAntiAffinity(state as NodePoolState)).toBe(expected);
+  });
+});
+
+describe('hasInvalidScalingOrAntiAffinityConfig', () => {
+  it('returns true if scaling is invalid', () => {
+    const nodePoolState = {
+      scaling: { isAutoscale: false, quantity: { desired: 11 } },
+      antiAffinity: false,
+      selectedAvailabilityZone: 'zone',
+    } as NodePoolState;
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const region = { type: DeploymentMode.MULTI_ZONES } as TRegionInformations;
+
+    expect(hasInvalidScalingOrAntiAffinityConfig(region, nodePoolState)).toBe(
+      true,
+    );
+  });
+
+  it('returns true if antiAffinity config is invalid', () => {
+    const nodePoolState = {
+      scaling: { isAutoscale: false, quantity: { desired: 6 } },
+      antiAffinity: true,
+      selectedAvailabilityZone: 'zone',
+    } as NodePoolState;
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const region = { type: DeploymentMode.MULTI_ZONES } as TRegionInformations;
+
+    expect(hasInvalidScalingOrAntiAffinityConfig(region, nodePoolState)).toBe(
+      true,
+    );
+  });
+
+  it('returns true if zone is not selected and not mono', () => {
+    const nodePoolState = {
+      scaling: { isAutoscale: false, quantity: { desired: 5 } },
+      antiAffinity: false,
+      selectedAvailabilityZone: undefined,
+    } as NodePoolState;
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const region = { type: DeploymentMode.MULTI_ZONES } as TRegionInformations;
+
+    expect(hasInvalidScalingOrAntiAffinityConfig(region, nodePoolState)).toBe(
+      true,
+    );
+  });
+
+  it('returns false if everything is valid', () => {
+    const nodePoolState = {
+      scaling: { isAutoscale: false, quantity: { desired: 5 } },
+      antiAffinity: false,
+      selectedAvailabilityZone: 'zone',
+    } as NodePoolState;
+    vi.mocked(deploymentUtils.isMonoDeploymentZone).mockReturnValue(false);
+    const region = { type: DeploymentMode.MULTI_ZONES } as TRegionInformations;
+
+    expect(hasInvalidScalingOrAntiAffinityConfig(region, nodePoolState)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/manager/apps/pci-kubernetes/src/helpers/node-pool.ts
+++ b/packages/manager/apps/pci-kubernetes/src/helpers/node-pool.ts
@@ -1,0 +1,47 @@
+import { ANTI_AFFINITY_MAX_NODES, NODE_RANGE } from '@/constants';
+import { isMonoDeploymentZone } from '.';
+import { NodePoolState } from '@/types';
+import { TRegionInformations } from '@/types/region';
+
+export const exceedsMaxNodes = (quantity: number) => quantity > NODE_RANGE.MAX;
+
+export const zoneAZisChecked = (
+  regionInformations: TRegionInformations,
+  nodePoolState: NodePoolState,
+) =>
+  isMonoDeploymentZone(regionInformations?.type) ||
+  !!nodePoolState.selectedAvailabilityZone;
+
+export const isScalingValid = (
+  nodePoolState: Pick<NodePoolState, 'scaling'>,
+) => {
+  if (!nodePoolState.scaling) return true;
+
+  const { isAutoscale, quantity } = nodePoolState.scaling;
+  const { desired, min, max } = quantity;
+
+  if (!isAutoscale) {
+    return !exceedsMaxNodes(desired);
+  }
+
+  const isMinValid = min >= 0 && min <= max;
+  const isMaxValid = max <= NODE_RANGE.MAX;
+  const isDesiredInRange = min <= desired && max >= desired;
+
+  return isMinValid && isMaxValid && isDesiredInRange;
+};
+
+export const hasMax5NodesAntiAffinity = (nodePoolState: NodePoolState) =>
+  !nodePoolState.antiAffinity ||
+  (nodePoolState.antiAffinity &&
+    nodePoolState.scaling &&
+    nodePoolState.scaling.quantity.desired <= ANTI_AFFINITY_MAX_NODES) ||
+  false;
+
+export const hasInvalidScalingOrAntiAffinityConfig = (
+  regionInformations: TRegionInformations,
+  nodePoolState: NodePoolState,
+) =>
+  !isScalingValid(nodePoolState) ||
+  !hasMax5NodesAntiAffinity(nodePoolState) ||
+  !zoneAZisChecked(regionInformations, nodePoolState);

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/Scale.page.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/Scale.page.tsx
@@ -18,7 +18,7 @@ import queryClient from '@/queryClient';
 import { Autoscaling } from '@/components/Autoscaling.component';
 import { useTrack } from '@/hooks/track';
 import { NODE_RANGE } from '@/constants';
-import { TAutoscalingState } from '@/types';
+import { TScalingState } from '@/types';
 import { isScalingValid } from '@/helpers/node-pool';
 
 export default function ScalePage(): JSX.Element {
@@ -36,7 +36,7 @@ export default function ScalePage(): JSX.Element {
 
   const { trackClick } = useTrack();
 
-  const [state, setState] = useState<TAutoscalingState | null>(null);
+  const [state, setState] = useState<TScalingState | null>(null);
 
   const { data: pools, isPending: isPoolsPending } = useClusterNodePools(
     projectId,
@@ -61,7 +61,7 @@ export default function ScalePage(): JSX.Element {
     }
   }, [pool]);
 
-  const { updateSize, isPending: isScaling } = useUpdateNodePoolSize({
+  const { updateSize, isPending: isPendingScaling } = useUpdateNodePoolSize({
     onError(cause: Error & { response: { data: { message: string } } }): void {
       addError(
         tScale('kube_node_pool_autoscaling_scale_error', {
@@ -84,11 +84,32 @@ export default function ScalePage(): JSX.Element {
   });
 
   const isDisabled =
-    isScaling ||
-    (state && !isScalingValid({ scaling: state })) ||
-    (state?.quantity.desired &&
-      pool?.minNodes &&
-      state?.quantity.desired < pool?.minNodes);
+    isPendingScaling || (state && !isScalingValid({ scaling: state }));
+
+  const scaleObject = useMemo(() => {
+    const desired = Number(state?.quantity.desired);
+    const minNodes = Number(pool?.minNodes);
+    const maxNodes = Number(pool?.maxNodes);
+
+    if (state?.isAutoscale) {
+      return {
+        maxNodes: state?.quantity.max || NODE_RANGE.MAX,
+        minNodes: state?.quantity.min || 0,
+      };
+    }
+
+    if (desired < minNodes) {
+      return {
+        minNodes: desired,
+      };
+    }
+    if (desired > maxNodes) {
+      return {
+        maxNodes: desired,
+      };
+    }
+    return {};
+  }, [state?.quantity, pool, state?.isAutoscale]);
 
   return (
     <OsdsModal
@@ -99,7 +120,7 @@ export default function ScalePage(): JSX.Element {
       }}
     >
       <slot name="content">
-        {!isPoolsPending && !isScaling ? (
+        {!isPoolsPending && !isPendingScaling ? (
           <Autoscaling
             initialScaling={{
               min: pool?.minNodes ?? 0,
@@ -136,10 +157,7 @@ export default function ScalePage(): JSX.Element {
           updateSize({
             autoscale: state?.isAutoscale ?? false,
             desiredNodes: state?.quantity.desired ?? NODE_RANGE.MIN,
-            ...(Boolean(state?.isAutoscale) && {
-              maxNodes: state?.quantity.max || NODE_RANGE.MAX,
-              minNodes: state?.quantity.min || 0,
-            }),
+            ...scaleObject,
           });
         }}
         {...(isDisabled ? { disabled: true } : {})}

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/Scale.page.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/Scale.page.tsx
@@ -5,25 +5,26 @@ import {
 } from '@ovhcloud/ods-components/react';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { ODS_BUTTON_VARIANT, ODS_SPINNER_SIZE } from '@ovhcloud/ods-components';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useMemo, useState } from 'react';
+import { useParam as useSafeParams } from '@ovh-ux/manager-pci-common';
 import { useNotifications } from '@ovh-ux/manager-react-components';
 import {
   useClusterNodePools,
   useUpdateNodePoolSize,
 } from '@/api/hooks/node-pools';
 import queryClient from '@/queryClient';
-import {
-  Autoscaling,
-  AutoscalingState,
-} from '@/components/Autoscaling.component';
+import { Autoscaling } from '@/components/Autoscaling.component';
 import { useTrack } from '@/hooks/track';
+import { NODE_RANGE } from '@/constants';
+import { TAutoscalingState } from '@/types';
+import { isScalingValid } from '@/helpers/node-pool';
 
 export default function ScalePage(): JSX.Element {
-  const { projectId, kubeId: clusterId } = useParams();
+  const { projectId, kubeId: clusterId } = useSafeParams('projectId', 'kubeId');
   const [searchParams] = useSearchParams();
-  const poolId = searchParams.get('nodePoolId');
+  const poolId = searchParams.get('nodePoolId') as string;
 
   const navigate = useNavigate();
   const goBack = () => navigate('..');
@@ -35,7 +36,7 @@ export default function ScalePage(): JSX.Element {
 
   const { trackClick } = useTrack();
 
-  const [state, setState] = useState<AutoscalingState>(null);
+  const [state, setState] = useState<TAutoscalingState | null>(null);
 
   const { data: pools, isPending: isPoolsPending } = useClusterNodePools(
     projectId,
@@ -82,6 +83,13 @@ export default function ScalePage(): JSX.Element {
     poolId,
   });
 
+  const isDisabled =
+    isScaling ||
+    (state && !isScalingValid({ scaling: state })) ||
+    (state?.quantity.desired &&
+      pool?.minNodes &&
+      state?.quantity.desired < pool?.minNodes);
+
   return (
     <OsdsModal
       headline={tListing('kube_common_node_pool_autoscaling_title')}
@@ -94,9 +102,9 @@ export default function ScalePage(): JSX.Element {
         {!isPoolsPending && !isScaling ? (
           <Autoscaling
             initialScaling={{
-              min: pool?.minNodes,
-              max: pool?.maxNodes,
-              desired: pool?.desiredNodes,
+              min: pool?.minNodes ?? 0,
+              max: pool?.maxNodes ?? NODE_RANGE.MAX,
+              desired: pool?.desiredNodes ?? NODE_RANGE.MIN,
             }}
             isMonthlyBilling={pool?.monthlyBilled}
             isAntiAffinity={pool?.antiAffinity}
@@ -126,13 +134,15 @@ export default function ScalePage(): JSX.Element {
         color={ODS_THEME_COLOR_INTENT.primary}
         onClick={() => {
           updateSize({
-            autoscale: state.isAutoscale,
-            desiredNodes: state.quantity.desired,
-            maxNodes: state.quantity.max,
-            minNodes: state.quantity.min,
+            autoscale: state?.isAutoscale ?? false,
+            desiredNodes: state?.quantity.desired ?? NODE_RANGE.MIN,
+            ...(Boolean(state?.isAutoscale) && {
+              maxNodes: state?.quantity.max || NODE_RANGE.MAX,
+              minNodes: state?.quantity.min || 0,
+            }),
           });
         }}
-        {...(isScaling ? { disabled: true } : {})}
+        {...(isDisabled ? { disabled: true } : {})}
       >
         {tListing('kube_common_save')}
       </OsdsButton>

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/New.page.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/New.page.tsx
@@ -129,7 +129,7 @@ export default function NewPage(): JSX.Element {
         getPriceByDesiredScale(
           flavor?.pricingsHourly?.price,
           flavor?.pricingsMonthly?.price,
-          store.autoScaling?.quantity.desired,
+          store.scaling?.quantity.desired,
         ),
     },
   );
@@ -155,7 +155,7 @@ export default function NewPage(): JSX.Element {
       })();
 
       const warnForAutoscaleBilling = Boolean(
-        store.isMonthlyBilling && store.autoScaling?.isAutoscale,
+        store.isMonthlyBilling && store.scaling?.isAutoscale,
       );
 
       setBillingState((prev) => ({
@@ -169,12 +169,7 @@ export default function NewPage(): JSX.Element {
         },
       }));
     }
-  }, [
-    store.flavor,
-    store.isMonthlyBilling,
-    store.autoScaling,
-    isCatalogPending,
-  ]);
+  }, [store.flavor, store.isMonthlyBilling, store.scaling, isCatalogPending]);
 
   const create = () => {
     trackClick(`details::nodepools::add::confirm`);
@@ -192,12 +187,12 @@ export default function NewPage(): JSX.Element {
       name: store.name.value,
       antiAffinity: store.antiAffinity,
       monthlyBilled: store.isMonthlyBilling,
-      autoscale: Boolean(store.autoScaling?.isAutoscale),
-      ...(Boolean(store.autoScaling?.isAutoscale) && {
-        minNodes: store.autoScaling?.quantity.min ?? 0,
-        maxNodes: store.autoScaling.quantity.max,
+      autoscale: Boolean(store.scaling?.isAutoscale),
+      ...(Boolean(store.scaling?.isAutoscale) && {
+        minNodes: store.scaling?.quantity.min ?? 0,
+        maxNodes: store.scaling.quantity.max,
       }),
-      desiredNodes: store.autoScaling?.quantity.desired ?? 0,
+      desiredNodes: store.scaling?.quantity.desired ?? 0,
     };
     createNodePool(projectId, clusterId, param)
       .then(() => {
@@ -388,7 +383,7 @@ export default function NewPage(): JSX.Element {
         order={3}
         next={{
           action: () => {
-            if (store.autoScaling) {
+            if (store.scaling) {
               store.check(StepsEnum.SIZE);
               store.lock(StepsEnum.SIZE);
               store.open(StepsEnum.BILLING);
@@ -400,8 +395,9 @@ export default function NewPage(): JSX.Element {
             hasInvalidScalingOrAntiAffinityConfig(regionInformations, {
               name: store.name.value,
               isTouched: store.name.isTouched,
-              scaling: store.autoScaling,
+              scaling: store.scaling,
               antiAffinity: store.antiAffinity,
+              selectedAvailabilityZone: store.selectedAvailabilityZone,
             })
           ),
         }}
@@ -426,7 +422,7 @@ export default function NewPage(): JSX.Element {
         )}
         <NodePoolSize
           isMonthlyBilled={store.isMonthlyBilling}
-          onScaleChange={(auto) => store.set.autoScaling(auto)}
+          onScaleChange={(auto) => store.set.scaling(auto)}
           antiAffinity={billingState.antiAffinity.isChecked}
         />
         <>
@@ -434,7 +430,7 @@ export default function NewPage(): JSX.Element {
             !isMultiDeploymentZones(regionInformations.type) && (
               <NodePoolAntiAffinity
                 isChecked={billingState.antiAffinity.isChecked}
-                isEnabled={!store.autoScaling?.isAutoscale}
+                isEnabled={!store.scaling?.isAutoscale}
                 onChange={billingState.antiAffinity.onChange}
               />
             )}

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.spec.ts
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.spec.ts
@@ -15,13 +15,29 @@ describe('NewPoolStore', () => {
     });
     it('should set flavor', () => {
       const { result } = renderHook(() => useNewPoolStore());
-      act(() => result.current.set.flavor(null));
-      expect(result.current.flavor).toBe(null);
+      act(() => result.current.set.flavor(undefined));
+      expect(result.current.flavor).toBe(undefined);
     });
     it('should set autoScaling', () => {
       const { result } = renderHook(() => useNewPoolStore());
-      act(() => result.current.set.autoScaling(undefined));
-      expect(result.current.autoScaling).toBe(undefined);
+      act(() =>
+        result.current.set.autoScaling({
+          isAutoscale: false,
+          quantity: {
+            desired: 3,
+            max: 100,
+            min: 0,
+          },
+        }),
+      );
+      expect(result.current.autoScaling).toStrictEqual({
+        isAutoscale: false,
+        quantity: {
+          desired: 3,
+          max: 100,
+          min: 0,
+        },
+      });
     });
     it('should set flavor', () => {
       const { result } = renderHook(() => useNewPoolStore());
@@ -116,7 +132,14 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: null,
+        autoScaling: {
+          isAutoscale: false,
+          quantity: {
+            desired: 3,
+            max: 100,
+            min: 0,
+          },
+        },
         flavor: undefined,
         isMonthlyBilling: false,
         name: { value: '', hasError: false, isTouched: false },
@@ -169,7 +192,14 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: null,
+        autoScaling: {
+          isAutoscale: false,
+          quantity: {
+            desired: 3,
+            max: 100,
+            min: 0,
+          },
+        },
         flavor: undefined,
         isMonthlyBilling: false,
         name: { hasError: false, isTouched: false, value: '' },
@@ -222,7 +252,14 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: null,
+        autoScaling: {
+          isAutoscale: false,
+          quantity: {
+            desired: 3,
+            max: 100,
+            min: 0,
+          },
+        },
         flavor: undefined,
         isMonthlyBilling: false,
         name: {

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.spec.ts
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.spec.ts
@@ -21,7 +21,7 @@ describe('NewPoolStore', () => {
     it('should set autoScaling', () => {
       const { result } = renderHook(() => useNewPoolStore());
       act(() =>
-        result.current.set.autoScaling({
+        result.current.set.scaling({
           isAutoscale: false,
           quantity: {
             desired: 3,
@@ -30,7 +30,7 @@ describe('NewPoolStore', () => {
           },
         }),
       );
-      expect(result.current.autoScaling).toStrictEqual({
+      expect(result.current.scaling).toStrictEqual({
         isAutoscale: false,
         quantity: {
           desired: 3,
@@ -118,7 +118,7 @@ describe('NewPoolStore', () => {
     > => ({
       name: state.name,
       flavor: state.flavor,
-      autoScaling: state.autoScaling,
+      scaling: state.scaling,
       selectedAvailabilityZone: state.selectedAvailabilityZone,
       antiAffinity: state.antiAffinity,
       isMonthlyBilling: state.isMonthlyBilling,
@@ -132,7 +132,7 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: {
+        scaling: {
           isAutoscale: false,
           quantity: {
             desired: 3,
@@ -192,7 +192,7 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: {
+        scaling: {
           isAutoscale: false,
           quantity: {
             desired: 3,
@@ -252,7 +252,7 @@ describe('NewPoolStore', () => {
 
       expect(extractState(result.current)).toEqual({
         antiAffinity: false,
-        autoScaling: {
+        scaling: {
           isAutoscale: false,
           quantity: {
             desired: 3,

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.ts
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import { createRef, RefObject } from 'react';
 import { StepsEnum } from '@/pages/detail/nodepools/new/steps.enum';
-import { AutoscalingState } from '@/components/Autoscaling.component';
+
 import { isNodePoolNameValid } from '@/helpers/matchers/matchers';
 import { TComputedKubeFlavor } from '@/components/flavor-selector/FlavorSelector.component';
+import { NODE_RANGE } from '@/constants';
+import { TAutoscalingState } from '@/types';
 
 type TStep = {
   isOpen: boolean;
@@ -20,7 +22,7 @@ export type TFormStore = {
   };
   flavor?: TComputedKubeFlavor;
   selectedAvailabilityZone: string;
-  autoScaling: AutoscalingState | null;
+  autoScaling: TAutoscalingState;
   antiAffinity: boolean;
   isMonthlyBilling: boolean;
   steps: Map<StepsEnum, TStep>;
@@ -28,7 +30,7 @@ export type TFormStore = {
     name: (val: string) => void;
     flavor: (val?: TComputedKubeFlavor) => void;
     selectedAvailabilityZone: (selectedZone: string) => void;
-    autoScaling: (val: AutoscalingState | null) => void;
+    autoScaling: (val: TAutoscalingState) => void;
     antiAffinity: (val: boolean) => void;
     isMonthlyBilling: (val: boolean) => void;
   };
@@ -88,6 +90,11 @@ const initialSteps = () =>
     ],
   ]);
 
+const initAutoscale = {
+  quantity: { desired: NODE_RANGE.MIN, min: 0, max: NODE_RANGE.MAX },
+  isAutoscale: false,
+};
+
 export const useNewPoolStore = create<TFormStore>()((set, get) => ({
   name: {
     value: '',
@@ -95,7 +102,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
     isTouched: false,
   },
   flavor: undefined,
-  autoScaling: null,
+  autoScaling: initAutoscale,
   antiAffinity: false,
   isMonthlyBilling: false,
   selectedAvailabilityZone: '',
@@ -119,7 +126,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
     },
 
     flavor: (val?: TComputedKubeFlavor) => set({ flavor: val }),
-    autoScaling: (val: AutoscalingState | null) => set({ autoScaling: val }),
+    autoScaling: (val: TAutoscalingState) => set({ autoScaling: val }),
     antiAffinity: (val: boolean) => set({ antiAffinity: val }),
     isMonthlyBilling: (val: boolean) => set({ isMonthlyBilling: val }),
   },
@@ -200,7 +207,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
         get().uncheck(StepsEnum.TYPE);
         get().unlock(StepsEnum.TYPE);
         // Reset size
-        get().set.autoScaling(null);
+        get().set.autoScaling(initAutoscale);
 
         get().close(StepsEnum.SIZE);
         get().uncheck(StepsEnum.SIZE);
@@ -215,7 +222,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
         break;
       case StepsEnum.TYPE:
         // Reset size
-        get().set.autoScaling(null);
+        get().set.autoScaling(initAutoscale);
 
         get().close(StepsEnum.SIZE);
         get().uncheck(StepsEnum.SIZE);
@@ -245,7 +252,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
       ...get(),
       name: { value: '', hasError: false, isTouched: false },
       flavor: undefined,
-      autoScaling: null,
+      autoScaling: initAutoscale,
       antiAffinity: false,
       isMonthlyBilling: false,
       steps: initialSteps(),

--- a/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.ts
+++ b/packages/manager/apps/pci-kubernetes/src/pages/detail/nodepools/new/store.ts
@@ -5,7 +5,7 @@ import { StepsEnum } from '@/pages/detail/nodepools/new/steps.enum';
 import { isNodePoolNameValid } from '@/helpers/matchers/matchers';
 import { TComputedKubeFlavor } from '@/components/flavor-selector/FlavorSelector.component';
 import { NODE_RANGE } from '@/constants';
-import { TAutoscalingState } from '@/types';
+import { TScalingState } from '@/types';
 
 type TStep = {
   isOpen: boolean;
@@ -22,7 +22,7 @@ export type TFormStore = {
   };
   flavor?: TComputedKubeFlavor;
   selectedAvailabilityZone: string;
-  autoScaling: TAutoscalingState;
+  scaling: TScalingState;
   antiAffinity: boolean;
   isMonthlyBilling: boolean;
   steps: Map<StepsEnum, TStep>;
@@ -30,7 +30,7 @@ export type TFormStore = {
     name: (val: string) => void;
     flavor: (val?: TComputedKubeFlavor) => void;
     selectedAvailabilityZone: (selectedZone: string) => void;
-    autoScaling: (val: TAutoscalingState) => void;
+    scaling: (val: TScalingState) => void;
     antiAffinity: (val: boolean) => void;
     isMonthlyBilling: (val: boolean) => void;
   };
@@ -90,7 +90,7 @@ const initialSteps = () =>
     ],
   ]);
 
-const initAutoscale = {
+const initScale = {
   quantity: { desired: NODE_RANGE.MIN, min: 0, max: NODE_RANGE.MAX },
   isAutoscale: false,
 };
@@ -102,7 +102,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
     isTouched: false,
   },
   flavor: undefined,
-  autoScaling: initAutoscale,
+  scaling: initScale,
   antiAffinity: false,
   isMonthlyBilling: false,
   selectedAvailabilityZone: '',
@@ -126,7 +126,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
     },
 
     flavor: (val?: TComputedKubeFlavor) => set({ flavor: val }),
-    autoScaling: (val: TAutoscalingState) => set({ autoScaling: val }),
+    scaling: (val: TScalingState) => set({ scaling: val }),
     antiAffinity: (val: boolean) => set({ antiAffinity: val }),
     isMonthlyBilling: (val: boolean) => set({ isMonthlyBilling: val }),
   },
@@ -207,7 +207,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
         get().uncheck(StepsEnum.TYPE);
         get().unlock(StepsEnum.TYPE);
         // Reset size
-        get().set.autoScaling(initAutoscale);
+        get().set.scaling(initScale);
 
         get().close(StepsEnum.SIZE);
         get().uncheck(StepsEnum.SIZE);
@@ -222,7 +222,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
         break;
       case StepsEnum.TYPE:
         // Reset size
-        get().set.autoScaling(initAutoscale);
+        get().set.scaling(initScale);
 
         get().close(StepsEnum.SIZE);
         get().uncheck(StepsEnum.SIZE);
@@ -252,7 +252,7 @@ export const useNewPoolStore = create<TFormStore>()((set, get) => ({
       ...get(),
       name: { value: '', hasError: false, isTouched: false },
       flavor: undefined,
-      autoScaling: initAutoscale,
+      scaling: initScale,
       antiAffinity: false,
       isMonthlyBilling: false,
       steps: initialSteps(),

--- a/packages/manager/apps/pci-kubernetes/src/pages/new/steps/NodePoolStep.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/new/steps/NodePoolStep.component.tsx
@@ -14,7 +14,7 @@ import {
   convertHourlyPriceToMonthly,
   Datagrid,
 } from '@ovh-ux/manager-react-components';
-import { TAutoscalingState, NodePoolState } from '@/types';
+import { TScalingState, NodePoolState } from '@/types';
 import { NODE_RANGE, TAGS_BLOB } from '@/constants';
 import { useClusterCreationStepper } from '../useCusterCreationStepper';
 import BillingStep from '@/components/create/BillingStep.component';
@@ -231,7 +231,7 @@ const NodePoolStep = ({
           <div className="mb-8">
             <NodePoolSize
               isMonthlyBilled={isMonthlyBilled}
-              onScaleChange={(scaling: TAutoscalingState) =>
+              onScaleChange={(scaling: TScalingState) =>
                 setNodePoolState((state) => ({ ...state, scaling }))
               }
               antiAffinity={nodePoolState.antiAffinity}

--- a/packages/manager/apps/pci-kubernetes/src/pages/new/steps/node-pool/NodePoolSize.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/new/steps/node-pool/NodePoolSize.component.tsx
@@ -5,15 +5,13 @@ import {
 } from '@ovhcloud/ods-components';
 import { OsdsText } from '@ovhcloud/ods-components/react';
 import { useTranslation } from 'react-i18next';
-import {
-  Autoscaling,
-  AutoscalingState,
-} from '@/components/Autoscaling.component';
+import { TAutoscalingState } from '@/types';
+import { Autoscaling } from '@/components/Autoscaling.component';
 
 export interface NodeSizeStepProps {
   isMonthlyBilled: boolean;
   antiAffinity: boolean;
-  onScaleChange: (scaling: AutoscalingState) => void;
+  onScaleChange: (scaling: TAutoscalingState) => void;
 }
 
 export default function NodePoolSize({

--- a/packages/manager/apps/pci-kubernetes/src/pages/new/steps/node-pool/NodePoolSize.component.tsx
+++ b/packages/manager/apps/pci-kubernetes/src/pages/new/steps/node-pool/NodePoolSize.component.tsx
@@ -5,13 +5,13 @@ import {
 } from '@ovhcloud/ods-components';
 import { OsdsText } from '@ovhcloud/ods-components/react';
 import { useTranslation } from 'react-i18next';
-import { TAutoscalingState } from '@/types';
+import { TScalingState } from '@/types';
 import { Autoscaling } from '@/components/Autoscaling.component';
 
 export interface NodeSizeStepProps {
   isMonthlyBilled: boolean;
   antiAffinity: boolean;
-  onScaleChange: (scaling: TAutoscalingState) => void;
+  onScaleChange: (scaling: TScalingState) => void;
 }
 
 export default function NodePoolSize({

--- a/packages/manager/apps/pci-kubernetes/src/types/index.ts
+++ b/packages/manager/apps/pci-kubernetes/src/types/index.ts
@@ -200,7 +200,7 @@ export type UrlRecord = { [Key in OvhSubsidiary]?: string } & {
   DEFAULT: string;
 };
 
-export type TAutoscalingState = {
+export type TScalingState = {
   quantity: {
     desired: number;
     min: number;
@@ -212,7 +212,7 @@ export type TAutoscalingState = {
 export type NodePoolState = {
   name: string;
   isTouched: boolean;
-  scaling: TAutoscalingState;
+  scaling: TScalingState;
   antiAffinity: boolean;
   selectedAvailabilityZone?: string;
 };

--- a/packages/manager/apps/pci-kubernetes/src/types/index.ts
+++ b/packages/manager/apps/pci-kubernetes/src/types/index.ts
@@ -199,3 +199,32 @@ export enum DeploymentMode {
 export type UrlRecord = { [Key in OvhSubsidiary]?: string } & {
   DEFAULT: string;
 };
+
+export type TAutoscalingState = {
+  quantity: {
+    desired: number;
+    min: number;
+    max: number;
+  };
+  isAutoscale: boolean;
+};
+
+export type NodePoolState = {
+  name: string;
+  isTouched: boolean;
+  scaling: TAutoscalingState;
+  antiAffinity: boolean;
+  selectedAvailabilityZone?: string;
+};
+
+export type TCreateNodePoolParam = {
+  flavorName: string;
+  name: string;
+  availabilityZones?: string[];
+  antiAffinity: boolean;
+  monthlyBilled: boolean;
+  autoscale: boolean;
+  minNodes?: number;
+  desiredNodes: number;
+  maxNodes?: number;
+};


### PR DESCRIPTION
ref: #TAPC-4453,  TAPC-4662
I took the opportunity to move the types into the types file.
I also ensured that Scale, Node Pool creation in the cluster, and the Node Pool page now all share the same validation mechanism for creation.
I fixed the nullability of the types.
I facilitated rules from Scale component. 
Lastly, I made sure the minNode and maxNode values are no longer modified when toggling autoscaling from true to false.


<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
