### PR TITLE
feat(manager-react-components): MRC V2 deprecate hooks

### DIFF
--- a/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.ts
+++ b/packages/manager-react-components/src/hooks/feature-availability/useFeatureAvailability.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, use useFeatureAvailability from @ovh-ux/manager-module-common-api'
+ */
+
 import { apiClient, ApiError } from '@ovh-ux/manager-core-api';
 import {
   DefinedInitialDataOptions,

--- a/packages/manager-react-components/src/hooks/services/api/get.ts
+++ b/packages/manager-react-components/src/hooks/services/api/get.ts
@@ -1,17 +1,28 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { apiClient } from '@ovh-ux/manager-core-api';
 import { ServiceDetails } from '../services.type';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type GetResourceServiceIdParams = {
   /** Filter on a specific service family */
   resourceName: string;
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getResourceServiceIdQueryKey = ({
   resourceName = '',
 }: GetResourceServiceIdParams) => [`get/services${resourceName}`];
 
 /**
  * allowedServices operations : List all services allowed in this vrack
+ * @deprecated This function is deprecated and will be removed in MRC V3.
  */
 export const getResourceServiceId = async ({
   resourceName,
@@ -20,5 +31,8 @@ export const getResourceServiceId = async ({
     `/services${resourceName ? `?resourceName=${resourceName}` : ''}`,
   );
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getServiceDetails = async (serviceId: number | string) =>
   apiClient.v6.get<ServiceDetails>(`/services/${serviceId}`);

--- a/packages/manager-react-components/src/hooks/services/api/index.ts
+++ b/packages/manager-react-components/src/hooks/services/api/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 export * from './get';
 export * from './put';
 export * from './post';

--- a/packages/manager-react-components/src/hooks/services/api/post.ts
+++ b/packages/manager-react-components/src/hooks/services/api/post.ts
@@ -1,11 +1,19 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { apiClient } from '@ovh-ux/manager-core-api';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type DeleteServiceParams = {
   serviceId: number;
 };
 
 /**
  * Terminiate a service
+ * @deprecated This function is deprecated and will be removed in MRC V3.
  */
 export const deleteService = async ({ serviceId }: DeleteServiceParams) =>
   apiClient.v6.post<{ message: string }>(`/services/${serviceId}/terminate`);

--- a/packages/manager-react-components/src/hooks/services/api/put.ts
+++ b/packages/manager-react-components/src/hooks/services/api/put.ts
@@ -1,5 +1,12 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { apiClient } from '@ovh-ux/manager-core-api';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UpdateServiceNameParams = {
   /** Service id */
   serviceId: number;
@@ -9,6 +16,7 @@ export type UpdateServiceNameParams = {
 
 /**
  * Update a service's display name
+ * @deprecated This function is deprecated and will be removed in MRC V3.
  */
 export const updateServiceName = async ({
   serviceId,

--- a/packages/manager-react-components/src/hooks/services/hooks/index.ts
+++ b/packages/manager-react-components/src/hooks/services/hooks/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 export * from './useDeleteService';
 export * from './useUpdateServiceName';
 export * from './useServiceDetails';

--- a/packages/manager-react-components/src/hooks/services/hooks/useDeleteService.ts
+++ b/packages/manager-react-components/src/hooks/services/hooks/useDeleteService.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { ApiError, ApiResponse } from '@ovh-ux/manager-core-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -6,18 +10,30 @@ import {
   deleteService,
 } from '../api';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type DeleteServiceMutationParams = {
   resourceName: string;
 };
 
+/**
+ * @deprecated The constant is deprecated and will be removed in MRC V3.
+ */
 export const deleteServiceMutationKey = ['delete-service'];
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UseDeleteServiceParams = {
   onSuccess?: () => void;
   onError?: (result: ApiError) => void;
   mutationKey?: string[];
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useDeleteService = ({
   onSuccess,
   onError,

--- a/packages/manager-react-components/src/hooks/services/hooks/useServiceDetails.ts
+++ b/packages/manager-react-components/src/hooks/services/hooks/useServiceDetails.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { ApiError, ApiResponse } from '@ovh-ux/manager-core-api';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -7,16 +11,25 @@ import {
 } from '../api';
 import { ServiceDetails } from '../services.type';
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getServiceDetailsQueryKey = (resourceName: string) => [
   'service-details',
   resourceName,
 ];
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UseServiceDetailsParams = {
   queryKey?: string[];
   resourceName: string;
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useServiceDetails = ({
   queryKey,
   resourceName,

--- a/packages/manager-react-components/src/hooks/services/hooks/useUpdateServiceName.ts
+++ b/packages/manager-react-components/src/hooks/services/hooks/useUpdateServiceName.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { ApiError, ApiResponse } from '@ovh-ux/manager-core-api';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import {
@@ -6,8 +10,14 @@ import {
   getResourceServiceIdQueryKey,
 } from '../api';
 
+/**
+ * @deprecated The constant is deprecated and will be removed in MRC V3.
+ */
 export const updateServiceNameMutationKey = ['put/services/displayName'];
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UpdateServiceNameMutationParams = {
   /** Resource name or id */
   resourceName: string;
@@ -15,12 +25,18 @@ export type UpdateServiceNameMutationParams = {
   displayName?: string;
 };
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UseUpdateServiceDisplayNameParams = {
   onSuccess?: () => void;
   onError?: (result: ApiError) => void;
   mutationKey?: string[];
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useUpdateServiceDisplayName = ({
   onSuccess,
   onError,

--- a/packages/manager-react-components/src/hooks/services/index.ts
+++ b/packages/manager-react-components/src/hooks/services/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 export * from './api';
 export * from './hooks';
 export * from './mocks';

--- a/packages/manager-react-components/src/hooks/services/mocks/index.ts
+++ b/packages/manager-react-components/src/hooks/services/mocks/index.ts
@@ -1,2 +1,6 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 export * from './services.handler';
 export * from './services.mock';

--- a/packages/manager-react-components/src/hooks/services/mocks/services.handler.ts
+++ b/packages/manager-react-components/src/hooks/services/mocks/services.handler.ts
@@ -1,8 +1,13 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { ServiceDetails } from '../services.type';
 import { defaultServiceResponse, servicesMockErrors } from './services.mock';
 
 /**
  * @deprecated Move GetServicesMocksParams out of mrc
+ * @deprecated The type is deprecated and will be removed in MRC V3.
  */
 export type GetServicesMocksParams = {
   getServicesKo?: boolean;
@@ -14,6 +19,7 @@ export type GetServicesMocksParams = {
 
 /**
  * @deprecated Move getServicesMocks out of mrc
+ * @deprecated This function is deprecated and will be removed in MRC V3.
  */
 export const getServicesMocks = ({
   getServicesKo,

--- a/packages/manager-react-components/src/hooks/services/mocks/services.mock.ts
+++ b/packages/manager-react-components/src/hooks/services/mocks/services.mock.ts
@@ -1,6 +1,13 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { CurrencyCode } from '../../../enumTypes';
 import { ServiceDetails } from '../services.type';
 
+/**
+ * @deprecated The constant is deprecated and will be removed in MRC V3.
+ */
 export const servicesMockErrors = {
   delete: 'Delete services error',
   update: 'Update services error',
@@ -8,6 +15,9 @@ export const servicesMockErrors = {
   getDetails: 'Get services details error',
 };
 
+/**
+ * @deprecated The constant is deprecated and will be removed in MRC V3.
+ */
 export const defaultServiceResponse: ServiceDetails = {
   route: {
     path: '/api/path/{id}',

--- a/packages/manager-react-components/src/hooks/services/services.type.ts
+++ b/packages/manager-react-components/src/hooks/services/services.type.ts
@@ -1,17 +1,30 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import { CurrencyCode } from '../../enumTypes';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type EndRuleStrategy =
   | 'CANCEL_SERVICE'
   | 'REACTIVATE_ENGAGEMENT'
   | 'STOP_ENGAGEMENT_FALLBACK_DEFAULT_PRICE'
   | 'STOP_ENGAGEMENT_KEEP_PRICE';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type LifecycleAction =
   | 'earlyRenewal'
   | 'terminate'
   | 'terminateAtEngagementDate'
   | 'terminateAtExpirationDate';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type LifecycleState =
   | 'active'
   | 'error'
@@ -21,6 +34,9 @@ export type LifecycleState =
   | 'unpaid'
   | 'unrenewed';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type PricingCapacity =
   | 'consumption'
   | 'detach'
@@ -30,23 +46,41 @@ export type PricingCapacity =
   | 'renew'
   | 'upgrade';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type EndAction =
   | 'CANCEL_SERVICE'
   | 'REACTIVATE_ENGAGEMENT'
   | 'STOP_ENGAGEMENT_FALLBACK_DEFAULT_PRICE'
   | 'STOP_ENGAGEMENT_KEEP_PRICE';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type RenewMode = 'automatic' | 'manual';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type EngagementType = 'periodic' | 'upfront';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type PricingType = 'consumption' | 'purchase' | 'rental';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type CustomerContact = {
   customerCode: string;
   type: 'administrator' | 'billing' | 'technical';
 };
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type ResourceStatus =
   | 'active'
   | 'deleted'
@@ -55,6 +89,9 @@ export type ResourceStatus =
   | 'toDelete'
   | 'toSuspend';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type ServiceDetails = {
   billing: {
     engagement: {

--- a/packages/manager-react-components/src/hooks/tasks/hooks/useTask.ts
+++ b/packages/manager-react-components/src/hooks/tasks/hooks/useTask.ts
@@ -1,7 +1,14 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 import React from 'react';
 import { ApiError, ApiResponse, apiClient } from '@ovh-ux/manager-core-api';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type UseTaskParams = {
   resourceUrl: string;
   apiVersion?: 'v2' | 'v6';
@@ -13,11 +20,17 @@ export type UseTaskParams = {
   refetchIntervalTime?: number;
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getDefaultQueryKey = (taskId: number | string) => [
   'manage-task',
   taskId,
 ];
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useTask = ({
   resourceUrl,
   apiVersion = 'v2',

--- a/packages/manager-react-components/src/hooks/tasks/index.ts
+++ b/packages/manager-react-components/src/hooks/tasks/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api' or already moved
+ */
 export * from './hooks/useTask';

--- a/packages/manager-react-components/src/hooks/useProjectRegions.ts
+++ b/packages/manager-react-components/src/hooks/useProjectRegions.ts
@@ -1,12 +1,22 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-pci-common
+ */
 import { fetchIcebergV6 } from '@ovh-ux/manager-core-api';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 type TRegionService = {
   endpoint: string;
   name: string;
   status: string;
 };
 
+/**
+ * @deprecated The type is deprecated and will be removed in MRC V3.
+ */
 export type TRegion = {
   continentCode: string;
   datacenterLocation: string;
@@ -17,6 +27,9 @@ export type TRegion = {
   services: TRegionService[];
 };
 
+/**
+ * @deprecated This function is deprecated and will be removed in MRC V3.
+ */
 export const getProjectRegions = async (
   projectId: string,
 ): Promise<TRegion[]> => {
@@ -26,12 +39,18 @@ export const getProjectRegions = async (
   return data;
 };
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectRegions = (projectId: string) =>
   useQuery({
     queryKey: ['project', projectId, 'regions'],
     queryFn: () => getProjectRegions(projectId),
   });
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectLocalRegions = (projectId: string) =>
   useQuery({
     queryKey: ['project', projectId, 'regions', 'local'],
@@ -40,6 +59,9 @@ export const useProjectLocalRegions = (projectId: string) =>
       regions.filter(({ type = [] }) => type === 'localzone'),
   });
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectNonLocalRegions = (projectId: string) =>
   useQuery({
     queryKey: ['project', projectId, 'regions', 'non-local'],

--- a/packages/manager-react-components/src/hooks/useProjectUrl.ts
+++ b/packages/manager-react-components/src/hooks/useProjectUrl.ts
@@ -1,7 +1,14 @@
+/**
+ * @deprecated This file is deprecated. Do not use any of its exports.
+ * @deprecated file will be removed in MRC v3, all code will be move in @ovh-ux/manager-module-common-api'
+ */
 import { useParams } from 'react-router-dom';
 import { useContext, useEffect, useState } from 'react';
 import { ShellContext } from '@ovh-ux/manager-react-shell-client';
 
+/**
+ * @deprecated This hook is deprecated and will be removed in MRC V3.
+ */
 export const useProjectUrl = (appName: string) => {
   const { projectId } = useParams();
   const { navigation } = useContext(ShellContext).shell;


### PR DESCRIPTION
ref: #MANAGER-19191

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

MRC V2 DEPRECATED
1 - packages/manager-react-components/src/hooks/services ✅ (move in common-api)
2 - useFeatureAvailability ✅
3 - packages/manager-react-components/src/hooks/tasks ✅
4 - packages/manager-react-components/src/hooks/useProjectRegions.ts ✅
5 - packages/manager-react-components/src/hooks/useProjectUrl.ts ✅



<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-12191
