### PR TITLE
fix(pci-instances): sync cache to display the right action status

### DIFF
--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/action/useInstanceAction.spec.tsx
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/action/useInstanceAction.spec.tsx
@@ -4,7 +4,7 @@ import { FC, PropsWithChildren } from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { isAxiosError } from 'axios';
-import { updateInstanceFromCache, useInstances } from '../useInstances';
+import { updateInstancesFromCache, useInstances } from '../useInstances';
 import { setupInstancesServer } from '@/__mocks__/instance/node';
 import { TAggregatedInstanceDto } from '@/types/instance/api.type';
 import { TInstancesServerResponse } from '@/__mocks__/instance/handlers';
@@ -84,7 +84,7 @@ let server: SetupServer;
 const handleError = vi.fn();
 const handleSuccess = vi.fn(
   (instance: TAggregatedInstanceDto, queryClient: QueryClient) => () =>
-    updateInstanceFromCache(queryClient, {
+    updateInstancesFromCache(queryClient, {
       projectId: fakeProjectId,
       instance: { ...instance, pendingTask: true },
     }),

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.spec.tsx
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.spec.tsx
@@ -1,18 +1,28 @@
 import { describe, expect, test } from 'vitest';
-import { buildPartialInstanceDto } from './instanceDto.builder';
+import {
+  buildPartialInstanceDto,
+  buildPartialInstanceFromInstancesDto,
+} from './instanceDto.builder';
 import {
   TAggregatedInstanceDto,
-  TPartialInstanceDto,
+  TPartialAggregatedInstanceDto,
 } from '@/types/instance/api.type';
+import { TPartialInstance } from '@/types/instance/entity.type';
 
 type Data = {
   desc: string;
-  initial: TPartialInstanceDto;
+  initial: TPartialAggregatedInstanceDto;
   steps: [
     keyof TAggregatedInstanceDto,
     TAggregatedInstanceDto[keyof TAggregatedInstanceDto],
   ][];
-  expected: TPartialInstanceDto;
+  expected: TPartialAggregatedInstanceDto;
+};
+
+type TInstanceDtoData = {
+  desc: string;
+  dto: TPartialAggregatedInstanceDto;
+  expected: TPartialInstance;
 };
 
 describe("Considering the 'buildPartialInstanceDto' function", () => {
@@ -61,6 +71,119 @@ describe("Considering the 'buildPartialInstanceDto' function", () => {
     });
 
     const result = builder.build();
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("Considering the 'buildPartialInstanceFromInstancesDto' function", () => {
+  test.each<TInstanceDtoData>([
+    {
+      desc: 'Should return TInstance with only id and name',
+      dto: {
+        id: 'instance-1',
+        name: 'instance 1',
+        flavorId: 'fake-flavor',
+        flavorName: 'fake-flavor-name',
+      },
+      expected: { id: 'instance-1', name: 'instance 1' },
+    },
+    {
+      desc: 'Should return TInstance with id and region',
+      dto: {
+        id: 'instance-1',
+        flavorId: 'fake-flavor',
+        flavorName: 'fake-flavor-name',
+        region: 'fake-region',
+      },
+      expected: {
+        id: 'instance-1',
+        region: { name: 'fake-region', type: '', availabilityZone: null },
+      },
+    },
+    {
+      desc: 'Should return TInstance with id and region',
+      dto: {
+        id: 'instance-1',
+        flavorId: 'fake-flavor',
+        flavorName: 'fake-flavor-name',
+        region: 'fake-region',
+        availabilityZone: 'fake-availabilityZone',
+      },
+      expected: {
+        id: 'instance-1',
+        region: {
+          name: 'fake-region',
+          type: '',
+          availabilityZone: 'fake-availabilityZone',
+        },
+      },
+    },
+    {
+      desc: 'Should return TInstance with id and status',
+      dto: {
+        id: 'instance-1',
+        status: 'BUILDING',
+      },
+      expected: {
+        id: 'instance-1',
+        status: 'BUILDING',
+      },
+    },
+    {
+      desc: 'Should return TInstance with id and task',
+      dto: {
+        id: 'instance-1',
+        pendingTask: true,
+        taskState: 'waiting',
+      },
+      expected: {
+        id: 'instance-1',
+        task: {
+          isPending: true,
+          status: 'waiting',
+        },
+      },
+    },
+    {
+      desc: 'Should return TInstance with id and task',
+      dto: {
+        id: 'instance-1',
+        pendingTask: false,
+        taskState: 'ACTIVE',
+      },
+      expected: {
+        id: 'instance-1',
+        task: {
+          isPending: false,
+          status: 'ACTIVE',
+        },
+      },
+    },
+    {
+      desc: 'Should return TInstance with actions',
+      dto: {
+        id: 'instance-1',
+        actions: [{ name: 'activate_monthly_billing', group: 'details' }],
+      },
+      expected: {
+        id: 'instance-1',
+        actions: [{ name: 'activate_monthly_billing', group: 'details' }],
+      },
+    },
+    {
+      desc: 'Should return TInstance with volumes',
+      dto: {
+        id: 'instance-1',
+        volumes: [{ id: 'fake-volume-1', name: 'fake-volume-1' }],
+      },
+      expected: {
+        id: 'instance-1',
+        volumes: [{ id: 'fake-volume-1', name: 'fake-volume-1', size: null }],
+      },
+    },
+  ])('$desc', ({ dto, expected }: TInstanceDtoData) => {
+    const result = buildPartialInstanceFromInstancesDto(dto);
+
     expect(result).toEqual(expected);
   });
 });

--- a/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.ts
+++ b/packages/manager/apps/pci-instances/src/data/hooks/instance/builder/instanceDto.builder.ts
@@ -1,9 +1,12 @@
 import {
   TAggregatedInstanceDto,
-  TPartialInstanceDto,
+  TPartialAggregatedInstanceDto,
 } from '@/types/instance/api.type';
+import { TPartialInstance } from '@/types/instance/entity.type';
 
-export const buildPartialInstanceDto = (initial: TPartialInstanceDto) => ({
+export const buildPartialInstanceDto = (
+  initial: TPartialAggregatedInstanceDto,
+) => ({
   with<K extends keyof TAggregatedInstanceDto>(
     key: K,
     value: TAggregatedInstanceDto[K],
@@ -14,3 +17,61 @@ export const buildPartialInstanceDto = (initial: TPartialInstanceDto) => ({
     return initial;
   },
 });
+
+export const buildPartialInstanceFromInstancesDto = (
+  dto: TPartialAggregatedInstanceDto,
+): TPartialInstance => {
+  const baseInstance: TPartialInstance = { id: dto.id };
+
+  const withName = (instance: TPartialInstance) =>
+    dto.name ? { ...instance, name: dto.name } : instance;
+
+  const withRegion = (instance: TPartialInstance) =>
+    dto.region
+      ? {
+          ...instance,
+          region: {
+            name: dto.region,
+            type: '',
+            availabilityZone: dto.availabilityZone ?? null,
+          },
+        }
+      : instance;
+
+  const withStatus = (instance: TPartialInstance) =>
+    dto.status ? { ...instance, status: dto.status } : instance;
+
+  const withTask = (instance: TPartialInstance) =>
+    dto.pendingTask !== undefined
+      ? {
+          ...instance,
+          task: {
+            status: dto.taskState ?? null,
+            isPending: dto.pendingTask,
+          },
+        }
+      : instance;
+
+  const withActions = (instance: TPartialInstance) =>
+    dto.actions ? { ...instance, actions: dto.actions } : instance;
+
+  const withVolumes = (instance: TPartialInstance) =>
+    dto.volumes
+      ? {
+          ...instance,
+          volumes: dto.volumes.map((volume) => ({
+            ...volume,
+            size: null,
+          })),
+        }
+      : instance;
+
+  return [
+    withName,
+    withRegion,
+    withStatus,
+    withTask,
+    withActions,
+    withVolumes,
+  ].reduce((acc, fn) => fn(acc), baseInstance);
+};

--- a/packages/manager/apps/pci-instances/src/pages/instances/action/InstanceAction.page.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/action/InstanceAction.page.tsx
@@ -6,7 +6,7 @@ import { DefaultError } from '@tanstack/react-query';
 import { OsdsLink } from '@ovhcloud/ods-components/react';
 import { OdsHTMLAnchorElementTarget } from '@ovhcloud/ods-common-core';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-import { updateInstanceFromCache } from '@/data/hooks/instance/useInstances';
+import { updateInstancesFromCache } from '@/data/hooks/instance/useInstances';
 import NotFound from '@/pages/404/NotFound.page';
 import queryClient from '@/queryClient';
 import { isApiErrorResponse, replaceToSnakeCase } from '@/utils';
@@ -41,7 +41,7 @@ const InstanceAction: FC = () => {
   const executeSuccessCallback = useCallback((): void => {
     if (!instance) return;
     const newInstance = { id: instance.id, pendingTask: true, actions: [] };
-    updateInstanceFromCache(queryClient, {
+    updateInstancesFromCache(queryClient, {
       projectId,
       instance: newInstance,
     });

--- a/packages/manager/apps/pci-instances/src/pages/instances/action/hooks/useInstanceActionModal.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/action/hooks/useInstanceActionModal.tsx
@@ -11,8 +11,11 @@ import {
   selectInstanceForActionModal,
   TInstanceActionModalViewModel,
 } from '../view-models/selectInstanceForActionModal';
-import { getInstanceById } from '@/data/hooks/instance/useInstances';
-import { useInstance } from '@/data/hooks/instance/useInstance';
+import { getAggregatedInstanceById } from '@/data/hooks/instance/useInstances';
+import {
+  useInstance,
+  getInstanceById,
+} from '@/data/hooks/instance/useInstance';
 
 const formatSection = (section: TSectionType | null): string | null => {
   if (!section) return null;
@@ -51,7 +54,9 @@ export const useInstanceActionModal = (
   const { t } = useTranslation('actions');
 
   const aggregatedInstance = useMemo(
-    () => getInstanceById(projectId, instanceId, queryClient),
+    () =>
+      getAggregatedInstanceById(projectId, instanceId, queryClient) ??
+      getInstanceById(projectId, instanceId || '', queryClient),
     [instanceId, projectId, queryClient],
   );
 

--- a/packages/manager/apps/pci-instances/src/pages/instances/action/view-models/selectInstanceForActionModal.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/action/view-models/selectInstanceForActionModal.ts
@@ -12,7 +12,7 @@ export type TInstanceActionModalViewModel = {
 
 const mapAggregatedInstanceDto = (instance: TAggregatedInstanceDto) => ({
   isImageDeprecated: instance.isImageDeprecated,
-  ip: instance.addresses[0]?.ip,
+  ip: instance.addresses[0]?.ip ?? '',
   region: instance.region,
   imageId: instance.imageId,
 });

--- a/packages/manager/apps/pci-instances/src/pages/instances/datagrid/hooks/useDatagridPolling.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/datagrid/hooks/useDatagridPolling.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { useNotifications } from '@ovh-ux/manager-react-components';
 import { ApiError } from '@ovh-ux/manager-core-api';
 import { useTranslation } from 'react-i18next';
-import { updateInstanceFromCache } from '@/data/hooks/instance/useInstances';
+import { updateInstancesFromCache } from '@/data/hooks/instance/useInstances';
 import { TInstance } from '@/types/instance/entity.type';
 import { useProjectId } from '@/hooks/project/useProjectId';
 import { buildPartialInstanceDto } from '@/data/hooks/instance/builder/instanceDto.builder';
@@ -43,7 +43,7 @@ export const useDatagridPolling = (pendingTasks: TPendingTask[]) => {
       const { status, task } = instance;
       const isDeleted = !task.isPending && status === 'DELETED';
       const deletedInstance = getPartialDeletedInstanceDto(instance.id);
-      updateInstanceFromCache(queryClient, {
+      updateInstancesFromCache(queryClient, {
         projectId,
         instance: isDeleted ? deletedInstance : getPartialInstanceDto(instance),
       });
@@ -65,7 +65,7 @@ export const useDatagridPolling = (pendingTasks: TPendingTask[]) => {
     (error: ApiError, instanceId: string) => {
       if (error.response?.status === 404) {
         const deletedInstance = getPartialDeletedInstanceDto(instanceId);
-        updateInstanceFromCache(queryClient, {
+        updateInstancesFromCache(queryClient, {
           projectId,
           instance: deletedInstance,
         });

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/Instance.page.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/Instance.page.tsx
@@ -59,9 +59,7 @@ const Instance: FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex-[0.8]">
               <LoadingCell isLoading={isInstanceLoading}>
-                {instance && (
-                  <InstanceName instance={instance} region={regionId} />
-                )}
+                {instance && <InstanceName instance={instance} />}
               </LoadingCell>
             </div>
             <div className="flex gap-x-3">

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/components/InstanceName.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/components/InstanceName.component.tsx
@@ -5,29 +5,31 @@ import { clsx } from 'clsx';
 import EditableText from '@/components/input/editableContent/EditableContent.component';
 import { useUpdateInstanceName } from '@/data/hooks/instance/useInstance';
 import { useProjectId } from '@/hooks/project/useProjectId';
-import { updateDashboardCache } from '../hooks/useDashboard';
 import { TInstanceDashboardViewModel } from '../view-models/selectInstanceDashboard';
+import { updateInstancesFromCache } from '@/data/hooks/instance/useInstances';
+import { useQueryClient } from '@tanstack/react-query';
 
 type TInstanceNameProps = {
   instance: NonNullable<TInstanceDashboardViewModel>;
-  region: string;
 };
 
-const InstanceName: FC<TInstanceNameProps> = ({ instance, region }) => {
+const InstanceName: FC<TInstanceNameProps> = ({ instance }) => {
   const { t } = useTranslation('dashboard');
+  const queryClient = useQueryClient();
   const { addError } = useNotifications();
   const projectId = useProjectId();
 
   const handleSuccessUpdate = useCallback(
-    (value: string) => {
-      updateDashboardCache({
+    (newInstanceName: string) => {
+      updateInstancesFromCache(queryClient, {
         projectId,
-        instanceId: instance.id,
-        region,
-        payload: { name: value },
+        instance: {
+          id: instance.id,
+          name: newInstanceName,
+        },
       });
     },
-    [instance.id, projectId],
+    [instance.id, projectId, queryClient],
   );
 
   const {

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/hooks/useDashboard.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/hooks/useDashboard.ts
@@ -2,9 +2,6 @@ import { useMemo } from 'react';
 import { useProjectUrl } from '@ovh-ux/manager-react-components';
 import { useInstance } from '@/data/hooks/instance/useInstance';
 import { selectInstanceDashboard } from '../view-models/selectInstanceDashboard';
-import { TInstance } from '@/types/instance/entity.type';
-import { instancesQueryKey } from '@/utils';
-import queryClient from '@/queryClient';
 
 type TUseDashboardArgs = {
   region: string | null;
@@ -27,37 +24,6 @@ export const useDashboard = ({ region, instanceId }: TUseDashboardArgs) => {
       instance: selectInstanceDashboard(projectUrl, instance),
       isPending,
     }),
-    [instance, isPending],
-  );
-};
-
-type TUpdateDashboardCacheArgs = {
-  projectId: string;
-  instanceId: string;
-  region: string;
-  payload: Partial<TInstance>;
-};
-
-export const updateDashboardCache = ({
-  projectId,
-  instanceId,
-  region,
-  payload,
-}: TUpdateDashboardCacheArgs) => {
-  queryClient.setQueryData<TInstance>(
-    instancesQueryKey(projectId, [
-      'region',
-      region,
-      'instance',
-      instanceId,
-      'withBackups',
-      'withImage',
-      'withNetworks',
-      'withVolumes',
-    ]),
-    (prevData) => {
-      if (!prevData) return undefined;
-      return { ...prevData, ...payload };
-    },
+    [instance, isPending, projectUrl],
   );
 };

--- a/packages/manager/apps/pci-instances/src/types/instance/api.type.ts
+++ b/packages/manager/apps/pci-instances/src/types/instance/api.type.ts
@@ -53,7 +53,7 @@ export type TAggregatedInstanceDto = {
   isImageDeprecated: boolean;
 };
 
-export type TPartialInstanceDto = Pick<TAggregatedInstanceDto, 'id'> &
+export type TPartialAggregatedInstanceDto = Pick<TAggregatedInstanceDto, 'id'> &
   Partial<TAggregatedInstanceDto>;
 
 export type TRetrieveInstancesQueryParams = DeepReadonly<{


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

This PR fix inconsistency cache data when performing action.

Listing page and dashboard page shared some common data. When after an action, both cache have to be updated to display good information and to sync the data polling.

I have create a function builder to build a Partial `TInstance` (which is needed by the dashboard) from a Partial `TAggregatedInstanceDto` (which is the listing data type). 

I will think about a good way to handle that and if we can have the same type of data 

<!-- Provide Jira ticket or Github issue -->
- Ticket Reference: #TAPC-4785

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
