### PR TITLE
fix(mrc): override viewport width rule on small screens

### DIFF
--- a/packages/manager-react-components/src/components/datagrid/datagrid.component.tsx
+++ b/packages/manager-react-components/src/components/datagrid/datagrid.component.tsx
@@ -486,7 +486,7 @@ export const Datagrid = <T,>({
                           onSortChange && header.column.getCanSort()
                             ? 'cursor-pointer'
                             : ''
-                        }`}
+                        } !min-w-0`}
                         {...{
                           ...(onSortChange && {
                             onClick: header.column.getToggleSortingHandler(),
@@ -539,6 +539,7 @@ export const Datagrid = <T,>({
                           {
                             'w-[2.5rem]': cell.id.indexOf('expander') !== -1,
                           },
+                          '!min-w-0',
                         )}
                         style={{
                           width: tableLayoutFixed
@@ -556,7 +557,10 @@ export const Datagrid = <T,>({
                   {row.getIsExpanded() && !!renderSubComponent && (
                     <tr className="sub-row">
                       {/* 2nd row is a custom 1 cell row */}
-                      <td colSpan={row.getVisibleCells().length}>
+                      <td
+                        className="!min-w-0"
+                        colSpan={row.getVisibleCells().length}
+                      >
                         {renderSubComponent(row, headerRefs)}
                       </td>
                     </tr>


### PR DESCRIPTION
ref: #ISSUE-20793

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

ODS sets a min-width on table columns which forces an overflow on small screens. This needed to be overwritten with the !important to set it to minimum content width.


<!-- Provide Jira ticket or Github issue -->

## Additional Information
<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
