### PR TITLE
fix(*): fix incorrect pagination params in iceberg fetch

### DIFF
--- a/packages/manager/core/api/src/iceberg.ts
+++ b/packages/manager/core/api/src/iceberg.ts
@@ -78,7 +78,7 @@ export const buildHeaders = () => {
       return builder;
     },
     setDisabledCache: (disableCache: boolean | undefined) => {
-      if (disableCache) headers['Pragma'] = 'no-cache';
+      if (disableCache) headers.Pragma = 'no-cache';
       return builder;
     },
     setPaginationSort: (sortBy: string | undefined, sortOrder = 'ASC') => {
@@ -153,7 +153,7 @@ export async function fetchIcebergV2<T>({
 
   return {
     data: response.data,
-    cursorNext: headers['x-pagination-cursor-next'] ?? '',
+    cursorNext: headers['x-pagination-cursor-next'],
     status: response.status,
   };
 }

--- a/packages/manager/core/api/src/types/iceberg.type.ts
+++ b/packages/manager/core/api/src/types/iceberg.type.ts
@@ -32,6 +32,6 @@ export type IcebergFetchResultV6<T> = {
 
 export type IcebergFetchResultV2<T> = {
   data: T[];
-  cursorNext: string;
+  cursorNext?: string;
   status: number;
 };


### PR DESCRIPTION
ref: #PRDCOL-182

## Description

Ticket Reference: #PRDCOL-182

## Additional Information

This PR fixes a bug in the Zimbra app caused by a regression introduced during the recent refactor of the core-api module. The issue was related to the **icebergeV2** service, where setting **cursorNext** to an empty string ("") caused **TanStack Query**'s useInfiniteQuery to enter an infinite re-render loop. The fix ensures that cursorNext is only set when a valid value is present, preventing this behavior and restoring correct pagination.
