### PR TITLE
fix(account): added angular-messages dependency

### DIFF
--- a/packages/manager/modules/account/package.json
+++ b/packages/manager/modules/account/package.json
@@ -42,6 +42,7 @@
     "angular-cookies": "^1.7.8",
     "angular-dynamic-locale": "^0.1.37",
     "angular-i18n": "^1.7.8",
+    "angular-messages": "^1.7.6",
     "angular-qr": "^0.2.3",
     "angular-resource": "^1.7.8",
     "angular-sanitize": "^1.7.8",

--- a/packages/manager/modules/account/src/contacts/update/user-contacts-update.module.js
+++ b/packages/manager/modules/account/src/contacts/update/user-contacts-update.module.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import 'angular-messages';
 
 import service from '../user-contacts.service';
 import routing from './user.contacts-update.routes';
@@ -6,7 +7,12 @@ import routing from './user.contacts-update.routes';
 const moduleName = 'UserAccountContactsUpdate';
 
 angular
-  .module(moduleName, ['oui', 'pascalprecht.translate', 'ui.router'])
+  .module(moduleName, [
+    'oui',
+    'pascalprecht.translate',
+    'ui.router',
+    'ngMessages',
+  ])
   .service('UserAccountContactUpdateService', service)
   .config(routing)
   .run(/* @ngTranslationsInject:json ./translations */);


### PR DESCRIPTION
## Description

After the slicing of account from dedicated, we missed a dependency to angular-messages resulting in the error messages being incorrectly displayed.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19220, #PRB0042689

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
