### PR TITLE
fix(dns-44): allow null (dot) target on MX DNS record (rfc7505)

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dashboard/domain-validator.service.js
+++ b/packages/manager/apps/web/client/app/domain/dashboard/domain-validator.service.js
@@ -337,6 +337,10 @@ angular.module('services').service(
      * @returns {boolean}
      */
     isValidMXTarget(value) {
+      if (value === '.') {
+        // allow MX null
+        return true;
+      }
       if (/\s+\.$/.test(value)) {
         // prevent spaces before dot
         return false;


### PR DESCRIPTION
ref: #DNS-44
Allow the null (".") target value into a MX DNS record target field (currently already supported by the API)