### PR TITLE
fix(ips): skipping the organisation selection when ordering non-US IP as an US user

### DIFF
--- a/packages/manager/apps/ips/src/pages/order/Ipv4Order.component.tsx
+++ b/packages/manager/apps/ips/src/pages/order/Ipv4Order.component.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+import { OvhSubsidiary } from '@ovh-ux/manager-react-components';
 import { ServiceSelectionSection } from './sections/ServiceSelectionSection.component';
 import { OrderContext } from './order.context';
 import { IpOffer, IpVersion } from './order.constant';
@@ -10,6 +12,7 @@ import { OrderButtonSection } from './sections/OrderButtonSection.component';
 import { useServiceRegion } from '@/data/hooks/useServiceRegion';
 import { useCheckServiceAvailability } from '@/data/hooks/useCheckServiceAvailability';
 import { ServiceType } from '@/types';
+import { isRegionInUs } from '@/components/RegionSelector/region-selector.utils';
 
 export const Ipv4Order: React.FC = () => {
   const {
@@ -23,6 +26,8 @@ export const Ipv4Order: React.FC = () => {
     addDisabledService,
   } = React.useContext(OrderContext);
 
+  const { environment } = React.useContext(ShellContext);
+
   const { serviceStatus } = useCheckServiceAvailability({
     serviceName: selectedService,
     serviceType: selectedServiceType,
@@ -34,14 +39,21 @@ export const Ipv4Order: React.FC = () => {
     serviceType: selectedServiceType,
   });
 
+  const computedRegion = region ?? selectedRegion;
+
   const isOrganisationSectionVisible =
     !!selectedService &&
     serviceStatus === 'ok' &&
     selectedOffer === IpOffer.blockAdditionalIp &&
     selectedServiceType !== ServiceType.dedicatedCloud &&
     !!selectedPlanCode &&
-    !!(region || selectedRegion) &&
-    !!selectedGeolocation;
+    !!computedRegion &&
+    !!selectedGeolocation &&
+    !(
+      environment.user.ovhSubsidiary === OvhSubsidiary.US &&
+      !isRegionInUs(computedRegion) &&
+      [ServiceType.ipParking, ServiceType.vrack].includes(selectedServiceType)
+    );
 
   const visibleSections = {
     service: ipVersion === IpVersion.ipv4,

--- a/packages/manager/apps/ips/src/pages/order/order.spec.tsx
+++ b/packages/manager/apps/ips/src/pages/order/order.spec.tsx
@@ -2,6 +2,7 @@ import { describe, it, vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assertTextVisibility } from '@ovh-ux/manager-core-test-utils';
+import { Subsidiary } from '@ovh-ux/manager-config';
 import {
   labels,
   getButtonByLabel,
@@ -25,6 +26,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[2].name,
       region: 'eu-west-lim',
+      isOrganisationSectionVisible: true,
       organisation: organisationMockList[2],
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
@@ -35,6 +37,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[2].name,
       region: 'eu-west-lim',
+      isOrganisationSectionVisible: true,
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'pn-000001)~(label~'country~value~'DE)~(label~'datacenter~value~'LIM))~duration~'P1M~planCode~'ip-v4-s30-ripe~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~'LIM))",
@@ -44,6 +47,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[3].name,
       region: 'eu-west-eri',
+      isOrganisationSectionVisible: true,
       organisation: organisationMockList[3],
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
@@ -54,6 +58,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[2].name,
       region: 'ca-east-bhs',
+      isOrganisationSectionVisible: true,
       organisation: organisationMockList[0],
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
@@ -64,6 +69,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: ipParkingOptionValue,
       region: 'ca-east-bhs',
+      isOrganisationSectionVisible: false,
       offer: IpOffer.additionalIp,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'parking)~(label~'country~value~'CA)~(label~'datacenter~value~'BHS))~duration~'P1M~planCode~'ip-failover-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~'BHS))",
@@ -74,6 +80,7 @@ describe('Order', async () => {
       serviceName: ipParkingOptionValue,
       region: 'eu-west-par',
       offer: IpOffer.blockAdditionalIp,
+      isOrganisationSectionVisible: true,
       organisation: organisationMockList[0],
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'parking)~(label~'country~value~'FR)~(label~'organisation~value~'ARIN_1)~(label~'datacenter~value~'PAR))~duration~'P1M~planCode~'ip-v4-s30-ripe~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~'PAR))",
@@ -83,6 +90,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: ipParkingOptionValue,
       region: 'eu-west-par',
+      isOrganisationSectionVisible: true,
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'parking)~(label~'country~value~'FR)~(label~'datacenter~value~'PAR))~duration~'P1M~planCode~'ip-v4-s30-ripe~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~'PAR))",
@@ -91,6 +99,7 @@ describe('Order', async () => {
       case: 'Dedicated Cloud',
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[0].name,
+      isOrganisationSectionVisible: false,
       offer: IpOffer.blockAdditionalIp,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'pcc-1)~(label~'country~value~'FR))~duration~'P1M~planCode~'pcc-option-ip-ripe-28~pricingMode~'pcc-servicepack-default~productId~'privateCloud~quantity~1~serviceName~'pcc-1~datacenter~null))",
@@ -99,6 +108,7 @@ describe('Order', async () => {
       case: 'Dedicated server (additional IP)',
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[4].name,
+      isOrganisationSectionVisible: false,
       offer: IpOffer.additionalIp,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'ns1111111.ip-111-222-333.net)~(label~'country~value~'CA))~duration~'P1M~planCode~'ip-failover-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
@@ -108,6 +118,7 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[4].name,
       offer: IpOffer.blockAdditionalIp,
+      isOrganisationSectionVisible: true,
       organisation: organisationMockList[0],
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'ns1111111.ip-111-222-333.net)~(label~'country~value~'CA)~(label~'organisation~value~'ARIN_1))~duration~'P1M~planCode~'ip-v4-s30-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
@@ -116,15 +127,17 @@ describe('Order', async () => {
       case: 'VPS',
       ipVersion: IpVersion.ipv4,
       serviceName: resourceMockList[5].name,
+      isOrganisationSectionVisible: false,
       offer: IpOffer.additionalIp,
       expectedOrderLink:
-        "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'vps-11111111.vps.ovh.ca)~(label~'country~value~'IN))~duration~'P1M~planCode~'ip-failover-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
+        "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'vps-11111111.vps.ovh.ca)~(label~'country~value~'FR))~duration~'P1M~planCode~'ip-failover-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
     },
     {
       case: 'IPv6 ARIN',
       ipVersion: IpVersion.ipv6,
       serviceName: resourceMockList[2].name,
       region: 'ca-east-bhs',
+      isOrganisationSectionVisible: false,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'pn-000001)~(label~'ip_region~value~'ca-east-bhs))~duration~'P1M~planCode~'ip-v6-s56-arin~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
     },
@@ -133,8 +146,20 @@ describe('Order', async () => {
       ipVersion: IpVersion.ipv6,
       serviceName: resourceMockList[2].name,
       region: 'eu-west-gra',
+      isOrganisationSectionVisible: false,
       expectedOrderLink:
         "https://www.ovh.com/fr/order/express/#/express/review?products=~(~(configuration~(~(label~'destination~value~'pn-000001)~(label~'ip_region~value~'eu-west-gra))~duration~'P1M~planCode~'ip-v6-s56-ripe~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~null))",
+    },
+    {
+      case: 'Parking + US user and non-US region',
+      ipVersion: IpVersion.ipv4,
+      ovhSubsidiary: 'US',
+      serviceName: ipParkingOptionValue,
+      region: 'eu-west-par',
+      offer: IpOffer.blockAdditionalIp,
+      isOrganisationSectionVisible: false,
+      expectedOrderLink:
+        "?products=~(~(configuration~(~(label~'destination~value~'parking)~(label~'country~value~'FR)~(label~'datacenter~value~'PAR))~duration~'P1M~planCode~'ip-v4-s30-ripe~pricingMode~'default~productId~'ip~quantity~1~serviceName~null~datacenter~'PAR))",
     },
   ])(
     'redirect to express order successfully ($case)',
@@ -145,8 +170,12 @@ describe('Order', async () => {
       organisation,
       offer,
       expectedOrderLink,
+      ovhSubsidiary,
+      isOrganisationSectionVisible,
     }) => {
-      const { container } = await goToOrder();
+      const { container } = await goToOrder({
+        ovhSubsidiary: ovhSubsidiary as Subsidiary,
+      });
 
       await selectIpVersion(ipVersion);
 
@@ -164,8 +193,21 @@ describe('Order', async () => {
         await selectOffer({ container, offer });
       }
 
-      if (organisation) {
-        await selectedOrganisation({ container, organisation });
+      if (isOrganisationSectionVisible) {
+        const organisationSelect = await getOrganisationSelect(container);
+        expect(organisationSelect).toBeDefined();
+        if (organisation) {
+          await selectedOrganisation({ container, organisation });
+        }
+      } else {
+        let organisationSelectFound = false;
+        try {
+          await getOrganisationSelect(container);
+          organisationSelectFound = true;
+        } catch (error) {
+          // do nothing
+        }
+        expect(organisationSelectFound).toBeFalsy();
       }
 
       // Click on order button

--- a/packages/manager/apps/ips/src/test-utils/render-test.tsx
+++ b/packages/manager/apps/ips/src/test-utils/render-test.tsx
@@ -19,6 +19,7 @@ import {
   toMswHandlers,
   WAIT_FOR_DEFAULT_OPTIONS,
 } from '@ovh-ux/manager-core-test-utils';
+import { Subsidiary } from '@ovh-ux/manager-config';
 import { translations, labels } from './test-i18n';
 import { TestApp } from './TestApp';
 import {
@@ -45,6 +46,10 @@ import {
   GetIpLoadBalancingMocksParams,
 } from '../../mocks';
 
+export type GetUserMocksParams = {
+  ovhSubsidiary?: Subsidiary;
+};
+
 export type MockParams = GetIpsMocksParams &
   GetIamMocksParams &
   GetDedicatedMocksParams &
@@ -55,7 +60,8 @@ export type MockParams = GetIpsMocksParams &
   GetVpsMocksParams &
   GetOrganisationMocksParams &
   GetCatalogMocksParams &
-  GetIpLoadBalancingMocksParams;
+  GetIpLoadBalancingMocksParams &
+  GetUserMocksParams;
 
 const APP_NAME = 'ips';
 
@@ -93,6 +99,9 @@ export const renderTest = async ({
   if (!context) {
     context = await initShellContext(APP_NAME);
   }
+
+  context.environment.getUser().ovhSubsidiary =
+    mockParams.ovhSubsidiary ?? 'FR';
 
   if (!i18nState) {
     i18nState = await initTestI18n(APP_NAME, translations);


### PR DESCRIPTION
ref: #MANAGER-19460

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR introduces a new condition for displaying the organisation select step when ordering an IPv4 service.
The step should not be displayed for US users that are selection non-US located (parking or vrack) services.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19460

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
