### PR TITLE
feat(billing): remove vrack termination in us region

### DIFF
--- a/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
+++ b/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
@@ -95,10 +95,12 @@ export default class BillingLinksService {
         `${autorenewLink}/resiliation?serviceId=${service.id}&serviceName=${service.serviceId}${serviceTypeParam}`;
 
       if (this.coreConfig.isRegion('US')) {
-        links.resiliateLink = this.buildResiliateModalLink(
-          autorenewLink,
-          service,
-        );
+        if (service.serviceType !== 'VRACK')
+          // Currently vRack termination is not handled by backend for vRack
+          links.resiliateLink = this.buildResiliateModalLink(
+            autorenewLink,
+            service,
+          );
         return links;
       }
 


### PR DESCRIPTION
ref: #MANAGER-20124

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description
Currently vRack termination is not handled by backend (termination is taken into account, but PU work is not triggered)
In order to avoid creating "dead" tasks on PU side, we should hide the action for such products on US.

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
