### PR TITLE
fix(manager-cli): monitor cli reports and commands after tools re-organization

### DIFF
--- a/packages/manager-tools/manager-cli/routes-migrate/steps/update-routers-init-cli.mjs
+++ b/packages/manager-tools/manager-cli/routes-migrate/steps/update-routers-init-cli.mjs
@@ -24,7 +24,7 @@ const findRouterCallsFiles = async (dir, results) => {
   let entries;
 
   try {
-    entries = await readdir(dir, { withFileTypes: true });
+    entries = await fs.readdir(dir, { withFileTypes: true });
   } catch (err) {
     console.warn(`⚠️  Failed to read directory: ${dir} (${err.message})`);
     return;

--- a/packages/manager-tools/manager-cli/routes-migrate/steps/update-routers-init-cli.mjs
+++ b/packages/manager-tools/manager-cli/routes-migrate/steps/update-routers-init-cli.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
 import path from 'path';
-import { readdir, writeFile } from 'fs/promises';
+import fs from 'fs/promises';
 import prettier from 'prettier';
+import { applicationsBasePath } from '../../utils/AppUtils.mjs';
 
 const appName = process.argv[2];
 const isDryRun = process.argv.includes('--dry-run');
 
-const appPath = path.resolve('../manager/apps', appName);
+const applicationPath = path.resolve(applicationsBasePath, appName);
 const foldersToScan = ['src'];
 const routerRegex = /\bcreate(Hash|Memory)Router\s*\(/;
 
@@ -36,7 +37,7 @@ const findRouterCallsFiles = async (dir, results) => {
       await findRouterCallsFiles(fullPath, results);
     } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
       try {
-        const content = await readFile(fullPath, 'utf-8');
+        const content = await fs.readFile(fullPath, 'utf-8');
         if (routerRegex.test(content)) {
           results.push({ path: fullPath, content });
         }
@@ -57,7 +58,7 @@ const findRouterInitFiles = async () => {
   const results = [];
 
   for (const folder of foldersToScan) {
-    const fullPath = path.join(appPath, folder);
+    const fullPath = path.join(applicationPath, folder);
     await findRouterCallsFiles(fullPath, results);
   }
 
@@ -179,7 +180,7 @@ const updateRoutersInitialization = async () => {
         console.log('--- TRANSFORMED ---');
         console.log(formatted.slice(0, 1000));
       } else {
-        await writeFile(filePath, formatted);
+        await fs.writeFile(filePath, formatted);
         console.log(`✅ Updated: ${filePath}`);
       }
     } catch (err) {

--- a/packages/manager-tools/manager-cli/static-analysis-migrate/steps/ts-config/addTSStaticKitConfig.mjs
+++ b/packages/manager-tools/manager-cli/static-analysis-migrate/steps/ts-config/addTSStaticKitConfig.mjs
@@ -7,7 +7,7 @@ import { readPackageJson, writePackageJson } from '../../../utils/DependenciesUt
 import { applicationsBasePath } from '../../../utils/AppUtils.mjs';
 
 // eslint-disable-next-line
-import reactTSBaseConfig from '../../../../manager/tools/static-analysis-kit/dist/tsconfig/react.json' with { type: 'json' };
+import reactTSBaseConfig from '../../../../../manager-tools/manager-static-analysis-kit/dist/tsconfig/react.json' with { type: 'json' };
 
 const appName = process.argv[2];
 const isDryRun = process.argv.includes('--dry-run');

--- a/packages/manager-tools/manager-cli/tests-migrate/unit/migrate-vitest.mjs
+++ b/packages/manager-tools/manager-cli/tests-migrate/unit/migrate-vitest.mjs
@@ -4,6 +4,7 @@ import { existsSync } from 'fs';
 import { updateDependencies } from './steps/updateDependencies.mjs';
 import { updateTestScripts } from './steps/updateScripts.mjs';
 import { updateConfiguration } from './steps/updateConfiguration.mjs';
+import { applicationsBasePath } from '../../utils/AppUtils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,10 +19,10 @@ if (!appName) {
   process.exit(1);
 }
 
-const appPath = path.resolve(__dirname, '../../../manager/apps', appName);
+const applicationPath = path.resolve(applicationsBasePath, appName);
 
-if (!existsSync(appPath)) {
-  console.error(`❌ App not found at: ${appPath}`);
+if (!existsSync(applicationPath)) {
+  console.error(`❌ App not found at: ${applicationPath}`);
   process.exit(1);
 }
 
@@ -29,9 +30,9 @@ console.log(`🚀 Starting Vitest migration for: ${appName}`);
 if (dryRun) console.log('🧪 Running in dry-run mode');
 
 (async () => {
-  await updateDependencies(appPath, dryRun);
-  await updateTestScripts(appPath, dryRun);
-  await updateConfiguration(appPath, dryRun);
+  await updateDependencies(applicationPath, dryRun);
+  await updateTestScripts(applicationPath, dryRun);
+  await updateConfiguration(applicationPath, dryRun);
 
   console.log(`✅ Finished Vitest migration for: ${appName}`);
 })();

--- a/packages/manager-tools/manager-cli/translations-checker/steps/check-duplicated-cli.mjs
+++ b/packages/manager-tools/manager-cli/translations-checker/steps/check-duplicated-cli.mjs
@@ -3,6 +3,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { applicationsBasePath, modulesBasePath } from '../../utils/AppUtils.mjs';
 
 // Helpers to get dirname equivalent in ESM
 const filename = fileURLToPath(import.meta.url);
@@ -11,7 +12,7 @@ const dirname = path.dirname(filename);
 // Hardcoded common folder path (constant)
 const commonFolder = path.resolve(
   dirname,
-  '../../../manager/modules/common-translations/public/translations/',
+  `${modulesBasePath}/common-translations/public/translations/`,
 );
 
 const args = process.argv.slice(2);
@@ -19,7 +20,7 @@ const appName = args[0];
 const projectRoot = process.cwd();
 const appFolder = path.resolve(
   dirname,
-  `../../../manager/apps/${appName}/public/translations/`,
+  `${applicationsBasePath}/${appName}/public/translations/`,
 );
 const targetFileName = 'Messages_fr_FR.json';
 

--- a/packages/manager-tools/manager-cli/utils/AppUtils.mjs
+++ b/packages/manager-tools/manager-cli/utils/AppUtils.mjs
@@ -4,7 +4,8 @@ import { dirname, resolve, join } from 'path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export const applicationsBasePath = resolve(__dirname, '../../manager/apps');
+export const applicationsBasePath = resolve(__dirname, '../../../manager/apps');
+export const modulesBasePath = resolve(__dirname, '../../../manager/modules');
 
 /**
  * Check if a given app is a React application

--- a/packages/manager-tools/manager-cli/utils/ExportUtils.mjs
+++ b/packages/manager-tools/manager-cli/utils/ExportUtils.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-export const reportOutputBasePath = resolve(__dirname, '../../../migration-status-reports');
+export const reportOutputBasePath = resolve(__dirname, '../../../../migration-status-reports');
 
 export const buildRoutesReportFileName = (outputFormat) => outputFormat === 'json'
   ? `${reportOutputBasePath}/routes-migration-report.json`

--- a/packages/manager-tools/manager-cli/utils/ScriptUtils.mjs
+++ b/packages/manager-tools/manager-cli/utils/ScriptUtils.mjs
@@ -7,10 +7,10 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import path, { dirname, resolve, join } from 'path';
 import { isCodeFileExistsSync } from './CodeTransformUtils.mjs';
+import { applicationsBasePath } from './AppUtils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const basePath = path.resolve('../manager/apps');
 
 /**
  * Runs a migration or setup process for a specific app or globally.
@@ -47,7 +47,7 @@ export const runMigration = ({
   enableLintFix = true,
   onEnd = () => {},
 }) => {
-  const appPath = appName ? path.join(basePath, appName) : null;
+  const appPath = appName ? path.join(applicationsBasePath, appName) : null;
 
   if (appName) {
     const isValidAppName = /^[a-zA-Z0-9_-]+$/.test(appName);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Check and fix all manager-cli commands after tools folder migration:
```js
hbenkhal@K59LFGX5Y4 manager % yarn manager-cli --help
yarn run v1.22.22
$ yarn workspace @ovh-ux/manager-cli run manager-cli --help
$ node ./manager-cli.mjs --help

🛠️  manager-cli

Usage:
  yarn manager-cli <command> [--app <app-name>] [--testType <unit|integration>] [--framework <name>] [--dry-run] [--type <routes|tests|swc>] [--format <json|html>]

Options:
  --list                  List available app names
  --help, -h              Show this help message

Commands:
  routes-migrate       Migrate React Router config from JSON to JSX components
  tests-migrate        Migrate test setup (unit, integration...) to centralized shared configuration (Vitest, Jest...)
  duplicated-translations Check for duplicate translations that already exist in the common module.
  static-analysis-migrate Migrate ESLint & TS config to static-analysis-kit (safe defaults + recommendations)
  migrations-status    Check status of all migrations across all apps

Examples:

# Migrate routes and affecting files
yarn manager-cli routes-migrate --app zimbra

# Preview changes without affecting files
yarn manager-cli routes-migrate --app zimbra --dry-run

# Migrate a unit test setup with Vitest (affect files)
yarn manager-cli tests-migrate --app zimbra --testType unit

# Migrate an integration test setup with Jest (affect files)
yarn manager-cli tests-migrate --app zimbra --testType integration --framework jest

# Preview changes without applying them (without affecting files)
yarn manager-cli tests-migrate --app zimbra --testType unit --dry-run

#Check duplicated translations on zimbra app
yarn manager-cli duplicated-translations --app zimbra

# Migrate to static-analysis-kit for an app (non-destructive)
yarn manager-cli static-analysis-migrate --app zimbra

# Preview changes without writing files
yarn manager-cli static-analysis-migrate --app zimbra --dry-run

# Check all migrations
yarn manager-cli migrations-status --type all

# Filter by type (routes, tests, swc, static-kit, all)
yarn manager-cli migrations-status --type routes
yarn manager-cli migrations-status --type tests
yarn manager-cli migrations-status --type swc
yarn manager-cli migrations-status --type static-kit

# Export as HTML or JSON
yarn manager-cli migrations-status --type routes --format json
yarn manager-cli migrations-status --type tests --format html

yarn manager-cli migrations-status --type all --format html
yarn manager-cli migrations-status --type all --format json

------------------------------------------------------------------------------------------
  yarn manager-cli --list
  yarn manager-cli --help
------------------------------------------------------------------------------------------

✨  Done in 0.92s.
hbenkhal@K59LFGX5Y4 manager % 
```

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19100

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->

<img width="822" height="393" alt="image" src="https://github.com/user-attachments/assets/39c9d300-cb91-4a05-b11b-1fec138396db" />
<img width="1441" height="683" alt="image" src="https://github.com/user-attachments/assets/b2677278-0edf-41b9-8264-27ec145e0958" />

