### PR TITLE
fix(pci-instances): update selected localization display in hidden results

### DIFF
--- a/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useForm.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useForm.ts
@@ -5,15 +5,14 @@ import { nameDefaultValue } from '../components/Name.component';
 import { quantityDefaultValue } from '../components/QuantitySelector.component';
 import { instanceCreationSchema } from '../CreateInstance.page';
 import { selectContinent } from '../view-models/continentsViewModel';
-import { selectDeploymentModes } from '../view-models/deploymentModeViewModel';
 import { selectLocalizations } from '../view-models/localizationsViewModel';
 import { TDeploymentMode } from '@/types/instance/common.type';
 import { mockedFlavorCategories } from '@/__mocks__/instance/constants';
 
 export const useForm = (projectId: string) => {
-  const deploymentModes = selectDeploymentModes(deps)(projectId);
   const deploymentModesDefaultValue: TDeploymentMode[] = [
-    deploymentModes[0]!.mode,
+    'region',
+    'region-3-az',
   ];
 
   const continents = selectContinent(deps)(
@@ -28,6 +27,7 @@ export const useForm = (projectId: string) => {
     deploymentModesDefaultValue,
     continentDefaultValue,
     'total',
+    null,
   );
 
   const macroRegionDefaultValue = localizations[0]!.macroRegion;

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/__tests__/localizationsViewModel.spec.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/__tests__/localizationsViewModel.spec.ts
@@ -28,6 +28,7 @@ describe('SelectLocalizations ViewModel', () => {
         ['region', 'region-3-az'],
         'western_europe',
         'total',
+        null,
       ),
     ).toStrictEqual({
       localizations: mockedLocalizationsData,
@@ -42,6 +43,7 @@ describe('SelectLocalizations ViewModel', () => {
         ['region', 'region-3-az'],
         'all',
         'total',
+        null,
       ),
     ).toStrictEqual({
       localizations: mockedLocalizationsDataForSelectedDeploymentZoneAndAllContinents,
@@ -51,7 +53,7 @@ describe('SelectLocalizations ViewModel', () => {
 
   it('should return all available regions for "all" continent selected and none deployment zone selected', () => {
     expect(
-      selectLocalizations(fakeDeps)(mockedProjectId, [], 'all', 'total'),
+      selectLocalizations(fakeDeps)(mockedProjectId, [], 'all', 'total', null),
     ).toStrictEqual({
       localizations: mockedLocalizationsDataForNoneDeploymentZoneAndAllContinents,
       hasMoreLocalizations: false,

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/localizationsViewModel.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/localizationsViewModel.ts
@@ -78,11 +78,38 @@ export type TRegionDataForCard = {
   hasMoreLocalizations: boolean;
 };
 
+const getLocalizationsPart = (
+  localizations: TRegionData[],
+  selectedMacroRegionId: string | null,
+) => {
+  const localizationsPartToDisplay = localizations.slice(
+    0,
+    MAX_DISPLAYED_LOCALIZATIONS,
+  );
+
+  const selectedLocalization = localizations.find(
+    (localization) => localization.macroRegion === selectedMacroRegionId,
+  );
+
+  const isSelectedLocalizationInHiddenResults =
+    !!selectedLocalization &&
+    !localizationsPartToDisplay.includes(selectedLocalization);
+
+  return isSelectedLocalizationInHiddenResults
+    ? [
+        selectedLocalization,
+        ...localizations.slice(0, MAX_DISPLAYED_LOCALIZATIONS - 1),
+      ]
+    : localizationsPartToDisplay;
+};
+
+// eslint-disable-next-line max-params
 type TSelectLocalizationsData = (
   projectId: string,
   deploymentMode: TDeploymentMode[],
   continentId: string,
   display: 'partial' | 'total',
+  selectedMacroRegionId: string | null,
 ) => TRegionDataForCard;
 
 const emptyLocalizations = {
@@ -92,7 +119,14 @@ const emptyLocalizations = {
 
 export const selectLocalizations: Reader<Deps, TSelectLocalizationsData> = (
   deps,
-) => (projectId, deploymentModes, continentId, display) => {
+) => (
+  projectId,
+  deploymentModes,
+  continentId,
+  display,
+  selectedMacroRegionId,
+  // eslint-disable-next-line max-params
+) => {
   const { messageProviderPort, instancesCatalogPort } = deps;
   const data = instancesCatalogPort.selectInstancesCatalog(projectId);
 
@@ -132,7 +166,7 @@ export const selectLocalizations: Reader<Deps, TSelectLocalizationsData> = (
     localizations:
       display === 'total'
         ? localizations
-        : localizations.slice(0, MAX_DISPLAYED_LOCALIZATIONS),
+        : getLocalizationsPart(localizations, selectedMacroRegionId),
     hasMoreLocalizations: localizations.length > MAX_DISPLAYED_LOCALIZATIONS,
   };
 };


### PR DESCRIPTION
This PR adjusts three things:
- The 3AZ & 1AZ deployment zones are now both preselected.
- The “See all locations” checkbox only appears when there are more than 12 locations.
- When the user selects a region that is, for example, 15th, if they uncheck “See all locations,” the region remains visible and moves to first place. If they check “See all locations” again, a smooth scroll returns to the selected

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
