### PR TITLE
feat(*): integrate and configure bundle analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage
 **/migration-status-reports/**
 .ide-config
 _out
+perf-budgets-reports/**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "list-dependents": "node scripts/list-dependents.js",
     "manager-cli": "yarn workspace @ovh-ux/manager-cli run manager-cli",
     "packages:publish": "scripts/publish.js",
+    "perf-budgets": "yarn manager-perf-budgets",
     "prepare": "husky install",
     "release": "scripts/release/release.sh",
     "start": "node scripts/start-application.mjs",

--- a/packages/manager-tools/manager-static-analysis-kit/bin/cli-utils.js
+++ b/packages/manager-tools/manager-static-analysis-kit/bin/cli-utils.js
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+
+/**
+ * Log an informational message with a standard prefix.
+ *
+ * @param {string} msg - The message to log.
+ * @returns {void}
+ */
+export function logInfo(msg) {
+  console.log(`[manager-perf-budget] ${msg}`);
+}
+
+/**
+ * Log a warning message with a standard prefix.
+ *
+ * @param {string} msg - The message to log.
+ * @returns {void}
+ */
+export function logWarn(msg) {
+  console.warn(`⚠️  [manager-perf-budget] ${msg}`);
+}
+
+/**
+ * Log an error message with a standard prefix.
+ *
+ * @param {string} msg - The message to log.
+ * @returns {void}
+ */
+export function logError(msg) {
+  console.error(`❌ [manager-perf-budget] ${msg}`);
+}
+
+/**
+ * Check if a given package.json belongs to a React app.
+ *
+ * A package is considered a React app if it declares `react`
+ * as a dependency, devDependency, or peerDependency.
+ *
+ * @param {string} pkgPath - Absolute path to a `package.json` file.
+ * @returns {boolean} True if the package depends on React, otherwise false.
+ */
+export function isReactApp(pkgPath) {
+  try {
+    if (!fs.existsSync(pkgPath)) return false;
+
+    /** @type {Record<string, any>} */
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (!pkg || typeof pkg !== 'object') return false;
+
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies };
+    return Boolean(deps.react);
+  } catch (err) {
+    logWarn(`Failed to read or parse ${pkgPath}: ${err.message}`);
+    return false;
+  }
+}

--- a/packages/manager-tools/manager-static-analysis-kit/bin/lint-cli.js
+++ b/packages/manager-tools/manager-static-analysis-kit/bin/lint-cli.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { spawn } from 'child_process';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { dirname, resolve, join } from 'path';
-import { cwd } from 'process';
-import { existsSync } from 'fs';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import process, { cwd } from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-// eslint-disable-next-line no-underscore-dangle
+import { logError, logInfo } from './cli-utils.js';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const userCwd = cwd();
 const eslintBin = resolve(__dirname, '../node_modules/.bin/eslint');
@@ -13,11 +14,13 @@ const eslintBin = resolve(__dirname, '../node_modules/.bin/eslint');
 const args = process.argv.slice(2);
 const hasExplicitConfigArg = args.includes('--config');
 const localConfigPath = join(userCwd, 'eslint.config.ts');
-const sharedDefaultPath = resolve(__dirname, '../dist/adapters/eslint/config/eslint-shared-config.js');
+const sharedDefaultPath = resolve(
+  __dirname,
+  '../dist/adapters/eslint/config/eslint-shared-config.js',
+);
 const hasLocalConfig = existsSync(localConfigPath);
 
 // Determine effective config path
-// eslint-disable-next-line no-nested-ternary
 const configPath = hasExplicitConfigArg
   ? args[args.indexOf('--config') + 1]
   : hasLocalConfig
@@ -34,8 +37,8 @@ function runLint(command, args, cwd) {
     });
 
     child.on('error', (err) => {
-      console.error('[manager-lint] Failed to run ESLint');
-      console.error(err);
+      logError('[manager-lint] Failed to run ESLint');
+      logError(err);
       reject(1);
     });
 
@@ -52,20 +55,19 @@ function runLint(command, args, cwd) {
     try {
       const mod = await import(url);
       const configContent = mod.default ?? mod;
-      console.log('[manager-lint] Loaded ESLint config from:', configPath);
+      logInfo('[manager-lint] Loaded ESLint config from:', configPath);
       console.dir(configContent, { depth: null });
     } catch (err) {
-      console.error(`[manager-lint] Failed to load config at ${configPath}`);
-      console.error(err);
+      logError(`[manager-lint] Failed to load config at ${configPath}`);
+      logError(err);
       process.exit(1);
     }
     process.exit(0);
   }
 
   // Construct full args
-  const fullArgs = hasExplicitConfigArg || hasLocalConfig
-    ? args
-    : ['--config', sharedDefaultPath, ...args];
+  const fullArgs =
+    hasExplicitConfigArg || hasLocalConfig ? args : ['--config', sharedDefaultPath, ...args];
 
   // Run ESLint using tsx and wait for completion
   const exitCode = await runLint('tsx', [eslintBin, ...fullArgs], userCwd);

--- a/packages/manager-tools/manager-static-analysis-kit/bin/perf-budgets-cli.js
+++ b/packages/manager-tools/manager-static-analysis-kit/bin/perf-budgets-cli.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  collectPerfBudgets,
+  generatePerfBudgetsHtml,
+} from '../dist/adapters/perf-budgets/helpers/perfs-bundle-analysis-helper.js';
+import { bundleAnalysisConfig } from '../dist/configs/bundle-analysis-config.js';
+import { isReactApp, logError, logInfo, logWarn } from './cli-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '../../..');
+const outputRootDir = path.resolve(__dirname, '../../../..');
+const appsDir = path.join(rootDir, 'manager/apps');
+const bundleAnalyzerBin = path.resolve(__dirname, '../node_modules/.bin/analyze');
+const perfBudgetsReportDirName = 'perf-budgets-reports';
+const perfBudgetCombinedJsonReportName = 'perf-budgets-combined-report.json';
+const perfBudgetCombinedHtmlReportName = 'perf-budgets-combined-report.html';
+
+/**
+ * Run vite-bundle-analyzer for given mode (html or json).
+ */
+function runAnalyzer(appDir, appShort, mode) {
+  const reportFile = `${bundleAnalysisConfig?.reportFile || 'bundle-report'}${
+    mode === 'json' ? '.json' : '.html'
+  }`;
+  const outputDir = path.join(outputRootDir, perfBudgetsReportDirName, appShort);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  logInfo(`Running bundle analyzer (${mode}) for ${appShort} → ${outputDir}`);
+
+  const analyzerArgs = [
+    '--mode',
+    mode,
+    '--no-open',
+    '--filename',
+    bundleAnalysisConfig?.reportFile || 'bundle-report',
+  ];
+
+  const result = spawnSync(bundleAnalyzerBin, analyzerArgs, {
+    cwd: appDir,
+    stdio: 'inherit',
+    shell: true,
+  });
+
+  if (result.status !== 0) {
+    logError(`Analyzer (${mode}) failed for ${appShort}`);
+    return;
+  }
+
+  const distReport = path.join(appDir, 'dist', reportFile);
+  const targetReport = path.join(outputDir, reportFile);
+
+  if (fs.existsSync(distReport)) {
+    fs.copyFileSync(distReport, targetReport);
+    logInfo(`✅ ${mode.toUpperCase()} report copied to ${targetReport}`);
+    return targetReport;
+  } else {
+    logWarn(`⚠️ Expected ${mode} report not found at ${distReport}`);
+  }
+}
+
+/**
+ * Build all selected apps with Turbo in one go.
+ */
+function buildApps(apps) {
+  const filters = apps.map((d) => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(appsDir, d, 'package.json'), 'utf-8'));
+    return pkg.name;
+  });
+
+  const turboArgs = ['run', 'build', ...filters.flatMap((f) => ['--filter', f])];
+  logInfo(`Building apps with Turbo (filters: ${filters.join(', ')})`);
+
+  const buildResult = spawnSync('turbo', turboArgs, {
+    cwd: rootDir,
+    stdio: 'inherit',
+    shell: true,
+  });
+
+  if (buildResult.status !== 0) {
+    logError('Turbo build failed for one or more apps. Aborting analysis.');
+    process.exit(1);
+  }
+}
+
+/**
+ * Analyze apps (assumes build is already done).
+ */
+function analyzeApps(apps) {
+  const analyzed = [];
+  for (const app of apps) {
+    const appDir = path.join(appsDir, app);
+    const pkg = JSON.parse(fs.readFileSync(path.join(appDir, 'package.json'), 'utf-8'));
+    const appName = pkg.name;
+    const appShort = appName.replace(/^@ovh-ux\//, '');
+
+    runAnalyzer(appDir, appShort, 'static');
+    runAnalyzer(appDir, appShort, 'json');
+
+    analyzed.push(appName);
+  }
+  return analyzed;
+}
+
+/**
+ * Remove old combined perf budget reports before regeneration.
+ */
+function cleanOldCombinedReports() {
+  const combinedJsonFilePath = path.join(
+    outputRootDir,
+    perfBudgetsReportDirName,
+    perfBudgetCombinedJsonReportName,
+  );
+  const combinedHtmlFilePath = path.join(
+    outputRootDir,
+    perfBudgetsReportDirName,
+    perfBudgetCombinedHtmlReportName,
+  );
+
+  [combinedJsonFilePath, combinedHtmlFilePath].forEach((file) => {
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+      logInfo(`🗑️ Removed old report: ${file}`);
+    }
+  });
+}
+
+/**
+ * Collect budgets and regenerate combined reports.
+ */
+function generateCombinedReports(root) {
+  cleanOldCombinedReports();
+
+  const summary = collectPerfBudgets(root);
+
+  const combinedJsonFilePath = path.join(
+    root,
+    perfBudgetsReportDirName,
+    perfBudgetCombinedJsonReportName,
+  );
+  fs.writeFileSync(combinedJsonFilePath, JSON.stringify(summary, null, 2));
+  logInfo(`✅ Combined JSON report written to ${combinedJsonFilePath}`);
+
+  const combinedHtmlFilePath = path.join(
+    root,
+    perfBudgetsReportDirName,
+    perfBudgetCombinedHtmlReportName,
+  );
+  fs.writeFileSync(combinedHtmlFilePath, generatePerfBudgetsHtml(summary));
+  logInfo(`✅ Combined HTML report written to ${combinedHtmlFilePath}`);
+}
+
+/**
+ * Main CLI entrypoint.
+ */
+function main() {
+  try {
+    if (!fs.existsSync(bundleAnalyzerBin)) {
+      logError(`Analyzer binary not found at ${bundleAnalyzerBin}`);
+      return;
+    }
+
+    // CLI options: --app <name>
+    const appArgIndex = process.argv.indexOf('--app');
+    let selectedApps = [];
+
+    if (appArgIndex !== -1 && process.argv[appArgIndex + 1]) {
+      const appName = process.argv[appArgIndex + 1];
+      if (!fs.existsSync(path.join(appsDir, appName))) {
+        logError(`App not found: ${appName}`);
+        process.exit(1);
+      }
+      selectedApps = [appName];
+      logInfo(`Running in single-app mode for ${appName}`);
+    } else {
+      // discover all React apps
+      selectedApps = fs
+        .readdirSync(appsDir)
+        .filter((directory) => {
+          const pkgPath = path.join(appsDir, directory, 'package.json');
+          return fs.existsSync(pkgPath) && isReactApp(pkgPath);
+        })
+        .slice(0, 3);
+
+      if (selectedApps.length === 0) {
+        logWarn('No React apps found to analyze.');
+        return;
+      }
+      logInfo(`Running in multi-app mode (${selectedApps.length} apps).`);
+    }
+
+    // Step 1: build selected apps
+    buildApps(selectedApps);
+
+    // Step 2: analyze apps
+    const analyzedApps = analyzeApps(selectedApps);
+
+    // Step 3: generate combined reports
+    if (analyzedApps.length > 0) {
+      generateCombinedReports(outputRootDir);
+    }
+  } catch (err) {
+    logError(`Fatal error: ${err.stack || err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/manager-tools/manager-static-analysis-kit/eslint.config.mts
+++ b/packages/manager-tools/manager-static-analysis-kit/eslint.config.mts
@@ -35,7 +35,7 @@ export default [
     },
   },
   {
-    files: ['**/prettier-config.ts', '**/*.config.{ts,js,mjs}'],
+    files: ['**/*.{ts,js,mjs}'],
     rules: {
       'import/no-nodejs-modules': 'off',
     },

--- a/packages/manager-tools/manager-static-analysis-kit/package.json
+++ b/packages/manager-tools/manager-static-analysis-kit/package.json
@@ -81,7 +81,8 @@
   "main": "./dist/code-analysis.js",
   "types": "./dist/code-analysis.d.ts",
   "bin": {
-    "manager-lint": "./bin/lint-cli.js"
+    "manager-lint": "./bin/lint-cli.js",
+    "manager-perf-budgets": "./bin/perf-budgets-cli.js"
   },
   "files": [
     "dist",
@@ -129,6 +130,7 @@
     "tsc-alias": "^1.8.16",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.35.0"
+    "typescript-eslint": "^8.35.0",
+    "vite-bundle-analyzer": "^1.2.3"
   }
 }

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/README.md
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/README.md
@@ -1,0 +1,130 @@
+# 📊 Performance Budgets Toolkit
+
+A developer and CI/CD utility for analyzing **bundle sizes of Manager React apps**, comparing them against **HTTP Archive medians**, and generating **combined JSON & HTML reports**.
+
+---
+
+## 🚀 Overview
+
+This toolkit runs **`vite-bundle-analyzer`** across all (or specific) Manager apps, collects asset size reports, and evaluates them against **performance budgets**.
+
+It provides:
+
+- **Per-app reports**: HTML + JSON with bundle breakdowns.
+- **Combined reports**: A global JSON + HTML dashboard with medians and status.
+- **Color-coded status**:
+  - 🟢 OK – below threshold
+  - 🟠 Near – >= 80% of median
+  - 🔴 Exceed – above 100% of median
+- **Inline asset insights**: Shows total size **and heaviest asset per type** (JS, CSS, HTML, Images).
+- **Details dropdown**: Top N assets per app (default: 5).
+- **Optimization tips**: Actionable best practices with references.
+
+---
+
+## 🏃 Usage
+
+Run the CLI from the **root of the monorepo**:
+
+### Analyze all apps
+
+```bash
+yarn manager-perf-budgets
+```
+
+This will:
+1. Run **Turbo** build for all apps under `packages/manager/apps`.
+2. Run **vite-bundle-analyzer** for each app (HTML + JSON reports).
+3. Generate **combined reports**:
+  - `perf-budgets-reports/perf-budgets-combined-report.json`
+  - `perf-budgets-reports/perf-budgets-combined-report.html`
+
+### Analyze a single app
+
+```bash
+yarn manager-perf-budgets --app manager-catalog-app
+```
+
+---
+
+## 📂 Output Structure
+
+```
+perf-budgets-reports/
+├── manager-catalog-app/
+│   ├── bundle-report.html
+│   ├── bundle-report.json
+├── manager-hub-app/
+│   ├── bundle-report.html
+│   ├── bundle-report.json
+├── perf-budgets-combined-report.json
+├── perf-budgets-combined-report.html
+```
+
+---
+
+## 🔎 JSON Report Format
+
+Example (`perf-budgets-combined-report.json`):
+
+```json
+{
+  "results": [
+    {
+      "app": "manager-catalog-app",
+      "jsKb": 4534.0,
+      "cssKb": 790.1,
+      "htmlKb": 0.8,
+      "imgKb": 0,
+      "jsStatus": "exceed",
+      "cssStatus": "exceed",
+      "htmlStatus": "ok",
+      "imgStatus": "ok",
+      "assets": [
+        { "filename": "index.js", "type": "js", "sizeKb": 4126.8 },
+        { "filename": "main.css", "type": "css", "sizeKb": 789.9 }
+      ]
+    }
+  ],
+  "scores": [
+    {
+      "app": "manager-catalog-app",
+      "scores": { "js": 2, "css": 2, "html": 0, "img": 0 },
+      "totalScore": 4,
+      "status": "fail"
+    }
+  ],
+  "medians": {
+    "jsKb": 747.5,
+    "cssKb": 86.8,
+    "imgKb": 1066.6,
+    "htmlKb": 35.5
+  }
+}
+```
+
+---
+
+## 🌐 HTML Report
+
+- Shows medians at the top (with HTTP Archive references).
+- Color-coded per-app analysis table.
+- Inline **total vs heaviest asset** per type.
+- Dropdown with top N assets.
+- Embedded optimization tips.
+
+---
+
+## 🤝 Contribution
+
+- Follow the existing code style and TypeScript types.
+- Run `yarn lint` and `yarn build` before submitting PRs.
+- Reports are meant for **CI/CD validation** and **developer awareness**.
+
+---
+
+## 📖 References
+
+- [HTTP Archive Page Weight Report](https://httparchive.org/reports/page-weight)
+- [web.dev Performance Guide](https://web.dev/performance)
+- [patterns.dev Performance Patterns](https://www.patterns.dev/)

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/helpers/perfs-bundle-analysis-helper.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/helpers/perfs-bundle-analysis-helper.ts
@@ -1,0 +1,264 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { assetsBudgetsConfig } from '../../../configs/assets-budgets-config';
+import { evaluatePerfBudgets } from '../rules/perfs-budgets-rules';
+import { scoreAllPerfBudgets } from '../rules/perfs-budgets-scoring';
+import { PerfBudgetResult, PerfBudgetsSummary } from '../types/PerfBudget';
+import { ParsedAsset, ParsedBundle } from '../types/PerfBudgetBundle';
+
+const perfBudgetsReportDirName = 'perf-budgets-reports';
+
+/**
+ * Escape HTML entities for safe embedding.
+ */
+export function escapeHtml(str: string): string {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Parse vite-bundle-analyzer JSON output to extract KB totals
+ * and per-asset details.
+ *
+ * @param raw - The parsed JSON from bundle-report.json
+ * @returns Aggregated bundle info with asset breakdown
+ */
+export function parseAnalyzerJson(raw: unknown): ParsedBundle {
+  if (!Array.isArray(raw)) {
+    return { jsKb: 0, cssKb: 0, htmlKb: 0, imgKb: 0, assets: [] };
+  }
+
+  const assets: ParsedAsset[] = raw.map((entry: any): ParsedAsset => {
+    const filename: string = entry?.filename ?? 'unknown';
+    const sizeKb: number = typeof entry?.parsedSize === 'number' ? entry.parsedSize / 1024 : 0;
+
+    let type: ParsedAsset['type'] = 'other';
+    if (/\.js$/i.test(filename)) type = 'js';
+    else if (/\.css$/i.test(filename)) type = 'css';
+    else if (/\.html$/i.test(filename)) type = 'html';
+    else if (/\.(png|jpe?g|gif|svg|webp)$/i.test(filename)) type = 'img';
+
+    return { filename, type, sizeKb };
+  });
+
+  const sumByType = (type: ParsedAsset['type']) =>
+    assets.filter((a) => a.type === type).reduce((sum, a) => sum + a.sizeKb, 0);
+
+  return {
+    jsKb: sumByType('js'),
+    cssKb: sumByType('css'),
+    htmlKb: sumByType('html'),
+    imgKb: sumByType('img'),
+    assets,
+  };
+}
+
+/**
+ * Collect and aggregate all performance budget reports across apps.
+ *
+ * This function parses JSON bundle reports (from vite-bundle-analyzer)
+ * generated per application, normalizes them against configured medians
+ * (HTTP Archive values), and produces a combined summary.
+ */
+export function collectPerfBudgets(rootDir: string): PerfBudgetsSummary {
+  const reportsRoot = path.join(rootDir, perfBudgetsReportDirName);
+
+  if (!fs.existsSync(reportsRoot)) {
+    throw new Error(`Reports directory not found: ${reportsRoot}`);
+  }
+
+  const apps = fs.readdirSync(reportsRoot).filter((d) => {
+    const appJson = path.join(reportsRoot, d, 'bundle-report.json');
+    return fs.existsSync(appJson);
+  });
+
+  const results: (PerfBudgetResult & { assets: ParsedAsset[] })[] = [];
+
+  for (const app of apps) {
+    const jsonPath = path.join(reportsRoot, app, 'bundle-report.json');
+    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+
+    const { jsKb, cssKb, htmlKb, imgKb, assets } = parseAnalyzerJson(raw);
+
+    const appResult = {
+      ...evaluatePerfBudgets({ app, jsKb, cssKb, htmlKb, imgKb }),
+      assets,
+    };
+
+    results.push(appResult);
+  }
+
+  const scores = scoreAllPerfBudgets(results);
+
+  return {
+    results,
+    scores,
+    medians: assetsBudgetsConfig.medians,
+  };
+}
+
+/**
+ * Generate a combined HTML dashboard from collected performance budgets.
+ *
+ * Each row shows totals and the single heaviest asset per type inline,
+ * plus a <details> dropdown with the top-N heaviest assets.
+ */
+// eslint-disable-next-line max-lines-per-function
+export function generatePerfBudgetsHtml(summary: PerfBudgetsSummary): string {
+  const { results, scores, medians } = summary;
+  const heavyCount = assetsBudgetsConfig.heavyAssetsCount;
+
+  function colorizeClass(status: 'ok' | 'near' | 'exceed'): string {
+    switch (status) {
+      case 'ok':
+        return 'status-ok';
+      case 'near':
+        return 'status-near';
+      case 'exceed':
+        return 'status-exceed';
+    }
+  }
+
+  function heaviestOfType(assets: (typeof results)[number]['assets'], type: string) {
+    return assets.filter((a) => a.type === type).sort((a, b) => b.sizeKb - a.sizeKb)[0];
+  }
+
+  function formatCell(
+    total: number,
+    status: 'ok' | 'near' | 'exceed',
+    type: 'js' | 'css' | 'html' | 'img',
+    assets: (typeof results)[number]['assets'],
+  ): string {
+    const heavy = heaviestOfType(assets, type);
+    const heavyInfo = heavy
+      ? `<br/><small><b>Largest ${type.toUpperCase()} asset:</b> <code>${escapeHtml(
+          heavy.filename,
+        )}</code> — ${heavy.sizeKb.toFixed(1)} KB</small>`
+      : '';
+
+    return `<td class="${colorizeClass(status)}">
+      <b>Total ${type.toUpperCase()} assets size:</b> ${total.toFixed(1)} KB
+      ${heavyInfo}
+    </td>`;
+  }
+
+  const rows = scores
+    .map((s) => {
+      const result = results.find((r) => r.app === s.app)!;
+
+      const heavyAssets = [...result.assets]
+        .sort((a, b) => b.sizeKb - a.sizeKb)
+        .slice(0, heavyCount);
+
+      const assetsHtml = heavyAssets
+        .map(
+          (a) =>
+            `<li><code>${escapeHtml(a.filename)}</code> — <strong>${a.sizeKb.toFixed(
+              1,
+            )} KB</strong> (${a.type})</li>`,
+        )
+        .join('\n');
+
+      return `
+        <tr>
+          <td><strong>${escapeHtml(s.app)}</strong></td>
+          ${formatCell(result.jsKb, result.jsStatus, 'js', result.assets)}
+          ${formatCell(result.cssKb, result.cssStatus, 'css', result.assets)}
+          ${formatCell(result.htmlKb, result.htmlStatus, 'html', result.assets)}
+          ${formatCell(result.imgKb, result.imgStatus, 'img', result.assets)}
+          <td><b>${escapeHtml(s.status.toUpperCase())}</b></td>
+          <td>
+            <details>
+              <summary>Top ${heavyCount} Assets</summary>
+              <ul>${assetsHtml || '<li>No assets found</li>'}</ul>
+            </details>
+          </td>
+        </tr>
+      `;
+    })
+    .join('\n');
+
+  const linksHtml = assetsBudgetsConfig.links.httpArchive
+    .map(
+      ({ label, url }) =>
+        `<li><a href="${escapeHtml(url)}" target="_blank">${escapeHtml(label)}</a></li>`,
+    )
+    .join('\n');
+
+  const tipsHtml = assetsBudgetsConfig.links.tips
+    .map(({ label, desc }) => `<li><strong>${escapeHtml(label)}:</strong> ${escapeHtml(desc)}</li>`)
+    .join('\n');
+
+  const optimizationHtml = assetsBudgetsConfig.links.optimization
+    .map(
+      ({ label, url }) =>
+        `<li><a href="${escapeHtml(url)}" target="_blank">${escapeHtml(label)}</a></li>`,
+    )
+    .join('\n');
+
+  return `
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>Perf Budgets Report</title>
+      <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background: #fafafa; }
+        h1, h2 { text-align: center; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; vertical-align: top; }
+        th { background: #f0f0f0; }
+        tr:nth-child(even) { background: #f9f9f9; }
+        tr:hover { background: #f1f7ff; }
+        .status-ok { background: #e6f9e6; color: #207520; }
+        .status-near { background: #fff8e1; color: #a87900; }
+        .status-exceed { background: #fdecea; color: #b71c1c; }
+        code { font-family: monospace; background: #f5f5f5; padding: 1px 3px; border-radius: 3px; }
+        details summary { cursor: pointer; }
+        .box { border: 1px solid #ccc; background: #fff; padding: 10px; margin: 15px 0; border-radius: 6px; }
+      </style>
+    </head>
+    <body>
+      <h1>Performance Budgets Report</h1>
+      <div class="box">
+        <h2>Medians (Desktop)</h2>
+        <p>
+          JS: ${medians.jsKb} KB ·
+          CSS: ${medians.cssKb} KB ·
+          HTML: ${medians.htmlKb} KB ·
+          IMG: ${medians.imgKb} KB
+        </p>
+        <p><b>Links:</b></p>
+        <ul>${linksHtml}</ul>
+      </div>
+
+      <div class="box">
+        <details open>
+          <summary><b>Optimization & Best Practices</b></summary>
+          <h3>Tips</h3>
+          <ul>${tipsHtml}</ul>
+          <h3>Resources</h3>
+          <ul>${optimizationHtml}</ul>
+        </details>
+      </div>
+
+      <h2>Applications</h2>
+      <table>
+        <tr>
+          <th>App</th>
+          <th>JS</th>
+          <th>CSS</th>
+          <th>HTML</th>
+          <th>IMG</th>
+          <th>Status</th>
+          <th>Details</th>
+        </tr>
+        ${rows}
+      </table>
+    </body>
+  </html>`;
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/rules/perfs-budgets-rules.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/rules/perfs-budgets-rules.ts
@@ -1,0 +1,40 @@
+import { assetsBudgetsConfig } from '../../../configs/assets-budgets-config';
+import { PerfBudgetResult } from '../types/PerfBudget';
+
+/**
+ * Determine status for a given asset size compared to thresholds.
+ * @param sizeKb - The actual asset size in KB.
+ * @param medianKb - Median value from config.
+ * @returns "ok", "near", or "exceed".
+ */
+export function evaluateAsset(sizeKb: number, medianKb: number): 'ok' | 'near' | 'exceed' {
+  const { nearFactor, exceedFactor } = assetsBudgetsConfig.thresholds;
+
+  if (sizeKb > medianKb * exceedFactor) {
+    return 'exceed';
+  } else if (sizeKb >= medianKb * nearFactor) {
+    return 'near';
+  }
+  return 'ok';
+}
+
+/**
+ * Evaluate performance budgets for a single app based on asset sizes.
+ * @param appReport - Object containing app name and asset sizes (in KB).
+ * @returns PerfBudgetResult with statuses for each asset type.
+ */
+export function evaluatePerfBudgets(appReport: {
+  app: string;
+  jsKb: number;
+  cssKb: number;
+  htmlKb: number;
+  imgKb: number;
+}): PerfBudgetResult {
+  return {
+    ...appReport,
+    jsStatus: evaluateAsset(appReport.jsKb, assetsBudgetsConfig.medians.jsKb),
+    cssStatus: evaluateAsset(appReport.cssKb, assetsBudgetsConfig.medians.cssKb),
+    htmlStatus: evaluateAsset(appReport.htmlKb, assetsBudgetsConfig.medians.htmlKb),
+    imgStatus: evaluateAsset(appReport.imgKb, assetsBudgetsConfig.medians.imgKb),
+  };
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/rules/perfs-budgets-scoring.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/rules/perfs-budgets-scoring.ts
@@ -1,0 +1,55 @@
+import { PerfBudgetResult } from '../types/PerfBudget';
+import { PerfBudgetScoreLevel, PerfBudgetScoreSummary } from '../types/PerfBudgetScore';
+
+/**
+ * Convert status string into a numeric score.
+ * @param status - One of "ok" | "near" | "exceed".
+ * @returns Numeric score (0–2).
+ */
+function statusToScore(status: 'ok' | 'near' | 'exceed'): PerfBudgetScoreLevel {
+  switch (status) {
+    case 'ok':
+      return 0;
+    case 'near':
+      return 1;
+    case 'exceed':
+      return 2;
+  }
+}
+
+/**
+ * Compute a scored summary for a single app.
+ * @param result - Result of performance budget evaluation.
+ * @returns ScoreSummary for the app.
+ */
+export function scorePerfBudget(result: PerfBudgetResult): PerfBudgetScoreSummary {
+  const scores = {
+    js: statusToScore(result.jsStatus),
+    css: statusToScore(result.cssStatus),
+    html: statusToScore(result.htmlStatus),
+    img: statusToScore(result.imgStatus),
+  };
+
+  const totalScore = Object.values(scores).reduce((sum: number, v) => sum + v, 0);
+
+  let status: 'pass' | 'warn' | 'fail';
+  if (totalScore === 0) status = 'pass';
+  else if (totalScore <= 2) status = 'warn';
+  else status = 'fail';
+
+  return {
+    app: result.app,
+    scores,
+    totalScore,
+    status,
+  };
+}
+
+/**
+ * Compute scores for multiple apps at once.
+ * @param results - List of PerfBudgetResult.
+ * @returns List of ScoreSummary.
+ */
+export function scoreAllPerfBudgets(results: PerfBudgetResult[]): PerfBudgetScoreSummary[] {
+  return results.map(scorePerfBudget);
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudget.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudget.ts
@@ -1,0 +1,80 @@
+import { assetsBudgetsConfig } from '../../../configs/assets-budgets-config';
+import { ParsedAsset } from './PerfBudgetBundle';
+import { PerfBudgetScoreSummary } from './PerfBudgetScore';
+
+/**
+ * Result of evaluating performance budgets for a single app.
+ */
+export interface PerfBudgetResult {
+  /** Application name */
+  app: string;
+  /** JavaScript bundle size in KB */
+  jsKb: number;
+  /** CSS bundle size in KB */
+  cssKb: number;
+  /** HTML size in KB */
+  htmlKb: number;
+  /** Image assets size in KB */
+  imgKb: number;
+
+  /** Evaluation status for JS */
+  jsStatus: 'ok' | 'near' | 'exceed';
+  /** Evaluation status for CSS */
+  cssStatus: 'ok' | 'near' | 'exceed';
+  /** Evaluation status for HTML */
+  htmlStatus: 'ok' | 'near' | 'exceed';
+  /** Evaluation status for images */
+  imgStatus: 'ok' | 'near' | 'exceed';
+}
+
+/**
+ * Combined summary of performance budget analysis across all applications.
+ *
+ * This structure is produced by {@link collectPerfBudgets} and consumed by
+ * {@link generatePerfBudgetsHtml}.
+ *
+ * @property results - Raw per-app evaluation results. Each entry extends
+ * {@link PerfBudgetResult} with the full list of parsed {@link ParsedAsset}
+ * items from the bundle report.
+ *
+ * Example result item:
+ * ```json
+ * {
+ *   "app": "manager-catalog-app",
+ *   "jsKb": 4533.9,
+ *   "cssKb": 790.1,
+ *   "htmlKb": 0.8,
+ *   "imgKb": 0,
+ *   "jsStatus": "exceed",
+ *   "cssStatus": "exceed",
+ *   "htmlStatus": "ok",
+ *   "imgStatus": "ok",
+ *   "assets": [
+ *     { "filename": "assets/index-Dy08JaXK.js", "type": "js", "sizeKb": 404.9 },
+ *     { "filename": "assets/index-BnnLBUth.css", "type": "css", "sizeKb": 790.1 }
+ *   ]
+ * }
+ * ```
+ *
+ * @property scores - Simplified per-app scoring results, produced by
+ * {@link scoreAllPerfBudgets}. Each entry summarizes the numeric scores and
+ * overall status (`pass` / `fail`) for a given app.
+ *
+ * Example score item:
+ * ```json
+ * {
+ *   "app": "manager-catalog-app",
+ *   "scores": { "js": 2, "css": 2, "html": 0, "img": 0 },
+ *   "totalScore": 4,
+ *   "status": "fail"
+ * }
+ * ```
+ *
+ * @property medians - Reference HTTP Archive medians (desktop) used as budget
+ * thresholds. Taken directly from {@link assetsBudgetsConfig.medians}.
+ */
+export interface PerfBudgetsSummary {
+  results: (PerfBudgetResult & { assets: ParsedAsset[] })[];
+  scores: PerfBudgetScoreSummary[];
+  medians: typeof assetsBudgetsConfig.medians;
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudgetBundle.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudgetBundle.ts
@@ -1,0 +1,27 @@
+/**
+ * Represents a single parsed asset from the bundle analyzer output.
+ */
+export interface ParsedAsset {
+  /** Full filename or path of the asset */
+  filename: string;
+  /** Asset type, inferred from extension */
+  type: 'js' | 'css' | 'html' | 'img' | 'other';
+  /** Size in kilobytes (KB), based on `parsedSize` */
+  sizeKb: number;
+}
+
+/**
+ * Represents aggregated bundle size information with per-asset details.
+ */
+export interface ParsedBundle {
+  /** Total JavaScript size in KB */
+  jsKb: number;
+  /** Total CSS size in KB */
+  cssKb: number;
+  /** Total HTML size in KB */
+  htmlKb: number;
+  /** Total image size in KB */
+  imgKb: number;
+  /** List of parsed individual assets */
+  assets: ParsedAsset[];
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudgetScore.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/adapters/perf-budgets/types/PerfBudgetScore.ts
@@ -1,0 +1,36 @@
+import { PerfBudgetResult } from './PerfBudget';
+
+/**
+ * Numeric score levels for statuses.
+ * - ok = 0
+ * - near = 1
+ * - exceed = 2
+ */
+export type PerfBudgetScoreLevel = 0 | 1 | 2;
+
+/**
+ * A scored performance budget for an app.
+ */
+export interface PerfBudgetScore extends PerfBudgetResult {
+  /** Numeric score for each status (0–2). */
+  score: PerfBudgetScoreLevel;
+}
+
+/**
+ * Summary of scores for an app across all assets.
+ */
+export interface PerfBudgetScoreSummary {
+  /** Application name */
+  app: string;
+  /** Scores per asset type */
+  scores: {
+    js: PerfBudgetScoreLevel;
+    css: PerfBudgetScoreLevel;
+    html: PerfBudgetScoreLevel;
+    img: PerfBudgetScoreLevel;
+  };
+  /** Total score (sum of all assets) */
+  totalScore: number;
+  /** Overall status: pass | warn | fail */
+  status: 'pass' | 'warn' | 'fail';
+}

--- a/packages/manager-tools/manager-static-analysis-kit/src/configs/assets-budgets-config.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/configs/assets-budgets-config.ts
@@ -1,0 +1,64 @@
+/**
+ * Performance budgets for assets, based on HTTP Archive medians (Desktop).
+ * Source: https://httparchive.org/reports/page-weight
+ */
+export const assetsBudgetsConfig = {
+  /**
+   * Median asset sizes in kilobytes, based on HTTP Archive.
+   */
+  medians: {
+    jsKb: 747.5,
+    cssKb: 86.8,
+    imgKb: 1066.6,
+    htmlKb: 35.5,
+  },
+
+  /**
+   * Threshold factors for budget evaluation.
+   */
+  thresholds: {
+    nearFactor: 0.8,
+    exceedFactor: 1.0,
+  },
+
+  /**
+   * Number of heaviest assets to show in the HTML <details> section.
+   */
+  heavyAssetsCount: 5,
+
+  /**
+   * Reference links and optimization tips.
+   */
+  links: {
+    httpArchive: [
+      { label: 'JavaScript Median', url: 'https://httparchive.org/reports/page-weight#bytesJs' },
+      { label: 'CSS Median', url: 'https://httparchive.org/reports/page-weight#bytesCss' },
+      { label: 'HTML Median', url: 'https://httparchive.org/reports/page-weight#bytesHtml' },
+      { label: 'Image Median', url: 'https://httparchive.org/reports/page-weight#bytesImg' },
+    ],
+    optimization: [
+      { label: 'Web.dev: Learn Performance', url: 'https://web.dev/learn/performance' },
+      { label: 'Web.dev: Performance Guide', url: 'https://web.dev/performance' },
+      { label: 'Bundle Splitting', url: 'https://www.patterns.dev/vanilla/bundle-splitting/' },
+      { label: 'Dynamic Import', url: 'https://www.patterns.dev/vanilla/dynamic-import/' },
+      {
+        label: 'Import on Interaction',
+        url: 'https://www.patterns.dev/vanilla/import-on-interaction/',
+      },
+      {
+        label: 'Import on Visibility',
+        url: 'https://www.patterns.dev/vanilla/import-on-visibility/',
+      },
+      { label: 'Loading Sequence', url: 'https://www.patterns.dev/vanilla/loading-sequence/' },
+      { label: 'Virtual Lists', url: 'https://www.patterns.dev/vanilla/virtual-lists/' },
+      { label: 'Third-party Scripts', url: 'https://www.patterns.dev/vanilla/third-party/' },
+    ],
+    tips: [
+      { label: 'State Localization', desc: 'Minimize unnecessary re-renders by localizing state.' },
+      { label: 'Memoization', desc: 'Use useMemo/useCallback for expensive calcs and functions.' },
+      { label: 'Lazy Loading', desc: 'Load components/routes lazily to improve initial load.' },
+      { label: 'Virtualization', desc: 'Use react-window/react-virtualized for large lists.' },
+      { label: 'Profiling', desc: 'Use React Profiler and browser DevTools to spot bottlenecks.' },
+    ],
+  },
+};

--- a/packages/manager-tools/manager-static-analysis-kit/src/configs/bundle-analysis-config.ts
+++ b/packages/manager-tools/manager-static-analysis-kit/src/configs/bundle-analysis-config.ts
@@ -1,0 +1,7 @@
+export const bundleAnalysisConfig = {
+  format: 'static', // HTML report
+  open: false, // never auto-open browser
+  gzipSize: true,
+  brotliSize: true,
+  reportFile: 'bundle-report', // base name for reports (html + json)
+};

--- a/packages/manager-tools/manager-vite-config/package.json
+++ b/packages/manager-tools/manager-vite-config/package.json
@@ -24,12 +24,12 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.7",
     "terser": "^5.16.0",
-    "vite": "^6.0.7",
+    "vite": "6.3.4",
     "vite-plugin-static-copy": "^2.0.0",
     "vite-plugin-svgr": "^4.3.0",
     "yn": "^5.0.0"
   },
   "peerDependencies": {
-    "vite": "^6.0.7"
+    "vite": "6.3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7013,6 +7013,11 @@
     "@ovh-ux/request-tagger" "^0.4.1"
     axios "^1.1.2"
 
+"@ovh-ux/manager-core-sso@^0.3.1", "@ovh-ux/manager-core-sso@^0.3.2":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-core-sso/-/manager-core-sso-0.3.3.tgz#138b5c1592c437c689ec4c523ddf0cc7aa26812e"
+  integrity sha512-22M6BY5AkjzOFMATSg+EpoFXkxYKVbqI2hev7eD2EsfNRCnBINjXMWy9FDD0cXMuwkP7RwxbLuf8dAC4x+JZtA==
+
 "@ovh-ux/manager-pci-common@^0.16.4":
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/@ovh-ux/manager-pci-common/-/manager-pci-common-0.16.4.tgz#0d9f4efd0140cd4f2eb0f9b508f3e53a8120e5c2"
@@ -7180,6 +7185,11 @@
   version "0.21.8"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ovh-at-internet/-/ovh-at-internet-0.21.8.tgz#91f6b35e77eb60839a715d787e6ab9a22e7ec183"
   integrity sha512-RBrew2Xnkhw/gqvDhLDBiv3mQMlTn6yLNDrF0kc8JtuYG1FiNdM7ucIOq581jZJ598GNhCMIbjvpQ2XjysnKuQ==
+
+"@ovh-ux/request-tagger@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/request-tagger/-/request-tagger-0.4.1.tgz#ae77381d54f345e657a5c6c3195ece119fe375a8"
+  integrity sha512-4mLN1zVa5CvpAQn+TGnUbxMM6Qr2zytQQQexw1a7WkoxuY/SQ+57PW/2/7VrQ1c1wLnjSUG2h88Wcy5AapZZAA==
 
 "@ovh-ux/rollup-plugin-less-inject@^1.0.5":
   version "1.0.6"
@@ -8502,6 +8512,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz#f768e3b2b0e6b55c595d7a053652c06413713983"
   integrity sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==
 
+"@rollup/rollup-android-arm-eabi@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz#939c1be9625d428d8513e4ab60d406fe8db23718"
+  integrity sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==
+
 "@rollup/rollup-android-arm64@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz#ffb84f1359c04ec8a022a97110e18a5600f5f638"
@@ -8536,6 +8551,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz#40379fd5501cfdfd7d8f86dfa1d3ce8d3a609493"
   integrity sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==
+
+"@rollup/rollup-android-arm64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz#b74005775903f7a8f4e363d2840c1dcef3776ff3"
+  integrity sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==
 
 "@rollup/rollup-darwin-arm64@4.16.4":
   version "4.16.4"
@@ -8572,6 +8592,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz#972c227bc89fe8a38a3f0c493e1966900e4e1ff7"
   integrity sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==
 
+"@rollup/rollup-darwin-arm64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz#8c04603cdcf1ec0cd6b27152b3827e49295f2962"
+  integrity sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==
+
 "@rollup/rollup-darwin-x64@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz#fcb25ccbaa3dd33a6490e9d1c64bab2e0e16b932"
@@ -8607,6 +8632,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz#96c919dcb87a5aa7dec5f7f77d90de881e578fdd"
   integrity sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==
 
+"@rollup/rollup-darwin-x64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz#19ec976f1cc663def2692cd7ffb32981f2b0b733"
+  integrity sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==
+
 "@rollup/rollup-freebsd-arm64@4.30.1":
   version "4.30.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz#233f8e4c2f54ad9b719cd9645887dcbd12b38003"
@@ -8622,6 +8652,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz#d199d8eaef830179c0c95b7a6e5455e893d1102c"
   integrity sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==
 
+"@rollup/rollup-freebsd-arm64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz#a96b4ad8346229f6fcbd9d57f1c53040b037c2da"
+  integrity sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==
+
 "@rollup/rollup-freebsd-x64@4.30.1":
   version "4.30.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz#dfba762a023063dc901610722995286df4a48360"
@@ -8636,6 +8671,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz#cab01f9e06ca756c1fabe87d64825ae016af4713"
   integrity sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==
+
+"@rollup/rollup-freebsd-x64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz#fa565a282bc57967ee6668607b181678bdd74e4a"
+  integrity sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==
 
 "@rollup/rollup-linux-arm-gnueabihf@4.16.4":
   version "4.16.4"
@@ -8672,6 +8712,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz#f6f1c42036dba0e58dc2315305429beff0d02c78"
   integrity sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==
 
+"@rollup/rollup-linux-arm-gnueabihf@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz#dfc88f7295e1f98d77f25296be787e8a5d6ced75"
+  integrity sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==
+
 "@rollup/rollup-linux-arm-musleabihf@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.16.4.tgz#7741df2448c11c56588b50835dbfe91b1a10b375"
@@ -8706,6 +8751,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz#1157e98e740facf858993fb51431dce3a4a96239"
   integrity sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz#32cd70c87455ca031f0361090cf17da5a2ef66d5"
+  integrity sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==
 
 "@rollup/rollup-linux-arm64-gnu@4.16.4":
   version "4.16.4"
@@ -8742,6 +8792,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz#b39db73f8a4c22e7db31a4f3fd45170105f33265"
   integrity sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==
 
+"@rollup/rollup-linux-arm64-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz#0e7e1fe7241e3384f6c6b4ccdbcfa8ad8c78b869"
+  integrity sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==
+
 "@rollup/rollup-linux-arm64-musl@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.16.4.tgz#e37ef259358aa886cc07d782220a4fb83c1e6970"
@@ -8777,6 +8832,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz#4043398049fe4449c1485312d1ae9ad8af4056dd"
   integrity sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==
 
+"@rollup/rollup-linux-arm64-musl@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz#5d421f2f3e4a84786c4dfd9ce97e595c9b59e7f4"
+  integrity sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==
+
 "@rollup/rollup-linux-loongarch64-gnu@4.30.1":
   version "4.30.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz#e957bb8fee0c8021329a34ca8dfa825826ee0e2e"
@@ -8791,6 +8851,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz#855a80e7e86490da15a85dcce247dbc25265bc08"
   integrity sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==
+
+"@rollup/rollup-linux-loongarch64-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz#a0fb5c7d0e88319e18acfd9436f19ee39354b027"
+  integrity sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==
 
 "@rollup/rollup-linux-powerpc64le-gnu@4.16.4":
   version "4.16.4"
@@ -8827,6 +8892,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz#8cf843cb7ab1d42e1dda680937cf0a2db6d59047"
   integrity sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==
 
+"@rollup/rollup-linux-ppc64-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz#a65b598af12f25210c3295da551a6e3616ea488d"
+  integrity sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==
+
 "@rollup/rollup-linux-riscv64-gnu@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.16.4.tgz#d32727dab8f538d9a4a7c03bcf58c436aecd0139"
@@ -8862,10 +8932,20 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz#287c085472976c8711f16700326f736a527f2f38"
   integrity sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==
 
+"@rollup/rollup-linux-riscv64-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz#10ba776214ae2857c5bf4389690dabb2fbaf7d98"
+  integrity sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==
+
 "@rollup/rollup-linux-riscv64-musl@4.44.1":
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz#095ad5e53a54ba475979f1b3226b92440c95c892"
   integrity sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==
+
+"@rollup/rollup-linux-riscv64-musl@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz#c2a46cbaa329d5f21e5808f5a66bb9c78cf68aac"
+  integrity sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==
 
 "@rollup/rollup-linux-s390x-gnu@4.16.4":
   version "4.16.4"
@@ -8902,6 +8982,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz#a3dec8281d8f2aef1703e48ebc65d29fe847933c"
   integrity sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==
 
+"@rollup/rollup-linux-s390x-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz#a07447be069d64462e30c66611be20c4513963ed"
+  integrity sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==
+
 "@rollup/rollup-linux-x64-gnu@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.16.4.tgz#6356c5a03a4afb1c3057490fc51b4764e109dbc7"
@@ -8936,6 +9021,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz#4b211e6fd57edd6a134740f4f8e8ea61972ff2c5"
   integrity sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==
+
+"@rollup/rollup-linux-x64-gnu@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz#8887c58bd51242754ae9c56947d6e883332dcc74"
+  integrity sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==
 
 "@rollup/rollup-linux-x64-musl@4.16.4":
   version "4.16.4"
@@ -8972,6 +9062,16 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz#3ecbf8e21b4157e57bb15dc6837b6db851f9a336"
   integrity sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==
 
+"@rollup/rollup-linux-x64-musl@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz#6403fda72a2b3b9fbbeeff93d14f1c45ef9775f3"
+  integrity sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==
+
+"@rollup/rollup-openharmony-arm64@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz#52809afccaff47e731b965a0c16e5686be819d5f"
+  integrity sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==
+
 "@rollup/rollup-win32-arm64-msvc@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.16.4.tgz#6cc0db57750376b9303bdb6f5482af8974fcae35"
@@ -9006,6 +9106,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz#d4aae38465b2ad200557b53c8c817266a3ddbfd0"
   integrity sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==
+
+"@rollup/rollup-win32-arm64-msvc@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz#23fe00ddbb40b27a3889bc1e99e6310d97353ad5"
+  integrity sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==
 
 "@rollup/rollup-win32-ia32-msvc@4.16.4":
   version "4.16.4"
@@ -9042,6 +9147,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz#0258e8ca052abd48b23fd6113360fa0cd1ec3e23"
   integrity sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==
 
+"@rollup/rollup-win32-ia32-msvc@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz#520b588076b593413d919912d69dfd5728a1f305"
+  integrity sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==
+
 "@rollup/rollup-win32-x64-msvc@4.16.4":
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.16.4.tgz#c09ad9a132ccb5a67c4f211d909323ab1294f95f"
@@ -9076,6 +9186,11 @@
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz#1c982f6a5044ffc2a35cd754a0951bdcb44d5ba0"
   integrity sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==
+
+"@rollup/rollup-win32-x64-msvc@4.50.0":
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz#d81efe6a12060c7feddf9805e2a94c3ab0679f48"
+  integrity sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -19484,6 +19599,11 @@ fdir@^6.4.6:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.6.tgz#2b268c0232697063111bbf3f64810a2a741ba281"
   integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
@@ -26175,6 +26295,11 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pidtree@0.6.0, pidtree@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
@@ -28583,6 +28708,36 @@ rollup@^4.30.1:
     "@rollup/rollup-win32-x64-msvc" "4.35.0"
     fsevents "~2.3.2"
 
+rollup@^4.34.9:
+  version "4.50.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.50.0.tgz#6f237f598b7163ede33ce827af8534c929aaa186"
+  integrity sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.50.0"
+    "@rollup/rollup-android-arm64" "4.50.0"
+    "@rollup/rollup-darwin-arm64" "4.50.0"
+    "@rollup/rollup-darwin-x64" "4.50.0"
+    "@rollup/rollup-freebsd-arm64" "4.50.0"
+    "@rollup/rollup-freebsd-x64" "4.50.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.50.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.50.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.50.0"
+    "@rollup/rollup-linux-arm64-musl" "4.50.0"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.50.0"
+    "@rollup/rollup-linux-ppc64-gnu" "4.50.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.50.0"
+    "@rollup/rollup-linux-riscv64-musl" "4.50.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.50.0"
+    "@rollup/rollup-linux-x64-gnu" "4.50.0"
+    "@rollup/rollup-linux-x64-musl" "4.50.0"
+    "@rollup/rollup-openharmony-arm64" "4.50.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.50.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.50.0"
+    "@rollup/rollup-win32-x64-msvc" "4.50.0"
+    fsevents "~2.3.2"
+
 rollup@^4.40.0:
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.44.1.tgz#641723932894e7acbe6052aea34b8e72ef8b7c8f"
@@ -30664,6 +30819,14 @@ tinyglobby@^0.2.10:
     fdir "^6.4.3"
     picomatch "^4.0.2"
 
+tinyglobby@^0.2.13:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+
 tinyglobby@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
@@ -32242,6 +32405,11 @@ victory-vendor@^36.6.8:
     d3-time "^3.0.0"
     d3-timer "^3.0.1"
 
+vite-bundle-analyzer@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/vite-bundle-analyzer/-/vite-bundle-analyzer-1.2.3.tgz#5a216544a4fb41d571f8cc0cd78adccfdff2ec96"
+  integrity sha512-8nhwDGHWMKKgg6oegAOpDgTT7/yzTVzeYzLF4y8WBJoYu9gO7h29UpHiQnXD2rAvfQzDy5Wqe/Za5cgqhnxi5g==
+
 vite-node@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.6.1.tgz#fff3ef309296ea03ceaa6ca4bb660922f5416c57"
@@ -32357,6 +32525,20 @@ vite-plugin-svgr@^4.3.0:
     "@rollup/pluginutils" "^5.1.3"
     "@svgr/core" "^8.1.0"
     "@svgr/plugin-jsx" "^8.1.0"
+
+vite@6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.4.tgz#d441a72c7cd9a93b719bb851250a4e6c119c9cff"
+  integrity sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
+    postcss "^8.5.3"
+    rollup "^4.34.9"
+    tinyglobby "^0.2.13"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 vite@^5.0.0:
   version "5.0.11"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR introduces a new **Performance Budgets analysis tool** for all React applications in the monorepo.  

It leverages `vite-bundle-analyzer` to generate per-app bundle reports (HTML + JSON) and aggregates them into a combined dashboard with medians, thresholds, and performance tips.

**Everything is fully encapsulated inside the Static Analysis Kit: no changes are required in individual apps. Thanks to installing the bundle analyzer as a devDependency and running with cwd, the analysis can be executed anywhere without npx permission issues.**

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19352

## Key Features

- ✅ **Turbo-powered builds**: All apps are built in one go before analysis.  
- ✅ **Bundle analysis**: Generates both `bundle-report.html` and `bundle-report.json` per app.  
- ✅ **Aggregated reports**: Produces combined JSON + HTML reports across all apps.  
- ✅ **Medians & thresholds**: Uses [HTTP Archive medians](https://httparchive.org/reports/page-weight) for JS, CSS, HTML, and IMG sizes.  
- ✅ **Status evaluation**: Marks assets as `ok`, `near`, or `exceed` based on thresholds.  
- ✅ **Inline + details view**: Each table row shows total size, largest asset, and a collapsible list of top-N assets.  
- ✅ **Performance tips**: Includes optimization guidance and useful links inline in the report.  
- ✅ **Cleanup**: Old combined reports are automatically removed before regeneration.  
- ✅ **Configurable**: Thresholds, medians, and top-N assets count are configurable in `assets-budgets-config.ts`.

## CLI Usage

Run the CLI script from the monorepo root:

```bash
# Analyze all React apps
yarn manager-perf-budgets

# Analyze a single app
yarn manager-perf-budgets --app manager-catalog-app
```

Generated artifacts:
- Per-app: `perf-budgets-reports/<app>/bundle-report.json` + `.html`
- Combined: `perf-budgets-reports/perf-budgets-combined-report.json` + `.html`

## CI/CD Integration

- The combined JSON is suitable for automation, CI pipelines, or quality gates.  
- The HTML dashboard can be uploaded as an artifact for visual inspection.

We can also trigger the `perf-budgets` script directly from **CDS (Continuous Deployment/Delivery)** to automatically build and publish the reports online.  

This makes the performance dashboard accessible to the whole team without running the script locally.  
Additionally, we could schedule a **daily cron job** in CDS to generate fresh reports at the end of each day, with notifications sent via **Webex and email**, similar to what we already do for the **migration status report**.

## Developer Benefits
- Clear visibility into bundle sizes per app.
- Early detection of regressions.
- Actionable insights with optimization resources.

## Contribution Notes
- Keep thresholds and medians updated in `assets-budgets-config.ts`.  
- Developers can extend rules in `perfs-budgets-rules.ts` or scoring logic in `perfs-budgets-scoring.ts`.  
- Reports should be reviewed regularly to detect regressions early.

## Example of reports:

[perf-budgets-reports.zip](https://github.com/user-attachments/files/22197617/perf-budgets-reports.zip)

<img width="1470" height="766" alt="image" src="https://github.com/user-attachments/assets/e3f8c329-2804-4a6d-b7db-e893caea241f" />
