### PR TITLE
[MUK]: Add datagrid size and variant

### DIFF
--- a/packages/manager-ui-kit/src/components/datagrid/Datagrid.component.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/Datagrid.component.tsx
@@ -1,8 +1,8 @@
 import { useRef } from 'react';
 
-import { Table } from '@ovhcloud/ods-react';
+import { TABLE_SIZE, TABLE_VARIANT, Table } from '@ovhcloud/ods-react';
 
-import { DatagridProps, ExpandableRow } from '@/components/datagrid/Datagrid.props';
+import { ContainerHeight, DatagridProps, RowHeight } from '@/components/datagrid/Datagrid.props';
 import { TableHeaderContent } from '@/components/datagrid/table/table-head';
 
 import { TableBody } from './table/table-body/TableBody.component';
@@ -11,10 +11,7 @@ import { Topbar } from './topbar/Topbar.component';
 import './translations';
 import { useDatagrid } from './useDatagrid';
 
-const DEFAULT_ROW_HEIGHT = 50;
-const DEFAULT_CONTAINER_HEIGHT = 570;
-
-export const Datagrid = <T extends ExpandableRow<T>>({
+export const Datagrid = <T extends Record<string, unknown>>({
   autoScroll = true,
   columns,
   columnVisibility,
@@ -25,18 +22,22 @@ export const Datagrid = <T extends ExpandableRow<T>>({
   filters,
   hasNextPage,
   isLoading,
-  maxRowHeight = DEFAULT_ROW_HEIGHT,
+  maxRowHeight,
   resourceType,
   rowSelection,
   search,
   sorting,
+  size = TABLE_SIZE.md,
   subComponentHeight,
   topbar,
   totalCount,
+  variant = TABLE_VARIANT.default,
   onFetchAllPages,
   onFetchNextPage,
   renderSubComponent,
 }: DatagridProps<T>) => {
+  const rowHeight = RowHeight[size];
+  const DEFAULT_CONTAINER_HEIGHT = maxRowHeight || ContainerHeight[size];
   const {
     features,
     getHeaderGroups,
@@ -56,6 +57,7 @@ export const Datagrid = <T extends ExpandableRow<T>>({
     setColumnVisibility: columnVisibility?.setColumnVisibility,
     rowSelection,
     expandable,
+    sizeRow: size,
   });
   const { hasSortingFeature, hasSearchFeature, hasColumnVisibilityFeature, hasFilterFeature } =
     features;
@@ -71,6 +73,7 @@ export const Datagrid = <T extends ExpandableRow<T>>({
   };
   const shouldRenderTopbar =
     topbar || hasSearchFeature || hasFilterFeature || hasColumnVisibilityFeature;
+
   return (
     <>
       {shouldRenderTopbar && (
@@ -91,7 +94,7 @@ export const Datagrid = <T extends ExpandableRow<T>>({
         />
       )}
       <div className="overflow-auto relative w-full" ref={tableContainerRef} style={containerStyle}>
-        <Table className="table table-fixed w-full">
+        <Table size={size} variant={variant}>
           <TableHeaderContent<T>
             headerGroups={headerGroups}
             onSortChange={sorting?.setSorting}
@@ -107,7 +110,7 @@ export const Datagrid = <T extends ExpandableRow<T>>({
             isLoading={isLoading ?? false}
             renderSubComponent={renderSubComponent}
             subComponentHeight={subComponentHeight}
-            maxRowHeight={maxRowHeight}
+            maxRowHeight={rowHeight}
             contentAlignLeft={contentAlignLeft}
           />
         </Table>

--- a/packages/manager-ui-kit/src/components/datagrid/Datagrid.props.ts
+++ b/packages/manager-ui-kit/src/components/datagrid/Datagrid.props.ts
@@ -10,6 +10,8 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table';
 
+import { TABLE_SIZE, TABLE_VARIANT } from '@ovhcloud/ods-react';
+
 import {
   FilterTypeCategories as DatagridColumnTypes,
   FilterComparator,
@@ -69,9 +71,11 @@ export type DatagridProps<T extends ExpandableRow<T>> = {
   rowSelection?: RowSelectionProps<T>;
   search?: SearchProps;
   sorting?: SortingProps;
+  size?: TABLE_SIZE;
   subComponentHeight?: number;
   topbar?: ReactNode;
   totalCount?: number;
+  variant?: TABLE_VARIANT;
   onFetchAllPages?: () => void;
   onFetchNextPage?: () => void;
   renderSubComponent?: (
@@ -86,7 +90,18 @@ export enum ColumnMetaType {
   BADGE = 'badge',
 }
 
-// export type ManagerColumnDef<T> = ColumnDef<T> & {
+export enum RowHeight {
+  sm = 32.5,
+  md = 48.5,
+  lg = 64.5,
+}
+
+export enum ContainerHeight {
+  sm = 375,
+  md = 550,
+  lg = 725,
+}
+
 export type DatagridColumn<T> = ColumnDef<T> & {
   /** set column comparator for the filter */
   comparator?: FilterComparator[];

--- a/packages/manager-ui-kit/src/components/datagrid/__tests__/Datagrid.snapshot.spec.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/__tests__/Datagrid.snapshot.spec.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 
+import { TABLE_SIZE, TABLE_VARIANT } from '@ovhcloud/ods-react';
+
 import { renderDataGrid } from '@/commons/tests-utils/Render.utils';
 import { IamAuthorizationResponse } from '@/hooks/iam/IAM.type';
 import { useAuthorizationIam } from '@/hooks/iam/useOvhIam';
@@ -30,80 +32,116 @@ describe('Datagrid Snapshot Tests', () => {
     mockedHook.mockReturnValue(mockIamResponse);
   });
 
-  it('should match snapshot with basic props', () => {
-    const { container } = renderDataGrid({ columns: mockBasicColumns, data: mockData });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with sorting enabled', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      sorting: {
-        sorting: [{ id: 'name', desc: false }],
-        setSorting: mockOnSortChange,
-        manualSorting: false,
+  it.each([
+    {
+      description: 'basic props',
+      props: { columns: mockBasicColumns, data: mockData },
+    },
+    {
+      description: 'sorting enabled',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        sorting: {
+          sorting: [{ id: 'name', desc: false }],
+          setSorting: mockOnSortChange,
+          manualSorting: false,
+        },
       },
-    });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with search enabled', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      search: mockSearch,
-    });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with filters enabled', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      filters: mockFilters,
-    });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with column visibility enabled', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      columnVisibility: {
-        columnVisibility: mockColumnVisibility,
-        setColumnVisibility: mockSetColumnVisibility,
+    },
+    {
+      description: 'search enabled',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        search: mockSearch,
       },
-    });
+    },
+    {
+      description: 'filters enabled',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        filters: mockFilters,
+      },
+    },
+    {
+      description: 'column visibility enabled',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        columnVisibility: {
+          columnVisibility: mockColumnVisibility,
+          setColumnVisibility: mockSetColumnVisibility,
+        },
+      },
+    },
+    {
+      description: 'pagination',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        hasNextPage: true,
+        onFetchNextPage: mockOnFetchNextPage,
+        onFetchAllPages: mockOnFetchAllPages,
+        totalCount: 100,
+        isLoading: false,
+      },
+    },
+    {
+      description: 'loading state',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        isLoading: true,
+      },
+    },
+    {
+      description: 'empty data',
+      props: {
+        columns: mockBasicColumns,
+        data: [],
+      },
+    },
+    {
+      description: 'row selection',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        rowSelection: mockRowSelection,
+      },
+    },
+    {
+      description: 'custom container height',
+      props: {
+        columns: mockBasicColumns,
+        data: mockData,
+        containerHeight: 400,
+      },
+    },
+  ])('should match snapshot with $description', ({ props }) => {
+    const { container } = renderDataGrid(props);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should match snapshot with pagination', () => {
+  it.each([
+    { size: TABLE_SIZE.sm, description: 'small size' },
+    { size: TABLE_SIZE.md, description: 'medium size' },
+    { size: TABLE_SIZE.lg, description: 'large size' },
+  ])('should match snapshot with $description', ({ size }) => {
     const { container } = renderDataGrid({
       columns: mockBasicColumns,
       data: mockData,
-      hasNextPage: true,
-      onFetchNextPage: mockOnFetchNextPage,
-      onFetchAllPages: mockOnFetchAllPages,
-      totalCount: 100,
-      isLoading: false,
+      size,
     });
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should match snapshot with loading state', () => {
+  it('should match snapshot with striped variant', () => {
     const { container } = renderDataGrid({
       columns: mockBasicColumns,
       data: mockData,
-      isLoading: true,
-    });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with empty data', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: [],
+      variant: TABLE_VARIANT.striped,
     });
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -121,24 +159,6 @@ describe('Datagrid Snapshot Tests', () => {
     const buttons = screen.queryAllByRole('button');
     expect(buttons.length).toBeGreaterThan(0);
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with row selection', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      rowSelection: mockRowSelection,
-    });
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('should match snapshot with custom container height', () => {
-    const { container } = renderDataGrid({
-      columns: mockBasicColumns,
-      data: mockData,
-      containerHeight: 400,
-    });
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/packages/manager-ui-kit/src/components/datagrid/__tests__/Datagrid.spec.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/__tests__/Datagrid.spec.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TABLE_SIZE, TABLE_VARIANT } from '@ovhcloud/ods-react';
+
 import { FilterComparator } from '@ovh-ux/manager-core-api';
 
 import { assertNotNull } from '@/commons/tests-utils/Assertions.utils';
@@ -307,6 +309,41 @@ describe('Datagrid', () => {
   });
 
   /* ------------------------- All Features Combined ------------------------- */
+  describe('Table Styles', () => {
+    it('should render with small size', () => {
+      const { container } = renderDataGrid({
+        columns: mockBasicColumns,
+        data: mockData,
+        size: TABLE_SIZE.sm,
+      });
+      const table = container.querySelector('table');
+      expect(table).toBeInTheDocument();
+      expect(table?.className).toContain('table--sm');
+    });
+
+    it('should render with large size', () => {
+      const { container } = renderDataGrid({
+        columns: mockBasicColumns,
+        data: mockData,
+        size: TABLE_SIZE.lg,
+      });
+      const table = container.querySelector('table');
+      expect(table).toBeInTheDocument();
+      expect(table?.className).toContain('table--lg');
+    });
+
+    it('should render with striped variant', () => {
+      const { container } = renderDataGrid({
+        columns: mockBasicColumns,
+        data: mockData,
+        variant: TABLE_VARIANT.striped,
+      });
+      const table = container.querySelector('table');
+      expect(table).toBeInTheDocument();
+      expect(table?.className).toContain('table--striped');
+    });
+  });
+
   describe('All Features Combined', () => {
     it('should render with all features enabled', () => {
       const customTopbar = <div data-testid="custom-topbar">Custom Topbar</div>;

--- a/packages/manager-ui-kit/src/components/datagrid/__tests__/__snapshots__/Datagrid.snapshot.spec.tsx.snap
+++ b/packages/manager-ui-kit/src/components/datagrid/__tests__/__snapshots__/Datagrid.snapshot.spec.tsx.snap
@@ -1,23 +1,1817 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Datagrid Snapshot Tests > should match snapshot with 'basic props' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'column visibility enabled' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'custom container height' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 400px; height: 400px;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'empty data' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="h-[3.25rem] w-full"
+      >
+        <td
+          class="absolute text-center w-full py-[15px]"
+          style="border-right: 1px solid var(--ods-color-neutral-100); left: 0px;"
+        >
+          <p
+            class="_text--paragraph_1aw48_54"
+            data-ods="text"
+          >
+            Aucun résultat
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'filters enabled' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'large size' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--lg_1xkmm_106"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 131px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 64.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 64.5px; transform: translateY(64.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'loading state' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 533.5px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="h-[50px]"
+      >
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+        <td
+          class="overflow-hidden py-[8px]"
+        >
+          <div
+            aria-busy="true"
+            class="w-full"
+          >
+            <div
+              aria-hidden="true"
+              class="_skeleton_kauw8_2"
+              data-ods="skeleton"
+            />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'medium size' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'pagination' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'row selection' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 30px; min-width: 30px; max-width: 30px;"
+        >
+          <label
+            class="_checkbox_18i6t_2"
+            data-ods="checkbox"
+            data-part="root"
+            data-scope="checkbox"
+            data-state="unchecked"
+            dir="ltr"
+            for="checkbox:select-all:input"
+            id="checkbox:select-all"
+          >
+            <div
+              aria-hidden="true"
+              class="_checkbox-control_gr69e_2"
+              data-ods="checkbox-control"
+              data-part="control"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              id="checkbox:select-all:control"
+            >
+              <div
+                data-part="indicator"
+                data-scope="checkbox"
+                data-state="unchecked"
+                dir="ltr"
+                hidden=""
+              >
+                <span
+                  class="_icon_10c23_2 _icon--check_10c23_76 _checkbox-control__icon_gr69e_49"
+                  data-ods="icon"
+                  role="presentation"
+                />
+              </div>
+              <div
+                data-part="indicator"
+                data-scope="checkbox"
+                data-state="unchecked"
+                dir="ltr"
+                hidden=""
+              >
+                <span
+                  class="_icon_10c23_2 _icon--minus_10c23_376 _checkbox-control__icon_gr69e_49"
+                  data-ods="icon"
+                  role="presentation"
+                />
+              </div>
+            </div>
+            <input
+              aria-invalid="false"
+              aria-labelledby="checkbox:select-all:label"
+              id="checkbox:select-all:input"
+              name="select-all"
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+              type="checkbox"
+              value="on"
+            />
+          </label>
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <label
+              class="_checkbox_18i6t_2"
+              data-ods="checkbox"
+              data-part="root"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              for="checkbox:1:input"
+              id="checkbox:1"
+            >
+              <div
+                aria-hidden="true"
+                class="_checkbox-control_gr69e_2"
+                data-ods="checkbox-control"
+                data-part="control"
+                data-scope="checkbox"
+                data-state="unchecked"
+                dir="ltr"
+                id="checkbox:1:control"
+              >
+                <div
+                  data-part="indicator"
+                  data-scope="checkbox"
+                  data-state="unchecked"
+                  dir="ltr"
+                  hidden=""
+                >
+                  <span
+                    class="_icon_10c23_2 _icon--check_10c23_76 _checkbox-control__icon_gr69e_49"
+                    data-ods="icon"
+                    role="presentation"
+                  />
+                </div>
+                <div
+                  data-part="indicator"
+                  data-scope="checkbox"
+                  data-state="unchecked"
+                  dir="ltr"
+                  hidden=""
+                >
+                  <span
+                    class="_icon_10c23_2 _icon--minus_10c23_376 _checkbox-control__icon_gr69e_49"
+                    data-ods="icon"
+                    role="presentation"
+                  />
+                </div>
+              </div>
+              <input
+                aria-invalid="false"
+                aria-labelledby="checkbox:1:label"
+                id="checkbox:1:input"
+                name="select-1"
+                style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+                type="checkbox"
+                value="on"
+              />
+            </label>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <label
+              class="_checkbox_18i6t_2"
+              data-ods="checkbox"
+              data-part="root"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              for="checkbox:2:input"
+              id="checkbox:2"
+            >
+              <div
+                aria-hidden="true"
+                class="_checkbox-control_gr69e_2"
+                data-ods="checkbox-control"
+                data-part="control"
+                data-scope="checkbox"
+                data-state="unchecked"
+                dir="ltr"
+                id="checkbox:2:control"
+              >
+                <div
+                  data-part="indicator"
+                  data-scope="checkbox"
+                  data-state="unchecked"
+                  dir="ltr"
+                  hidden=""
+                >
+                  <span
+                    class="_icon_10c23_2 _icon--check_10c23_76 _checkbox-control__icon_gr69e_49"
+                    data-ods="icon"
+                    role="presentation"
+                  />
+                </div>
+                <div
+                  data-part="indicator"
+                  data-scope="checkbox"
+                  data-state="unchecked"
+                  dir="ltr"
+                  hidden=""
+                >
+                  <span
+                    class="_icon_10c23_2 _icon--minus_10c23_376 _checkbox-control__icon_gr69e_49"
+                    data-ods="icon"
+                    role="presentation"
+                  />
+                </div>
+              </div>
+              <input
+                aria-invalid="false"
+                aria-labelledby="checkbox:2:label"
+                id="checkbox:2:input"
+                name="select-2"
+                style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+                type="checkbox"
+                value="on"
+              />
+            </label>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'search enabled' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'small size' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--sm_1xkmm_2"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 67px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 32.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 32.5px; transform: translateY(32.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with 'sorting enabled' 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="cursor-pointer select-none h-[20px]"
+            data-testid="header-name"
+          >
+            <span>
+              name
+            </span>
+            <span
+              class="align-middle inline-block pl-1 -mt-1"
+            >
+              <span
+                class="_icon_10c23_2 _icon--arrow-up_10c23_37"
+                data-ods="icon"
+                role="presentation"
+              />
+            </span>
+          </div>
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="cursor-pointer select-none h-[20px]"
+            data-testid="header-age"
+          >
+            <span>
+              age
+            </span>
+            <span
+              class="align-middle inline-block pl-1 -mt-1"
+            >
+              <span
+                class="_icon_10c23_2 _icon--arrow-down_10c23_19 invisible"
+                data-ods="icon"
+                role="presentation"
+              />
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Datagrid Snapshot Tests > should match snapshot with all features enabled 1`] = `
 <div
   class="overflow-auto relative w-full"
   style="max-height: 500px; height: 500px;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
             class=" h-[20px]"
@@ -36,8 +1830,8 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
             class=" h-[20px]"
@@ -114,7 +1908,7 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
@@ -136,7 +1930,7 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
@@ -160,27 +1954,27 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div
-              class="text-center"
               style="padding-left: 0rem;"
             >
               <button
-                class="_button_1koyw_2 _button--primary_1koyw_100 _button--xs_1koyw_25 _button--ghost_1koyw_151"
+                class="_button_1koyw_2 _button--primary_1koyw_100 _button--sm_1koyw_34 _button--ghost_1koyw_151 m-0 p-0"
                 data-ods="button"
                 data-testid="manager-button"
                 type="button"
@@ -195,11 +1989,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <label
               class="_checkbox_18i6t_2"
@@ -261,11 +2056,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -273,11 +2069,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -288,21 +2085,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div
-              class="text-center"
               style="padding-left: 0rem;"
             >
               <button
-                class="_button_1koyw_2 _button--primary_1koyw_100 _button--xs_1koyw_25 _button--ghost_1koyw_151"
+                class="_button_1koyw_2 _button--primary_1koyw_100 _button--sm_1koyw_34 _button--ghost_1koyw_151 m-0 p-0"
                 data-ods="button"
                 data-testid="manager-button"
                 type="button"
@@ -317,11 +2114,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <label
               class="_checkbox_18i6t_2"
@@ -383,11 +2181,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -395,11 +2194,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with all features enabl
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -418,23 +2218,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with basic props 1`] = 
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -442,20 +2240,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with basic props 1`] = 
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -463,11 +2262,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with basic props 1`] = 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -478,14 +2278,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with basic props 1`] = 
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -493,11 +2294,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with basic props 1`] = 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -516,23 +2318,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with column visibility 
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -540,20 +2340,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with column visibility 
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -561,11 +2362,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with column visibility 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -576,14 +2378,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with column visibility 
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -591,11 +2394,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with column visibility 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -614,23 +2418,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with custom container h
   style="max-height: 400px; height: 400px;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -638,20 +2440,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with custom container h
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -659,11 +2462,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with custom container h
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -674,14 +2478,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with custom container h
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -689,11 +2494,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with custom container h
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -712,23 +2518,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with empty data 1`] = `
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -762,27 +2566,25 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         />
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -790,27 +2592,27 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div
-              class="text-center"
               style="padding-left: 0rem;"
             >
               <button
-                class="_button_1koyw_2 _button--primary_1koyw_100 _button--xs_1koyw_25 _button--ghost_1koyw_151"
+                class="_button_1koyw_2 _button--primary_1koyw_100 _button--sm_1koyw_34 _button--ghost_1koyw_151 m-0 p-0"
                 data-ods="button"
                 data-testid="manager-button"
                 type="button"
@@ -825,11 +2627,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -837,11 +2640,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -852,21 +2656,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div
-              class="text-center"
               style="padding-left: 0rem;"
             >
               <button
-                class="_button_1koyw_2 _button--primary_1koyw_100 _button--xs_1koyw_25 _button--ghost_1koyw_151"
+                class="_button_1koyw_2 _button--primary_1koyw_100 _button--sm_1koyw_34 _button--ghost_1koyw_151 m-0 p-0"
                 data-ods="button"
                 data-testid="manager-button"
                 type="button"
@@ -881,11 +2685,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -893,11 +2698,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with expandable rows 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -916,23 +2722,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with filters enabled 1`
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -940,20 +2744,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with filters enabled 1`
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -961,11 +2766,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with filters enabled 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -976,14 +2782,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with filters enabled 1`
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -991,11 +2798,112 @@ exports[`Datagrid Snapshot Tests > should match snapshot with filters enabled 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with large size 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--lg_1xkmm_106"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 131px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 64.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 64.5px; transform: translateY(64.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -1014,23 +2922,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -1038,20 +2944,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 550px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 533.5px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -1059,11 +2966,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -1074,14 +2982,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -1089,11 +2998,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -1426,29 +3336,27 @@ exports[`Datagrid Snapshot Tests > should match snapshot with loading state 1`] 
 </div>
 `;
 
-exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
+exports[`Datagrid Snapshot Tests > should match snapshot with medium size 1`] = `
 <div
   class="overflow-auto relative w-full"
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -1456,20 +3364,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -1477,11 +3386,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -1492,14 +3402,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -1507,11 +3418,112 @@ exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with pagination 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -1530,18 +3542,16 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <label
             class="_checkbox_18i6t_2"
@@ -1602,13 +3612,13 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
           </label>
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -1616,20 +3626,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <label
               class="_checkbox_18i6t_2"
@@ -1691,11 +3702,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -1703,11 +3715,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -1718,14 +3731,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
-          style="width: 20px; min-width: 20px; max-width: 20px;"
+          class="pl-4"
+          style="width: 30px; min-width: 30px; max-width: 30px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <label
               class="_checkbox_18i6t_2"
@@ -1787,11 +3801,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -1799,11 +3814,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with row selection 1`] 
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -1822,23 +3838,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with search enabled 1`]
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           name
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           age
@@ -1846,20 +3860,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with search enabled 1`]
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -1867,11 +3882,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with search enabled 1`]
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
@@ -1882,14 +3898,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with search enabled 1`]
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -1897,11 +3914,112 @@ exports[`Datagrid Snapshot Tests > should match snapshot with search enabled 1`]
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with small size 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--sm_1xkmm_2"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 67px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 32.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 32.5px; transform: translateY(32.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -1920,17 +4038,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
   style="max-height: 100%; height: 100%;"
 >
   <table
-    class="_table--md_1xkmm_54 table table-fixed w-full"
+    class="_table--md_1xkmm_54"
     data-ods="table"
   >
     <thead
       class="sticky top-[-1px] z-10 bg-white overflow-hidden"
     >
-      <tr
-        class="w-full"
-      >
+      <tr>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
@@ -1952,7 +4068,7 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
           </div>
         </th>
         <th
-          class="text-left pl-4 whitespace-nowrap"
+          class="text-left pl-4 whitespace-nowrap "
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
@@ -1976,20 +4092,21 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
       </tr>
     </thead>
     <tbody
-      class="w-full relative p-0 overflow-hidden"
-      style="height: 102px;"
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
     >
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="0"
-        style="left: -1px; height: 50px; transform: translateY(0px);"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               Jane Smith
@@ -1997,11 +4114,12 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               25
@@ -2012,14 +4130,15 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
       <tr
         class="table overflow-hidden absolute top-0 w-full table table-fixed"
         data-index="1"
-        style="left: -1px; height: 50px; transform: translateY(50px);"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
       >
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               John Doe
@@ -2027,14 +4146,115 @@ exports[`Datagrid Snapshot Tests > should match snapshot with sorting enabled 1`
           </div>
         </td>
         <td
-          class="py-[8px] pl-4"
+          class="pl-4"
           style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
         >
           <div
-            class="overflow-hidden text-ellipsis block w-full"
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
           >
             <div>
               30
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Datagrid Snapshot Tests > should match snapshot with striped variant 1`] = `
+<div
+  class="overflow-auto relative w-full"
+  style="max-height: 100%; height: 100%;"
+>
+  <table
+    class="_table--md_1xkmm_54 _table--striped_1xkmm_158"
+    data-ods="table"
+  >
+    <thead
+      class="sticky top-[-1px] z-10 bg-white overflow-hidden"
+    >
+      <tr>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          name
+        </th>
+        <th
+          class="text-left pl-4 whitespace-nowrap "
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          age
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="relative p-0 overflow-hidden"
+      style="height: 99px;"
+    >
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="0"
+        style="left: -1px; height: 48.5px; transform: translateY(0px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              John Doe
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              30
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="table overflow-hidden absolute top-0 w-full table table-fixed"
+        data-index="1"
+        style="left: -1px; height: 48.5px; transform: translateY(48.5px);"
+      >
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              Jane Smith
+            </div>
+          </div>
+        </td>
+        <td
+          class="pl-4"
+          style="width: 150px; min-width: 20px; max-width: 9007199254740991px;"
+        >
+          <div
+            class="overflow-hidden text-ellipsis flex items-center w-full"
+            style="line-height: 1;"
+          >
+            <div>
+              25
             </div>
           </div>
         </td>

--- a/packages/manager-ui-kit/src/components/datagrid/builder/TableBuilderProps.props.ts
+++ b/packages/manager-ui-kit/src/components/datagrid/builder/TableBuilderProps.props.ts
@@ -2,6 +2,8 @@ import { JSX, MutableRefObject } from 'react';
 
 import type { ColumnDef, ColumnSort, Row, VisibilityState } from '@tanstack/react-table';
 
+import { TABLE_SIZE } from '@ovhcloud/ods-react';
+
 import {
   ExpandableRow,
   ExpandedProps,
@@ -24,4 +26,5 @@ export type TableBuilderProps<T extends ExpandableRow<T>> = {
   rowSelection?: RowSelectionProps<T> | null;
   setColumnVisibility: (columnVisibility: VisibilityState) => void;
   sorting: ColumnSort[];
+  size: TABLE_SIZE;
 };

--- a/packages/manager-ui-kit/src/components/datagrid/builder/TableHeaderBuilder.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/builder/TableHeaderBuilder.tsx
@@ -7,25 +7,35 @@ import {
   CheckboxControl,
   ICON_NAME,
   Icon,
+  TABLE_SIZE,
 } from '@ovhcloud/ods-react';
 
 import { Button } from '@/components/button/Button.component';
 import type { ExpandedProps } from '@/components/datagrid/Datagrid.props';
 
-export const getExpandable = <T,>(expandable: ExpandedProps) => ({
+const ROW_SIZE = 30;
+
+const SIZE_TO_BUTTON_SIZE: Record<TABLE_SIZE, BUTTON_SIZE> = {
+  [TABLE_SIZE.sm]: BUTTON_SIZE.xs,
+  [TABLE_SIZE.md]: BUTTON_SIZE.sm,
+  [TABLE_SIZE.lg]: BUTTON_SIZE.md,
+};
+
+export const getExpandable = <T,>(expandable: ExpandedProps, size: TABLE_SIZE) => ({
   cell: ({ row }: { row: Row<T> }) => {
+    const ButtonSize = SIZE_TO_BUTTON_SIZE[size] ?? BUTTON_SIZE.md;
     return row.getCanExpand() ? (
       <div
-        className="text-center"
         style={{
           ...(expandable && { paddingLeft: `${row.depth * 2}rem` }),
         }}
       >
         {expandable && row.depth ? null : (
           <Button
+            className="m-0 p-0"
             onClick={row.getToggleExpandedHandler()}
             variant={BUTTON_VARIANT.ghost}
-            size={BUTTON_SIZE.xs}
+            size={ButtonSize}
           >
             <Icon name={row.getIsExpanded() ? ICON_NAME.chevronDown : ICON_NAME.chevronRight} />
           </Button>
@@ -36,7 +46,8 @@ export const getExpandable = <T,>(expandable: ExpandedProps) => ({
   enableHiding: false,
   enableResizing: true,
   id: 'expander',
-  maxSize: 20,
+  maxSize: ROW_SIZE,
+  minSize: ROW_SIZE,
 });
 
 export const getRowSelection = <T,>() => ({
@@ -64,5 +75,6 @@ export const getRowSelection = <T,>() => ({
     </Checkbox>
   ),
   id: 'select',
-  maxSize: 20,
+  maxSize: ROW_SIZE,
+  minSize: ROW_SIZE,
 });

--- a/packages/manager-ui-kit/src/components/datagrid/builder/useTableBuilder.ts
+++ b/packages/manager-ui-kit/src/components/datagrid/builder/useTableBuilder.ts
@@ -19,6 +19,7 @@ export const useTableBuilder = <T extends ExpandableRow<T>>({
   rowSelection,
   setColumnVisibility,
   sorting,
+  size,
 }: TableBuilderProps<T>) => {
   const params: Partial<TableOptions<T>> = {};
   const builder = {
@@ -29,7 +30,7 @@ export const useTableBuilder = <T extends ExpandableRow<T>>({
         cols = [getRowSelection(), ...cols];
       }
       if ((hasExpandableFeature && expandable) || renderSubComponent) {
-        cols = [getExpandable(expandable), ...cols];
+        cols = [getExpandable(expandable, size), ...cols];
       }
       params.columns = cols;
       return builder;

--- a/packages/manager-ui-kit/src/components/datagrid/table/table-body/TableBody.component.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/table/table-body/TableBody.component.tsx
@@ -41,16 +41,15 @@ export const TableBody = <T,>({
     }
   }, [rows?.length]);
 
-  const EXPANDED_SIZE = subComponentHeight;
   const getOffset = useCallback(
     (index: number) => {
       let count = 0;
       for (let i = 0; i < index; i += 1) {
         if (rows[i]?.getIsExpanded()) count += 1;
       }
-      return count * EXPANDED_SIZE;
+      return count * subComponentHeight;
     },
-    [rows],
+    [subComponentHeight],
   );
 
   const totalHeight = useMemo(() => {
@@ -67,7 +66,7 @@ export const TableBody = <T,>({
   return (
     <tbody
       key={`table-body-${rows.length}`}
-      className="w-full relative p-0 overflow-hidden"
+      className="relative p-0 overflow-hidden"
       style={{
         height: totalHeight,
       }}
@@ -75,9 +74,7 @@ export const TableBody = <T,>({
       {rowVirtualizer.getVirtualItems().map((virtualRow) => {
         const row = rows[virtualRow?.index];
         if (!row) return null;
-
-        const offset = renderSubComponent ? getOffset(virtualRow.index) : 0;
-
+        const offset = renderSubComponent ? getOffset(virtualRow?.index) : 0;
         return (
           <Fragment key={`table-body-tr-${row.id}`}>
             <tr
@@ -94,7 +91,7 @@ export const TableBody = <T,>({
               {row.getVisibleCells().map((cell) => (
                 <td
                   key={cell.id}
-                  className={`py-[8px] ${contentAlignLeft ? 'pl-4' : 'text-center'}`}
+                  className={`${contentAlignLeft ? 'pl-4' : 'text-center'}`}
                   style={{
                     width: cell.column.getSize(),
                     minWidth: cell.column.columnDef.minSize ?? 0,
@@ -102,7 +99,10 @@ export const TableBody = <T,>({
                     borderTop: 'none',
                   }}
                 >
-                  <div className="overflow-hidden text-ellipsis block w-full">
+                  <div
+                    className="overflow-hidden text-ellipsis flex items-center w-full"
+                    style={{ lineHeight: 1 }}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </div>
                 </td>
@@ -116,7 +116,7 @@ export const TableBody = <T,>({
                 offset={offset}
                 renderSubComponent={renderSubComponent}
                 subComponentHeight={subComponentHeight}
-                maxRowHeight={maxRowHeight}
+                maxRowHeight={virtualRow?.size ?? maxRowHeight}
               />
             )}
           </Fragment>

--- a/packages/manager-ui-kit/src/components/datagrid/table/table-body/sub-row/SubRow.component.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/table/table-body/sub-row/SubRow.component.tsx
@@ -13,20 +13,17 @@ export const SubRow = ({
   <tr
     key={`${row.id}-expanded-tr`}
     data-index={`${virtualRow.index}-expanded-tr`}
-    className={`overflow-hidden absolute top-0 display-table table-layout-fixed`}
+    className={`overflow-hidden absolute top-0 display-table table-layout-fixed h-full`}
     style={{
       left: -1,
       height: `${subComponentHeight}px`,
       width: '-webkit-fill-available',
-      borderRight: '1px solid var(--ods-color-neutral-100)',
-      borderLeft: '1px solid var(--ods-color-neutral-100)',
-      borderBottom: '1px solid var(--ods-color-neutral-100)',
-      transform: `translateY(${virtualRow.start + offset + maxRowHeight}px)`,
+      transform: `translateY(${virtualRow.start + offset + maxRowHeight - 1}px)`,
     }}
   >
-    <div className="overflow-hidden p-[8px] text-ellipsis block w-full">
+    <td className="overflow-hidden p-[8px] text-ellipsis block w-full h-full">
       {renderSubComponent(row)}
-    </div>
+    </td>
   </tr>
 );
 

--- a/packages/manager-ui-kit/src/components/datagrid/table/table-head/table-header-content/TableHeaderContent.component.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/table/table-head/table-header-content/TableHeaderContent.component.tsx
@@ -13,11 +13,11 @@ const TableHeaderContentComponent = <T,>({
 }: TableHeaderContentProps<T>) => (
   <thead className={`sticky top-[-1px] z-10 bg-white overflow-hidden`}>
     {headerGroups?.map((headerGroup) => (
-      <tr key={headerGroup.id} className="w-full">
+      <tr key={headerGroup.id}>
         {headerGroup.headers.map((header) => (
           <th
             key={header.id}
-            className={`${contentAlignLeft ? 'text-left pl-4' : 'text-center'} whitespace-nowrap`}
+            className={`${contentAlignLeft ? 'text-left pl-4' : 'text-center'} whitespace-nowrap `}
             style={{
               width: header.column.getSize(),
               minWidth: header.column.columnDef.minSize ?? 0,

--- a/packages/manager-ui-kit/src/components/datagrid/useDatagrid.props.ts
+++ b/packages/manager-ui-kit/src/components/datagrid/useDatagrid.props.ts
@@ -2,6 +2,8 @@ import { JSX, MutableRefObject } from 'react';
 
 import type { ColumnSort, Row, VisibilityState } from '@tanstack/react-table';
 
+import { TABLE_SIZE } from '@ovhcloud/ods-react';
+
 import {
   DatagridColumn,
   ExpandableRow,
@@ -23,4 +25,5 @@ export type UseDatagridTableProps<T extends ExpandableRow<T>> = {
   rowSelection?: RowSelectionProps<T> | null;
   setColumnVisibility?: (columnVisibility: VisibilityState) => void;
   sorting?: ColumnSort[];
+  sizeRow?: TABLE_SIZE;
 };

--- a/packages/manager-ui-kit/src/components/datagrid/useDatagrid.tsx
+++ b/packages/manager-ui-kit/src/components/datagrid/useDatagrid.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { useReactTable } from '@tanstack/react-table';
 
+import { TABLE_SIZE } from '@ovhcloud/ods-react';
+
 import { ExpandableRow } from '@/components/datagrid/Datagrid.props';
 
 import { useTableBuilder } from './builder/useTableBuilder';
@@ -16,6 +18,7 @@ export const useDatagrid = <T extends ExpandableRow<T>>({
   onSortChange,
   renderSubComponent,
   rowSelection,
+  sizeRow,
   setColumnVisibility,
   sorting,
 }: UseDatagridTableProps<T>) => {
@@ -45,6 +48,7 @@ export const useDatagrid = <T extends ExpandableRow<T>>({
     rowSelection,
     setColumnVisibility: setColumnVisibility ?? (() => {}),
     sorting: sorting ?? [],
+    size: sizeRow ?? TABLE_SIZE.md,
   })
     .setColumns()
     .setColumnsVisibility()

--- a/packages/manager-wiki/stories/manager-ui-kit/components/Datagrid/datagrid.stories.tsx
+++ b/packages/manager-wiki/stories/manager-ui-kit/components/Datagrid/datagrid.stories.tsx
@@ -7,6 +7,8 @@ import {
   Icon,
   ICON_NAME,
   Input,
+  TABLE_SIZE,
+  TABLE_VARIANT,
 } from '@ovhcloud/ods-react';
 import { Datagrid, DatagridProps, useColumnFilters } from '@ovh-ux/muk';
 import {
@@ -121,6 +123,8 @@ const DatagridStory = (args: DatagridProps<DatagridStoryData>) => {
     subComponentHeight,
     maxRowHeight,
     isLoading,
+    size,
+    variant,
     totalCount,
     topbar,
   } = args;
@@ -196,6 +200,8 @@ const DatagridStory = (args: DatagridProps<DatagridStoryData>) => {
       <Datagrid
         columns={colsArgs}
         data={applyFilters(itemsArgs, filters)}
+        {...('size' in args && { size })}
+        {...('variant' in args && { variant })}
         {...('containerHeight' in args && {
           containerHeight: containerHeightStyle,
         })}
@@ -275,6 +281,29 @@ Default.args = {
   data,
 };
 
+export const Size = DatagridStory.bind({});
+
+Size.args = {
+  columns,
+  data,
+  size: TABLE_SIZE.sm,
+  hasNextPage: true,
+  onFetchNextPage: () => {},
+  onFetchAllPages: () => {},
+};
+
+
+
+export const Variant = DatagridStory.bind({});
+
+Variant.args = {
+  columns,
+  data,
+  variant: TABLE_VARIANT.striped,
+};
+
+
+
 export const Sorting = DatagridStory.bind({});
 
 Sorting.args = {
@@ -339,6 +368,7 @@ SubComponent.args = {
     </>
   ),
   subComponentHeight: 80,
+  size: TABLE_SIZE.md,
 };
 
 export const Expandable = DatagridStory.bind({});
@@ -472,6 +502,16 @@ const meta = {
   },
   args: {},
   argTypes: {
+    size: {
+      description: 'Controls the table row size',
+      control: 'select',
+      options: [TABLE_SIZE.sm, TABLE_SIZE.md, TABLE_SIZE.lg],
+    },
+    variant: {
+      description: 'Controls the table variant style',
+      control: 'select',
+      options: [TABLE_VARIANT.default, TABLE_VARIANT.striped],
+    },
     hasNextPage: {
       description: 'Controls whether pagination buttons are shown',
       control: 'boolean',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

#  Datagrid Component : Size and Variant attributes & Tests

<img width="1324" height="506" alt="Screenshot 2025-10-29 at 16 43 42" src="https://github.com/user-attachments/assets/4a49a3df-de12-4789-9a8b-2624061ade8c" />
<img width="1331" height="429" alt="Screenshot 2025-10-29 at 16 43 21" src="https://github.com/user-attachments/assets/be3097ee-ef31-4ef3-b71a-2bbbd66399f2" />
<img width="1331" height="414" alt="Screenshot 2025-10-29 at 16 39 20" src="https://github.com/user-attachments/assets/3e9a75da-ba10-4457-b3e4-23194dfeaa54" />
<img width="1287" height="448" alt="Screenshot 2025-10-29 at 16 39 04" src="https://github.com/user-attachments/assets/95486fa2-b1d7-4f70-8f86-fe7cdab95154" />

## Test Coverage Additions

### 1. Snapshot Tests (`Datagrid.snapshot.spec.tsx`)
- Added **4 new snapshot tests** for size and variant attributes:
  - Small size (`TABLE_SIZE.sm`)
  - Medium size (`TABLE_SIZE.md`) 
  - Large size (`TABLE_SIZE.lg`)
  - Striped variant (`TABLE_VARIANT.striped`)

### 2. Functional Tests (`Datagrid.spec.tsx`)
- Created new **"Table Styles" test suite** with 3 tests:
  - Small size → validates `table--sm` class
  - Large size → validates `table--lg` class
  - Striped variant → validates `table--striped` class
- Applied code formatting improvements (line breaks, spacing)

### 3. Storybook Controls (`datagrid.stories.tsx`)
- Added **interactive controls** in Storybook's control panel:
  - `size` control: select dropdown with sm/md/lg options
  - `variant` control: select dropdown with default/striped options

## Technical Changes
- Added imports for `TABLE_SIZE` and `TABLE_VARIANT` from `@ovhcloud/ods-react`
