### PR TITLE
fix(telecom-dashboard): create service in every case

### DIFF
--- a/packages/manager/modules/telecom-dashboard/src/ftth-eligibility/telecom-dashboard-ftth-eligibility.controller.js
+++ b/packages/manager/modules/telecom-dashboard/src/ftth-eligibility/telecom-dashboard-ftth-eligibility.controller.js
@@ -102,13 +102,17 @@ export default class FtthEligibilityCtrl {
       ) {
         return this.FtthEligibilityService.getFiberEligibilities(
           service.accessName,
-        ).then((data) =>
-          this.createService(
-            service,
-            data[0].status,
-            data[0].firstCopperClosure,
-          ),
-        );
+        )
+          .then((data) =>
+            this.createService(
+              service,
+              data[0].status,
+              data[0].firstCopperClosure,
+            ),
+          )
+          .catch(() =>
+            this.createService(service, this.ELIGIBILITY.not_concerned),
+          );
       }
       return this.createService(service, this.ELIGIBILITY.not_concerned);
     });


### PR DESCRIPTION
## Description

On telecom dashboard, on 5 first services table, display all services even if we have an error on call API to get fiber eligibilities, just set not concerned status in this case.

Ticket Reference: #MANAGER-20128