### PR TITLE
fix(pci-gateway): remove extra info from title

### DIFF
--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_de_DE.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_de_DE.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Die Gateways bieten Konnektivität für private Instanzen. Dies ermöglicht einen gesicherten Zugang zu externen Netzwerken sowie einen externen Zugang zu einer Anwendung:",
-  "pci_projects_project_public_gateways_intro_part_2": "Im ersten Fall fungiert Gateway als SNAT-Gateway und erlaubt es Instanzen, auf das Internet zuzugreifen, jedoch nicht umgekehrt.",
-  "pci_projects_project_public_gateways_intro_part_3": "Im zweiten Beispiel wird ein Service per Internet zugänglich gemacht, der einer privaten Instanz oder einem Loadbalancer nachgeschaltet ist. Dies erfolgt durch Floating IPs.",
   "pci_projects_project_public_gateway_create": "Gateway erstellen",
   "pci_projects_project_public_gateway_name": "Name/ID",
   "pci_projects_project_public_gateway_region": "Region",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Gateway-Einstellungen bearbeiten",
   "pci_projects_project_public_gateway_go_to_private_networks": "Mein privates Netzwerk anzeigen",
   "pci_projects_project_public_gateway_delete": "Löschen",
-  "pci_projects_project_public_gateway_no_data": "Es sind keine Daten verfügbar."
+  "pci_projects_project_public_gateway_no_data": "Es sind keine Daten verfügbar.",
+  "pci_projects_project_public_gateways_intro": "Die Gateways bieten Konnektivität zu privaten Instanzen, was einen sicheren Zugriff auf externe Netzwerke oder einen externen Zugriff der Anwendung ermöglicht."
 }

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_en_GB.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_en_GB.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Gateways provide connectivity to private instances, enabling secure access to external networks or exposing the application to external access:",
-  "pci_projects_project_public_gateways_intro_part_2": "In the first case, the Gateway acts as a SNAT gateway, allowing instances to reach the internet, but not the other way around.",
-  "pci_projects_project_public_gateways_intro_part_3": "In the second example, you can expose a service behind a private instance or Load Balancer to the internet using Floating IPs.",
   "pci_projects_project_public_gateway_create": "Create a Gateway",
   "pci_projects_project_public_gateway_name": "Name/ID",
   "pci_projects_project_public_gateway_region": "Region",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Modify Gateway",
   "pci_projects_project_public_gateway_go_to_private_networks": "View my private network",
   "pci_projects_project_public_gateway_delete": "Delete",
-  "pci_projects_project_public_gateway_no_data": "No data available."
+  "pci_projects_project_public_gateway_no_data": "No data available.",
+  "pci_projects_project_public_gateways_intro": "Gateways provide connectivity to private instances, allowing secure access to external networks or exposing the application to external access."
 }

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_es_ES.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_es_ES.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Los servicios Gateway proporcionan conectividad a las instancias privadas, permitiendo acceder de forma segura a las redes externas o exponer la aplicación a un acceso externo:",
-  "pci_projects_project_public_gateways_intro_part_2": "En el primer caso, el servicio Gateway actúa como pasarela SNAT, permitiendo que las instancias accedan a internet, pero no al contrario.",
-  "pci_projects_project_public_gateways_intro_part_3": "En el segundo caso, es posible exponer un servicio detrás de una instancia privada o un Load Balancer en internet utilizando las Floating IP.",
   "pci_projects_project_public_gateway_create": "Crear un servicio Gateway",
   "pci_projects_project_public_gateway_name": "Nombre/ID",
   "pci_projects_project_public_gateway_region": "Región",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Modificar su servicio Gateway",
   "pci_projects_project_public_gateway_go_to_private_networks": "Ver mi red privada",
   "pci_projects_project_public_gateway_delete": "Eliminar",
-  "pci_projects_project_public_gateway_no_data": "No hay ningún dato disponible."
+  "pci_projects_project_public_gateway_no_data": "No hay ningún dato disponible.",
+  "pci_projects_project_public_gateways_intro": "Los servicios Gateway ofrecen conectividad a las instancias privadas, permitiendo un acceso seguro a las redes externas o la exposición de la aplicación a un acceso externo."
 }

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_fr_CA.json
@@ -1,8 +1,6 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Les Gateways fournissent une connectivité aux instances privées, permettant d’accéder de manière sécurisée aux réseaux externes ou d’exposer l'application à un accès externe :",
-  "pci_projects_project_public_gateways_intro_part_2": "Dans le premier cas, Gateway agit comme une passerelle SNAT, autorisant les instances à atteindre Internet, mais pas le contraire.",
-  "pci_projects_project_public_gateways_intro_part_3": "Dans le second exemple, il s’agit de donner la possibilité d’exposer un service derrière une instance privée ou un Load Balancer à Internet en utilisant des Floating IP.",
+  "pci_projects_project_public_gateways_intro": "Les Gateways offrent une connectivité aux instances privées, permettant un accès sécurisé aux réseaux externes ou l'exposition de l'application à un accès externe.",
   "pci_projects_project_public_gateway_create": "Créer une Gateway",
   "pci_projects_project_public_gateway_name": "Nom/ID",
   "pci_projects_project_public_gateway_region": "Région",

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_fr_FR.json
@@ -1,8 +1,6 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Les Gateways fournissent une connectivité aux instances privées, permettant d’accéder de manière sécurisée aux réseaux externes ou d’exposer l'application à un accès externe :",
-  "pci_projects_project_public_gateways_intro_part_2": "Dans le premier cas, Gateway agit comme une passerelle SNAT, autorisant les instances à atteindre Internet, mais pas le contraire.",
-  "pci_projects_project_public_gateways_intro_part_3": "Dans le second exemple, il s’agit de donner la possibilité d’exposer un service derrière une instance privée ou un Load Balancer à Internet en utilisant des Floating IP.",
+  "pci_projects_project_public_gateways_intro": "Les Gateways offrent une connectivité aux instances privées, permettant un accès sécurisé aux réseaux externes ou l'exposition de l'application à un accès externe.",
   "pci_projects_project_public_gateway_create": "Créer une Gateway",
   "pci_projects_project_public_gateway_name": "Nom/ID",
   "pci_projects_project_public_gateway_region": "Région",

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_it_IT.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_it_IT.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Il servizio Gateway fornisce connettività alle istanze private, permettendo di accedere in modo sicuro alle reti esterne o esporre le applicazioni a un accesso esterno.",
-  "pci_projects_project_public_gateways_intro_part_2": "Nel primo caso, Gateway funziona come un gateway SNAT, che autorizza le istanze a raggiungere Internet, ma non il contrario.",
-  "pci_projects_project_public_gateways_intro_part_3": "Nel secondo esempio, l’utente ha la possibilità di esporre un servizio da un'istanza privata o un Load Balancer verso Internet utilizzando dei Floating IP.",
   "pci_projects_project_public_gateway_create": "Creare Gateway",
   "pci_projects_project_public_gateway_name": "Nome/ID",
   "pci_projects_project_public_gateway_region": "Region",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Modificare il tuo Gateway",
   "pci_projects_project_public_gateway_go_to_private_networks": "Visualizza la tua rete privata",
   "pci_projects_project_public_gateway_delete": "Elimina",
-  "pci_projects_project_public_gateway_no_data": "Nessun dato disponibile"
+  "pci_projects_project_public_gateway_no_data": "Nessun dato disponibile",
+  "pci_projects_project_public_gateways_intro": "Il servizio Gateway offre connettività alle istanze private, permettendo un accesso sicuro alle reti esterne o l'esposizione dell'applicazione ad un accesso esterno."
 }

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_pl_PL.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Gateway zapewnia łączność z prywatnymi instancjami, umożliwiając bezpieczny dostęp do sieci zewnętrznych lub dając dostęp do aplikacji z zewnątrz:",
-  "pci_projects_project_public_gateways_intro_part_2": "W pierwszym przypadku Gateway działa jako brama SNAT, umożliwiając instancjom dostęp do Internetu, ale nie odwrotnie.",
-  "pci_projects_project_public_gateways_intro_part_3": "W drugim przypadku możliwe jest wystawienie usługi za prywatną instancją lub Load Balancerem w Internecie przy użyciu adresów Floating IP.",
   "pci_projects_project_public_gateway_create": "Utwórz Gateway",
   "pci_projects_project_public_gateway_name": "Nazwa/ID",
   "pci_projects_project_public_gateway_region": "Region",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Zmień Gateway",
   "pci_projects_project_public_gateway_go_to_private_networks": "Wyświetl sieć prywatną",
   "pci_projects_project_public_gateway_delete": "Usuń",
-  "pci_projects_project_public_gateway_no_data": "Brak dostępnych danych."
+  "pci_projects_project_public_gateway_no_data": "Brak dostępnych danych.",
+  "pci_projects_project_public_gateways_intro": "Gateway zapewnia łączność z prywatnymi instancjami, umożliwiając bezpieczny dostęp do sieci zewnętrznych lub dając dostęp do aplikacji z zewnątrz."
 }

--- a/packages/manager/apps/pci-gateway/public/translations/common/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-gateway/public/translations/common/Messages_pt_PT.json
@@ -1,8 +1,5 @@
 {
   "pci_projects_project_public_gateway_title": "Gateway",
-  "pci_projects_project_public_gateways_intro_part_1": "Os Gateways oferecem uma ligação às instâncias privadas que permite aceder de forma segura às redes externas ou expor a aplicação a um acesso externo.",
-  "pci_projects_project_public_gateways_intro_part_2": "No primeiro caso, o Gateway atua como uma porta SNAT, permitindo que as instâncias cheguem à Internet, mas não o contrário.",
-  "pci_projects_project_public_gateways_intro_part_3": "No segundo exemplo, trata-se de dar a possibilidade de expor à Internet um serviço por trás de uma instância privada ou um Load Balancer por meio de Floating IP.",
   "pci_projects_project_public_gateway_create": "Criar um Gateway",
   "pci_projects_project_public_gateway_name": "Nome/ID",
   "pci_projects_project_public_gateway_region": "Região",
@@ -14,5 +11,6 @@
   "pci_projects_project_public_gateway_modify": "Modificar o seu Gateway",
   "pci_projects_project_public_gateway_go_to_private_networks": "Ver a minha rede privada",
   "pci_projects_project_public_gateway_delete": "Eliminar",
-  "pci_projects_project_public_gateway_no_data": "Nenhum dado disponível."
+  "pci_projects_project_public_gateway_no_data": "Nenhum dado disponível.",
+  "pci_projects_project_public_gateways_intro": "Os Gateways oferecem uma ligação às instâncias privadas, permitindo um acesso seguro às redes externas ou a exposição da aplicação a um acesso externo."
 }

--- a/packages/manager/apps/pci-gateway/src/pages/list/List.page.tsx
+++ b/packages/manager/apps/pci-gateway/src/pages/list/List.page.tsx
@@ -97,7 +97,7 @@ export default function ListingPage() {
         <div className="header mb-6 mt-8">
           <Headers
             title={t('pci_projects_project_public_gateway_title')}
-            description={t('pci_projects_project_public_gateways_intro_part_1')}
+            description={t('pci_projects_project_public_gateways_intro')}
             headerButton={<PciGuidesHeader category="instances" />}
             changelogButton={
               <ChangelogButton
@@ -106,16 +106,6 @@ export default function ListingPage() {
               />
             }
           />
-          <OsdsText
-            color={ODS_THEME_COLOR_INTENT.text}
-            level={ODS_THEME_TYPOGRAPHY_LEVEL.body}
-            size={ODS_THEME_TYPOGRAPHY_SIZE._400}
-          >
-            <ul>
-              <li>{t('pci_projects_project_public_gateways_intro_part_2')}</li>
-              <li>{t('pci_projects_project_public_gateways_intro_part_3')}</li>
-            </ul>
-          </OsdsText>
         </div>
 
         <OsdsDivider></OsdsDivider>


### PR DESCRIPTION
I've divided the ticket into two commit to make the review easier.

I'm not sure I could remove or rename trad keys.

Before:
<img width="1296" height="550" alt="image" src="https://github.com/user-attachments/assets/a548701a-09fe-49c9-b5b9-e96d4f44d2aa" />

After:
<img width="1118" height="491" alt="image" src="https://github.com/user-attachments/assets/052b7cc9-34a2-4f3f-827d-9dd1a5b654a8" />
