### PR TITLE
Fix tab settings not activated when selected

### DIFF
--- a/packages/manager/apps/pci-project/src/hooks/useProjectTabs.ts
+++ b/packages/manager/apps/pci-project/src/hooks/useProjectTabs.ts
@@ -1,0 +1,29 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { PROJECT_TABS } from '@/constants/tabs.constant';
+
+export type ProjectTabWithFullPath = {
+  name: string;
+  titleKey: string;
+  title: string;
+  to: string; // Full path instead of relative path
+};
+
+/**
+ * Hook to build complete paths for project tabs
+ * Fixes the issue where TabsPanel doesn't activate tabs correctly due to path mismatch
+ */
+export const useProjectTabs = (): ProjectTabWithFullPath[] => {
+  const { t } = useTranslation('project');
+  const { projectId } = useParams<{ projectId: string }>();
+
+  return PROJECT_TABS.map((tab) => ({
+    ...tab,
+    title: t(tab.titleKey),
+    // Construct full path based on the route structure
+    to:
+      tab.to === ''
+        ? `/pci/projects/${projectId}` // Home tab (empty string)
+        : `/pci/projects/${projectId}/${tab.to}`, // Settings tab ('edit')
+  }));
+};

--- a/packages/manager/apps/pci-project/src/pages/home/Header.page.tsx
+++ b/packages/manager/apps/pci-project/src/pages/home/Header.page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@ovhcloud/ods-components/react';
 
 import { ROADMAP_CHANGELOG_LINKS } from '@/constants';
-import { PROJECT_TABS } from '@/constants/tabs.constant';
+import { useProjectTabs } from '@/hooks/useProjectTabs';
 import QuotaAlert from './components/QuotaAlert.component';
 
 export default function ProjectHeader() {
@@ -27,11 +27,7 @@ export default function ProjectHeader() {
 
   const hrefProject = useProjectUrl('public-cloud');
   const { data: project, isLoading, error } = useProject();
-
-  const tabs = PROJECT_TABS.map((tab) => ({
-    ...tab,
-    title: t(tab.titleKey),
-  }));
+  const tabs = useProjectTabs();
 
   const isDiscovery = isDiscoveryProject(project);
 


### PR DESCRIPTION
Fix : Tab settings not activated when selected.
Bug : MRC cannot compare relative path, only absolute.

Here’s the least bad solution I could come up with : calculate the absolute path to give it to MRC.