### PR TITLE
feat(dedicated-cloud.datastores): adding datastores usage

### DIFF
--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/dedicatedCloud-datacenter-datastore.controller.js
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/dedicatedCloud-datacenter-datastore.controller.js
@@ -14,11 +14,13 @@ export default class {
   /* @ngInject */
   constructor(
     $q,
+    $translate,
     ovhManagerPccDatacenterService,
     ovhManagerPccDatacenterDatastoreService,
     coreConfig,
   ) {
     this.$q = $q;
+    this.$translate = $translate;
     this.ovhManagerPccDatacenterService = ovhManagerPccDatacenterService;
     this.ovhManagerPccDatacenterDatastoreService = ovhManagerPccDatacenterDatastoreService;
     this.DEDICATED_CLOUD_DATACENTER = DEDICATED_CLOUD_DATACENTER;
@@ -84,6 +86,13 @@ export default class {
 
       return datastore;
     };
+  }
+
+  getDatastoreUsage(datastore) {
+    const datastoreUnit = this.$translate.instant(
+      `unit_size_${datastore.size.unit}`,
+    );
+    return `${datastore.spaceUsed} / ${datastore.size.value} ${datastoreUnit}`;
   }
 
   chooseConsumptionFetchingMethod(datastore) {

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/dedicatedCloud-datacenter-datastore.html
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/dedicatedCloud-datacenter-datastore.html
@@ -6,31 +6,61 @@
     data-translate-values="{ billingGuideUrl: $ctrl.guides.billing, vMotionGuideUrl: $ctrl.guides.vMotion }"
 ></p>
 
-<oui-datagrid data-rows-loader="$ctrl.loadDatastores($config)">
+<oui-datagrid
+    data-rows-loader="$ctrl.loadDatastores($config)"
+    data-customizable
+>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_id' | translate"
         data-property="filerId"
+        data-filterable
+        data-sortable
+        data-hidden
     >
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_name' | translate"
         data-property="name"
+        data-searchable
+        data-filterable
+        data-sortable
+        data-prevent-customization
     >
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_profile' | translate"
         data-property="fullProfile"
+        data-filterable
+        data-sortable
     >
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_size' | translate"
+        data-property="size.value"
+        data-filterable
+        data-sortable
     >
         <span
             data-ng-bind="$row.size.value + ' ' + ('unit_size_' + $row.size.unit | translate)"
         ></span>
     </oui-datagrid-column>
     <oui-datagrid-column
+        data-title=":: 'dedicatedCloud_tab_datastores_usage' | translate"
+        data-property="spaceUsed"
+        data-filterable
+        data-sortable
+    >
+        <oui-progress data-max-value="{{$row.size.value}}">
+            <oui-progress-bar data-type="info" data-value="$row.spaceUsed">
+                <span data-ng-bind="$ctrl.getDatastoreUsage($row)"></span>
+            </oui-progress-bar>
+        </oui-progress>
+    </oui-datagrid-column>
+    <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_active_node' | translate"
+        data-property="activeNode"
+        data-filterable
+        data-sortable
     >
         <span
             data-ng-bind="'dedicatedCloud_tab_datastores_active_node_' + $row.activeNode | translate"
@@ -42,6 +72,9 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_billing' | translate"
+        data-property="billingType"
+        data-filterable
+        data-sortable
     >
         <span
             data-ng-bind="'dedicatedCloud_tab_datastores_billing_' + $row.billingType | translate"
@@ -49,6 +82,9 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_status' | translate"
+        data-property="state"
+        data-filterable
+        data-sortable
     >
         <span
             data-ng-bind="'dedicatedCloud_tab_datastores_status_' + $row.state | translate"
@@ -56,6 +92,9 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_scope' | translate"
+        data-property="isGlobal"
+        data-filterable
+        data-sortable
     >
         <span
             data-ng-if="$row.isGlobal"
@@ -68,6 +107,9 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_location_datacenter' | translate"
+        data-property="location.datacenter"
+        data-filterable
+        data-sortable
     >
         <oui-skeleton size="xs" data-ng-if="$row.asyncLoading"></oui-skeleton>
         <span
@@ -77,6 +119,10 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_location_room' | translate"
+        data-property="location.room"
+        data-filterable
+        data-sortable
+        data-hidden
     >
         <oui-skeleton size="xs" data-ng-if="$row.asyncLoading"></oui-skeleton>
         <span
@@ -86,6 +132,9 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_location_rack' | translate"
+        data-property="location.rack"
+        data-filterable
+        data-sortable
     >
         <oui-skeleton size="xs" data-ng-if="$row.asyncLoading"></oui-skeleton>
         <span
@@ -95,6 +144,10 @@
     </oui-datagrid-column>
     <oui-datagrid-column
         data-title=":: 'dedicatedCloud_tab_datastores_consumption' | translate"
+        data-property="consumption"
+        data-filterable
+        data-sortable
+        data-hidden
     >
         <oui-skeleton size="xs" data-ng-if="$row.asyncLoading"></oui-skeleton>
         <span

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_de_DE.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_de_DE.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "Ein globaler Datastore ist ein Datastore, der auf allen virtuellen Clustern und/oder Rechenzentren einer VMware-Infrastruktur gemountet ist. Er wird also von mehreren vDC genutzt. Manche Datastores sind möglicherweise nicht kompatibel. In diesem Fall können Sie neue Datastores bestellen und VMware Storage vMotion verwenden. Lesen Sie hierzu unsere Anleitungen <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">Abrechnung von Private Cloud</a> und <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware Storage vMotion</a>.",
   "dedicatedCloud_tab_datastores_scope": "Scope",
   "dedicatedCloud_tab_datastores_scope_global": "Global",
-  "dedicatedCloud_tab_datastores_scope_not_global": "Nicht global"
+  "dedicatedCloud_tab_datastores_scope_not_global": "Nicht global",
+  "dedicatedCloud_tab_datastores_usage": "Verwendung"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_en_GB.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_en_GB.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "A global datastore is a datastore mounted on all virtual clusters/datacentres of a VMware infrastructure, i.e. shared between multiple vDCs. Some datastores may not be compatible, in which case you can order new datastores and use VMware vMotion Storage. To do this, please refer to our guides for <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">information on Private Cloud</a> and <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware vMotion Storage</a> billing.",
   "dedicatedCloud_tab_datastores_scope": "Scope",
   "dedicatedCloud_tab_datastores_scope_global": "Global",
-  "dedicatedCloud_tab_datastores_scope_not_global": "Local"
+  "dedicatedCloud_tab_datastores_scope_not_global": "Local",
+  "dedicatedCloud_tab_datastores_usage": "Use"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_es_ES.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_es_ES.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "Un datastore global es un datastore montado en todos los clusters o datacenters virtuales de una infraestructura VMware, es decir, compartido entre varios vDC. Algunos datastores pueden no ser compatibles, en cuyo caso puede contratar nuevos datastores y utilizar VMware Storage vMotion. Para más información, consulte nuestras guías sobre <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">la facturación de Private Cloud</a> y <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware Storage vMotion</a>.",
   "dedicatedCloud_tab_datastores_scope": "Alcance",
   "dedicatedCloud_tab_datastores_scope_global": "Global",
-  "dedicatedCloud_tab_datastores_scope_not_global": "No global"
+  "dedicatedCloud_tab_datastores_scope_not_global": "No global",
+  "dedicatedCloud_tab_datastores_usage": "Uso"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_fr_CA.json
@@ -8,6 +8,7 @@
   "dedicatedCloud_tab_datastores_active_node_master": "Primaire",
   "dedicatedCloud_tab_datastores_active_node_slave": "Réplicat",
   "dedicatedCloud_tab_datastores_size": "Taille",
+  "dedicatedCloud_tab_datastores_usage": "Utilisation",
   "dedicatedCloud_tab_datastores_billing": "Paiement",
   "dedicatedCloud_tab_datastores_billing_hourly": "A l'heure",
   "dedicatedCloud_tab_datastores_billing_monthly": "Au mois",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_fr_FR.json
@@ -8,6 +8,7 @@
   "dedicatedCloud_tab_datastores_active_node_master": "Primaire",
   "dedicatedCloud_tab_datastores_active_node_slave": "Réplicat",
   "dedicatedCloud_tab_datastores_size": "Taille",
+  "dedicatedCloud_tab_datastores_usage": "Utilisation",
   "dedicatedCloud_tab_datastores_billing": "Paiement",
   "dedicatedCloud_tab_datastores_billing_hourly": "A l'heure",
   "dedicatedCloud_tab_datastores_billing_monthly": "Au mois",

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_it_IT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_it_IT.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "Un datastore globale è un datastore montato su tutti i cluster/datacenter virtuali di un'infrastruttura VMware, cioè condiviso tra più vDC. Alcuni datastore possono non essere compatibili: in questo caso è possibile ordinare nuovi datastore e utilizzare VMware Storage vMotion. A questo proposito, consulta le nostre guide <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">Informazioni sulla fatturazione Private Cloud</a> e <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware Storage vMotion</a>.",
   "dedicatedCloud_tab_datastores_scope": "Portata",
   "dedicatedCloud_tab_datastores_scope_global": "Globale",
-  "dedicatedCloud_tab_datastores_scope_not_global": "Non globale"
+  "dedicatedCloud_tab_datastores_scope_not_global": "Non globale",
+  "dedicatedCloud_tab_datastores_usage": "Utilizzo"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_pl_PL.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "Datastore globalny to datastore zamontowany na wszystkich wirtualnych klastrach/centrach danych infrastruktury VMware, czyli współdzielony przez kilka vDC. Niektóre datastores mogą nie być kompatybilne. W tym przypadku możesz zamówić nowe datastores i korzystać z usługi VMware Storage vMotion. Aby dowiedzieć się więcej, sprawdź nasze przewodniki <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">Informacje o płatnościach za Dedicated Cloud</a> i <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware Storage vMotion</a>.",
   "dedicatedCloud_tab_datastores_scope": "Zakres",
   "dedicatedCloud_tab_datastores_scope_global": "Globalny",
-  "dedicatedCloud_tab_datastores_scope_not_global": "Nie globalny"
+  "dedicatedCloud_tab_datastores_scope_not_global": "Nie globalny",
+  "dedicatedCloud_tab_datastores_usage": "Wykorzystanie"
 }

--- a/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/dedicated/client/app/components/dedicated-cloud/datacenter/datastore/translations/Messages_pt_PT.json
@@ -32,5 +32,6 @@
   "dedicatedCloud_tab_datastores_global_information": "Um datastore global é um datastore montado no conjunto dos clusters/datacenters virtuais de uma infraestrutura VMware, ou seja, partilhado entre vários vDC. Alguns datastores podem não ser compatíveis, caso em que pode encomendar novos datastores e utilizar o VMware Storage vMotion. Para isso, consulte os nossos manuais <a href=\"{{ billingGuideUrl }}\" target=\"_blank\">Informações sobre faturação Private Cloud</a> e <a href=\"{{ vMotionGuideUrl }}\" target=\"_blank\">VMware Storage vMotion</a>.",
   "dedicatedCloud_tab_datastores_scope": "Alcance",
   "dedicatedCloud_tab_datastores_scope_global": "Global",
-  "dedicatedCloud_tab_datastores_scope_not_global": "Não global"
+  "dedicatedCloud_tab_datastores_scope_not_global": "Não global",
+  "dedicatedCloud_tab_datastores_usage": "Utilização"
 }


### PR DESCRIPTION
## Description

In the datastores listing page, adding the datastore usage (space used).
Hide by default less relevant columns to free some space for that new one.

Preview :
<img width="600" src="https://github.com/user-attachments/assets/009b716f-5c93-47b4-93d5-7c74cbe49b74" />



Ticket Reference: #MANAGER-19549
