### PR TITLE
fix(telecom): change sms reply options text

### DIFF
--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_de_DE.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_de_DE.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "Lors de la réception d’un SMS suite à l’envoi d’un SMS permettant la réponse, trois choix s’offrent à vous :",
   "sms_options_response_information_list_item_1": "Ne rien faire",
   "sms_options_response_information_list_item_2": "Appeler un script hébergé par vos soins",
-  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Automatisch mit vordefiniertem Text antworten <em>(Kosten: mindestens 1 SMS je nach gewünschtem vordefiniertem Text)</em>",
   "sms_options_response_information_text_2": "Vous pouvez également, en parallèle, être notifié de la réception d'un SMS par Email <em>(gratuit)</em> ou SMS <em>(coût : 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Veuillez noter que le client ne pourra répondre que sous 48 H. Passé ce délai technique, la réponse ne vous parviendra pas.",
   "sms_options_response_sr_only_actions": "Aktionen",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_en_GB.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_en_GB.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "When you receive a reply to an SMS that allows for responses, you can do three things:",
   "sms_options_response_information_list_item_1": "Do nothing",
   "sms_options_response_information_list_item_2": "Call a script hosted by you",
-  "sms_options_response_information_list_item_3": "Reply automatically with a pre-defined text <em>(cost: 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Reply automatically with a pre-defined text <em>(cost: 1 SMS minimum depending on the pre-defined text requested)</em>",
   "sms_options_response_information_text_2": "You can also be receive notifications for receiving an SMS message via email <em>(free)</em> or text <em>(cost: 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Please note that the customer can only reply within 48 hours. After this period, the reply will not reach you.",
   "sms_options_response_sr_only_actions": "Actions",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_es_ES.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_es_ES.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "Cuando se reciba un SMS enviado que permita responder, puede elegir una de las siguientes opciones:",
   "sms_options_response_information_list_item_1": "No hacer nada",
   "sms_options_response_information_list_item_2": "Llamar un script alojado por usted mismo",
-  "sms_options_response_information_list_item_3": "Responder automáticamente mediante un mensaje de texto preestablecido <em>(coste: 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Responder automáticamente mediante un mensaje de texto preestablecido <em>(coste: 1 SMS mínimo según el texto predefinido solicitado)</em>",
   "sms_options_response_information_text_2": "Asimismo, también puede recibir una notificación de la recepción de un SMS por correo electrónico <em>(gratuito)</em> o SMS <em>(coste: 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Recuerde que el cliente dispondrá de un plazo de 48 horas para responder. Una vez transcurrido este período de tiempo, usted no recibirá la respuesta.",
   "sms_options_response_sr_only_actions": "Acciones",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_fr_CA.json
@@ -5,7 +5,7 @@
   "sms_options_response_information_text_1": "Lors de la réception d’un SMS suite à l’envoi d’un SMS permettant la réponse, trois choix s’offrent à vous :",
   "sms_options_response_information_list_item_1": "Ne rien faire",
   "sms_options_response_information_list_item_2": "Appeler un script hébergé par vos soins",
-  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS minimum selon le texte prédéfini demandé)</em>",
   "sms_options_response_information_text_2": "Vous pouvez également, en parallèle, être notifié de la réception d'un SMS par Email <em>(gratuit)</em> ou SMS <em>(coût : 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Veuillez noter que le client ne pourra répondre que sous 48 H. Passé ce délai technique, la réponse ne vous parviendra pas.",
   "sms_options_response_sr_only_actions": "Actions",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_fr_FR.json
@@ -5,7 +5,7 @@
   "sms_options_response_information_text_1": "Lors de la réception d’un SMS suite à l’envoi d’un SMS permettant la réponse, trois choix s’offrent à vous :",
   "sms_options_response_information_list_item_1": "Ne rien faire",
   "sms_options_response_information_list_item_2": "Appeler un script hébergé par vos soins",
-  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS minimum selon le texte prédéfini demandé)</em>",
   "sms_options_response_information_text_2": "Vous pouvez également, en parallèle, être notifié de la réception d'un SMS par Email <em>(gratuit)</em> ou SMS <em>(coût : 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Veuillez noter que le client ne pourra répondre que sous 48 H. Passé ce délai technique, la réponse ne vous parviendra pas.",
   "sms_options_response_sr_only_actions": "Actions",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_it_IT.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_it_IT.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "Alla ricezione di un SMS in seguito all'invio di un SMS che consente la risposta, sono disponibili tre opzioni:",
   "sms_options_response_information_list_item_1": "Non fare nulla",
   "sms_options_response_information_list_item_2": "Eseguire uno dei tuoi script",
-  "sms_options_response_information_list_item_3": "Rispondi automaticamente con un messaggio predefinito <em>(costo: 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Rispondi automaticamente con un messaggio predefinito <em>(costo: 1 SMS minimo in base al testo predefinito richiesto)</em>",
   "sms_options_response_information_text_2": "Parallelamente è possibile ricevere notifiche sulla ricezione di un SMS tramite email <em>(gratis)</em> o SMS <em>(costo: 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Il cliente avrà la possibilità di rispondere entro 48 ore. Trascorso questo periodo, la risposta non verrà trasmessa.",
   "sms_options_response_sr_only_actions": "Azioni",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_pl_PL.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "W przypadku odebrania wiadomości po wysłaniu SMS-a umożliwiającego odpowiedź, masz do wyboru trzy opcje:",
   "sms_options_response_information_list_item_1": "Nie wykonujesz żadnego działania",
   "sms_options_response_information_list_item_2": "Wywołujesz hostowany przez Ciebie skrypt ",
-  "sms_options_response_information_list_item_3": "Wysyłasz automatyczną odpowiedź, wykorzystując przygotowany wcześniej tekst <em>(koszt: 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Automatyczna odpowiedź z gotowym tekstem <em>(koszt: minimum 1 SMS, w zależności od wybranego gotowego tekstu).</em>",
   "sms_options_response_information_text_2": "Możesz również, równolegle, zostać powiadomiony o otrzymaniu SMS-a w e-mailu <em>(bez opłat)</em> lub SMS <em>(koszt): 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Pamiętaj, że klient ma tylko 48 godzin na przesłanie odpowiedzi. Po upływie tego czasu odpowiedź do Ciebie nie dotrze.",
   "sms_options_response_sr_only_actions": "Operacje",

--- a/packages/manager/modules/sms/src/sms/options/response/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/sms/src/sms/options/response/translations/Messages_pt_PT.json
@@ -4,7 +4,7 @@
   "sms_options_response_information_text_1": "Lors de la réception d’un SMS suite à l’envoi d’un SMS permettant la réponse, trois choix s’offrent à vous :",
   "sms_options_response_information_list_item_1": "Ne rien faire",
   "sms_options_response_information_list_item_2": "Appeler un script hébergé par vos soins",
-  "sms_options_response_information_list_item_3": "Répondre automatiquement via un texte prédéfini <em>(coût : 1 SMS)</em>",
+  "sms_options_response_information_list_item_3": "Responder automaticamente através de um texto predefinido <em>(custo: Mínimo de 1 SMS em função do texto predefinido pedido)</em>",
   "sms_options_response_information_text_2": "Vous pouvez également, en parallèle, être notifié de la réception d'un SMS par Email <em>(gratuit)</em> ou SMS <em>(coût : 1 SMS)</em>.",
   "sms_options_response_information_text_3": "Veuillez noter que le client ne pourra répondre que sous 48 H. Passé ce délai technique, la réponse ne vous parviendra pas.",
   "sms_options_response_sr_only_actions": "Ações",


### PR DESCRIPTION
ref: #PRDCOL-16

## Description
In telecom > sms > options > reply options ,change :
"Répondre automatiquement via un texte prédéfini (coût : 1 SMS)" to "Répondre automatiquement via un texte prédéfini (coût : 1 SMS minimum selon le texte prédéfini demandé)"

## Additional Information
<img width="967" height="433" alt="image" src="https://github.com/user-attachments/assets/9c450402-1475-49a4-aead-e68f437f48fc" />
