### PR TITLE
fix(web): add "ASIA" subsidiary to language override

### DIFF
--- a/packages/manager/apps/web/client/app/domain/list/list-domain-layout.constants.js
+++ b/packages/manager/apps/web/client/app/domain/list/list-domain-layout.constants.js
@@ -110,7 +110,7 @@ export const DOMAIN_DNSSEC_STATE_CLASS = {
 export const DOMAIN_COLUMN_DNSSEC = 'DNSSEC';
 
 export const IDN_PREFIX = 'xn--';
-export const LANGUAGE_OVERRIDE = { IN: `en-IN` };
+export const LANGUAGE_OVERRIDE = { IN: `en-IN`, ASIA: `en-ASIA` };
 
 export const MONTH_DATE_FORMAT = {
   month: '2-digit',


### PR DESCRIPTION
## Description

Fix: RangeError - Invalid language tag: asia for region CA
Ticket Reference: #DCE-78
