### PR TITLE
fix(account): allow contacts sub routes to be defined early

### DIFF
--- a/packages/manager/modules/account/src/account.module.js
+++ b/packages/manager/modules/account/src/account.module.js
@@ -1,5 +1,6 @@
-import contacts from './contacts';
+import contacts from './contacts/user-contacts.module';
 import contactUpdate from './contacts/update';
+import contactRequest from './contacts/request';
 import redirection from './account.redirection';
 import routing from './account.routing';
 import user from './user';
@@ -19,6 +20,7 @@ angular
   .module(moduleName, [
     contacts,
     contactUpdate,
+    contactRequest,
     'oui',
     'pascalprecht.translate',
     'ui.bootstrap',

--- a/packages/manager/modules/account/src/account.redirection.js
+++ b/packages/manager/modules/account/src/account.redirection.js
@@ -8,7 +8,7 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
   // make a redirect to the new url of ui route
   $urlRouterProvider.when(
     /^\/useraccount\/contacts\/[0-9]+$/,
-    ($location, $state, $window) => {
+    ($location, $state, $window, coreURLBuilder) => {
       const hasToken = has($location.search(), 'token');
       const requestTabAsked = get($location.search(), 'tab') === 'REQUESTS';
 
@@ -19,8 +19,12 @@ export default /* @ngInject */ ($stateProvider, $urlRouterProvider) => {
       const taskId = last($location.path().split('/'));
       const token = get($location.search(), 'token');
 
-      $state.go('account.contacts.requests', { taskId, token });
-      return $window.reload();
+      // eslint-disable-next-line no-param-reassign
+      $window.top.location.href = coreURLBuilder.buildURL(
+        'account',
+        $state.href('account.contacts.requests', { taskId, token }),
+      );
+      return false;
     },
   );
 

--- a/packages/manager/modules/account/src/contacts/request/index.js
+++ b/packages/manager/modules/account/src/contacts/request/index.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+import '@uirouter/angularjs';
+import 'oclazyload';
+
+const moduleName = 'ovhManagerAccountContactsRequestLazyLoading';
+
+angular.module(moduleName, ['ui.router', 'oc.lazyLoad']).config(
+  /* @ngInject */ ($stateProvider) => {
+    console.log('Registering contacts request lazy loading');
+    $stateProvider.state('account.contact-requests.**', {
+      url: '/requests',
+      lazyLoad: ($transition$) => {
+        const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+        return import('./user-contacts-request.module').then((mod) =>
+          $ocLazyLoad.inject(mod.default || mod),
+        );
+      },
+    });
+  },
+);
+
+export default moduleName;


### PR DESCRIPTION
## Description

Reomve lazy loading for the contacts page in order to be able to get correct href for its sub routes used for the account redirections


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19475

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
