### PR TITLE
revert(*): replace account-emails with communication app

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/account-sidebar/Shortcuts/useShortcuts.ts
+++ b/packages/manager/apps/container/src/container/legacy/account-sidebar/Shortcuts/useShortcuts.ts
@@ -58,12 +58,16 @@ const useShortcuts = (): UseShortcuts => {
               url: navigation.getURL('catalog', '#/'),
             },
           ]),
-      {
-        id: 'emails',
-        icon: getOdsIcon(ODS_ICON_NAME.ENVELOP_LETTER_CONCEPT),
-        url: navigation.getURL('communication', '#/'),
-        tracking: 'hub::sidebar::shortcuts::go-to-emails',
-      },
+      ...(['EU', 'CA'].includes(region)
+        ? [
+            {
+              id: 'emails',
+              icon: getOdsIcon(ODS_ICON_NAME.ENVELOP_LETTER_CONCEPT),
+              url: navigation.getURL('dedicated', '#/useraccount/emails'),
+              tracking: 'hub::sidebar::shortcuts::go-to-emails',
+            },
+          ]
+        : []),
       ...(['EU', 'CA'].includes(region)
         ? [
             {

--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/AccountSidebar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/AccountSidebar.tsx
@@ -143,13 +143,6 @@ export default function AccountSidebar() {
       });
     }
 
-    menu.push({
-      id: 'my-communication',
-      label: t('sidebar_communication'),
-      href: navigation.getURL('communication', '/'),
-      pathMatcher: new RegExp('^/communication')
-    });
-
     if (isEUOrCA) {
       menu.push({
         id: 'my-contacts',

--- a/packages/manager/apps/container/src/container/nav-reshuffle/header/user-account-menu/constants.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/header/user-account-menu/constants.ts
@@ -47,11 +47,12 @@ export const links: UserLink[] = [
     region: ['EU', 'CA'],
   },
   {
-    app: 'communication',
+    app: 'account',
     key: 'myCommunications',
-    hash: '#/',
+    hash: '#/useraccount/emails',
     i18nKey: 'user_account_menu_my_communication',
     trackingHit: tracking.accountContacts,
+    region: ['EU', 'CA'],
   },
   {
     app: 'billing',

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_de_DE.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_de_DE.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag-Management",
   "sidebar_pci_quantum_qpu": "QPUs",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed Hosting for WordPress",
-  "sidebar_communication": "Meine Mitteilungen"
+  "sidebar_web_hosting_managed_wordpress": "Managed Hosting for WordPress"
 }

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_en_GB.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_en_GB.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag Management",
   "sidebar_pci_quantum_qpu": "QPUs",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress",
-  "sidebar_communication": "My communications"
+  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress"
 }

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_es_ES.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_es_ES.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag Management",
   "sidebar_pci_quantum_qpu": "QPU",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress",
-  "sidebar_communication": "Mis comunicaciones"
+  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress"
 }

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_CA.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_CA.json
@@ -157,7 +157,6 @@
   "sidebar_account": "Mon compte",
   "sidebar_billing": "Mes factures",
   "sidebar_orders": "Mes commandes",
-  "sidebar_communication": "Mes communications",
   "sidebar_account_profile": "Mon profil",
   "sidebar_account_contacts": "Mes contacts",
   "sidebar_carbon_footprint": "Mon empreinte carbone",

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_fr_FR.json
@@ -157,7 +157,6 @@
   "sidebar_account": "Mon compte",
   "sidebar_billing": "Mes factures",
   "sidebar_orders": "Mes commandes",
-  "sidebar_communication": "Mes communications",
   "sidebar_account_profile": "Mon profil",
   "sidebar_account_contacts": "Mes contacts",
   "sidebar_carbon_footprint": "Mon empreinte carbone",

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_it_IT.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_it_IT.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag Management",
   "sidebar_pci_quantum_qpu": "QPU",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress",
-  "sidebar_communication": "Le mie comunicazioni"
+  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress"
 }

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_pl_PL.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_pl_PL.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag Management",
   "sidebar_pci_quantum_qpu": "QPUs",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress",
-  "sidebar_communication": "Moje wiadomości"
+  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress"
 }

--- a/packages/manager/apps/container/src/public/translations/sidebar/Messages_pt_PT.json
+++ b/packages/manager/apps/container/src/public/translations/sidebar/Messages_pt_PT.json
@@ -226,6 +226,5 @@
   "sidebar_security_identity_operations_iam_tag-management": "Tag Management",
   "sidebar_pci_quantum_qpu": "QPU",
   "sidebar_security_identity_operations_secret_manager": "Secret Manager",
-  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress",
-  "sidebar_communication": "Minhas comunicações"
+  "sidebar_web_hosting_managed_wordpress": "Managed hosting for WordPress"
 }

--- a/packages/manager/modules/account/src/user/translations/Messages_de_DE.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_de_DE.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Hoppla! Beim Löschen der Notfall-Codes ist ein Fehler aufgetreten:",
   "user_account_security_ip_restrictions_alt": "Einschränkung des Zugangs nach IP",
   "user_account_title_infos": "Mein Account",
-  "user_account_description": "Verwalten Sie Ihr Kundenkonto. In dieser Rubrik verwalten Sie die Sicherheit Ihres Kontos, Ihre Supportstufe und Ihre Benutzerkonten.",
+  "user_account_description": "Verwalten Sie Ihr Kundenkonto. In dieser Rubrik verwalten Sie die Sicherheit Ihres Kontos, Ihre Supportstufe und Ihre Benutzerkonten. Sie können auch die im Zusammenhang mit Ihren Diensten erhaltenen E-Mails einsehen.",
   "user_account_title_subscriptions": "Meine Abos",
   "user_agreements_accepting": "Die Änderungen werden gespeichert",
   "user_account_emails_title": "Empfangene E-Mails",

--- a/packages/manager/modules/account/src/user/translations/Messages_en_GB.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_en_GB.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Oops! An error has occurred deleting the backup codes:",
   "user_account_security_ip_restrictions_alt": "IP access restriction",
   "user_account_title_infos": "My account",
-  "user_account_description": "Manage your customer account. In this topic, you manage your account security, support level, and users.",
+  "user_account_description": "Manage your customer account. In this topic, you manage your account security, support level, and users. You can also check the emails received for your services.",
   "user_account_title_subscriptions": "My subscriptions",
   "user_agreements_accepting": "Saving...",
   "user_account_emails_title": "Emails received",

--- a/packages/manager/modules/account/src/user/translations/Messages_es_ES.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_es_ES.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "¡Vaya! Se ha producido un error al eliminar los códigos de seguridad:",
   "user_account_security_ip_restrictions_alt": "Restricción de acceso por IP",
   "user_account_title_infos": "Mi cuenta",
-  "user_account_description": "Administre su cuenta de cliente. Desde aquí podrá gestionar la seguridad de su cuenta, el nivel de soporte y los usuarios.",
+  "user_account_description": "Administre su cuenta de cliente. Desde aquí podrá gestionar la seguridad de su cuenta, el nivel de soporte y los usuarios. También puede consultar los mensajes recibidos relacionados con sus servicios.",
   "user_account_title_subscriptions": "Mis suscripciones",
   "user_agreements_accepting": "Guardando...",
   "user_account_emails_title": "Mensajes recibidos",

--- a/packages/manager/modules/account/src/user/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_fr_CA.json
@@ -600,7 +600,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Oups ! Une erreur est survenue lors de la suppression des codes de secours :",
   "user_account_security_ip_restrictions_alt": "Restriction d’accès par IP",
   "user_account_title_infos": "Mon compte",
-  "user_account_description": "Administrez votre compte client. Dans cette rubrique, vous gérez la sécurité de votre compte, votre niveau de support et vos utilisateurs.",
+  "user_account_description": "Administrez votre compte client. Dans cette rubrique, vous gérez la sécurité de votre compte, votre niveau de support et vos utilisateurs. Vous pouvez également consulter les e-mails reçus liés à vos services.",
   "user_account_title_subscriptions": "Mes abonnements",
   "user_agreements_accepting": "En cours d'enregistrement",
   "user_account_emails_title": "Emails reçus",

--- a/packages/manager/modules/account/src/user/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_fr_FR.json
@@ -600,7 +600,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Oups ! Une erreur est survenue lors de la suppression des codes de secours :",
   "user_account_security_ip_restrictions_alt": "Restriction d’accès par IP",
   "user_account_title_infos": "Mon compte",
-  "user_account_description": "Administrez votre compte client. Dans cette rubrique, vous gérez la sécurité de votre compte, votre niveau de support et vos utilisateurs.",
+  "user_account_description": "Administrez votre compte client. Dans cette rubrique, vous gérez la sécurité de votre compte, votre niveau de support et vos utilisateurs. Vous pouvez également consulter les e-mails reçus liés à vos services.",
   "user_account_title_subscriptions": "Mes abonnements",
   "user_agreements_accepting": "En cours d'enregistrement",
   "user_account_emails_title": "Emails reçus",

--- a/packages/manager/modules/account/src/user/translations/Messages_it_IT.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_it_IT.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Ops! Si è verificato un errore durante l'eliminazione dei codici di sicurezza:",
   "user_account_security_ip_restrictions_alt": "Restrizione degli accessi per IP",
   "user_account_title_infos": "Il mio account",
-  "user_account_description": "Gestisci il tuo account cliente. In questa sezione puoi gestire la sicurezza dell’account, il livello di supporto e gli utenti.",
+  "user_account_description": "Gestisci il tuo account cliente. In questa sezione puoi gestire la sicurezza dell’account, il livello di supporto e gli utenti. È inoltre possibile consultare le email ricevute relative ai propri servizi.",
   "user_account_title_subscriptions": "I miei abbonamenti",
   "user_agreements_accepting": "Registrazione in corso...",
   "user_account_emails_title": "Email ricevute",

--- a/packages/manager/modules/account/src/user/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_pl_PL.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Ojej! Wystąpił błąd podczas usuwania kodów zapasowych:",
   "user_account_security_ip_restrictions_alt": "Ograniczenie dostępu przez IP",
   "user_account_title_infos": "Moje konto",
-  "user_account_description": "Zarządzaj kontem klienta. W tej sekcji możesz zarządzać swoim kontem, poziomem wsparcia oraz użytkownikami.",
+  "user_account_description": "Zarządzaj kontem klienta. W tej sekcji możesz zarządzać swoim kontem, poziomem wsparcia oraz użytkownikami. Możesz również sprawdzić wiadomości e-mail dotyczące Twoich usług. ",
   "user_account_title_subscriptions": "Moje abonamenty",
   "user_agreements_accepting": "Trwa zapisywanie",
   "user_account_emails_title": "Otrzymane e-maile",

--- a/packages/manager/modules/account/src/user/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/account/src/user/translations/Messages_pt_PT.json
@@ -599,7 +599,7 @@
   "user_account_security_double_auth_type_backup_code_delete_error": "Ups! Ocorreu um erro aquando da eliminação dos códigos de segurança:",
   "user_account_security_ip_restrictions_alt": "Restrição de acesso por IP",
   "user_account_title_infos": "A minha conta",
-  "user_account_description": "Administre a sua conta de cliente. Nesta secção, poderá gerir a segurança da sua conta, o seu nível de suporte e os seus utilizadores.",
+  "user_account_description": "Administre a sua conta de cliente. Nesta secção, poderá gerir a segurança da sua conta, o seu nível de suporte e os seus utilizadores. Também pode consultar os e-mails recebidos associados aos seus serviços.",
   "user_account_title_subscriptions": "Subscrições",
   "user_agreements_accepting": "Registo em curso",
   "user_account_emails_title": "E-mails recebidos",

--- a/packages/manager/modules/account/src/user/user.html
+++ b/packages/manager/modules/account/src/user/user.html
@@ -15,6 +15,12 @@
                 ><span data-translate="user_account_security_title"></span>
             </oui-header-tabs-item>
             <oui-header-tabs-item
+                data-href="{{ $ctrl.$state.href('account.user.emails') }}"
+                data-ng-if="$ctrl.$state.href('account.user.emails')"
+                data-active="$ctrl.$state.includes('account.user.emails')"
+                ><span data-translate="user_account_emails_title"></span>
+            </oui-header-tabs-item>
+            <oui-header-tabs-item
                 data-href="{{ $ctrl.$state.href('account.user.support-level') }}"
                 data-active="$ctrl.$state.includes('account.user.support-level')"
                 data-ng-if="$ctrl.supportLevel"


### PR DESCRIPTION
This reverts commit f01b0a9002d29ce6412eec579d9f81abaac5afc5.

ref: #MANAGER-20243

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
