### PR TITLE
fix(muk): correct re-rendering in useDataApi

### DIFF
--- a/packages/manager-ui-kit/src/hooks/data-api/adapters/iceberg/useIceberg.ts
+++ b/packages/manager-ui-kit/src/hooks/data-api/adapters/iceberg/useIceberg.ts
@@ -5,11 +5,14 @@ import type { SortingState } from '@tanstack/react-table';
 import { fetchWithIceberg } from '@ovh-ux/manager-core-api';
 import type { IcebergFetchResult } from '@ovh-ux/manager-core-api';
 
+import {
+  DEFAULT_DATA_API_RESPONSE,
+  DEFAULT_PAGE_SIZE,
+} from '@/hooks/data-api/ports/useDataApi.constants';
 import { UseDataApiResult } from '@/hooks/data-api/ports/useDataApi.types';
 import { useDataRetrievalOperations } from '@/hooks/data-api/useDataRetrievalOperations';
 
 import { UseInifiniteQueryResult, useInfiniteQuery } from '../../infra/tanstack';
-import { DEFAULT_PAGE_SIZE } from '../../ports/useDataApi.constants';
 import { API_V6_MAX_PAGE_SIZE } from './useIceberg.constants';
 import { UseIcebergData, UseIcebergParams } from './useIceberg.type';
 
@@ -92,10 +95,21 @@ export const useIceberg = <TData = Record<string, unknown>>({
   });
 
   useEffect(() => {
-    if (fetchAll && hasNextPage) {
+    if (fetchAll && hasNextPage && enabled) {
       void fetchNextPage();
     }
-  }, [dataSelected]);
+  }, [dataSelected, fetchAll, hasNextPage, fetchNextPage, enabled]);
+
+  if (!enabled) {
+    return {
+      ...DEFAULT_DATA_API_RESPONSE,
+      sorting: {
+        sorting: [],
+        setSorting: () => {},
+        manualSorting: false,
+      },
+    };
+  }
 
   return {
     ...(dataSelected && { ...dataSelected }),

--- a/packages/manager-ui-kit/src/hooks/data-api/adapters/v2/useV2.ts
+++ b/packages/manager-ui-kit/src/hooks/data-api/adapters/v2/useV2.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { fetchV2 } from '@ovh-ux/manager-core-api';
 import type { FetchV2Result } from '@ovh-ux/manager-core-api';
 
+import { DEFAULT_DATA_API_RESPONSE } from '@/hooks/data-api/ports/useDataApi.constants';
 import { UseDataApiResult } from '@/hooks/data-api/ports/useDataApi.types';
 
 import { UseInifiniteQueryResult, useInfiniteQuery } from '../../infra/tanstack';
@@ -42,10 +43,14 @@ export const useV2 = <TData = Record<string, unknown>>({
     });
 
   useEffect(() => {
-    if (fetchAll && hasNextPage) {
+    if (fetchAll && hasNextPage && enabled) {
       void fetchNextPage();
     }
-  }, [data]);
+  }, [data, fetchAll, hasNextPage, fetchNextPage, enabled]);
+
+  if (!enabled) {
+    return DEFAULT_DATA_API_RESPONSE;
+  }
 
   return {
     ...(data && { ...data }),

--- a/packages/manager-ui-kit/src/hooks/data-api/adapters/v6/useV6.ts
+++ b/packages/manager-ui-kit/src/hooks/data-api/adapters/v6/useV6.ts
@@ -5,6 +5,7 @@ import type { SortingState } from '@tanstack/react-table';
 import { v6 } from '@ovh-ux/manager-core-api';
 
 import { useQuery } from '@/hooks/data-api/infra/tanstack';
+import { DEFAULT_DATA_API_RESPONSE } from '@/hooks/data-api/ports/useDataApi.constants';
 import { UseDataApiResult } from '@/hooks/data-api/ports/useDataApi.types';
 import { useDataRetrievalOperations } from '@/hooks/data-api/useDataRetrievalOperations';
 
@@ -56,17 +57,28 @@ export const useV6 = <TData = Record<string, unknown>>({
   });
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && enabled) {
       setTotalCount(filteredAndSortedData.length);
       setPageIndex(0);
       setFlattenData(filteredAndSortedData);
     }
-  }, [filteredAndSortedData]);
+  }, [filteredAndSortedData, isLoading, enabled]);
 
   const fetchNextPage = useCallback(
     () => setPageIndex((previousPageIndex) => previousPageIndex + 1),
-    [pageIndex],
+    [],
   );
+
+  if (!enabled) {
+    return {
+      ...DEFAULT_DATA_API_RESPONSE,
+      sorting: {
+        sorting: [],
+        setSorting: () => {},
+        manualSorting: false,
+      },
+    };
+  }
 
   return {
     error,

--- a/packages/manager-ui-kit/src/hooks/data-api/ports/useDataApi.constants.ts
+++ b/packages/manager-ui-kit/src/hooks/data-api/ports/useDataApi.constants.ts
@@ -1,1 +1,16 @@
 export const DEFAULT_PAGE_SIZE = 10;
+
+export const DEFAULT_DATA_API_RESPONSE = {
+  isLoading: false,
+  isError: false,
+  error: null,
+  isSuccess: false,
+  isFetching: false,
+  status: 'pending',
+  fetchNextPage: () => {},
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  pageIndex: 0,
+  totalCount: 0,
+  flattenData: [],
+};


### PR DESCRIPTION
ref: #MANAGER-20274

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

- Correct issue in useDataApi
- Return empty object in useV6, useV2, useIceberg


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20274

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
