### PR TITLE
fix(account-creation): query params persistence

### DIFF
--- a/packages/manager/apps/account-creation/src/context/user/user.provider.spec.tsx
+++ b/packages/manager/apps/account-creation/src/context/user/user.provider.spec.tsx
@@ -33,6 +33,12 @@ vi.spyOn(useApplicationsApi, 'useApplications').mockReturnValue({
 const mockedUsedNavigate = vi.fn();
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockedUsedNavigate,
+  useSearchParams: () => [
+    new URLSearchParams({
+      test: 'test',
+    }),
+    vi.fn(),
+  ], 
 }));
 
 vi.mock('@/context/tracking/useTracking', () => ({
@@ -60,7 +66,7 @@ describe('User Provider', () => {
     renderComponent();
 
     await vi.waitFor(() => {
-      expect(mockedUsedNavigate).toHaveBeenCalledWith(urls.settings);
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(`${urls.settings}?test=test`);
     });
   });
 
@@ -74,7 +80,7 @@ describe('User Provider', () => {
     renderComponent();
 
     await vi.waitFor(() => {
-      expect(mockedUsedNavigate).toHaveBeenCalledWith(urls.accountType);
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(`${urls.accountType}?test=test`);
     });
   });
 

--- a/packages/manager/apps/account-creation/src/context/user/user.provider.tsx
+++ b/packages/manager/apps/account-creation/src/context/user/user.provider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Country,
   LegalForm,
@@ -24,6 +24,7 @@ type Props = {
 
 export const UserProvider = ({ children = [] }: Props): JSX.Element => {
   const navigate = useNavigate();
+  const [ searchParams ] = useSearchParams();
   const { setUser } = useTrackingContext();
   const { data: me, isFetched, error } = useMe({ retry: 0 });
   const { data: availability } = useFeatureAvailability(
@@ -50,7 +51,7 @@ export const UserProvider = ({ children = [] }: Props): JSX.Element => {
   useEffect(() => {
     if (isFetched) {
       if (error?.status === 401) {
-        navigate(urls.settings);
+        navigate(`${urls.settings}?${searchParams.toString()}`);
         return;
       }
       setLegalForm(me?.legalform);
@@ -70,7 +71,7 @@ export const UserProvider = ({ children = [] }: Props): JSX.Element => {
       if (!availability[NEW_ACCOUNT_CREATION_ACCESS_FEATURE]) {
         redirectToLegacySignup();
       } else {
-        navigate(urls.accountType);
+        navigate(`${urls.accountType}?${searchParams.toString()}`);
       }
     }
   }, [availability]);

--- a/packages/manager/apps/account-creation/src/data/hooks/useMe.ts
+++ b/packages/manager/apps/account-creation/src/data/hooks/useMe.ts
@@ -16,5 +16,6 @@ export const useMe = (
   useQuery({
     queryKey: [`me`],
     queryFn: getMe,
+    retry: 0,
     ...options,
   });


### PR DESCRIPTION
## Description

Persist query params in the url after redirecting to the correct page from the user provider
Remove unnecessary retry on /me


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-17394

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
