### PR TITLE
fix(pci-instances): prevent planCode to be null

### DIFF
--- a/packages/manager/modules/pci/src/projects/project/instances/instance/instance.controller.js
+++ b/packages/manager/modules/pci/src/projects/project/instances/instance/instance.controller.js
@@ -31,7 +31,11 @@ export default class PciInstanceController {
     this.localZoneUrl = this.PciProject.getDocumentUrl('LOCAL_ZONE');
     this.zone3azUrl = this.PciProject.getDocumentUrl('REGIONS_3AZ');
 
-    this.is3az = this.instance.planCode.includes('3AZ');
+    try {
+      this.is3az = this.instance.planCode?.includes('3AZ');
+    } catch (e) {
+      console.error(e);
+    }
 
     this.regionsTypesAvailability = {};
     this.fetchRegionsTypesAvailability();


### PR DESCRIPTION
This prevents angular dashboard to crash when an instance is deleted right before react redirect.