### PR TITLE
feat(pci-instances): add unavailable image tooltip

### DIFF
--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_de_DE.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_de_DE.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Bitte wählen Sie einen anderen Namen, dieser ist bereits vergeben.",
   "pci_instance_creation_select_image_distribution_version_label": "Bildversion",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Version nicht verfügbar",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} inkl. MwSt./vCore/Stunde"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} inkl. MwSt./vCore/Stunde",
+  "pci_instance_creation_image_available_on_other_models": "Dieses Bild ist in anderen Modellen verfügbar."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_en_GB.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_en_GB.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Thank you for choosing a different name, this one is already in use.",
   "pci_instance_creation_select_image_distribution_version_label": "Image version",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Version unavailable",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} ex VAT/vCore/hour"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} ex VAT/vCore/hour",
+  "pci_instance_creation_image_available_on_other_models": "This image is available on other models."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_es_ES.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_es_ES.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Gracias por elegir un nombre diferente, este ya está en uso.",
   "pci_instance_creation_select_image_distribution_version_label": "Versión de la imagen",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Versión no disponible",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} /hora + IVA por vCore"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} /hora + IVA por vCore",
+  "pci_instance_creation_image_available_on_other_models": "Esta imagen está disponible en otros modelos."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_CA.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Merci de choisir un nom différent, celui-ci est déjà utilisé",
   "pci_instance_creation_select_image_distribution_version_label": "Version de l'image",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Version indisponible",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} HT/vCore/heure"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} HT/vCore/heure",
+  "pci_instance_creation_image_available_on_other_models": "Cette image est disponible sur d'autres modèles."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_FR.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Merci de choisir un nom différent, celui-ci est déjà utilisé",
   "pci_instance_creation_select_image_distribution_version_label": "Version de l'image",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Version indisponible",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} HT/vCore/heure"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} HT/vCore/heure",
+  "pci_instance_creation_image_available_on_other_models": "Cette image est disponible sur d'autres modèles."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_it_IT.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_it_IT.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Grazie per aver scelto un nome diverso, questo è già in uso.",
   "pci_instance_creation_select_image_distribution_version_label": "Versione dell'immagine",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Versione non disponibile",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} +IVA/vCore/ora"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} +IVA/vCore/ora",
+  "pci_instance_creation_image_available_on_other_models": "Questa immagine è disponibile su altri modelli."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_pl_PL.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Dziękujemy za wybranie innej nazwy, ta jest już używana.",
   "pci_instance_creation_select_image_distribution_version_label": "Wersja obrazu",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Wersja niedostępna",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} netto/vCore/godz."
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} netto/vCore/godz.",
+  "pci_instance_creation_image_available_on_other_models": "Ten obraz jest dostępny w innych modelach."
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_pt_PT.json
@@ -93,5 +93,6 @@
   "pci_instance_creation_select_sshKey_add_name_unavailable_error": "Obrigado por escolher um nome diferente, este já está em uso.",
   "pci_instance_creation_select_image_distribution_version_label": "Versão da imagem",
   "pci_instance_creation_select_image_distribution_version_unavailable": "Versão indisponível",
-  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} /hora + IVA por vCore"
+  "pci_instance_creation_windows_image_hourly_price": "+ {{ price }} /hora + IVA por vCore",
+  "pci_instance_creation_image_available_on_other_models": "Esta imagem está disponível em outros modelos."
 }

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionImageType.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionImageType.component.tsx
@@ -58,9 +58,9 @@ const DistributionImageType = () => {
 
     trackClick({
       location: PageLocation.funnel,
-      buttonType: ButtonType.tab,
+      buttonType: ButtonType.tile,
       actionType: 'action',
-      actions: ['add_instance', 'select_image', imageType],
+      actions: ['add_instance', 'select_image_type', imageType],
     });
   };
 

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionImageVariants.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionImageVariants.component.tsx
@@ -5,6 +5,9 @@ import {
   RadioGroup,
   RadioLabel,
   Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@ovhcloud/ods-react';
 import {
   ButtonType,
@@ -20,7 +23,7 @@ import {
 } from 'react-hook-form';
 import { TInstanceCreationForm } from '../../CreateInstance.page';
 import { TImageOption } from '../../view-models/imagesViewModel';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCatalogPrice } from '@ovh-ux/manager-react-components';
 
@@ -108,39 +111,68 @@ const Distributionvariants = ({ variants }: TDistributionvariants) => {
           onValueChange={handleSelectImage(field)}
         >
           {variants.map(
-            ({ label, available, value, windowsHourlyPrice, windowsId }) => (
-              <PciCard
-                key={value}
-                selectable
-                disabled={!available}
-                className="justify-center p-5"
-                selected={selectedImageVariantId === value}
-                onClick={handleSelectImage(field, value, windowsId)}
-              >
-                <PciCard.Header>
-                  <Radio disabled={!available} value={value}>
-                    <RadioControl />
-                    <RadioLabel className={imageLabelClassname}>
-                      <DistributionImageLabel
-                        name={getImageLabelForIcon(value)}
-                      >
-                        <span className="flex-1 max-w-full pr-8">
-                          {label}
-                          {windowsHourlyPrice && (
-                            <Text className="text-sm font-medium text-[--ods-color-success-500]">
-                              {t(
-                                'creation:pci_instance_creation_windows_image_hourly_price',
-                                { price: getTextPrice(windowsHourlyPrice) },
-                              )}
-                            </Text>
-                          )}
-                        </span>
-                      </DistributionImageLabel>
-                    </RadioLabel>
-                  </Radio>
-                </PciCard.Header>
-              </PciCard>
-            ),
+            ({ label, available, value, windowsHourlyPrice, windowsId }) => {
+              // eslint-disable-next-line react/no-multi-comp
+              const Card = React.forwardRef<
+                HTMLDivElement,
+                React.ComponentProps<typeof PciCard>
+              >((props, ref) => (
+                <PciCard
+                  ref={ref}
+                  selectable
+                  disabled={!available}
+                  className="justify-center p-5"
+                  selected={selectedImageVariantId === value}
+                  onClick={handleSelectImage(field, value, windowsId)}
+                  {...props}
+                >
+                  <PciCard.Header>
+                    <Radio disabled={!available} value={value}>
+                      <RadioControl />
+                      <RadioLabel className={imageLabelClassname}>
+                        <DistributionImageLabel
+                          name={getImageLabelForIcon(value)}
+                        >
+                          <span className="flex-1 max-w-full pr-8">
+                            {label}
+                            {windowsHourlyPrice && (
+                              <Text className="text-sm font-medium text-[--ods-color-success-500]">
+                                {t(
+                                  'creation:pci_instance_creation_windows_image_hourly_price',
+                                  { price: getTextPrice(windowsHourlyPrice) },
+                                )}
+                              </Text>
+                            )}
+                          </span>
+                        </DistributionImageLabel>
+                      </RadioLabel>
+                    </Radio>
+                  </PciCard.Header>
+                </PciCard>
+              ));
+
+              Card.displayName = `DistributionVariantCard_${value}`;
+
+              if (available) return <Card key={value} />;
+
+              return (
+                <Tooltip key={value}>
+                  <TooltipTrigger asChild>
+                    <Card />
+                  </TooltipTrigger>
+                  <TooltipContent
+                    withArrow
+                    className="px-6 max-w-[220px] text-center"
+                  >
+                    <Text>
+                      {t(
+                        'creation:pci_instance_creation_image_available_on_other_models',
+                      )}
+                    </Text>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            },
           )}
         </RadioGroup>
       )}

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionVersionList.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/components/distributionImage/DistributionVersionList.component.tsx
@@ -18,6 +18,11 @@ import {
   TAvailableOption,
   TCustomData,
 } from '../../view-models/imagesViewModel';
+import {
+  ButtonType,
+  PageLocation,
+  useOvhTracking,
+} from '@ovh-ux/manager-react-shell-client';
 
 type TDistributionVersionList = {
   versions: SelectOptionItem<TCustomData>[];
@@ -25,6 +30,7 @@ type TDistributionVersionList = {
 
 const DistributionVersionList = ({ versions }: TDistributionVersionList) => {
   const { t } = useTranslation('creation');
+  const { trackClick } = useOvhTracking();
   const { control, setValue } = useFormContext<TInstanceCreationForm>();
   const selectedVersion = useWatch({
     control,
@@ -43,6 +49,13 @@ const DistributionVersionList = ({ versions }: TDistributionVersionList) => {
 
   const handleSelectVersion = ({ items }: SelectValueChangeDetail) => {
     const version = (items as TAvailableOption[])[0];
+    if (version)
+      trackClick({
+        location: PageLocation.funnel,
+        buttonType: ButtonType.tile,
+        actionType: 'action',
+        actions: ['add_instance', 'select_image', version.label],
+      });
     updateImageVersionFields(version ?? null);
   };
 


### PR DESCRIPTION
ref: #TAPC-5226

This PR adds tooltip on unavailable images:
<img width="892" height="393" alt="Capture d’écran 2025-12-03 à 09 14 29" src="https://github.com/user-attachments/assets/b6dccf0b-4770-498c-8a42-a4b96be32faf" />

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
