### PR TITLE
feat(network-security): enabling network security data display up to 2 months

### DIFF
--- a/packages/manager/apps/dedicated/client/app/network-security/network-security.constant.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/network-security.constant.js
@@ -55,10 +55,13 @@ export const GUIDE_LINKS = {
 
 export const TRACKING_PREFIX = 'network-security::anti-ddos-dashboard';
 
+export const TRAFFIC_MAX_DATA_RETENTION_DAYS = 60;
+
 export default {
   API_PATH,
   PAGE_SIZE,
   ENTITY,
   GUIDE_LINKS,
   TRACKING_PREFIX,
+  TRAFFIC_MAX_DATA_RETENTION_DAYS,
 };

--- a/packages/manager/apps/dedicated/client/app/network-security/scrubbing-center/scrubbing-center.controller.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/scrubbing-center/scrubbing-center.controller.js
@@ -1,6 +1,9 @@
 import { AbstractCursorDatagridController } from '@ovh-ux/manager-ng-apiv2-helper';
 import { PERIODS, PERIOD_LIST } from './scrubbing-center.constant';
-import { PAGE_SIZE } from '../network-security.constant';
+import {
+  PAGE_SIZE,
+  TRAFFIC_MAX_DATA_RETENTION_DAYS,
+} from '../network-security.constant';
 import NetworkSecurityService from '../network-security.service';
 
 export default class ScrubbingCenterController extends AbstractCursorDatagridController {
@@ -15,6 +18,7 @@ export default class ScrubbingCenterController extends AbstractCursorDatagridCon
     this.PERIODS = PERIODS;
     this.PERIOD_LIST = PERIOD_LIST;
     this.PAGE_SIZE = PAGE_SIZE;
+    this.TRAFFIC_MAX_DATA_RETENTION_DAYS = TRAFFIC_MAX_DATA_RETENTION_DAYS;
   }
 
   $onInit() {
@@ -142,7 +146,9 @@ export default class ScrubbingCenterController extends AbstractCursorDatagridCon
 
   static displayAction(row) {
     const twoWeeksDate = new Date();
-    twoWeeksDate.setDate(twoWeeksDate.getDate() - 14);
+    twoWeeksDate.setDate(
+      twoWeeksDate.getDate() - TRAFFIC_MAX_DATA_RETENTION_DAYS,
+    );
     let result = false;
     if (!row.endedAt || row.endedAt > twoWeeksDate.toISOString()) {
       result = true;

--- a/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.constant.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.constant.js
@@ -8,6 +8,14 @@ export const TRAFFIC_PERIODS = [
     key: 'last14d',
     value: 'network_security_dashboard_filter_14_days',
   },
+  {
+    key: 'last1M',
+    value: 'network_security_dashboard_filter_1_month',
+  },
+  {
+    key: 'last2M',
+    value: 'network_security_dashboard_filter_2_months',
+  },
 ];
 
 export const TRAFFIC_PERIOD_LIST = {
@@ -15,6 +23,8 @@ export const TRAFFIC_PERIOD_LIST = {
   last24h: 'last24h',
   last7d: 'last7d',
   last14d: 'last14d',
+  last1M: 'last1M',
+  last2M: 'last2M',
 };
 
 export const CHART = {
@@ -139,4 +149,9 @@ export const CHART = {
   units: ['b', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb'],
 };
 
-export default { PAGE_SIZE, TRAFFIC_PERIODS, TRAFFIC_PERIOD_LIST, CHART };
+export default {
+  PAGE_SIZE,
+  TRAFFIC_PERIODS,
+  TRAFFIC_PERIOD_LIST,
+  CHART,
+};

--- a/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.controller.js
+++ b/packages/manager/apps/dedicated/client/app/network-security/traffic/traffic.controller.js
@@ -5,6 +5,7 @@ import {
   TRAFFIC_PERIOD_LIST,
   CHART,
 } from './traffic.constant';
+import { TRAFFIC_MAX_DATA_RETENTION_DAYS } from '../network-security.constant';
 
 export default class TrafficController {
   /* @ngInject */
@@ -16,6 +17,7 @@ export default class TrafficController {
 
     this.TRAFFIC_PERIODS = TRAFFIC_PERIODS;
     this.TRAFFIC_PERIOD_LIST = TRAFFIC_PERIOD_LIST;
+    this.TRAFFIC_MAX_DATA_RETENTION_DAYS = TRAFFIC_MAX_DATA_RETENTION_DAYS;
     this.CHART = CHART;
     this.PAGE_SIZE = PAGE_SIZE;
   }
@@ -38,7 +40,9 @@ export default class TrafficController {
 
     if (this.dateTime) {
       const dateLimit = new Date();
-      dateLimit.setDate(dateLimit.getDate() - 14);
+      dateLimit.setDate(
+        dateLimit.getDate() - this.TRAFFIC_MAX_DATA_RETENTION_DAYS,
+      );
       if (this.dateTime >= dateLimit) {
         const customPeriod = {
           name: 'custom',
@@ -153,6 +157,12 @@ export default class TrafficController {
         break;
       case this.TRAFFIC_PERIOD_LIST.last14d:
         after.setDate(after.getDate() - 14);
+        break;
+      case this.TRAFFIC_PERIOD_LIST.last1M:
+        after.setDate(after.getDate() - 30);
+        break;
+      case this.TRAFFIC_PERIOD_LIST.last2M:
+        after.setDate(after.getDate() - 60);
         break;
       case 'custom':
         after.setTime(this.dateTime);

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_de_DE.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Zeitzone: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Datenverkehrsdiagramme",
   "network_security_dashboard_filter_custom": "Personalisiert",
-  "network_security_dashboard_warning_period": "Achtung: Die gewünschten Daten sind nicht verfügbar. Beachten Sie, dass Traffic-Daten 14 Tage lang aufbewahrt werden.",
-  "network_security_dashboard_warning_default": "Stattdessen wird das aktuelle Datenverkehrsdiagramm für die ausgewählte IP-Adresse angezeigt."
+  "network_security_dashboard_warning_period": "Achtung: Die angeforderten Daten sind nicht verfügbar, da die Aufbewahrungsdauer der Traffic-Daten überschritten wurde.",
+  "network_security_dashboard_warning_default": "Stattdessen wird das aktuelle Datenverkehrsdiagramm für die ausgewählte IP-Adresse angezeigt.",
+  "network_security_dashboard_filter_1_month": "1 Monat",
+  "network_security_dashboard_filter_2_months": "2 Monate"
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_en_GB.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Timezone: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Traffic graphs",
   "network_security_dashboard_filter_custom": "Custom",
-  "network_security_dashboard_warning_period": "Warning: the requested data is unavailable. Keep in mind that traffic data is only stored for 14 days.",
-  "network_security_dashboard_warning_default": "Instead of the selected IP address, the recent traffic graph will be shown."
+  "network_security_dashboard_warning_period": "Warning: the requested data is no longer available, as the retention period for traffic data has ended.",
+  "network_security_dashboard_warning_default": "Instead of the selected IP address, the recent traffic graph will be shown.",
+  "network_security_dashboard_filter_1_month": "1 month",
+  "network_security_dashboard_filter_2_months": "2 months"
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_es_ES.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Zona horaria: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Gráficos de tráfico",
   "network_security_dashboard_filter_custom": "Personalizado",
-  "network_security_dashboard_warning_period": "Atención: Los datos solicitados no están disponibles. Tenga en cuenta que el período de conservación de los datos de tráfico es de 14 días.",
-  "network_security_dashboard_warning_default": "En su lugar, se mostrará un gráfico del tráfico reciente para la dirección IP seleccionada."
+  "network_security_dashboard_warning_period": "Atención: los datos solicitados no están disponibles porque se ha superado el tiempo de conservación de los datos de tráfico.",
+  "network_security_dashboard_warning_default": "En su lugar, se mostrará un gráfico del tráfico reciente para la dirección IP seleccionada.",
+  "network_security_dashboard_filter_1_month": "1 mes",
+  "network_security_dashboard_filter_2_months": "2 meses"
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_CA.json
@@ -18,6 +18,8 @@
   "network_security_dashboard_filter_24_hours": "24 heures",
   "network_security_dashboard_filter_7_days": "7 jours",
   "network_security_dashboard_filter_14_days": "14 jours",
+  "network_security_dashboard_filter_1_month": "1 mois",
+  "network_security_dashboard_filter_2_months": "2 mois",
   "network_security_dashboard_filter_day": "Jour",
   "network_security_dashboard_filter_week": "Semaine",
   "network_security_dashboard_filter_month": "Mois",
@@ -65,6 +67,6 @@
   "network_security_dashboard_like_this_tooltip": "Vous aimez cette page ? Faites nous part de vos remarques !",
   "network_security_dashboard_refresh": "Raffraîchir les données",
   "network_security_dashboard_time_zone": "(Timezone: UTC{{ timeZoneOffset }})",
-  "network_security_dashboard_warning_period": "Attention: les données demandées ne sont pas disponibles. Veuillez noter que la durée de conservation des données de trafic est de 14 jours.",
+  "network_security_dashboard_warning_period": "Attention : les données demandées ne sont pas disponibles car la durée de conservation des données de trafic est dépassée.",
   "network_security_dashboard_warning_default": "Le graphique du trafic récent sera affiché à la place pour l'adresse IP sélectionnée."
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_fr_FR.json
@@ -18,6 +18,8 @@
   "network_security_dashboard_filter_24_hours": "24 heures",
   "network_security_dashboard_filter_7_days": "7 jours",
   "network_security_dashboard_filter_14_days": "14 jours",
+  "network_security_dashboard_filter_1_month": "1 mois",
+  "network_security_dashboard_filter_2_months": "2 mois",
   "network_security_dashboard_filter_day": "Jour",
   "network_security_dashboard_filter_week": "Semaine",
   "network_security_dashboard_filter_month": "Mois",
@@ -65,6 +67,6 @@
   "network_security_dashboard_like_this_tooltip": "Vous aimez cette page ? Faites nous part de vos remarques !",
   "network_security_dashboard_refresh": "Raffraîchir les données",
   "network_security_dashboard_time_zone": "(Timezone: UTC{{ timeZoneOffset }})",
-  "network_security_dashboard_warning_period": "Attention: les données demandées ne sont pas disponibles. Veuillez noter que la durée de conservation des données de trafic est de 14 jours.",
+  "network_security_dashboard_warning_period": "Attention : les données demandées ne sont pas disponibles car la durée de conservation des données de trafic est dépassée.",
   "network_security_dashboard_warning_default": "Le graphique du trafic récent sera affiché à la place pour l'adresse IP sélectionnée."
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_it_IT.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Timezone: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Grafici di traffico",
   "network_security_dashboard_filter_custom": "Personalizzato",
-  "network_security_dashboard_warning_period": "Attenzione: i dati richiesti non sono disponibili. Ti ricordiamo che la durata di conservazione dei dati del traffico è di 14 giorni.",
-  "network_security_dashboard_warning_default": "Il grafico del traffico recente verrà mostrato per l'indirizzo IP selezionato."
+  "network_security_dashboard_warning_period": "Attenzione: i dati richiesti non sono disponibili perché la durata di conservazione dei dati di traffico è scaduta.",
+  "network_security_dashboard_warning_default": "Il grafico del traffico recente verrà mostrato per l'indirizzo IP selezionato.",
+  "network_security_dashboard_filter_1_month": "1 mese",
+  "network_security_dashboard_filter_2_months": "2 mesi"
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_pl_PL.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Strefa czasowa: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Wykresy ruchu",
   "network_security_dashboard_filter_custom": "Spersonalizowany",
-  "network_security_dashboard_warning_period": "Uwaga: wymagane dane nie są dostępne. Pamiętaj, że okres przechowywania danych o ruchu wynosi 14 dni.",
-  "network_security_dashboard_warning_default": "Zamiast tego wyświetlony zostanie wykres dotyczący ostatniego ruchu dla wybranego adresu IP."
+  "network_security_dashboard_warning_period": "Uwaga: żądane dane są niedostępne, ponieważ został przekroczony limit czasu przechowywania informacji dotyczących ruchu.",
+  "network_security_dashboard_warning_default": "Zamiast tego wyświetlony zostanie wykres dotyczący ostatniego ruchu dla wybranego adresu IP.",
+  "network_security_dashboard_filter_1_month": "1 miesiąc",
+  "network_security_dashboard_filter_2_months": "2 miesiące"
 }

--- a/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/network-security/translations/Messages_pt_PT.json
@@ -65,6 +65,8 @@
   "network_security_dashboard_time_zone": "(Timezone: UTC{{ timeZoneOffset }})",
   "network_security_dashboard_traffic_breadcrumb": "Gráficos do tráfego",
   "network_security_dashboard_filter_custom": "Personalizado",
-  "network_security_dashboard_warning_period": "Atenção: os dados pedidos não estão disponíveis. Tenha em conta que o período de conservação dos dados de tráfego é de 14 dias.",
-  "network_security_dashboard_warning_default": "Será apresentado um gráfico de tráfego recente para o endereço IP selecionado."
+  "network_security_dashboard_warning_period": "Atenção: os dados pedidos não estão disponíveis, pois o período de conservação dos dados de tráfego foi ultrapassado.",
+  "network_security_dashboard_warning_default": "Será apresentado um gráfico de tráfego recente para o endereço IP selecionado.",
+  "network_security_dashboard_filter_1_month": "1 mês",
+  "network_security_dashboard_filter_2_months": "2 meses"
 }


### PR DESCRIPTION

ref: #MANAGER-18587

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR updates the following:
 - Enabling security traffic data to be displayed up to 2 months (adding 1 month and 2 months as available filter choices)
 - Displaying the "display traffic" grid action for security issues that have been detected up to 2 months
 - Updating the warning message when accessing outdated data to not mention anymore a limit  of 14 days.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference:  #MANAGER-18587

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
