### PR TITLE
fix(container): use native js object name property for modal name

### DIFF
--- a/packages/manager/apps/container/src/components/SuggestionModal/SuggestionModal.component.tsx
+++ b/packages/manager/apps/container/src/components/SuggestionModal/SuggestionModal.component.tsx
@@ -68,7 +68,7 @@ const SuggestionModal: FC = () => {
 
   const closeModal = () => useCallback(() => {
     setShowModal(false);
-    ux.notifyModalActionDone(SuggestionModal.displayName);
+    ux.notifyModalActionDone(SuggestionModal.name);
     // Update preference so the modal is not display until 30 days later, time for the update to be done on our side
     const DAYS_DELAY = 30;
     updatePreference(time + DAYS_DELAY * 24 * 60 * 60);
@@ -94,7 +94,7 @@ const SuggestionModal: FC = () => {
     if (shouldDisplayModal !== undefined) {
       setShowModal(shouldDisplayModal);
       if (!shouldDisplayModal) {
-        ux.notifyModalActionDone(SuggestionModal.displayName);
+        ux.notifyModalActionDone(SuggestionModal.name);
       } else {
         // only trigger tracking if the modal is actually displayed and not skipped
         tracking.trackPage({

--- a/packages/manager/apps/container/src/identity-documents-modal/IdentityDocumentsModal.tsx
+++ b/packages/manager/apps/container/src/identity-documents-modal/IdentityDocumentsModal.tsx
@@ -61,7 +61,7 @@ export const IdentityDocumentsModal: FC = () => {
 
   const onCancel = () => {
     setShowModal(false);
-    uxPlugin.notifyModalActionDone(IdentityDocumentsModal.displayName);
+    uxPlugin.notifyModalActionDone(IdentityDocumentsModal.name);
     trackingPlugin.trackClick({
       name: `${trackingPrefix}::pop-up::link::kyc::cancel`,
       type: 'action',
@@ -93,7 +93,7 @@ export const IdentityDocumentsModal: FC = () => {
         updatePreference(time);
       }
       else {
-        uxPlugin.notifyModalActionDone(IdentityDocumentsModal.displayName);
+        uxPlugin.notifyModalActionDone(IdentityDocumentsModal.name);
       }
     }
   }, [shouldDisplayModal]);

--- a/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
+++ b/packages/manager/apps/container/src/payment-modal/PaymentModal.tsx
@@ -58,7 +58,7 @@ const PaymentModal: FC = () => {
 
   const closeHandler = () => {
     setShowPaymentModal(false);
-    ux.notifyModalActionDone(PaymentModal.displayName);
+    ux.notifyModalActionDone(PaymentModal.name);
   };
   const validateHandler = () => {
     setShowPaymentModal(false);
@@ -69,7 +69,7 @@ const PaymentModal: FC = () => {
     if (shouldDisplayModal !== undefined) {
       setShowPaymentModal(shouldDisplayModal);
       if (!shouldDisplayModal) {
-        ux.notifyModalActionDone(PaymentModal.displayName);
+        ux.notifyModalActionDone(PaymentModal.name);
       }
     }
   }, [shouldDisplayModal]);


### PR DESCRIPTION
## Description

Changed name used to notify a modal action is done to use native property name instead of displayName which was undefined


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-14721

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
