### PR TITLE
feat(access-list): rework on closure date order

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.controller.js
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.controller.js
@@ -152,10 +152,7 @@ export default class XdslAccessListCtrl {
       newService.firstCopperClosure = firstCopperClosure;
       if (migrationAvailable) {
         if (firstCopperClosure.date) {
-          newService.closureDate = this.$filter('date')(
-            firstCopperClosure.date,
-            'shortDate',
-          );
+          newService.closureDate = firstCopperClosure.date;
         } else {
           newService.closureDate = this.$translate.instant(
             'xdsl_access_list_not_available',

--- a/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.html
+++ b/packages/manager/apps/telecom/src/app/telecom/pack/access-list/xdsl-access-list.html
@@ -68,7 +68,7 @@
             data-property="closureDate"
             data-sortable
         >
-            <span data-ng-bind="$row.closureDate"></span>
+            <span data-ng-bind="$row.closureDate | date: 'shortDate'"></span>
         </oui-datagrid-column>
         <oui-datagrid-column
             data-title="'xdsl_access_list_actions' | translate"


### PR DESCRIPTION

## Description

On access list, update the display of the closure date to have order on the timestamp version and not on the string version.

Ticket Reference: #MANAGER-20188
