### PR TITLE
fix(user-emails-details): do not include trailing > as part of a link

### DIFF
--- a/packages/manager/modules/account/src/user/emails/details/user-emails-details.controller.js
+++ b/packages/manager/modules/account/src/user/emails/details/user-emails-details.controller.js
@@ -20,7 +20,7 @@ export default /* @ngInject */ function UserAccountEmailsDetailsController(
 
     /* each other links inside the text */
     parsedBody = parsedBody.replace(
-      /([^"']|^)(https?:\/\/([^/\s]+\/)*([^/\s]+)\/?)(?!"|')(\s|$)/gi,
+      /([^"']|^)(https?:\/\/([^/\s]+\/)*([^/>\s]+)\/?)(?!"|')([>\s]|$)/gi,
       '$1<a href="$2" target="_blank">$2</a>$5',
     );
 


### PR DESCRIPTION
## Description

Mail content may include URLs such as <$url>.
This commit makes sure the trailing '>' is not included in the auto-generated href.

Ticket Reference: #...
