### PR TITLE
feat(web-domains): Resiliation modal improvement

### DIFF
--- a/packages/manager/apps/web-domains/src/alldoms/pages/service/serviceDetail/serviceDetail.tsx
+++ b/packages/manager/apps/web-domains/src/alldoms/pages/service/serviceDetail/serviceDetail.tsx
@@ -5,21 +5,24 @@ import {
   useNotifications,
 } from '@ovh-ux/manager-react-components';
 import React, { useState } from 'react';
-import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import {
+  Outlet,
+  useParams,
+  useNavigate,
+  Link as RouterLink,
+} from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigationGetUrl } from '@ovh-ux/manager-react-shell-client';
 import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import {
   Icon,
   ICON_NAME,
-  Link,
   Message,
   MESSAGE_COLOR,
   MessageIcon,
   Text,
   TEXT_PRESET,
+  Link as OdsLink,
 } from '@ovhcloud/ods-react';
-import appConfig from '@/web-domains.config';
 import ServiceDetailDomains from '@/alldoms/components/ServiceDetail/ServiceDetailDomains';
 import ServiceDetailInformation from '@/alldoms/components/ServiceDetail/ServiceDetailInformation';
 import ServiceDetailSubscribing from '@/alldoms/components/ServiceDetail/ServiceDetailSubscribing/ServiceDetailSubscribing.component';
@@ -46,12 +49,6 @@ export default function ServiceDetail() {
   const { data: alldomService, isLoading } = useGetAllDom({
     serviceName,
   });
-
-  const { data: url } = useNavigationGetUrl([
-    appConfig.rootLabel,
-    `/alldoms/${serviceName}/${CANCEL_TERMINATE_URL()}`,
-    {},
-  ]);
 
   if (isLoading) {
     return <Loading />;
@@ -93,10 +90,13 @@ export default function ServiceDetail() {
                     components={{ strong: <strong /> }}
                   />
                 </Text>
-                <Link href={url as string} className="link-banner">
+                <OdsLink
+                  as={RouterLink}
+                  to={`/alldoms/${serviceName}/${CANCEL_TERMINATE_URL()}`}
+                >
                   <Icon name={ICON_NAME.arrowRight} />
                   {t('allDom_detail_page_manuel_renew_warning_link')}
-                </Link>
+                </OdsLink>
               </div>
             </Message>
           )}


### PR DESCRIPTION
## Description

Currently, when when we click on the "Annuler la résiliation" link on the banner of a alldom details page, the page in the background changes to the loading page, displays the modal, and then, on validation or cancellation, displays the loading page again before returning to the alldom details page. It's weird, and the success notification (if any) is lost in the process.


Ticket Reference: #MANAGER-19392

