### PR TITLE
feat(manager-react-components): refactor setup test for vitest

### DIFF
--- a/packages/manager-ui-kit/setupTest.tsx
+++ b/packages/manager-ui-kit/setupTest.tsx
@@ -1,7 +1,52 @@
-// vitest.setup.ts
+import React, { ComponentType } from 'react';
+import { RenderOptions, RenderResult, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import 'element-internals-polyfill';
 import { vi } from 'vitest';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import i18n from 'i18next';
+
+i18n.use(initReactI18next).init({
+  fallbackLng: 'fr_FR',
+  interpolation: {
+    escapeValue: false,
+  },
+  resources: {
+    fr: {
+      'action-menu': {
+        common_actions: 'Actions',
+      },
+    },
+  },
+});
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: {
+      retry: false,
+    },
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const Wrappers = ({ children }: { children: React.ReactElement }) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+    </QueryClientProvider>
+  );
+};
+
+const customRender = (
+  ui: React.JSX.Element,
+  options?: Omit<RenderOptions, 'queries'>,
+): RenderResult =>
+  render(ui, { wrapper: Wrappers as ComponentType, ...options });
+
+export { customRender as render };
 
 // This polyfill exists because of an issue with jsdom and the EventTarget class
 // when testing a component with an OdsDatepicker (addEventListener crashes at component initialization).

--- a/packages/manager-ui-kit/src/components/Link/__tests__/Link.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/Link/__tests__/Link.snapshot.test.tsx
@@ -1,6 +1,6 @@
 import { Link } from '../Link.component';
 import { LinkType } from '../Link.props';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 
 describe('Link component', () => {
   it('renders a simple link correctly', () => {

--- a/packages/manager-ui-kit/src/components/Link/__tests__/Link.spec.tsx
+++ b/packages/manager-ui-kit/src/components/Link/__tests__/Link.spec.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import apiClient from '@ovh-ux/manager-core-api';
 import { Link } from '../Link.component';
 import { LinkType } from '../Link.props';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 
 const PROPS_LINK = {
   children: 'Link',

--- a/packages/manager-ui-kit/src/components/action-menu/__tests__/ActionMenu.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/action-menu/__tests__/ActionMenu.snapshot.test.tsx
@@ -13,7 +13,7 @@ import {
   BUTTON_VARIANT,
 } from '@ovhcloud/ods-react';
 import { ActionMenu } from '../index';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { useAuthorizationIam } from '../../../hooks/iam';
 
 // Mock the IAM hook

--- a/packages/manager-ui-kit/src/components/action-menu/__tests__/ActionMenu.spec.tsx
+++ b/packages/manager-ui-kit/src/components/action-menu/__tests__/ActionMenu.spec.tsx
@@ -3,7 +3,7 @@ import type { MockInstance } from 'vitest';
 import { act, waitFor, screen, fireEvent } from '@testing-library/react';
 import { POPOVER_POSITION, ICON_NAME } from '@ovhcloud/ods-react';
 import { ActionMenu, ActionMenuProps } from '../index';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { useAuthorizationIam } from '../../../hooks/iam';
 
 vitest.mock('../../../hooks/iam');

--- a/packages/manager-ui-kit/src/components/badge/__tests__/badge.spec.tsx
+++ b/packages/manager-ui-kit/src/components/badge/__tests__/badge.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { waitFor, screen } from '@testing-library/react';
 import { BADGE_COLOR, BADGE_SIZE } from '@ovhcloud/ods-react';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Badge } from '../badge.component';
 
 describe('Badge component', () => {

--- a/packages/manager-ui-kit/src/components/base-layout/__tests__/__snapshots__/BaseLayout.snapshot.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/base-layout/__tests__/__snapshots__/BaseLayout.snapshot.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`BaseLayout component - Snapshot tests > renders the complete Base Layou
             aria-controls="popover::r0::content"
             aria-expanded="false"
             aria-haspopup="dialog"
-            aria-label="user_account_guides_header"
+            aria-label="Guides"
             class="_button_10f3x_2 _button--primary_10f3x_99 _button--sm_10f3x_34 _button--ghost_10f3x_150"
             data-part="trigger"
             data-scope="popover"
@@ -56,7 +56,7 @@ exports[`BaseLayout component - Snapshot tests > renders the complete Base Layou
               aria-hidden="true"
               class="_icon_i4xp0_2 _icon--book_i4xp0_52"
             />
-            user_account_guides_header
+            Guides
           </button>
         </div>
       </header>

--- a/packages/manager-ui-kit/src/components/breadcrumb/__tests__/Breadcrumb.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/breadcrumb/__tests__/Breadcrumb.snapshot.test.tsx
@@ -1,5 +1,5 @@
 import { vitest } from 'vitest';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Breadcrumb } from '../Breadcrumb.component';
 
 vitest.mock('../../../hooks/breadcrumb/useBreadcrumb', () => ({

--- a/packages/manager-ui-kit/src/components/breadcrumb/__tests__/Breadcrumb.spec.tsx
+++ b/packages/manager-ui-kit/src/components/breadcrumb/__tests__/Breadcrumb.spec.tsx
@@ -1,5 +1,5 @@
 import { vitest } from 'vitest';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Breadcrumb } from '../Breadcrumb.component';
 
 vitest.mock('../../../hooks/breadcrumb/useBreadcrumb', () => ({

--- a/packages/manager-ui-kit/src/components/button/__tests__/Button.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/button/__tests__/Button.snapshot.test.tsx
@@ -1,7 +1,7 @@
 import { vitest } from 'vitest';
 import type { MockInstance } from 'vitest';
 import { TOOLTIP_POSITION } from '@ovhcloud/ods-react';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Button } from '../index';
 import { useAuthorizationIam } from '../../../hooks/iam';
 

--- a/packages/manager-ui-kit/src/components/button/__tests__/Button.spec.tsx
+++ b/packages/manager-ui-kit/src/components/button/__tests__/Button.spec.tsx
@@ -1,7 +1,7 @@
 import { vitest } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 import { Button, ButtonProps } from '../index';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import fr_FR from '../translations/Messages_fr_FR.json';
 import { useAuthorizationIam } from '../../../hooks/iam';
 import { IamAuthorizationResponse } from '../../../hooks/iam/iam.interface';

--- a/packages/manager-ui-kit/src/components/changelog-menu/__tests__/ChangelogMenu.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/changelog-menu/__tests__/ChangelogMenu.snapshot.test.tsx
@@ -1,6 +1,6 @@
 import { vitest } from 'vitest';
 import { ChangelogMenu } from '../ChangelogMenu.component';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Links, chapters } from './ChangelogMenu.utils';
 
 vitest.mock('@ovh-ux/manager-react-shell-client', () => ({

--- a/packages/manager-ui-kit/src/components/changelog-menu/__tests__/ChangelogMenu.spec.tsx
+++ b/packages/manager-ui-kit/src/components/changelog-menu/__tests__/ChangelogMenu.spec.tsx
@@ -3,7 +3,7 @@ import type { MockInstance } from 'vitest';
 import { act, screen, fireEvent } from '@testing-library/react';
 import { useOvhTracking } from '@ovh-ux/manager-react-shell-client';
 import { ChangelogMenu, CHANGELOG_PREFIXES } from '../ChangelogMenu.component';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import TradFr from '../translations/Messages_fr_FR.json';
 import { Links, chapters } from './ChangelogMenu.utils';
 

--- a/packages/manager-ui-kit/src/components/delete-modal/DeleteModal.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/delete-modal/DeleteModal.snapshot.test.tsx
@@ -1,5 +1,5 @@
 import { vitest } from 'vitest';
-import { render } from '../../utils/test.provider';
+import { render } from '@/setupTest';
 import { DeleteModal } from './DeleteModal.component';
 import { DeleteModalProps } from './DeleteModal.props';
 

--- a/packages/manager-ui-kit/src/components/delete-modal/DeleteModal.spec.tsx
+++ b/packages/manager-ui-kit/src/components/delete-modal/DeleteModal.spec.tsx
@@ -1,7 +1,7 @@
 import { vitest } from 'vitest';
 import { waitFor, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from '../../utils/test.provider';
+import { render } from '@/setupTest';
 import { DeleteModal } from './DeleteModal.component';
 import { DeleteModalProps } from './DeleteModal.props';
 

--- a/packages/manager-ui-kit/src/components/drawer/DrawerBase.spec.tsx
+++ b/packages/manager-ui-kit/src/components/drawer/DrawerBase.spec.tsx
@@ -1,58 +1,61 @@
 import { getOdsButtonByLabel } from '@ovh-ux/manager-core-test-utils';
 import { act, render, screen } from '@testing-library/react';
+import i18n from 'i18next';
 import userEvent from '@testing-library/user-event';
 import { mockedProps } from './DrawerBase.mock';
 import { DrawerBase } from './DrawerBase.component';
 
-it('should display the drawer', async () => {
-  const { container } = render(<DrawerBase {...mockedProps} />);
-  expect(screen.getByTestId('drawer')).not.toBeNull();
-  expect(screen.queryByText('Drawer heading')).not.toBeNull();
-  expect(screen.queryByText('Drawer content')).not.toBeNull();
+describe('DrawerBase', () => {
+  it('should display the drawer', async () => {
+    const { container } = render(<DrawerBase {...mockedProps} />);
+    expect(screen.getByTestId('drawer')).not.toBeNull();
+    expect(screen.queryByText('Drawer heading')).not.toBeNull();
+    expect(screen.queryByText('Drawer content')).not.toBeNull();
 
-  const dismissButton = screen.getByTestId('drawer-dismiss-button');
-  const primaryButton = await getOdsButtonByLabel({
-    container,
-    label: mockedProps.primaryButtonLabel || '',
+    const dismissButton = screen.getByTestId('drawer-dismiss-button');
+    const primaryButton = await getOdsButtonByLabel({
+      container,
+      label: mockedProps.primaryButtonLabel || '',
+    });
+    const secondaryButton = await getOdsButtonByLabel({
+      container,
+      label: mockedProps.secondaryButtonLabel || '',
+    });
+
+    expect(dismissButton).toHaveAttribute('aria-label', 'Fermer');
+
+    expect(primaryButton).toHaveAttribute('label', 'Confirm');
+    expect(primaryButton).toHaveAttribute('color', 'primary');
+    expect(primaryButton).toHaveAttribute('variant', 'default');
+    expect(primaryButton).toHaveAttribute('is-loading', 'false');
+    expect(primaryButton).toHaveAttribute('is-disabled', 'false');
+
+    expect(secondaryButton).toHaveAttribute('label', 'Cancel');
+    expect(secondaryButton).toHaveAttribute('color', 'primary');
+    expect(secondaryButton).toHaveAttribute('variant', 'ghost');
+    expect(secondaryButton).toHaveAttribute('is-loading', 'false');
+    expect(secondaryButton).toHaveAttribute('is-disabled', 'false');
+
+    expect(screen.queryByTestId('drawer-handle')).toBeNull();
   });
-  const secondaryButton = await getOdsButtonByLabel({
-    container,
-    label: mockedProps.secondaryButtonLabel || '',
+
+  it('should show a loader when isLoading is true', () => {
+    render(<DrawerBase {...mockedProps} isLoading={true} />);
+    expect(screen.getByTestId('drawer')).not.toBeNull();
+    expect(screen.queryByText('Drawer heading')).toBeNull();
+    expect(screen.queryByText('Drawer content')).toBeNull();
+    expect(screen.getByTestId('drawer-spinner')).not.toBeNull();
   });
 
-  expect(dismissButton).toHaveAttribute('aria-label', 'close');
+  it('should close the drawer when the dismiss button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DrawerBase {...mockedProps} />);
 
-  expect(primaryButton).toHaveAttribute('label', 'Confirm');
-  expect(primaryButton).toHaveAttribute('color', 'primary');
-  expect(primaryButton).toHaveAttribute('variant', 'default');
-  expect(primaryButton).toHaveAttribute('is-loading', 'false');
-  expect(primaryButton).toHaveAttribute('is-disabled', 'false');
+    expect(screen.getByTestId('drawer')).not.toBeNull();
 
-  expect(secondaryButton).toHaveAttribute('label', 'Cancel');
-  expect(secondaryButton).toHaveAttribute('color', 'primary');
-  expect(secondaryButton).toHaveAttribute('variant', 'ghost');
-  expect(secondaryButton).toHaveAttribute('is-loading', 'false');
-  expect(secondaryButton).toHaveAttribute('is-disabled', 'false');
+    const dismissButton = screen.getByTestId('drawer-dismiss-button');
+    await act(() => user.click(dismissButton));
 
-  expect(screen.queryByTestId('drawer-handle')).toBeNull();
-});
-
-it('should show a loader when isLoading is true', () => {
-  render(<DrawerBase {...mockedProps} isLoading={true} />);
-  expect(screen.getByTestId('drawer')).not.toBeNull();
-  expect(screen.queryByText('Drawer heading')).toBeNull();
-  expect(screen.queryByText('Drawer content')).toBeNull();
-  expect(screen.getByTestId('drawer-spinner')).not.toBeNull();
-});
-
-it('should close the drawer when the dismiss button is clicked', async () => {
-  const user = userEvent.setup();
-  render(<DrawerBase {...mockedProps} />);
-
-  expect(screen.getByTestId('drawer')).not.toBeNull();
-
-  const dismissButton = screen.getByTestId('drawer-dismiss-button');
-  await act(() => user.click(dismissButton));
-
-  expect(mockedProps.onDismiss).toHaveBeenCalled();
+    expect(mockedProps.onDismiss).toHaveBeenCalled();
+  });
 });

--- a/packages/manager-ui-kit/src/components/filters/filter-add.spec.tsx
+++ b/packages/manager-ui-kit/src/components/filters/filter-add.spec.tsx
@@ -1,7 +1,7 @@
 import { vi, vitest } from 'vitest';
 import { act, fireEvent, waitFor } from '@testing-library/react';
 import { FilterAdd, FilterAddProps } from './filter-add.component';
-import { render } from '../../utils/test.provider';
+import { render } from '@/setupTest';
 import { TagsFilterFormProps } from './interface';
 
 vi.mock('./tags-filter-form.component', () => {

--- a/packages/manager-ui-kit/src/components/filters/filter-list.spec.tsx
+++ b/packages/manager-ui-kit/src/components/filters/filter-list.spec.tsx
@@ -3,7 +3,7 @@ import { vitest } from 'vitest';
 import { OdsTag } from '@ovhcloud/ods-components';
 import { act } from '@testing-library/react';
 import { FilterList, FilterListProps } from './filter-list.component';
-import { render } from '../../utils/test.provider';
+import { render } from '@/setupTest';
 
 const renderComponent = (props: FilterListProps) => {
   return render(<FilterList {...props} />);

--- a/packages/manager-ui-kit/src/components/filters/tags-filter-form.component.spec.tsx
+++ b/packages/manager-ui-kit/src/components/filters/tags-filter-form.component.spec.tsx
@@ -5,7 +5,7 @@ import {
   TagsFilterForm,
   TagsFilterFormProps,
 } from './tags-filter-form.component';
-import { render } from '../../utils/test.provider';
+import { render } from '@/setupTest';
 
 const mocks = vi.hoisted(() => ({
   useGetResourceTags: vi.fn(),

--- a/packages/manager-ui-kit/src/components/grid-layout/__tests__/GridLayout.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/grid-layout/__tests__/GridLayout.snapshot.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { GridLayout } from '../GridLayout.component';
 import { Tile } from '../../tile';
 import { Text } from '../../text';

--- a/packages/manager-ui-kit/src/components/guide-menu/__tests__/GuideMenu.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/guide-menu/__tests__/GuideMenu.snapshot.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import { GuideMenu } from '../GuideMenu.component';
 import { GuideMenuItem } from '../GuideMenu.props';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 
 describe('GuideMenu', () => {
   const mockItems: GuideMenuItem[] = [

--- a/packages/manager-ui-kit/src/components/guide-menu/__tests__/GuideMenu.spec.tsx
+++ b/packages/manager-ui-kit/src/components/guide-menu/__tests__/GuideMenu.spec.tsx
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { GuideMenu } from '../GuideMenu.component';
 import { GuideMenuItem } from '../GuideMenu.props';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 
 describe('GuideMenu component', () => {
   const mockItems: GuideMenuItem[] = [

--- a/packages/manager-ui-kit/src/components/link-card/__tests__/__snapshots__/LinkCard.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/link-card/__tests__/__snapshots__/LinkCard.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`LinkCard Component Snapshot Tests > renders the complete component 1`] 
             class="_link_udbet_2"
             tab-index="-1"
           >
-            see_more_label
+            En savoir plus
             <span
               class="_icon_i4xp0_2 _icon--arrow-right_i4xp0_31"
             />
@@ -123,7 +123,7 @@ exports[`LinkCard Component Snapshot Tests > renders the component with badges 1
             class="_link_udbet_2"
             tab-index="-1"
           >
-            see_more_label
+            En savoir plus
             <span
               class="_icon_i4xp0_2 _icon--arrow-right_i4xp0_31"
             />
@@ -179,7 +179,7 @@ exports[`LinkCard Component Snapshot Tests > renders the component with image 1`
             class="_link_udbet_2"
             tab-index="-1"
           >
-            see_more_label
+            En savoir plus
             <span
               class="_icon_i4xp0_2 _icon--arrow-right_i4xp0_31"
             />
@@ -230,7 +230,7 @@ exports[`LinkCard Component Snapshot Tests > renders the component with texts 1`
             class="_link_udbet_2"
             tab-index="-1"
           >
-            see_more_label
+            En savoir plus
             <span
               class="_icon_i4xp0_2 _icon--arrow-right_i4xp0_31"
             />

--- a/packages/manager-ui-kit/src/components/onboarding-layout/__tests__/OnboardingLayout.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/onboarding-layout/__tests__/OnboardingLayout.snapshot.test.tsx
@@ -1,6 +1,6 @@
 import { vitest } from 'vitest';
 import type { MockInstance } from 'vitest';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { OnboardingLayout } from '../OnboardingLayout.component';
 import { LinkCard } from '../../link-card/LinkCard.component';
 import { useAuthorizationIam } from '../../../hooks/iam';

--- a/packages/manager-ui-kit/src/components/onboarding-layout/__tests__/OnboardingLayout.spec.tsx
+++ b/packages/manager-ui-kit/src/components/onboarding-layout/__tests__/OnboardingLayout.spec.tsx
@@ -1,7 +1,7 @@
 import { vi, vitest } from 'vitest';
 import { OdsText } from '@ovhcloud/ods-components/react';
 import { fireEvent, screen, act } from '@testing-library/react';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { OnboardingLayout } from '../index';
 import placeholderSrc from '../../../../public/assets/placeholder.png';
 import { useAuthorizationIam } from '../../../hooks/iam';

--- a/packages/manager-ui-kit/src/components/order/__tests__/Order.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/order/__tests__/Order.snapshot.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { vitest } from 'vitest';
 import type { MockInstance } from 'vitest';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { Order } from '../Order.component';
 import { useAuthorizationIam } from '../../../hooks/iam';
 

--- a/packages/manager-ui-kit/src/components/order/__tests__/Order.spec.tsx
+++ b/packages/manager-ui-kit/src/components/order/__tests__/Order.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { vi, vitest } from 'vitest';
 import type { MockInstance } from 'vitest';
 import { Order } from '../Order.component';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { useAuthorizationIam } from '../../../hooks/iam';
 import fr_FR from '../translations/Messages_fr_FR.json';
 

--- a/packages/manager-ui-kit/src/components/price/__tests__/__snapshots__/Price.snapshot.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/price/__tests__/__snapshots__/Price.snapshot.test.tsx.snap
@@ -16,12 +16,12 @@ exports[`Price Component > displays both GST-excl and GST-incl in Asia format if
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_gst_excl_label
+        ex. GST
       </span>
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
     <span
@@ -36,7 +36,7 @@ exports[`Price Component > displays both GST-excl and GST-incl in Asia format if
       <span
         class="_text--span_1aw48_60"
       >
-        price_gst_incl_label
+        incl. GST
       </span>
       )
     </span>
@@ -60,12 +60,12 @@ exports[`Price Component > displays both HT and TTC in French format when tax > 
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_ht_label
+        HT
       </span>
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
     <span
@@ -80,7 +80,7 @@ exports[`Price Component > displays both HT and TTC in French format when tax > 
       <span
         class="_text--span_1aw48_60"
       >
-        price_ttc_label
+        TTC
       </span>
       )
     </span>
@@ -104,12 +104,12 @@ exports[`Price Component > displays only GST-excl in Asia format if no tax 1`] =
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_gst_excl_label
+        ex. GST
       </span>
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
   </p>
@@ -132,12 +132,12 @@ exports[`Price Component > displays only HT in French format when no tax 1`] = `
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_ht_label
+        HT
       </span>
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
   </p>
@@ -160,7 +160,7 @@ exports[`Price Component > displays price with tax in German format 1`] = `
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
   </p>
@@ -183,7 +183,7 @@ exports[`Price Component > displays price without tax label in US format 1`] = `
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_month
+        /mois
       </span>
     </span>
   </p>
@@ -206,7 +206,7 @@ exports[`Price Component > does not show intervalUnitText if intervalUnit is "no
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_ht_label
+        HT
       </span>
     </span>
     <span
@@ -221,7 +221,7 @@ exports[`Price Component > does not show intervalUnitText if intervalUnit is "no
       <span
         class="_text--span_1aw48_60"
       >
-        price_ttc_label
+        TTC
       </span>
       )
     </span>
@@ -245,12 +245,12 @@ exports[`Price Component > handles different interval units correctly 1`] = `
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_ht_label
+        HT
       </span>
       <span
         class="_text--span_1aw48_60 mr-1"
       >
-        price_per_year
+        /an
       </span>
     </span>
     <span
@@ -265,7 +265,7 @@ exports[`Price Component > handles different interval units correctly 1`] = `
       <span
         class="_text--span_1aw48_60"
       >
-        price_ttc_label
+        TTC
       </span>
       )
     </span>
@@ -279,7 +279,7 @@ exports[`Price Component > renders free price when value is 0 1`] = `
     class="_text--paragraph_1aw48_54"
   >
     <span>
-      price_free
+      Inclus
     </span>
   </p>
 </div>

--- a/packages/manager-ui-kit/src/components/text/__tests__/Text.spec.tsx
+++ b/packages/manager-ui-kit/src/components/text/__tests__/Text.spec.tsx
@@ -2,7 +2,7 @@ import { vitest } from 'vitest';
 import type { MockInstance } from 'vitest';
 import { screen, act, fireEvent } from '@testing-library/react';
 import { Text } from '../index';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import fr_FR from '../translations/Messages_fr_FR.json';
 import { useAuthorizationIam } from '../../../hooks/iam';
 

--- a/packages/manager-ui-kit/src/components/update-name-modal/__tests__/UpdateNameModal.snapshot.test.tsx
+++ b/packages/manager-ui-kit/src/components/update-name-modal/__tests__/UpdateNameModal.snapshot.test.tsx
@@ -1,5 +1,5 @@
 import { vitest } from 'vitest';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { UpdateNameModal } from '../UpdateNameModal.component';
 
 const mockUpdateDisplayName = vitest.fn();

--- a/packages/manager-ui-kit/src/components/update-name-modal/__tests__/UpdateNameModal.spec.tsx
+++ b/packages/manager-ui-kit/src/components/update-name-modal/__tests__/UpdateNameModal.spec.tsx
@@ -1,6 +1,6 @@
 import { vitest, describe, it, expect, beforeEach } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { render } from '../../../utils/test.provider';
+import { render } from '@/setupTest';
 import { UpdateNameModal } from '../UpdateNameModal.component';
 import { UpdateNameModalProps } from '../UpdateNameModal.props';
 

--- a/packages/manager-ui-kit/src/hooks/date/useFormatDate/__tests__/useFormatDateEnglish.spec.ts
+++ b/packages/manager-ui-kit/src/hooks/date/useFormatDate/__tests__/useFormatDateEnglish.spec.ts
@@ -1,8 +1,12 @@
 import { renderHook } from '@testing-library/react';
+import i18n from 'i18next';
 import { useFormatDate } from '../useFormatDate';
 import { DEFAULT_UNKNOWN_DATE_LABEL } from '../useFormatDate.type';
 
 describe('useFormatDate', () => {
+  beforeEach(() => {
+    i18n.changeLanguage('en_GB');
+  });
   it.each([
     {
       case: 'label for no date',

--- a/packages/manager-ui-kit/src/utils/Test.utils.tsx
+++ b/packages/manager-ui-kit/src/utils/Test.utils.tsx
@@ -3,7 +3,7 @@ import {
   ShellContext,
   ShellContextType,
 } from '@ovh-ux/manager-react-shell-client';
-import { render } from './test.provider';
+import { render } from '../../setupTest';
 
 export const mockTrackPage = vitest.fn();
 export const mockGetEnvironment = vitest.fn();

--- a/packages/manager-ui-kit/tsconfig.json
+++ b/packages/manager-ui-kit/tsconfig.json
@@ -3,9 +3,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@/setupTest": ["./setupTest.tsx"]
+    }
   },
-  "files": ["global.d.ts"],
+  "files": ["global.d.ts", "setupTest.tsx"],
   "include": ["src/**/*", "*.spec.tsx", ".storybook/i18n.ts", "**/*.json"],
   "exclude": ["./src/**/*.stories.*"]
 }

--- a/packages/manager-ui-kit/vite.config.mts
+++ b/packages/manager-ui-kit/vite.config.mts
@@ -10,6 +10,12 @@ const baseConfig = getBaseConfig({});
 export default defineConfig({
   ...baseConfig,
   assetsInclude: ['**/*.png', '**/*.jpg', '**/*.svg'],
+  resolve: {
+    alias: {
+      '@/setupTest': path.resolve(__dirname, 'setupTest.tsx'),
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   plugins: [
     ...baseConfig.plugins,
     dts({

--- a/packages/manager-ui-kit/vitest.config.js
+++ b/packages/manager-ui-kit/vitest.config.js
@@ -7,7 +7,7 @@ import {
 
 export default mergeConfig(createConfig(), {
   test: {
-    setupFiles: 'setupTest.ts',
+    setupFiles: 'setupTest.tsx',
     globals: true,
     environment: 'jsdom',
     coverage: {
@@ -33,6 +33,7 @@ export default mergeConfig(createConfig(), {
   },
   resolve: {
     alias: {
+      '@/setupTest': path.resolve(__dirname, 'setupTest.tsx'),
       '@': path.resolve(__dirname, 'src'),
     },
     mainFields: ['module'],


### PR DESCRIPTION
ref: #MANAGER-19196

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

### Consolidate test setup and add alias configuration

Consolidated test setup configuration and added alias support for cleaner test imports.

**Changes:**

- Moved src/utils/test.provider.tsx to root-level setupTest.tsx to serve as the central test setup file
- Added @/setupTest path alias in tsconfig.json and vitest.config.js
- Updated all test files to use import { render } from '@/setupTest' instead of relative paths

**Benefits:**

- Single source of truth for test configuration (i18n, QueryClient, test providers)
- Eliminates deep relative imports like '../../../../setupTest' across test files
- Better alignment with Vitest's setupFiles configuration

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19196
