### PR TITLE
feat(account-creation): add query params persistence in type and company

### DIFF
--- a/packages/manager/apps/account-creation/src/pages/accountDetails/accountDetails.page.tsx
+++ b/packages/manager/apps/account-creation/src/pages/accountDetails/accountDetails.page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Controller, SubmitHandler, useForm, useWatch } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -885,6 +886,7 @@ export default function AccountDetailsPage() {
   const { t } = useTranslation('account-details');
   const { t: tCommon } = useTranslation('common');
   const { t: tAction } = useTranslation(NAMESPACES.ACTIONS);
+  const [ searchParams ] = useSearchParams();
   const { legalForm, organisation } = useUserContext();
   const { data: currentUser } = useMe();
   const wentThroughOrganizationSearch = shouldAccessOrganizationSearch(
@@ -934,7 +936,7 @@ export default function AccountDetailsPage() {
         iconAlignment={ODS_LINK_ICON_ALIGNMENT.left}
         href={`#${
           wentThroughOrganizationSearch ? urls.company : urls.accountType
-        }`}
+        }?${searchParams.toString()}`}
         label={tAction('back')}
         className="flex mb-6"
       />

--- a/packages/manager/apps/account-creation/src/pages/accountType/AccountType.page.tsx
+++ b/packages/manager/apps/account-creation/src/pages/accountType/AccountType.page.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   OdsRadio,
   OdsFormField,
@@ -24,6 +24,7 @@ export default function AccountType() {
   const { t: tAction } = useTranslation(NAMESPACES.ACTIONS);
   const { t: tForm } = useTranslation(NAMESPACES.FORM);
   const navigate = useNavigate();
+  const [ searchParams ] = useSearchParams();
   const { ovhSubsidiary, country, legalForm, setLegalForm } = useUserContext();
   const { data: rule, isLoading } = useLegalFormRules({
     ovhSubsidiary,
@@ -35,9 +36,9 @@ export default function AccountType() {
     if (!legalForm) {
       setLegalFormError(true);
     } else if (shouldAccessOrganizationSearch(country, legalForm)) {
-      navigate(urls.company);
+      navigate(`${urls.company}?${searchParams.toString()}`);
     } else {
-      navigate(urls.accountDetails);
+      navigate(`${urls.accountDetails}?${searchParams.toString()}`);
     }
   }, [legalForm, country]);
 

--- a/packages/manager/apps/account-creation/src/pages/accountType/AccountType.spec.tsx
+++ b/packages/manager/apps/account-creation/src/pages/accountType/AccountType.spec.tsx
@@ -27,7 +27,15 @@ vi.spyOn(RulesHooks, 'useLegalFormRules').mockReturnValue({
   isLoading: false,
 } as UseQueryResult<Rule>);
 
-vi.spyOn(ReactRouterDom, 'useNavigate').mockReturnValue(navigate);
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+  useSearchParams: () => [
+    new URLSearchParams({
+      onsuccess: 'https://www.ovh.com/manager',
+    }),
+    vi.fn(),
+  ],
+}));
 
 vi.mock('@/context/user/useUser', () => {
   return {
@@ -103,7 +111,7 @@ describe('AccountTypePage', () => {
 
     const validateButtonElement = screen.getByText('validate');
     await act(() => validateButtonElement.click());
-    expect(navigate).toHaveBeenCalledWith('/company');
+    expect(navigate).toHaveBeenCalledWith('/company?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fmanager');
   });
 
   it('should navigate to info page for FR non corporation', async () => {
@@ -112,6 +120,6 @@ describe('AccountTypePage', () => {
 
     const validateButtonElement = screen.getByText('validate');
     await act(() => validateButtonElement.click());
-    expect(navigate).toHaveBeenCalledWith('/details');
+    expect(navigate).toHaveBeenCalledWith('/details?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fmanager');
   });
 });

--- a/packages/manager/apps/account-creation/src/pages/company/Company.page.tsx
+++ b/packages/manager/apps/account-creation/src/pages/company/Company.page.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -43,6 +43,7 @@ export default function CompanyPage() {
   const { t: tForm } = useTranslation(NAMESPACES.FORM);
   const { t: tError } = useTranslation(NAMESPACES.ERROR);
   const navigate = useNavigate();
+  const [ searchParams ] = useSearchParams();
 
   const queryClient = useQueryClient();
 
@@ -72,7 +73,7 @@ export default function CompanyPage() {
   }, [legalForm]);
 
   const onFallbackButtonClicked = useCallback(() => {
-    navigate(urls.accountDetails);
+    navigate(`${urls.accountDetails}?${searchParams.toString()}`);
   }, [legalForm]);
 
   const submitCompanySearch: SubmitHandler<SearchFormData> = useCallback(
@@ -101,7 +102,7 @@ export default function CompanyPage() {
 
   const selectCompany = useCallback((company: Company) => {
     setCompany(company);
-    navigate('/details');
+    navigate(`${urls.accountDetails}?${searchParams.toString()}`);
   }, []);
 
   return (
@@ -109,7 +110,7 @@ export default function CompanyPage() {
       <OdsLink
         icon={ODS_ICON_NAME.arrowLeft}
         iconAlignment={ODS_LINK_ICON_ALIGNMENT.left}
-        href={`#${urls.accountType}`}
+        href={`#${urls.accountType}?${searchParams.toString()}`}
         label={tAction('back')}
         className="flex mb-6"
       />

--- a/packages/manager/apps/account-creation/src/pages/company/Company.spec.tsx
+++ b/packages/manager/apps/account-creation/src/pages/company/Company.spec.tsx
@@ -44,7 +44,15 @@ const setSearchValue = async (input: HTMLElement, value: string) => {
   );
 };
 
-vi.spyOn(ReactRouterDom, 'useNavigate').mockReturnValue(navigate);
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+  useSearchParams: () => [
+    new URLSearchParams({
+      onsuccess: 'https://www.ovh.com/manager',
+    }),
+    vi.fn(),
+  ],
+}));
 
 vi.mock('@ovhcloud/ods-components/react', async (importOriginal) => {
   const module = await importOriginal<


### PR DESCRIPTION
## Description

Add query params persistence on account type and company search pages


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20444

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
