### PR TITLE
feat(mrc): add loading and custom element in stepper next button

### DIFF
--- a/packages/manager-react-components/src/components/container/step/Step.component.tsx
+++ b/packages/manager-react-components/src/components/container/step/Step.component.tsx
@@ -21,6 +21,7 @@ export type TStepProps = {
     action: (id: string) => void;
     label: string | JSX.Element;
     isDisabled?: boolean;
+    isLoading?: boolean;
   };
   edit?: {
     action: (id: string) => void;
@@ -127,16 +128,21 @@ export const StepComponent = ({
               <div className="flex items-center gap-6 mt-6">
                 {next?.action && !isLocked && (
                   <div data-testid="next">
-                    <OdsButton
-                      data-testid="next-cta"
-                      label={next.label as string}
-                      size={ODS_BUTTON_SIZE.md}
-                      onClick={() => {
-                        next.action(id);
-                      }}
-                      className="w-fit"
-                      isDisabled={next.isDisabled || undefined}
-                    />
+                    {typeof next.label === 'string' ? (
+                      <OdsButton
+                        data-testid="next-cta"
+                        label={next.label}
+                        size={ODS_BUTTON_SIZE.md}
+                        onClick={() => {
+                          next.action(id);
+                        }}
+                        className="w-fit"
+                        isDisabled={next.isDisabled || undefined}
+                        isLoading={next.isLoading || false}
+                      />
+                    ) : (
+                      next.label
+                    )}
                   </div>
                 )}
                 {skip?.action && (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Currently, stepper 'next' button does not handle loading state and custom button elements.
Two features needed in pci-project application for the following reasons:

Form submission can take up to 6 seconds. Without a loading state, the user experience feels bad
Paypal payment requires a special "Paypal" button, impossible to do with the current stepper

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #18754 

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
