### PR TITLE
feat(telecom): replace action menu in voip page  with two buttons

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/telephony.html
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/telephony.html
@@ -33,20 +33,20 @@
         data-columns="$ctrl.columnsConfig"
     >
         <oui-datagrid-topbar>
-            <oui-action-menu
-                text="{{:: 'telephony_table_header_action' | translate }}"
+            <oui-button
+                variant="primary"
+                type="button"
+                data-on-click="$ctrl.gotoOrder()"
             >
-                <oui-action-menu-item data-on-click="$ctrl.gotoOrder()">
-                    <span data-translate="telephony_order"></span>
-                </oui-action-menu-item>
-                <oui-action-menu-item
-                    data-on-click="$ctrl.goToTelephonyRepayments()"
-                >
-                    <span
-                        data-translate="telephony_table_action_item_telephony_repayments"
-                    ></span>
-                </oui-action-menu-item>
-            </oui-action-menu>
+                <span data-translate="telephony_order"></span>
+            </oui-button>
+            <oui-button
+                variant="secondary"
+                type="button"
+                data-on-click="$ctrl.goToTelephonyRepayments()"
+            >
+                <span data-translate="telephony_table_action_item_telephony_repayments"></span>
+            </oui-button>
         </oui-datagrid-topbar>
 
         <oui-datagrid-column


### PR DESCRIPTION
ref: #PRDCOL-277

## Description

In Telecom > voip & fax, replace the action menu with 2 buttons (order and manage my repayments)

<img width="857" height="193" alt="image" src="https://github.com/user-attachments/assets/c3e1d2ef-f4fd-4f86-8d9e-02f0c44407b0" />
