### PR TITLE
ci(shell-client): add test configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,24 +8,25 @@
     "packages": [
       "docs",
       "packages/components/*",
+      "packages/manager-cli",
+      "packages/manager-react-components",
+      "packages/manager-wiki",
       "packages/manager/apps/*",
       "packages/manager/core/api",
       "packages/manager/core/application",
       "packages/manager/core/generator",
       "packages/manager/core/ovh-product-icons",
       "packages/manager/core/request-tagger",
+      "packages/manager/core/shell-client",
       "packages/manager/core/sso",
       "packages/manager/core/tailwind-config",
+      "packages/manager/core/test-utils",
+      "packages/manager/core/tests-setup",
       "packages/manager/core/url-builder",
       "packages/manager/core/utils",
       "packages/manager/core/vite-config",
-      "packages/manager/core/test-utils",
-      "packages/manager/core/tests-setup",
       "packages/manager/modules/*",
-      "packages/manager/tools/*",
-      "packages/manager-cli",
-      "packages/manager-react-components",
-      "packages/manager-wiki"
+      "packages/manager/tools/*"
     ]
   },
   "scripts": {

--- a/packages/manager/core/shell-client/package.json
+++ b/packages/manager/core/shell-client/package.json
@@ -14,19 +14,22 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc",
-    "prepare": "tsc"
+    "prepare": "tsc",
+    "test": "manager-test",
+    "test:ci": "manager-test run --coverage"
   },
   "dependencies": {
-    "@ovh-ux/manager-config": "^8.2.1",
-    "@ovh-ux/ovh-at-internet": "^0.21.6",
-    "@ovh-ux/request-tagger": "^0.4.0",
-    "@ovh-ux/shell": "^4.1.0",
-    "@ovh-ux/url-builder": "^2.0.0",
+    "@ovh-ux/manager-config": "^8.5.0",
+    "@ovh-ux/ovh-at-internet": "^0.24.0",
+    "@ovh-ux/request-tagger": "^0.4.1",
+    "@ovh-ux/shell": "^4.5.6",
+    "@ovh-ux/url-builder": "^2.0.3",
     "@tanstack/react-query": "^5.64.1",
     "i18next": "^23.8.2",
     "i18next-http-backend": "^2.4.2"
   },
   "devDependencies": {
+    "@ovh-ux/manager-tests-setup": "^0.2.0",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {

--- a/packages/manager/core/shell-client/vitest.config.js
+++ b/packages/manager/core/shell-client/vitest.config.js
@@ -1,0 +1,13 @@
+import {
+  createConfig,
+  mergeConfig,
+  defaultExcludedFiles,
+} from '@ovh-ux/manager-tests-setup';
+
+export default mergeConfig(createConfig(), {
+  test: {
+    coverage: {
+      exclude: [...defaultExcludedFiles],
+    },
+  },
+});


### PR DESCRIPTION
This PR adds test configuration inherited from `@ovh-ux/manager-tests-setup` shared config.

BYW, it adds the package in the workspace main configuration that was causing the module to be treated out of the mono repository, as a standalone package. 

It should also fix the auto-versionning that was not working anymore due to workspace configuration.