### PR TITLE
feat(manager-react-components): MRCV2 deprecate pci hooks

### DIFF
--- a/packages/manager-react-components/src/hooks/pci-project-provider/constants.ts
+++ b/packages/manager-react-components/src/hooks/pci-project-provider/constants.ts
@@ -1,1 +1,9 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The constants will be available in the `@ovh-ux/manager-pci-common` package.
+ */
+
+/**
+ * @deprecated This constant is deprecated and will be removed in MRC V3.
+ */
 export const DISCOVERY_PROJECT_PLANCODE = 'project.discovery';

--- a/packages/manager-react-components/src/hooks/pci-project-provider/index.ts
+++ b/packages/manager-react-components/src/hooks/pci-project-provider/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { useProjectQuota } from './useProject';
 
+/**
+ * @deprecated This export is deprecated and will be removed in MRC V3.
+ */
 export { useProjectQuota };

--- a/packages/manager-react-components/src/hooks/pci-project-provider/publicCloudProject.interface.ts
+++ b/packages/manager-react-components/src/hooks/pci-project-provider/publicCloudProject.interface.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
+
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type TProjectStatus =
   | 'creating'
   | 'deleted'
@@ -5,6 +13,9 @@ export type TProjectStatus =
   | 'ok'
   | 'suspended';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type PublicCloudProject = {
   access: 'full' | 'restricted';
   creationDate: string;

--- a/packages/manager-react-components/src/hooks/pci-project-provider/useProject.ts
+++ b/packages/manager-react-components/src/hooks/pci-project-provider/useProject.ts
@@ -1,7 +1,14 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { useQuery } from '@tanstack/react-query';
 
 import { v6 } from '@ovh-ux/manager-core-api';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type TProjectQuota = {
   region: string;
   instance: {
@@ -46,6 +53,9 @@ export type TProjectQuota = {
   share: any | null;
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getProjectQuota = async (projectId: string) => {
   const { data } = await v6.get<TProjectQuota[]>(
     `/cloud/project/${projectId}/quota`,
@@ -54,6 +64,9 @@ export const getProjectQuota = async (projectId: string) => {
   return data;
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectQuota = (projectId: string) =>
   useQuery({
     queryKey: ['project', projectId, 'quota'],

--- a/packages/manager-react-components/src/hooks/pci/useAggregatedPrivateNetworks.tsx
+++ b/packages/manager-react-components/src/hooks/pci/useAggregatedPrivateNetworks.tsx
@@ -1,13 +1,23 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { useMemo } from 'react';
 import { v6 } from '@ovh-ux/manager-core-api';
 import { useQuery } from '@tanstack/react-query';
 import { Region } from './useProjectRegions';
 
+/**
+ * @deprecated The interface is deprecated and will be removed in MRC V3.
+ */
 export interface Subnet {
   region: string;
   id: string;
 }
 
+/**
+ * @deprecated The interface is deprecated and will be removed in MRC V3.
+ */
 interface Network {
   id: string;
   name: string;
@@ -16,10 +26,16 @@ interface Network {
   vlanId: number;
 }
 
+/**
+ * @deprecated The interface is deprecated and will be removed in MRC V3.
+ */
 export interface AggregatedNetwork {
   resources: Network[];
 }
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getAggregatedNetwork = async (
   projectId: string,
 ): Promise<AggregatedNetwork> => {
@@ -29,11 +45,16 @@ export const getAggregatedNetwork = async (
   return data;
 };
 
-export const getAggregatedPrivateNetworksQueryKey = (projectId: string) => [
-  'aggregated-network',
-  projectId,
-];
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
+export const getAggregatedPrivateNetworksQueryKey = (projectId: string) => {
+  return ['aggregated-network', projectId];
+};
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useAggregatedPrivateNetworks = (
   projectId: string,
   customerRegions: Region[],
@@ -72,6 +93,9 @@ export const useAggregatedPrivateNetworks = (
   });
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useAggregatedPrivateNetworksRegions = (
   projectId: string,
   customerRegions: Region[],

--- a/packages/manager-react-components/src/hooks/pci/useMaintenance.tsx
+++ b/packages/manager-react-components/src/hooks/pci/useMaintenance.tsx
@@ -1,7 +1,14 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { useAggregatedPrivateNetworksRegions } from './useAggregatedPrivateNetworks';
 import { useMigrationSteins } from './useMigrationSteins';
 import { useProjectRegions } from './useProjectRegions';
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export function useProductMaintenance(projectId: string) {
   const { data: customerRegions } = useProjectRegions(projectId);
   const { data: steins } = useMigrationSteins();
@@ -12,9 +19,9 @@ export function useProductMaintenance(projectId: string) {
 
   const regionsMaintenance = steins?.map(({ zone }) => zone) || [];
 
-  const isProductConcernedByMaintenance = (
-    productRegions || []
-  ).some((region) => regionsMaintenance.includes(region));
+  const isProductConcernedByMaintenance = (productRegions || []).some(
+    (region) => regionsMaintenance.includes(region),
+  );
 
   return {
     hasMaintenance: isProductConcernedByMaintenance,

--- a/packages/manager-react-components/src/hooks/pci/useMigrationSteins.tsx
+++ b/packages/manager-react-components/src/hooks/pci/useMigrationSteins.tsx
@@ -1,19 +1,35 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { v6 } from '@ovh-ux/manager-core-api';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * @deprecated The interface is deprecated and will be removed in MRC V3.
+ */
 export interface Stein {
   date: string;
   zone: string;
   travaux: string;
 }
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getMigrationSteins = async (): Promise<Stein[]> => {
   const { data } = await v6.get<Stein[]>('/cloud/migrationStein');
   return data;
 };
 
+/**
+ * @deprecated This constant is deprecated and will be removed in MRC V3.
+ */
 export const migrationSteinsQueryKey = ['migrationSteins'];
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useMigrationSteins = () =>
   useQuery({
     queryKey: migrationSteinsQueryKey,

--- a/packages/manager-react-components/src/hooks/pci/useProjectRegions.tsx
+++ b/packages/manager-react-components/src/hooks/pci/useProjectRegions.tsx
@@ -1,6 +1,13 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * The hooks will be available in the `@ovh-ux/manager-pci-common` package.
+ */
 import { useQuery } from '@tanstack/react-query';
 import { fetchIcebergV6 } from '@ovh-ux/manager-core-api';
 
+/**
+ * @deprecated The interface is deprecated and will be removed in MRC V3.
+ */
 export interface Region {
   continentCode: string;
   datacenterLocation: string;
@@ -9,12 +16,18 @@ export interface Region {
   type: string;
 }
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getProjectRegionsQueryKey = (projectId: string) => [
   'project',
   projectId,
   'regions',
 ];
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getProjectRegions = async (
   projectId: string,
 ): Promise<Region[]> => {
@@ -24,6 +37,9 @@ export const getProjectRegions = async (
   return data;
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectRegions = (projectId: string) =>
   useQuery({
     queryKey: getProjectRegionsQueryKey(projectId),


### PR DESCRIPTION
ref: #MANAGER-19193

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

- Deprecate all PCI hooks in MRC

MRC V2 DEPRECATED

1 - packages/manager-react-components/src/hooks/pci/*  ✅ 
2 - packages/manager-react-components/src/hooks/pci-project-provider/*  ✅ 
3 - packages/manager-react-components/src/hooks/useProjectRegions.ts  ✅ 

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19193
