### PR TITLE
feat(ldp): no opensearch url if iam enabled

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/home/logs-aliases-home.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/aliases/home/logs-aliases-home.html
@@ -87,7 +87,10 @@
                 on-click="ctrl.attachContent($row)"
                 ><span data-translate="logs_aliases_attach_content"></span
             ></oui-action-menu-item>
-            <oui-action-menu-item data-on-click="ctrl.openOpenSearch($row)">
+            <oui-action-menu-item
+                data-ng-if="!ctrl.service.isIamEnabled"
+                data-on-click="ctrl.openOpenSearch($row)"
+            >
                 <span data-translate="logs_index_access_os_api"></span>
                 <i
                     class="oui-icon oui-icon-external-link"

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.html
@@ -124,6 +124,7 @@
                         </a>
                         <div data-ng-if="ctrl.accountDetails">
                             <a
+                                data-ng-if="!ctrl.service.isIamEnabled"
                                 data-ng-href="{{ ctrl.accountDetails.elasticSearchApiUrl }}"
                                 class="oui-tile__button oui-button oui-link_icon oui-button_ghost"
                                 data-ng-class="{

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/index/logs-index.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/index/logs-index.html
@@ -86,7 +86,10 @@
                 data-on-click="ctrl.add($row)"
                 ><span data-translate="logs_edit"></span
             ></oui-action-menu-item>
-            <oui-action-menu-item data-on-click="ctrl.openOpenSearch($row)">
+            <oui-action-menu-item
+                data-ng-if="!ctrl.service.isIamEnabled"
+                data-on-click="ctrl.openOpenSearch($row)"
+            >
                 <span data-translate="logs_index_access_os_api"></span>
                 <i
                     class="oui-icon oui-icon-external-link"


### PR DESCRIPTION
ref: #OB-8548

## Description

Once IAM enabled, access to OpenSearch API will requires extra settings as described here: https://help.ovhcloud.com/csm/fr-logs-data-platform-iam-presentation-faq?id=kb_article_view&sysparm_article=KB0071686#how-to-interact-with-logs-data-platform-backends-api

To avoid confusion, we decide to remove theses shortcuts if we know that the service has not be migrated.