### PR TITLE
fix(manager-pci-common): add showTooltip to RegionTile

### DIFF
--- a/packages/manager/modules/manager-pci-common/src/components/region-selector/RegionTile.tsx
+++ b/packages/manager/modules/manager-pci-common/src/components/region-selector/RegionTile.tsx
@@ -9,12 +9,14 @@ export interface RegionTileProps {
   region: TLocalisation;
   isSelected: boolean;
   isCompact?: boolean;
+  showTooltip?: boolean;
 }
 
 export const RegionTile = ({
   region,
   isSelected,
   isCompact,
+  showTooltip,
 }: Readonly<RegionTileProps>) => (
   <div className="flex flex-col w-full items-center">
     <div className={isCompact ? 'my-4' : ''}>
@@ -30,7 +32,7 @@ export const RegionTile = ({
       <>
         <hr className="w-full border-solid border-0 border-b border-ods-primary-200" />
         <div>
-          <RegionChipByType type={region.type} />
+          <RegionChipByType showTooltip={!!showTooltip} type={region.type} />
         </div>
       </>
     )}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
Added the ability to display a tooltip for the RegionChipByType component. A new showTooltip parameter has been added to the RegionTileProps interface to enable/disable this feature. The RegionTile component can now display a tooltip for the region type if showTooltip is set to true.

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #TAPC-4008    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
