### PR TITLE
fix(cloud-connect.statistics): display charts for available ports

### DIFF
--- a/packages/manager/modules/cloud-connect/src/details/statistics/statistics.controller.js
+++ b/packages/manager/modules/cloud-connect/src/details/statistics/statistics.controller.js
@@ -40,11 +40,6 @@ export default class CloudConnectStatisticsCtrl {
     this.graphType = this.TYPE.TRAFFIC;
     this.graphPeriod = this.PERIOD.DAILY;
 
-    this.trafficLoader = {
-      series: [],
-      data: [],
-    };
-
     this.displayedGraph = this.TYPE.TRAFFIC;
     this.colors = this.STATISTICS.colors;
     this.chart = new this.ChartFactory({
@@ -135,6 +130,9 @@ export default class CloudConnectStatisticsCtrl {
   loadErrorGraph() {
     this.series = [];
     this.data = [];
+    this.chart.data = {
+      datasets: [],
+    };
     this.isLoading = true;
 
     // Update options
@@ -147,6 +145,9 @@ export default class CloudConnectStatisticsCtrl {
   loadLightGraph() {
     this.series = [];
     this.data = [];
+    this.chart.data = {
+      datasets: [],
+    };
     this.isLoading = true;
 
     // Update options
@@ -159,6 +160,9 @@ export default class CloudConnectStatisticsCtrl {
   loadTrafficGraph() {
     this.series = [];
     this.data = [];
+    this.chart.data = {
+      datasets: [],
+    };
     this.isLoading = true;
 
     // Update options
@@ -172,6 +176,9 @@ export default class CloudConnectStatisticsCtrl {
     this.isNoData = false;
     this.series = [];
     this.data = [];
+    this.chart.data = {
+      datasets: [],
+    };
     this.isLoading = true;
 
     // Update options
@@ -242,12 +249,15 @@ export default class CloudConnectStatisticsCtrl {
       this.data.push(map(get(stats, prop), (value) => value[1].value));
     });
 
-    this.chart.data.datasets = dataProperties.map((prop, i) => ({
-      label: serieLabels[i],
-      data: map(get(stats, prop), (value) => value[1].value),
-      borderColor: this.colors[i].borderColor,
-      backgroundColor: this.colors[i].borderColor,
-    }));
+    dataProperties.forEach((prop, i) => {
+      const j = this.chart.data.datasets.length;
+      this.chart.data.datasets.push({
+        label: serieLabels[i],
+        data: map(get(stats, prop), (value) => value[1].value),
+        borderColor: this.colors[j].borderColor,
+        backgroundColor: this.colors[j].borderColor,
+      });
+    });
   }
 
   loadStatistics(connectId, interfaceId, type, period) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

Display charts for all available ports


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #UXCT-771

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
