### PR TITLE
fix(billing-components): put back service status on subscription tile

### DIFF
--- a/packages/manager/modules/billing-components/src/components/subscription-tile/index.js
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/index.js
@@ -7,6 +7,7 @@ import '@ovh-ux/manager-core';
 import '@ovh-ux/ng-at-internet';
 
 import utils from '../utils';
+import renewStatus from './renew-status';
 import component from './subscription-tile.component';
 
 const moduleName = 'ovhManagerBillingSubscriptionTile';
@@ -20,6 +21,7 @@ angular
     'oui',
     'ovhManagerCore',
     utils,
+    renewStatus,
   ])
   .component('billingSubscriptionTile', component)
   .run(/* @ngTranslationsInject:json ./translations */);

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/index.js
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/index.js
@@ -1,0 +1,20 @@
+import 'angular-translate';
+import '@ovh-ux/ng-translate-async-loader';
+import '@ovh-ux/ui-kit';
+import ovhManagerCore from '@ovh-ux/manager-core';
+
+import component from './renew-status.component';
+
+const moduleName = 'ovhManagerBillingRenewStatus';
+
+angular
+  .module(moduleName, [
+    'pascalprecht.translate',
+    'ngTranslateAsyncLoader',
+    'oui',
+    ovhManagerCore,
+  ])
+  .component('renewStatus', component)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.component.js
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.component.js
@@ -1,0 +1,10 @@
+import controller from './renew-status.controller';
+import template from './renew-status.template.html';
+
+export default {
+  bindings: {
+    service: '<',
+  },
+  controller,
+  template,
+};

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.constants.js
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.constants.js
@@ -1,0 +1,10 @@
+export const RENEW_STATES_BADGES_CLASSES_MAP = {
+  error: ['expired', 'delete_at_expiration'],
+  success: ['auto', 'automatic'],
+  warning: ['manual', 'manualPayment'],
+  info: ['billing_suspended', 'forced_manual'],
+};
+
+export default {
+  RENEW_STATES_BADGES_CLASSES_MAP,
+};

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.controller.js
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.controller.js
@@ -1,0 +1,13 @@
+import { RENEW_STATES_BADGES_CLASSES_MAP } from './renew-status.constants';
+
+export default class {
+  constructor() {
+    this.RENEW_STATES_BADGES_CLASSES_MAP = RENEW_STATES_BADGES_CLASSES_MAP;
+  }
+
+  shouldHideAutorenewStatus() {
+    return (
+      this.service.isOneShot?.() || ['SMS'].includes(this.service.serviceType)
+    );
+  }
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.template.html
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/renew-status.template.html
@@ -1,0 +1,41 @@
+<p>
+    <span
+        class="oui-badge oui-badge_error"
+        data-ng-if="$ctrl.service.hasDebt()"
+        data-translate="manager_billing_service_status_pending_debt"
+    >
+    </span>
+    <span
+        data-ng-if="$ctrl.shouldHideAutorenewStatus() && !$ctrl.service.isResiliated()"
+        >-</span
+    >
+    <span
+        data-ng-if="$ctrl.shouldHideAutorenewStatus() && $ctrl.service.isResiliated()"
+        class="oui-badge oui-badge_error"
+        data-translate="manager_billing_service_status_expired"
+    >
+    </span>
+    <span
+        class="oui-badge text-wrap"
+        data-ng-class="{
+        'oui-badge_error': $ctrl.RENEW_STATES_BADGES_CLASSES_MAP.error.includes($ctrl.service.getRenew()),
+        'oui-badge_warning': $ctrl.RENEW_STATES_BADGES_CLASSES_MAP.warning.includes($ctrl.service.getRenew()),
+        'oui-badge_success': $ctrl.RENEW_STATES_BADGES_CLASSES_MAP.success.includes($ctrl.service.getRenew()),
+        'oui-badge_info': $ctrl.RENEW_STATES_BADGES_CLASSES_MAP.info.includes($ctrl.service.getRenew()),
+    }"
+        data-ng-if="!$ctrl.service.hasDebt() && !$ctrl.shouldHideAutorenewStatus() && $ctrl.service.getRenew()"
+        data-translate="{{:: 'manager_billing_service_status_' + $ctrl.service.getRenew() | translate }}"
+    ></span>
+    <span
+        data-ng-if="$ctrl.service.isRestorable"
+        class="oui-badge text-wrap oui-badge_warning"
+        data-translate="{{:: 'manager_billing_service_status_restorable' | translate }}"
+    ></span>
+    <button
+        type="button"
+        class="oui-popover-button"
+        data-ng-if="$ctrl.service.statusHelp"
+        data-oui-popover="{{ $ctrl.service.statusHelp }}"
+        data-oui-popover-placement="bottom"
+    ></button>
+</p>

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_de_DE.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_de_DE.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Status",
+  "manager_billing_service_status_auto": "Automatische Verlängerung",
+  "manager_billing_service_status_automatic": "Automatische Verlängerung",
+  "manager_billing_service_status_manual": "Manuelle Verlängerung",
+  "manager_billing_service_status_manualPayment": "Manuelle Verlängerung",
+  "manager_billing_service_status_pending_debt": "Zahlungsausfall",
+  "manager_billing_service_status_delete_at_expiration": "Geplante Kündigung",
+  "manager_billing_service_status_expired": "Gekündigt",
+  "manager_billing_service_status_billing_suspended": "Abrechnung verschoben",
+  "manager_billing_service_status_forced_manual": "Zwangsweise manuelle Verlängerung",
+  "manager_billing_service_status_restorable": "Wiederherstellbar"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_en_GB.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_en_GB.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Status",
+  "manager_billing_service_status_auto": "Via automatic renewal:",
+  "manager_billing_service_status_automatic": "Via automatic renewal:",
+  "manager_billing_service_status_manual": "Manual renewal",
+  "manager_billing_service_status_manualPayment": "Manual renewal",
+  "manager_billing_service_status_pending_debt": "Non-payment",
+  "manager_billing_service_status_delete_at_expiration": "Scheduled cancellation",
+  "manager_billing_service_status_expired": "Cancelled",
+  "manager_billing_service_status_billing_suspended": "Deferred billing",
+  "manager_billing_service_status_forced_manual": "Forced manual renewal",
+  "manager_billing_service_status_restorable": "Restorable"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_es_ES.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_es_ES.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Estado",
+  "manager_billing_service_status_auto": "Renovación automática ",
+  "manager_billing_service_status_automatic": "Renovación automática ",
+  "manager_billing_service_status_manual": "Renovación manual",
+  "manager_billing_service_status_manualPayment": "Renovación manual",
+  "manager_billing_service_status_pending_debt": "Impago",
+  "manager_billing_service_status_delete_at_expiration": "Cancelación programada",
+  "manager_billing_service_status_expired": "Cancelado",
+  "manager_billing_service_status_billing_suspended": "Facturación diferida",
+  "manager_billing_service_status_forced_manual": "Renovación manual forzada",
+  "manager_billing_service_status_restorable": "Restaurable"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_fr_CA.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Statut",
+  "manager_billing_service_status_auto": "Renouvellement automatique",
+  "manager_billing_service_status_automatic": "Renouvellement automatique",
+  "manager_billing_service_status_manual": "Renouvellement manuel",
+  "manager_billing_service_status_manualPayment": "Renouvellement manuel",
+  "manager_billing_service_status_pending_debt": "Défaut de paiement",
+  "manager_billing_service_status_delete_at_expiration": "Résiliation programmée",
+  "manager_billing_service_status_expired": "Résilié",
+  "manager_billing_service_status_billing_suspended": "Facturation reportée",
+  "manager_billing_service_status_forced_manual": "Renouvellement manuel forcé",
+  "manager_billing_service_status_restorable": "Restaurable"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_fr_FR.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Statut",
+  "manager_billing_service_status_auto": "Renouvellement automatique",
+  "manager_billing_service_status_automatic": "Renouvellement automatique",
+  "manager_billing_service_status_manual": "Renouvellement manuel",
+  "manager_billing_service_status_manualPayment": "Renouvellement manuel",
+  "manager_billing_service_status_pending_debt": "Défaut de paiement",
+  "manager_billing_service_status_delete_at_expiration": "Résiliation programmée",
+  "manager_billing_service_status_expired": "Résilié",
+  "manager_billing_service_status_billing_suspended": "Facturation reportée",
+  "manager_billing_service_status_forced_manual": "Renouvellement manuel forcé",
+  "manager_billing_service_status_restorable": "Restaurable"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_it_IT.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_it_IT.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Status",
+  "manager_billing_service_status_auto": "Rinnovo automatico",
+  "manager_billing_service_status_automatic": "Rinnovo automatico",
+  "manager_billing_service_status_manual": "Rinnovo manuale",
+  "manager_billing_service_status_manualPayment": "Rinnovo manuale",
+  "manager_billing_service_status_pending_debt": "Mancato pagamento",
+  "manager_billing_service_status_delete_at_expiration": "Cancellazione programmata",
+  "manager_billing_service_status_expired": "Cancellato",
+  "manager_billing_service_status_billing_suspended": "Fatturazione posticipata",
+  "manager_billing_service_status_forced_manual": "Rinnovo manuale forzato",
+  "manager_billing_service_status_restorable": "Ripristinabile"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_pl_PL.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Status",
+  "manager_billing_service_status_auto": "Automatyczne odnowienie",
+  "manager_billing_service_status_automatic": "Automatyczne odnowienie",
+  "manager_billing_service_status_manual": "Ręczne odnawianie",
+  "manager_billing_service_status_manualPayment": "Ręczne odnawianie",
+  "manager_billing_service_status_pending_debt": "Problem z płatnością",
+  "manager_billing_service_status_delete_at_expiration": "Zaplanowane rozwiązanie",
+  "manager_billing_service_status_expired": "Rozwiązany",
+  "manager_billing_service_status_billing_suspended": "Fakturowanie opóźnione",
+  "manager_billing_service_status_forced_manual": "Wymuszone ręczne odnawianie",
+  "manager_billing_service_status_restorable": "Możliwe do przywrócenia"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/renew-status/translations/Messages_pt_PT.json
@@ -1,0 +1,13 @@
+{
+  "manager_billing_service_status": "Estado",
+  "manager_billing_service_status_auto": "Renovação automática",
+  "manager_billing_service_status_automatic": "Renovação automática",
+  "manager_billing_service_status_manual": "Renovação manual",
+  "manager_billing_service_status_manualPayment": "Renovação manual",
+  "manager_billing_service_status_pending_debt": "Pagamento em falta",
+  "manager_billing_service_status_delete_at_expiration": "Rescisão programada",
+  "manager_billing_service_status_expired": "Rescindido",
+  "manager_billing_service_status_billing_suspended": "Faturação adiada",
+  "manager_billing_service_status_forced_manual": "Renovação manual forçada",
+  "manager_billing_service_status_restorable": "Restaurável"
+}

--- a/packages/manager/modules/billing-components/src/components/subscription-tile/subscription-tile.html
+++ b/packages/manager/modules/billing-components/src/components/subscription-tile/subscription-tile.html
@@ -17,7 +17,7 @@
         <oui-tile-description>
             <oui-skeleton size="s" data-ng-if="$ctrl.isLoading"></oui-skeleton>
             <p data-ng-if="!$ctrl.isLoading">
-                <billing-status service="$ctrl.serviceInfos"></billing-status>
+                <renew-status service="$ctrl.serviceInfos"></renew-status>
             </p>
         </oui-tile-description>
     </oui-tile-definition>


### PR DESCRIPTION
## Description

Recreated old service status component to use in the subscription tile (keeping old behavior to display the renewal status)


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20155, #INC0163675

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
