### PR TITLE
fix(exchange): display activate double authentification in dedicated …

### DIFF
--- a/packages/manager/modules/exchange/src/security/security.controller.js
+++ b/packages/manager/modules/exchange/src/security/security.controller.js
@@ -85,7 +85,6 @@ export default class ExchangeServicesConfigureCtrl {
         this.originalService = clone(this.service);
         this.owaMfa = server.owaMfa;
         this.isMfaAvailable =
-          this.services.coreConfig.isRegion('EU') &&
           this.services.exchangeSelectedService.isMfaAvailable();
         return this.service;
       })

--- a/packages/manager/modules/exchange/src/services/exchange.selectedService.service.js
+++ b/packages/manager/modules/exchange/src/services/exchange.selectedService.service.js
@@ -77,9 +77,6 @@ export default class ExchangeSelectedService {
 
   isMfaAvailable() {
     return (
-      (this.exchangeServiceInfrastructure.isHosted() ||
-        this.exchangeServiceInfrastructure.isProvider() ||
-        this.exchangeServiceInfrastructure.isDedicated()) &&
       this.exchangeVersion.isAfter(2010)
     );
   }


### PR DESCRIPTION
…cluster offer

ref: #PRDCOL-76

## Description

In Manager > Exchange > Security :
- Allow Activate 2FA in dedicated cluster offer.
- Allow Activate 2FA in all regions

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/05cbbb65-647b-4dc9-b3d3-70c9dc79b603" />
