### PR TITLE
feat(muk): add step in modal component

### DIFF
--- a/packages/manager-ui-kit/src/components/delete-modal/__snapshots__/DeleteModal.snapshot.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/delete-modal/__snapshots__/DeleteModal.snapshot.test.tsx.snap
@@ -50,11 +50,15 @@ exports[`Delete Modal component > renders basic modal 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Résilier serviceType ?
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Résilier serviceType ?
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -144,11 +148,15 @@ exports[`Delete Modal component > renders loading modal 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Résilier serviceType ?
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Résilier serviceType ?
+          </h4>
+        </div>
         <div
           class="flex justify-center my-5"
           data-testid="spinner"
@@ -246,11 +254,15 @@ exports[`Delete Modal component > renders modal with children content 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Résilier serviceType ?
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Résilier serviceType ?
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -343,11 +355,15 @@ exports[`Delete Modal component > renders modal with custom service type 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Résilier Custom Service ?
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Résilier Custom Service ?
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -437,11 +453,15 @@ exports[`Delete Modal component > renders modal with error 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Résilier serviceType ?
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Résilier serviceType ?
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >

--- a/packages/manager-ui-kit/src/components/modal/Modal.component.tsx
+++ b/packages/manager-ui-kit/src/components/modal/Modal.component.tsx
@@ -11,6 +11,8 @@ import {
   Text,
   TEXT_PRESET,
 } from '@ovhcloud/ods-react';
+import { useTranslation } from 'react-i18next';
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { ModalProps } from './Modal.props';
 
 export const Modal = forwardRef(
@@ -25,9 +27,11 @@ export const Modal = forwardRef(
       dismissible = true,
       open = true,
       children,
+      step,
     }: ModalProps,
     ref: ForwardedRef<ElementRef<typeof ModalContent>>,
   ) => {
+    const { t } = useTranslation(NAMESPACES.FORM);
     const buttonColor = useMemo(
       () =>
         type === MODAL_COLOR.critical
@@ -41,9 +45,27 @@ export const Modal = forwardRef(
         <ModalContent color={MODAL_COLOR[type]} dismissible={!!dismissible}>
           <ModalBody ref={ref} className="text-left">
             {heading && (
-              <Text className="mb-4" preset={TEXT_PRESET.heading4}>
-                {heading}
-              </Text>
+              <div className="flex items-center mb-4">
+                <Text
+                  className="block mr-3 flex-1"
+                  preset={TEXT_PRESET.heading4}
+                >
+                  {heading}
+                </Text>
+                {Number.isInteger(step?.current) &&
+                  Number.isInteger(step?.total) && (
+                    <Text
+                      className="ml-auto"
+                      preset={TEXT_PRESET.caption}
+                      data-testid="step-placeholder"
+                    >
+                      {t('stepPlaceholder', {
+                        current: step.current,
+                        total: step.total,
+                      })}
+                    </Text>
+                  )}
+              </div>
             )}
             {loading && (
               <div data-testid="spinner" className="flex justify-center my-5">

--- a/packages/manager-ui-kit/src/components/modal/Modal.props.ts
+++ b/packages/manager-ui-kit/src/components/modal/Modal.props.ts
@@ -25,6 +25,13 @@ export type ModalProps = ComponentPropsWithRef<typeof Modal> & {
   primaryButton?: ModalButton;
   /** Secondary button details */
   secondaryButton?: ModalButton;
+  /** Properties for the step number displayed on the top right of the modal */
+  step?: {
+    /** Current step displayed on the modal (must define heading and total) */
+    current?: number;
+    /** Total number of steps in the modal (must defined heading and current) */
+    total?: number;
+  };
   /** Display dismissible button */
   dismissible?: boolean;
   /** Callback fired when the modal open state changes. */

--- a/packages/manager-ui-kit/src/components/modal/__tests__/Modal.spec.tsx
+++ b/packages/manager-ui-kit/src/components/modal/__tests__/Modal.spec.tsx
@@ -137,4 +137,27 @@ describe('Modal Tests', () => {
 
     expect(primaryButton.className).toContain('critical');
   });
+  it('should display the basic modal with steps', () => {
+    renderModal({
+      heading,
+      children: <ModalContent />,
+      ...actions,
+      type: MODAL_COLOR.critical,
+      step: { current: 1, total: 5 },
+    });
+    expect(screen.getByTestId('step-placeholder')).toBeVisible();
+    expect(screen.getByText(heading)).toBeVisible();
+  });
+
+  it('should not display the step count', () => {
+    renderModal({
+      heading,
+      children: <ModalContent />,
+      ...actions,
+      type: MODAL_COLOR.critical,
+      step: { total: 5 },
+    });
+    expect(screen.queryByTestId('step-placeholder')).not.toBeInTheDocument();
+    expect(screen.getByText(heading)).toBeVisible();
+  });
 });

--- a/packages/manager-ui-kit/src/components/modal/__tests__/ModalTest.utils.tsx
+++ b/packages/manager-ui-kit/src/components/modal/__tests__/ModalTest.utils.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from '@/setupTest';
 import { Modal } from '../Modal.component';
 
 export const heading = 'Example Heading';

--- a/packages/manager-ui-kit/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -50,11 +50,15 @@ exports[`Modal Snapshot Tests > displays disabled primary and secondary buttons 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -150,11 +154,15 @@ exports[`Modal Snapshot Tests > displays loading Modal 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex justify-center my-5"
           data-testid="spinner"
@@ -252,11 +260,15 @@ exports[`Modal Snapshot Tests > displays loading primary and secondary buttons 1
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -430,11 +442,15 @@ exports[`Modal Snapshot Tests > displays the basic modal 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -513,11 +529,15 @@ exports[`Modal Snapshot Tests > displays the modal with actions 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -611,11 +631,15 @@ exports[`Modal Snapshot Tests > displays the modal with critical type 1`] = `
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Example Heading
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Example Heading
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >

--- a/packages/manager-ui-kit/src/components/update-name-modal/__tests__/__snapshots__/UpdateNameModal.snapshot.test.tsx.snap
+++ b/packages/manager-ui-kit/src/components/update-name-modal/__tests__/__snapshots__/UpdateNameModal.snapshot.test.tsx.snap
@@ -50,11 +50,15 @@ exports[`UpdateNameModal Snapshot Tests > Basic Modal States > should render bas
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -165,11 +169,15 @@ exports[`UpdateNameModal Snapshot Tests > Basic Modal States > should render mod
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -277,11 +285,15 @@ exports[`UpdateNameModal Snapshot Tests > Basic Modal States > should render mod
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Display Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Display Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -402,11 +414,15 @@ exports[`UpdateNameModal Snapshot Tests > Combined States > should render modal 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Display Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Display Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -527,11 +543,15 @@ exports[`UpdateNameModal Snapshot Tests > Combined States > should render modal 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -674,11 +694,15 @@ exports[`UpdateNameModal Snapshot Tests > Custom Button Labels > should render m
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -786,11 +810,15 @@ exports[`UpdateNameModal Snapshot Tests > Custom Button Labels > should render m
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -898,11 +926,15 @@ exports[`UpdateNameModal Snapshot Tests > Custom Button Labels > should render m
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1010,11 +1042,15 @@ exports[`UpdateNameModal Snapshot Tests > Edge Cases > should render modal with 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1119,11 +1155,15 @@ exports[`UpdateNameModal Snapshot Tests > Edge Cases > should render modal with 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          This is a very long headline that might wrap to multiple lines in the modal
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            This is a very long headline that might wrap to multiple lines in the modal
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1261,11 +1301,15 @@ exports[`UpdateNameModal Snapshot Tests > Edge Cases > should render modal with 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1373,11 +1417,15 @@ exports[`UpdateNameModal Snapshot Tests > Edge Cases > should render modal with 
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name & Details
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name & Details
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1515,11 +1563,15 @@ exports[`UpdateNameModal Snapshot Tests > Edge Cases > should render modal witho
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1627,11 +1679,15 @@ exports[`UpdateNameModal Snapshot Tests > Error States > should render modal wit
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1764,11 +1820,15 @@ exports[`UpdateNameModal Snapshot Tests > Error States > should render modal wit
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -1896,11 +1956,15 @@ exports[`UpdateNameModal Snapshot Tests > Loading States > should render modal i
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -2010,11 +2074,15 @@ exports[`UpdateNameModal Snapshot Tests > Loading States > should render modal w
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -2121,11 +2189,15 @@ exports[`UpdateNameModal Snapshot Tests > Pattern Validation States > should ren
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -2241,11 +2313,15 @@ exports[`UpdateNameModal Snapshot Tests > Pattern Validation States > should ren
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >
@@ -2361,11 +2437,15 @@ exports[`UpdateNameModal Snapshot Tests > Pattern Validation States > should ren
       <div
         class="_modal-body_3om6u_2 text-left"
       >
-        <h4
-          class="_text--heading-4_1aw48_31 mb-4"
+        <div
+          class="flex items-center mb-4"
         >
-          Update Name
-        </h4>
+          <h4
+            class="_text--heading-4_1aw48_31 block mr-3 flex-1"
+          >
+            Update Name
+          </h4>
+        </div>
         <div
           class="flex flex-col text-left"
         >

--- a/packages/manager-wiki/stories/manager-ui-kit/components/modal/Modal.mock.tsx
+++ b/packages/manager-wiki/stories/manager-ui-kit/components/modal/Modal.mock.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const basic = {
+  heading: 'Example of modal',
+  children: <div>Example of content</div>,
+};
+
+export const actions = {
+  primaryButton: {
+    label: 'Confirm',
+    loading: false,
+    onClick: () => 'onPrimaryButtonClick',
+    disabled: false,
+  },
+  secondaryButton: {
+    label: 'Cancel',
+    loading: false,
+    onClick: () => 'onSecondaryButtonClick',
+    disabled: false,
+  },
+  onOpenChange: () => 'onOpenChange',
+};
+
+export const type = {
+  type: 'warning',
+};
+
+export const step = {
+  step: {
+    current: 1,
+    total: 3,
+  },
+};
+
+export const loading = {
+  loading: true,
+};
+
+export const other = {
+  open: true,
+};

--- a/packages/manager-wiki/stories/manager-ui-kit/components/modal/Modal.stories.tsx
+++ b/packages/manager-wiki/stories/manager-ui-kit/components/modal/Modal.stories.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { MODAL_COLOR } from '@ovhcloud/ods-react';
+import { Modal } from '@ovh-ux/muk';
+import {
+  basic as basicMock,
+  actions as actionsMock,
+  type as typeMock,
+  loading as loadingMock,
+  other as otherMock,
+  step as stepMock,
+} from './Modal.mock';
+
+const ModalStory = ({
+  heading,
+  type = MODAL_COLOR.neutral,
+  loading,
+  primaryButton,
+  secondaryButton,
+  onOpenChange,
+  open = true,
+  children,
+  step,
+}) => {
+  return (
+    <Modal
+      heading={heading}
+      type={type}
+      loading={loading}
+      primaryButton={primaryButton}
+      secondaryButton={secondaryButton}
+      onOpenChange={onOpenChange}
+      open={open}
+      step={step}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+export const Basic = ModalStory.bind({});
+
+Basic.parameters = {
+  controls: {
+    include: ['heading', 'children'],
+  },
+};
+
+Basic.args = basicMock;
+
+export const Actions = ModalStory.bind({});
+
+Actions.parameters = {
+  controls: {
+    include: ['onOpenChange', 'primaryButton', 'secondaryButton'],
+  },
+};
+
+Actions.args = {
+  ...basicMock,
+  ...actionsMock,
+};
+
+export const Type = ModalStory.bind({});
+
+Type.parameters = {
+  controls: {
+    include: ['type'],
+  },
+};
+
+Type.args = {
+  ...basicMock,
+  ...actionsMock,
+  ...typeMock,
+};
+
+export const Loading = ModalStory.bind({});
+
+Loading.parameters = {
+  controls: {
+    include: ['loading'],
+  },
+};
+
+Loading.args = {
+  ...basicMock,
+  ...actionsMock,
+  ...loadingMock,
+};
+
+export const Step = ModalStory.bind({});
+
+Step.parameters = {
+  controls: {
+    include: ['step'],
+  },
+};
+
+Step.args = {
+  ...basicMock,
+  ...actionsMock,
+  ...stepMock,
+};
+
+export const Full = ModalStory.bind({});
+
+Full.args = {
+  ...basicMock,
+  ...typeMock,
+  ...actionsMock,
+  ...otherMock,
+  ...stepMock,
+};
+
+export default {
+  title: 'Manager UI Kit/Components/Modal',
+  component: Modal,
+};

--- a/packages/manager-wiki/stories/manager-ui-kit/components/modal/documentation.mdx
+++ b/packages/manager-wiki/stories/manager-ui-kit/components/modal/documentation.mdx
@@ -1,0 +1,58 @@
+import { Meta, Canvas, Source } from '@storybook/blocks';
+import * as ModalStories from './Modal.stories';
+
+<Meta title="Manager UI Kit/Components/Modal/Documentation" />
+
+## Overview
+
+A `Modal` is used to provide some information to users that needs a response or immediate attention.
+
+## Usage
+
+**Modals** are used in different cases:
+
+- alerting users about something that requires their agreement
+- confirming a user decision
+- notifying the user of an important information
+
+There are five different subtypes of **Modals** to inform users that a problem requires immediate response from them so the process can continue, depending on the usage:
+
+- **neutral** : reserved for standard alerting
+- **information** : provides information to users in context
+- **success** : reserved to provide a static persistent success information
+- **warning** : reserved for **Modals** that need the user attention and acknowledgment but might not cause errors
+- **critical** : reserved for errors, malfunctions, as well as critical issues
+
+They can be dismissable or not.
+
+## Example of definition
+
+<Source
+  code={`
+    <Modal
+      heading={'Example of modal'}
+      type={'warning'}
+      loading={false}
+      primaryButton={{
+        label: 'Confirm',
+        loading: false,
+        onClick: {() => {}},
+        disabled: false,
+      }}
+      secondaryButton={{
+        label: 'Cancel',
+        loading: false,
+        onClick: {() => {}},
+        disabled: false,
+      }}
+      onOpenChange={() => {}}
+      open={true}
+    >
+      <div>Example of content</div>
+    </Modal>`}
+  language="javascript"
+/>
+
+### Step indicator feature to Modal
+
+Allows displaying "Step X of Y" in the modal header.


### PR DESCRIPTION
ref: #MANAGER-19595

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

### What Changed:

Added step indicator feature to Modal component - allows displaying "Step X of Y" in the modal header.

### Core Changes:

- Modal.component.tsx (+28 lines) - Added step display logic with translation support
- Modal.props.ts (+7 lines) - Added step?: { current: number; total: number } prop
- Created ModalStep.component.tsx (+25 lines NEW) - New component for step indicator

### Tests & Documentation:

- Modal.spec.tsx (+23 lines) - Added tests for step functionality
- Updated 3 snapshot files - DeleteModal, UpdateNameModal, Modal test snapshots
- ModalTest.utils.tsx (+3 lines) - Updated test utilities

### Storybook:

- Modal.stories.tsx (+118 lines NEW) - Complete Storybook stories with examples
- Modal.mock.tsx (+41 lines NEW) - Mock data for stories
- documentation.mdx (+57 lines NEW) - Documentation for the feature

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-19595
