### PR TITLE
fix(billing): fix difference between interval of commitment option

### DIFF
--- a/packages/manager/modules/models/service/Commitment.class.js
+++ b/packages/manager/modules/models/service/Commitment.class.js
@@ -16,7 +16,13 @@ export default class Commitment {
   }
 
   addOptionCommitment(optionEngagement) {
-    this.price += optionEngagement.price;
+    if (this.pricing.interval === optionEngagement.pricing.interval) {
+      this.price += optionEngagement.price;
+    } else {
+      this.price +=
+        optionEngagement.price *
+        (this.pricing.interval / optionEngagement.pricing.interval);
+    }
     this.pricing = new Pricing(
       {
         ...this.pricing,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In the current commitment page, some vps with Plesk licence have a price 12 times upper than they should. The thing is the upfront12 option has an interval of 12 that differ from the service 1. So for this reason we check if the option's interval is equal to the service's interval


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #INC0174363

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
