### PR TITLE
feat(mrc): add hooks to use location data

### DIFF
--- a/packages/manager-react-components/src/hooks/index.ts
+++ b/packages/manager-react-components/src/hooks/index.ts
@@ -21,5 +21,6 @@ export {
   useTranslatedMicroRegions,
   isLocalZone,
 } from './region/useTranslatedMicroRegions';
+export * from './location';
 
 export type TRegion = Region;

--- a/packages/manager-react-components/src/hooks/location/index.ts
+++ b/packages/manager-react-components/src/hooks/location/index.ts
@@ -1,0 +1,2 @@
+export * from './useLocation';
+export * from './location.type';

--- a/packages/manager-react-components/src/hooks/location/location.type.ts
+++ b/packages/manager-react-components/src/hooks/location/location.type.ts
@@ -1,0 +1,42 @@
+type CardinalPoint =
+  | 'CENTRAL'
+  | 'EAST'
+  | 'NORTH'
+  | 'NORTHEAST'
+  | 'NORTHWEST'
+  | 'SOUTH'
+  | 'SOUTHEAST'
+  | 'SOUTHWEST'
+  | 'WEST';
+type SpecificType = 'BACKUP' | 'LZ' | 'SNC' | 'STANDARD';
+type Type = 'LOCAL-ZONE' | 'REGION-1-AZ' | 'REGION-3-AZ';
+
+export type Location = {
+  availabilityZones: string[];
+  cardinalPoint: CardinalPoint;
+  cityCode: string;
+  cityLatitude: number;
+  cityLongitude: number;
+  cityName: string;
+  code: string;
+  countryCode: string;
+  countryName: string;
+  geographyCode: string;
+  geographyName: string;
+  location: string;
+  name: string;
+  openingYear: number;
+  specificType: SpecificType;
+  type: Type;
+};
+
+export enum LocationType {
+  '1AZ' = 'REGION-1-AZ',
+  '3AZ' = 'REGION-3-AZ',
+  'LZ' = 'LOCAL-ZONE',
+}
+
+export type Country = {
+  code: string;
+  name: string;
+};

--- a/packages/manager-react-components/src/hooks/location/useLocation.spec.tsx
+++ b/packages/manager-react-components/src/hooks/location/useLocation.spec.tsx
@@ -1,0 +1,244 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  ShellContext,
+  ShellContextType,
+} from '@ovh-ux/manager-react-shell-client';
+import {
+  useLocationByName,
+  useAllLocationsByType,
+  useAllCountries,
+  useCityByCode,
+} from './useLocation';
+import { LocationType } from './location.type';
+
+const locations = vi.hoisted(() => ({
+  '3AZ': [
+    {
+      code: 'code1',
+      name: 'name1',
+      location: 'location1',
+      type: 'REGION-3-AZ',
+      specificType: 'STANDARD',
+      cardinalPoint: 'WEST',
+      openingYear: 2023,
+      cityName: 'cityName1',
+      cityCode: 'cityCode1',
+      cityLatitude: 48.85,
+      cityLongitude: 2.35,
+      countryName: 'countryName1',
+      countryCode: 'countryCode1',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: [
+        'availabilityZones11',
+        'availabilityZones12',
+        'availabilityZones13',
+      ],
+    },
+    {
+      code: 'code2',
+      name: 'name2',
+      location: 'location2',
+      type: 'REGION-3-AZ',
+      specificType: 'STANDARD',
+      cardinalPoint: 'WEST',
+      openingYear: 2007,
+      cityName: 'cityName2',
+      cityCode: 'cityCode2',
+      cityLatitude: 50.6833333333333,
+      cityLongitude: 3.18333333333333,
+      countryName: 'countryName1',
+      countryCode: 'countryCode1',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: ['availabilityZones21'],
+    },
+  ],
+  '1AZ': [
+    {
+      code: 'code3',
+      name: 'name3',
+      location: 'location3',
+      type: 'REGION-1-AZ',
+      specificType: 'STANDARD',
+      cardinalPoint: 'WEST',
+      openingYear: 2017,
+      cityName: 'cityName3',
+      cityCode: 'cityCode3',
+      cityLatitude: 48.5666666666667,
+      cityLongitude: 7.75,
+      countryName: 'countryName1',
+      countryCode: 'countryCode1',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: ['availabilityZones31'],
+    },
+    {
+      code: 'code4',
+      name: 'name4',
+      location: 'location4',
+      type: 'REGION-1-AZ',
+      specificType: 'STANDARD',
+      cardinalPoint: 'WEST',
+      openingYear: 2017,
+      cityName: 'cityName4',
+      cityCode: 'cityCode4',
+      cityLatitude: 48.0333333333333,
+      cityLongitude: 12.1833333333333,
+      countryName: 'countryName2',
+      countryCode: 'countryCode2',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: ['availabilityZones41'],
+    },
+  ],
+  LZ: [
+    {
+      code: 'code5',
+      name: 'name5',
+      location: 'location5',
+      type: 'LOCAL-ZONE',
+      specificType: 'STANDARD',
+      cardinalPoint: 'CENTRAL',
+      openingYear: 2016,
+      cityName: 'cityName5',
+      cityCode: 'cityCode5',
+      cityLatitude: 50.8833333333333,
+      cityLongitude: 21.6666666666667,
+      countryName: 'countryName3',
+      countryCode: 'countryCode3',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: ['availabilityZones51'],
+    },
+    {
+      code: 'code6',
+      name: 'name6',
+      location: 'location6',
+      type: 'LOCAL-ZONE',
+      specificType: 'STANDARD',
+      cardinalPoint: 'CENTRAL',
+      openingYear: 2016,
+      cityName: 'cityName6',
+      cityCode: 'cityCode6',
+      cityLatitude: 50.8833333333333,
+      cityLongitude: 21.6666666666667,
+      countryName: 'countryName2',
+      countryCode: 'countryCode2',
+      geographyName: 'geographyName1',
+      geographyCode: 'geographyCode1',
+      availabilityZones: ['availabilityZones61'],
+    },
+    {
+      code: 'code7',
+      name: 'name7',
+      location: 'location7',
+      type: 'LOCAL-ZONE',
+      specificType: 'STANDARD',
+      cardinalPoint: 'CENTRAL',
+      openingYear: 2016,
+      cityName: 'cityName7',
+      cityCode: 'cityCode7',
+      cityLatitude: 50.8833333333333,
+      cityLongitude: 21.6666666666667,
+      countryName: 'countryName3',
+      countryCode: 'countryCode3',
+      geographyName: 'geographyName2',
+      geographyCode: 'geographyCode2',
+      availabilityZones: ['availabilityZones71'],
+    },
+  ],
+}));
+const shellContext = {
+  shell: {
+    location: {
+      getLocations: () => {
+        return Promise.resolve([
+          ...locations['3AZ'],
+          ...locations['1AZ'],
+          ...locations.LZ,
+        ]);
+      },
+    },
+  },
+};
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <ShellContext.Provider value={shellContext as unknown as ShellContextType}>
+      {children}
+    </ShellContext.Provider>
+  </QueryClientProvider>
+);
+
+describe('useLocation', () => {
+  describe('useLocationByName', () => {
+    it('should return location for the given name', async () => {
+      const { result } = renderHook(() => useLocationByName('name3'), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(result.current.isFetched).toBe(true);
+      });
+      const { data: location } = result.current;
+      expect(location).toStrictEqual({
+        code: 'code3',
+        name: 'name3',
+        location: 'location3',
+        type: 'REGION-1-AZ',
+        specificType: 'STANDARD',
+        cardinalPoint: 'WEST',
+        openingYear: 2017,
+        cityName: 'cityName3',
+        cityCode: 'cityCode3',
+        cityLatitude: 48.5666666666667,
+        cityLongitude: 7.75,
+        countryName: 'countryName1',
+        countryCode: 'countryCode1',
+        geographyName: 'geographyName1',
+        geographyCode: 'geographyCode1',
+        availabilityZones: ['availabilityZones31'],
+      });
+    });
+  });
+
+  describe('useAllLocationsByType', () => {
+    it('should return locations matching the given type', () => {
+      const { result } = renderHook(
+        () => useAllLocationsByType(LocationType['1AZ']),
+        {
+          wrapper,
+        },
+      );
+      const { data: allLocations } = result.current;
+      expect(allLocations).toStrictEqual(locations['1AZ']);
+    });
+  });
+
+  describe('useCityByCode', () => {
+    it('should return the city name for the given city code', () => {
+      const { result } = renderHook(() => useCityByCode('cityCode1'), {
+        wrapper,
+      });
+      const { data: city } = result.current;
+      expect(city).toStrictEqual('cityName1');
+    });
+  });
+
+  describe('useAllCountries', () => {
+    it('should return all distinct countries for the available locations', () => {
+      const { result } = renderHook(() => useAllCountries(), {
+        wrapper,
+      });
+      const { data: countries } = result.current;
+      expect(countries).toStrictEqual([
+        { code: 'countryCode1', name: 'countryName1' },
+        { code: 'countryCode2', name: 'countryName2' },
+        { code: 'countryCode3', name: 'countryName3' },
+      ]);
+    });
+  });
+});

--- a/packages/manager-react-components/src/hooks/location/useLocation.tsx
+++ b/packages/manager-react-components/src/hooks/location/useLocation.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useContext } from 'react';
+import { queryOptions, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+import { Country, Location, LocationType } from './location.type';
+
+const useLocationsQueryOptions = () => {
+  const {
+    shell: { location },
+  } = useContext(ShellContext);
+  return queryOptions({
+    queryKey: ['shell', 'getLocations'],
+    queryFn: () => Promise.resolve(location.getLocations()),
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: false,
+    retry: 3,
+    retryDelay: 5000,
+  });
+};
+
+export const useLocationByName = (name: string): UseQueryResult<Location> => {
+  const select = useCallback(
+    (locations: Location[]) =>
+      locations.find((location: Location) => location.name === name),
+    [name],
+  );
+  const options = useLocationsQueryOptions();
+  return useQuery({ ...options, select });
+};
+
+export const useAllLocationsByType = (
+  type: LocationType,
+): UseQueryResult<Location[]> => {
+  const select = useCallback(
+    (locations: Location[]) =>
+      locations.filter((location: Location) => location.type === type),
+    [type],
+  );
+  const options = useLocationsQueryOptions();
+  return useQuery({ ...options, select });
+};
+
+export const useCityByCode = (code: string): UseQueryResult<string> => {
+  const select = useCallback(
+    (locations: Location[]) =>
+      locations.find((location: Location) => location.cityCode === code)
+        ?.cityName,
+    [code],
+  );
+  const options = useLocationsQueryOptions();
+  return useQuery({ ...options, select });
+};
+
+function extractUniqueCountries(locations: Location[]) {
+  const set = new Set();
+  return locations.reduce((countries: Country[], location: Location) => {
+    // Ensuring uniqueness by checking if country was already computed
+    if (!set.has(location.countryCode)) {
+      countries.push({
+        code: location.countryCode,
+        name: location.countryName,
+      });
+      set.add(location.countryCode);
+    }
+    return countries;
+  }, []);
+}
+
+export const useAllCountries = (): UseQueryResult<Country[]> => {
+  const options = useLocationsQueryOptions();
+  return useQuery({ ...options, select: extractUniqueCountries });
+};

--- a/packages/manager-wiki/stories/manager-react-components/hooks/useLocation/documentation.mdx
+++ b/packages/manager-wiki/stories/manager-react-components/hooks/useLocation/documentation.mdx
@@ -1,0 +1,132 @@
+import { Meta, Source, ArgTypes } from '@storybook/blocks';
+
+<Meta title="Manager React Components/Hooks/useLocation" />
+
+
+## useLocation
+
+The useLocation exposes utils methods to access Locations.
+
+## API
+
+The hook rely on the `location` plugin using the following v2 API endpoint
+<Source
+code={`
+GET /location
+`}
+/>
+
+## Methods
+
+### useLocationByName
+Allow you to find a specific location using its name
+
+#### Usage
+<Source
+code={`const { data: location } = useLocationByName('locationName');`}
+language="ts"
+/>
+
+#### Parameters
+<Source
+code={`string`}
+language="ts"
+/>
+
+#### Returns
+Returns a `UseQueryResult` object with:
+- `data`: a `Location` object matching the name given in parameter
+
+
+### useAllLocationsByType
+Allow you to find all location of a certain type
+
+#### Usage
+<Source
+code={`const { data: locations } = useAllLocationsByType(LocationType.LZ);`}
+language="ts"
+/>
+
+#### Parameters
+<Source
+code={`enum LocationType {
+    '1AZ' = 'REGION-1-AZ',
+    '3AZ' = 'REGION-3-AZ',
+    'LZ' = 'LOCAL-ZONE',
+};`}
+language="ts"
+/>
+
+#### Returns
+Returns a `UseQueryResult` object with:
+- `data`: an `Array` of `Location` matching the type given in parameter
+
+### useCityByCode
+Allow you to retrieve a city name using its code
+
+#### Usage
+<Source
+code={`const { data: cityName } = useCityByCode('cityCode');`}
+language="ts"
+/>
+
+#### Parameters
+<Source
+code={`string`}
+language="ts"
+/>
+
+#### Returns
+Returns a `UseQueryResult` object with:
+- `data`: a `string` representing the name of the city matching the code given in parameter
+
+### useAllCountries
+Allow you to get all countries with their name and code
+
+#### Usage
+<Source
+code={`const { data: countries } = useAllCountries();`}
+language="ts"
+/>
+
+#### Returns
+Returns a `UseQueryResult` object with:
+- `data`: an `Array` of unique `Country` extracted from the list of all `Location`
+
+## Types
+
+### Location
+Type representing a `Location` (exposed by `@ovh-ux/shell` package)
+
+<Source
+code={`type Location = {
+    availabilityZones: string[];
+    cardinalPoint: CardinalPoint;
+    cityCode: string;
+    cityLatitude: number;
+    cityLongitude: number;
+    cityName: string;
+    code: string;
+    countryCode: string;
+    countryName: string;
+    geographyCode: string;
+    geographyName: string;
+    location: string;
+    name: string;
+    openingYear: number;
+    specificType: SpecificType;
+    type: Type;
+}`}
+language="ts"
+/>
+
+### Country
+Type representing a `Country` with its name and code
+
+<Source
+code={`type Country = {
+    code: string;
+    name: string;
+}`}
+language="ts"
+/>


### PR DESCRIPTION
## Description

Added hooks to use data from the API v2 /location

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-18341, #15916

## Additional Information

We took advantage of tanstack useQuery select behavior to use the same data source (and the same query key) to handle the differents utils hooks (cf useQuery documentation: "The select function will only run if data changed, or if the reference to the select function itself changes. To optimize, wrap the function in useCallback.")

This Pull request is dependant on this [one](https://github.com/ovh/manager/pull/18762), as it uses the plugin location introduce in this PR.
