### PR TITLE
feat(web-ongoing-operations): fix duplicate translation

### DIFF
--- a/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_FR.json
+++ b/packages/manager/apps/web-ongoing-operations/public/translations/dashboard/Messages_fr_FR.json
@@ -1,6 +1,5 @@
 {
   "title": "Dashboard page",
-  "back_link": "Retour à la liste",
   "domain_operations": "Opération",
   "domain_operation_comment": "Commentaire de l'opération : <strong>{{t0}}</strong>",
   "domain_operation_data": "Vous pouvez modifier les données relatives à l'opération : <strong>{{t0}}</strong>",
@@ -8,13 +7,11 @@
   "domain_operations_relaunch_title": "Relancer l'opération",
   "domain_operations_cancel_title": "Annuler l'opération",
   "domain_operations_table_header_comment": "Commentaire",
-  "domain_operations_table_header_creationDate": "Date de création",
   "domain_operations_table_header_lastUpdate": "Date de mise à jour",
   "domain_operations_table_header_doneDate": "Date de fin",
   "domain_operations_table_header_status": "État",
   "domain_operations_table_header_domain": "Domaine",
   "domain_operations_table_header_allDom": "Alldom",
-  "domain_operations_table_header_name": "Nom",
   "domain_operations_dashboard_title": "Opérations en cours",
   "domain_operations_dashboard_info": "Vous trouverez ci-dessous l'ensemble des opérations en cours. Selon l'opération, une action de votre part peut être nécessaire.",
   "domain_operations_tab_popover_update": "Modifier l'opération",
@@ -130,8 +127,5 @@
   "domain_operations_update_nicbilling_click": "Changez les informations du contact facturation en cliquant ici",
   "domain_operations_accelerate_success": "L'opération a été accélérée avec succès.",
   "domain_operations_cancel_success": "L'opération a été annulée avec succès.",
-  "domain_operations_relaunch_success": "L'opération a été relancée avec succès.",
-  "wizard_confirm": "Confirmer",
-  "wizard_cancel": "Annuler",
-  "domain_operations_guides": "Informations générales"
+  "domain_operations_relaunch_success": "L'opération a été relancée avec succès."
 }

--- a/packages/manager/apps/web-ongoing-operations/src/components/SubHeader/SubHeader.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/components/SubHeader/SubHeader.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigationGetUrl } from '@ovh-ux/manager-react-shell-client';
-import { Icon, ICON_NAME, Link, Text, TEXT_PRESET } from '@ovhcloud/ods-react';
+import { Link, Text, TEXT_PRESET } from '@ovhcloud/ods-react';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import config from '@/web-ongoing-operations.config';
 
 interface SubHeaderProps {
@@ -9,16 +10,19 @@ interface SubHeaderProps {
 }
 
 export default function SubHeader({ title }: SubHeaderProps) {
-  const { t } = useTranslation('dashboard');
+  const { t: tAction } = useTranslation(NAMESPACES.ACTIONS);
   const { data: customUrl } = useNavigationGetUrl([config.rootLabel, '', {}]);
   const url = `${customUrl as string}/domain`;
 
   return (
     <section className="mb-8 flex flex-col gap-y-2">
-      <Link href={url} disabled={!url}>
-        <Icon name={ICON_NAME.arrowLeft} />
-        {t('back_link')}
-      </Link>
+      <Link
+        href={url}
+        icon="arrow-left"
+        iconAlignment="left"
+        label={tAction('back_to_list')}
+        isDisabled={!url}
+      />
       <Text preset={TEXT_PRESET.heading3}>{title}</Text>
     </section>
   );

--- a/packages/manager/apps/web-ongoing-operations/src/components/Update/Content/UpdateActions.component.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/components/Update/Content/UpdateActions.component.tsx
@@ -15,6 +15,7 @@ import {
   RadioLabel,
   RadioValueChangeDetail,
 } from '@ovhcloud/ods-react';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { TOngoingOperations } from '@/types';
 import { ActionNameEnum } from '@/enum/actionName.enum';
 import { urls } from '@/routes/routes.constant';
@@ -36,7 +37,7 @@ export default function UpdateActions({
   onValidate,
   setActionName,
 }: UpdateActionsProps) {
-  const { t } = useTranslation('dashboard');
+  const { t } = useTranslation(['dashboard', NAMESPACES.ACTIONS]);
   const navigate = useNavigate();
 
   return (
@@ -93,7 +94,8 @@ export default function UpdateActions({
           <MessageBody>{t('domain_operations_accelerate_warning')}</MessageBody>
         </Message>
       )}
-      <div className="flex gap-x-2">
+
+      <div className="flex gap-x-2 mt-8">
         <Button
           slot="actions"
           onClick={() => {
@@ -101,7 +103,7 @@ export default function UpdateActions({
           }}
           variant={BUTTON_VARIANT.ghost}
         >
-          {t('wizard_cancel')}
+          t(`${NAMESPACES.ACTIONS}:cancel`)
         </Button>
         <Button
           slot="actions"
@@ -109,7 +111,7 @@ export default function UpdateActions({
           disabled={disabled}
           loading={isActionLoading}
         >
-          {t('wizard_confirm')}
+          t(`${NAMESPACES.ACTIONS}:confirm`)
         </Button>
       </div>
     </section>

--- a/packages/manager/apps/web-ongoing-operations/src/hooks/useOngoingOperationDatagridColumns.spec.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/hooks/useOngoingOperationDatagridColumns.spec.tsx
@@ -2,6 +2,7 @@ import '@/setupTests';
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { useOngoingOperationDatagridColumns } from '@/hooks/useOngoingOperationDatagridColumns';
 import { ParentEnum } from '@/enum/parent.enum';
 
@@ -30,7 +31,7 @@ describe('useDatagridColumn', () => {
       domain: 'domain_operations_table_header_domain',
       function: 'domain_operations',
       comment: 'domain_operations_table_header_comment',
-      created_on: 'domain_operations_table_header_creationDate',
+      created_on: `${NAMESPACES.DASHBOARD}:creation_date`,
       last_updated: 'domain_operations_table_header_lastUpdate',
       status: 'domain_operations_table_header_status',
     };

--- a/packages/manager/apps/web-ongoing-operations/src/hooks/useOngoingOperationDatagridColumns.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/hooks/useOngoingOperationDatagridColumns.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { TOngoingOperations } from 'src/types';
 import { FilterCategories } from '@ovh-ux/manager-core-api';
 import { ODS_BUTTON_VARIANT } from '@ovhcloud/ods-components';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { ParentEnum } from '@/enum/parent.enum';
 import { removeQuotes } from '@/utils/utils';
 import OngoingOperationDatagridDomain from '@/components/OngoingOperationDatagrid/OngoingOperationDatagridDomain';
@@ -27,7 +28,11 @@ export const useOngoingOperationDatagridColumns = (
   searchableColumnID: string,
   parent: ParentEnum,
 ) => {
-  const { t } = useTranslation('dashboard');
+  const { t } = useTranslation([
+    'dashboard',
+    NAMESPACES.FORM,
+    NAMESPACES.DASHBOARD,
+  ]);
   const { clearNotifications } = useNotifications();
   const navigate = useNavigate();
   const location = useLocation();
@@ -56,8 +61,7 @@ export const useOngoingOperationDatagridColumns = (
         (parent === ParentEnum.DOMAIN &&
           t('domain_operations_table_header_domain')) ||
         (parent === ParentEnum.ZONE && DNS_OPERATIONS_TABLE_HEADER_DOMAIN) ||
-        (parent === ParentEnum.ALLDOM &&
-          t('domain_operations_table_header_name')),
+        (parent === ParentEnum.ALLDOM && t(`${NAMESPACES.FORM}:lastname`)),
       comparator: FilterCategories.String,
       isFilterable: true,
       isSearchable: true,
@@ -96,7 +100,7 @@ export const useOngoingOperationDatagridColumns = (
           {formatDate({ date: props.creationDate, format: 'P p' })}
         </DataGridTextCell>
       ),
-      label: t('domain_operations_table_header_creationDate'),
+      label: t(`${NAMESPACES.DASHBOARD}:creation_date`),
       enableHiding: true,
     },
     {

--- a/packages/manager/apps/web-ongoing-operations/src/pages/dashboard/Dashboard.tsx
+++ b/packages/manager/apps/web-ongoing-operations/src/pages/dashboard/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
   useNotifications,
 } from '@ovh-ux/manager-react-components';
 import { Tab, TabList, Tabs } from '@ovhcloud/ods-react';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { GUIDES_LIST } from '@/guides.constants';
 import { getLanguageKey } from '@/utils/utils';
 import { urls } from '@/routes/routes.constant';
@@ -42,7 +43,7 @@ export default function DashboardPage() {
   const [displayAllDom, setDisplayAllDom] = useState<boolean>(true);
   const location = useLocation();
   const navigate = useNavigate();
-  const { t, i18n } = useTranslation('dashboard');
+  const { t, i18n } = useTranslation(['dashboard', NAMESPACES.DASHBOARD]);
   const { notifications } = useNotifications();
   const langCode = getLanguageKey(i18n.language);
 
@@ -51,7 +52,7 @@ export default function DashboardPage() {
       id: 1,
       href: GUIDES_LIST.domains.url[langCode],
       target: '_blank',
-      label: t('domain_operations_guides'),
+      label: t(`${NAMESPACES.DASHBOARD}:general_information`),
     },
   ];
   const { data: allDomIAMRessources } = useGetIAMResourceAllDom();


### PR DESCRIPTION
## Description

CLI to Identify duplicate translations:
We now have a new CLI command that can assist us in reducing the translation burden by identifying the duplicated content that has already been translated in the common-translations package.

Ticket Reference: #MANAGER-19096
