### PR TITLE
fix(hub): correct displayed status for notpaid orders

### DIFF
--- a/packages/manager/apps/hub/src/components/hub-order-tracking/HubOrderTracking.component.tsx
+++ b/packages/manager/apps/hub/src/components/hub-order-tracking/HubOrderTracking.component.tsx
@@ -35,6 +35,7 @@ import { useLastOrderTracking } from '@/data/hooks/lastOrderTracking/useLastOrde
 import {
   ERROR_STATUS,
   WAITING_PAYMENT_LABEL,
+  NOT_PAID,
 } from '@/data/api/order/order.constants';
 import useDateFormat from '@/hooks/dateFormat/useDateFormat';
 import { LastOrderTrackingResponse, OrderHistory } from '@/types/order.type';
@@ -98,7 +99,14 @@ export default function HubOrderTracking() {
     return getLatestStatus(orderDataResponse.history);
   }, [orderDataResponse, isLastOrderLoading]);
 
-  const isWaitingPayment = currentStatus?.label === WAITING_PAYMENT_LABEL;
+  const displayedLabel = useMemo(() => {
+    if (!currentStatus) return undefined;
+    return orderDataResponse?.status === NOT_PAID
+      ? WAITING_PAYMENT_LABEL
+      : currentStatus.label;
+  }, [currentStatus, orderDataResponse?.status]);
+
+  const isWaitingPayment = displayedLabel === WAITING_PAYMENT_LABEL;
 
   const { format } = useDateFormat({
     options: {
@@ -193,14 +201,14 @@ export default function HubOrderTracking() {
                       className="inline-block mr-1"
                     >
                       <strong>{format(new Date(currentStatus.date))}</strong>
-                      &nbsp;{t(`order_tracking_history_${currentStatus.label}`)}
+                      &nbsp;{t(`order_tracking_history_${displayedLabel}`)}
                     </OsdsText>
                     <span className="inline-block size-[16px]">
                       <OsdsIcon
                         size={ODS_ICON_SIZE.xxs}
                         color={ODS_THEME_COLOR_INTENT.text}
                         name={
-                          !ERROR_STATUS.includes(currentStatus.label) &&
+                          !ERROR_STATUS.includes(displayedLabel) &&
                           !isWaitingPayment
                             ? ODS_ICON_NAME.OK
                             : ODS_ICON_NAME.CLOSE

--- a/packages/manager/apps/hub/src/components/hub-order-tracking/HubOrderTracking.spec.tsx
+++ b/packages/manager/apps/hub/src/components/hub-order-tracking/HubOrderTracking.spec.tsx
@@ -140,4 +140,25 @@ describe('HubOrderTracking Component', async () => {
     const formattedDate = screen.getByText(new Date().toLocaleDateString());
     expect(formattedDate).toBeInTheDocument();
   });
+
+  it('displays payment not received when status is notPaid', async () => {
+    useLastOrderTrackingMockValue.isLoading = false;
+    useLastOrderTrackingMockValue.error = false;
+    useLastOrderTrackingMockValue.data = {
+      orderId: 231474541,
+      date: new Date().toISOString(),
+      status: 'notPaid',
+      history: [
+        { date: new Date().toISOString(), label: 'PAYMENT_INITIATED' },
+      ],
+    };
+
+    renderComponent(<HubOrderTracking />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('order_tracking_history_custom_payment_waiting'),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/manager/apps/hub/src/data/hooks/orderCompleteHistory/useOrderCompleteHistory.tsx
+++ b/packages/manager/apps/hub/src/data/hooks/orderCompleteHistory/useOrderCompleteHistory.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { getCompleteHistory } from '@/data/api/order/order';
+import { NOT_PAID } from '@/data/api/order/order.constants';
 import { OrderHistory } from '@/types/order.type';
 
 export const useOrderCompleteHistory = (
@@ -11,6 +12,6 @@ export const useOrderCompleteHistory = (
   return useQuery<Array<OrderHistory>, AxiosError>({
     queryKey: ['orderCompleteHistory', orderId, orderStatus, orderDate],
     queryFn: () => getCompleteHistory(orderId, orderStatus, orderDate),
-    enabled: !!orderId && !!orderStatus && !!orderDate,
+    enabled: !!orderId && !!orderStatus && orderStatus !== NOT_PAID && !!orderDate,
   });
 };


### PR DESCRIPTION
ref: #MANAGER-19809

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19809 #PRB0042678

Fix the hub “Last order” tile to show “Payment not received” when the order status is notPaid, instead of the misleading “Payment in validation”

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
