### PR TITLE
fix(pci-instances): migrate ActionMenu to ODS19 and fix button to ghost

### DIFF
--- a/packages/manager/apps/pci-instances/src/components/menu/ActionsMenu.component.tsx
+++ b/packages/manager/apps/pci-instances/src/components/menu/ActionsMenu.component.tsx
@@ -1,18 +1,19 @@
 /* eslint-disable react/no-multi-comp */
-import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-import { ODS_ICON_NAME, ODS_ICON_SIZE } from '@ovhcloud/ods-components';
-import { OsdsIcon } from '@ovhcloud/ods-components/react';
 import { FC, PropsWithChildren, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHref } from 'react-router-dom';
 import {
   Button,
+  BUTTON_COLOR,
+  BUTTON_VARIANT,
+  ButtonProp,
   Divider,
+  Icon,
+  ICON_NAME,
+  Link,
   Popover,
   PopoverContent,
   PopoverTrigger,
-  Link,
-  ButtonProp,
 } from '@ovhcloud/ods-react';
 import { DeepReadonly } from '@/types/utils.type';
 
@@ -26,6 +27,7 @@ export type TActionsMenuItem = DeepReadonly<{
 
 export type TActionsMenuProps = DeepReadonly<{
   items: Map<string, TActionsMenuItem[]>;
+  actionButton?: Pick<ButtonProp, 'variant'>;
 }>;
 
 export type TActionsMenuLinkProps = DeepReadonly<{
@@ -67,12 +69,12 @@ const ActionMenuContainer: FC<PropsWithChildren & ButtonProp> = ({
       onOpenChange={({ open }) => setOpen(open)}
     >
       <PopoverTrigger asChild>
-        <Button data-testid="actions-menu-button" {...props}>
-          <OsdsIcon
-            name={ODS_ICON_NAME.ELLIPSIS_VERTICAL}
-            color={ODS_THEME_COLOR_INTENT.primary}
-            size={ODS_ICON_SIZE.xxs}
-          />
+        <Button
+          data-testid="actions-menu-button"
+          color={BUTTON_COLOR.primary}
+          {...props}
+        >
+          <Icon name={ICON_NAME.ellipsisVertical} />
         </Button>
       </PopoverTrigger>
       <PopoverContent withArrow onClick={() => setOpen(false)}>
@@ -82,8 +84,13 @@ const ActionMenuContainer: FC<PropsWithChildren & ButtonProp> = ({
   );
 };
 
-export const ActionsMenu = ({ items }: TActionsMenuProps) => (
-  <ActionMenuContainer variant="outline" size="sm" disabled={!items.size}>
+export const ActionsMenu = ({ items, actionButton }: TActionsMenuProps) => (
+  <ActionMenuContainer
+    size="sm"
+    disabled={!items.size}
+    variant={BUTTON_VARIANT.outline}
+    {...actionButton}
+  >
     {Array.from(items.entries()).map(([group, item], index, arr) => (
       <div key={group}>
         {item.map((elt) => (

--- a/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/components/InstanceGeneralInfoBlock.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/instance/dashboard/components/InstanceGeneralInfoBlock.component.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHref } from 'react-router-dom';
 import { OsdsLink, OsdsText } from '@ovhcloud/ods-components/react';
-import { ODS_TEXT_SIZE, ODS_TEXT_LEVEL } from '@ovhcloud/ods-components';
+import { ODS_TEXT_LEVEL, ODS_TEXT_SIZE } from '@ovhcloud/ods-components';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import {
   Links,
@@ -12,6 +12,7 @@ import {
 } from '@ovh-ux/manager-react-components';
 import { RegionChipByType } from '@ovh-ux/manager-pci-common';
 import {
+  BUTTON_VARIANT,
   Clipboard,
   ClipboardControl,
   ClipboardTrigger,
@@ -169,7 +170,12 @@ const InstanceGeneralInfoBlock: FC = () => {
             >
               {t('pci_instances_dashboard_all_actions')}
             </OsdsText>
-            <ActionsMenu items={instance.actions} />
+            <ActionsMenu
+              items={instance.actions}
+              actionButton={{
+                variant: BUTTON_VARIANT.ghost,
+              }}
+            />
           </div>
         </TileBlock>
       )}


### PR DESCRIPTION
ref: #TAPC-4861

Before:
<img width="382" height="260" alt="Screenshot 2025-09-01 at 15 06 08" src="https://github.com/user-attachments/assets/334d9d44-2b0c-49cc-bd9d-a769605cc8e6" />

After:
<img width="525" height="200" alt="image" src="https://github.com/user-attachments/assets/20db2098-f7cf-496f-9949-6878f03149d5" />
