### PR TITLE
ci(pci-instances): remover useless bundler module resolution

### DIFF
--- a/packages/manager/apps/pci-instances/tsconfig.json
+++ b/packages/manager/apps/pci-instances/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@ovh-ux/manager-static-analysis-kit/tsconfig/react-strict",
   "compilerOptions": {
     "baseUrl": ".",
-    "moduleResolution": "bundler",
     "paths": {
       "@/public/*": ["./public/*"],
       "@/*": ["./src/*"]


### PR DESCRIPTION
This PR removes this useless conf because it's already handled in `react-strict.json` in `static-analysis-kit`.

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
