### PR TITLE
feat(*): include migration status for particular apps

### DIFF
--- a/packages/manager-tools/manager-cli/utils/AppUtils.mjs
+++ b/packages/manager-tools/manager-cli/utils/AppUtils.mjs
@@ -44,6 +44,11 @@ export const resolveRoutePath = (appName, { verbose = false } = {}) => {
     join(applicationsBasePath, appName, 'src/routes/routes.tsx'),
     join(applicationsBasePath, appName, 'src/routes.tsx'),
     join(applicationsBasePath, appName, 'src/routes/index.tsx'),
+
+    // special projects cases
+    join(applicationsBasePath, appName, 'src/alldoms/routes/routes.tsx'),
+    join(applicationsBasePath, appName, 'src/core/routing/redirections.tsx'),
+    join(applicationsBasePath, appName, 'src/core/routing/iframe-app-router.tsx'),
   ];
 
   for (const path of candidates) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The goal of this PR is to include special apps to migration cli report:

```
Hello everyone !
Regarding this documentation : https://[internal_url]/digital-tools-manager/manager/manager-migration-monitor-cli/manager/migration-status-reports/migration-status-full-report.html our project web-domains isn't mark as done for route migration.

But if you check this file : https://github.com/ovh/manager/blob/master/packages/manager/apps/web-domains/src/alldoms/routes/routes.tsx you can see we use the last route manager version.

I think it is because our path is that way : /web-domains/src/alldoms/routes


Hello team, "quick question": how is it determined if an app has migrated its routes definition ? (https://[internal_url]/digital-tools-manager/manager/manager-migration-monitor-cli/manager/migration-status-reports/migration-status-full-report.html)
On container, which is marked as TODO, the routes are already defined as components, but they are not defined in the common way
```

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19013

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
