### PR TITLE
fix(exchange): rename advanced settings button in exchange offers

### DIFF
--- a/packages/manager/modules/exchange/src/account/add/account-add.html
+++ b/packages/manager/modules/exchange/src/account/add/account-add.html
@@ -515,7 +515,7 @@
             data-icon-right="{{'oui-icon-chevron-' + ($ctrl.displayAdvancedSections ? 'up' : 'down')}}"
             data-ng-click="$ctrl.displayAdvancedSections = !$ctrl.displayAdvancedSections"
         >
-            <span data-translate="exchange_account_add_sections_title"></span>
+            <span data-translate="exchange_account_add_contact_account_info_title"></span>
         </oui-button>
 
         <!--Company info-->

--- a/packages/manager/modules/exchange/src/account/update/account-update.html
+++ b/packages/manager/modules/exchange/src/account/update/account-update.html
@@ -521,7 +521,7 @@
             data-ng-click="$ctrl.displayAdvancedSections = !$ctrl.displayAdvancedSections"
         >
             <span
-                data-translate="exchange_account_update_sections_title"
+                data-translate="exchange_account_update_contact_account_info_title"
             ></span>
         </oui-button>
 

--- a/packages/manager/modules/exchange/src/account/update/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/exchange/src/account/update/translations/Messages_fr_FR.json
@@ -5,7 +5,6 @@
   "exchange_account_update_personal_account_info_title": "Informations du compte",
   "exchange_account_update_company_account_info_title": "Informations de la société",
   "exchange_account_update_contact_account_info_title": "Informations de contact",
-  "exchange_account_update_sections_title": "Paramètres avancés",
   "exchange_account_update_accountType_label": "Type de compte (obligatoire)",
   "exchange_account_update_accountType_tooltip": "E-mail pro : profitez de 10 Go de stockage, des protocoles POP, IMAP et SMTP.\nExchange : profitez de 50 Go de stockage, des protocoles MAPI et ActiveSync.\n",
   "exchange_account_update_emailAddress_label": "Adresse e-mail (obligatoire)",

--- a/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/exchange/src/dashboard/translations/Messages_fr_FR.json
@@ -491,7 +491,6 @@
   "exchange_account_add_personal_account_info_title": "Informations du compte",
   "exchange_account_add_company_account_info_title": "Informations de la société",
   "exchange_account_add_contact_account_info_title": "Informations de contact",
-  "exchange_account_add_sections_title": "Paramètres avancés",
   "exchange_account_add_accountType_label": "Type de compte (obligatoire)",
   "exchange_account_add_accountType_tooltip": "E-mail pro : profitez de 10 Go de stockage, des protocoles POP, IMAP et SMTP.\nExchange : profitez de 50 Go de stockage, des protocoles MAPI et ActiveSync.\n",
   "exchange_account_add_emailAddress_label": "Adresse e-mail (obligatoire)",


### PR DESCRIPTION
## Description
Rename advanced settings button in exchange offers

Ticket Reference: #PRDCOL-267

