### PR TITLE
fix(*): tasks post check timeout

### DIFF
--- a/.github/workflows/check-duplicates-translations.yml
+++ b/.github/workflows/check-duplicates-translations.yml
@@ -39,7 +39,7 @@ jobs:
             SHOULD_CONTINUE=true
             echo "should_continue<<EOF" >> $GITHUB_OUTPUT
             echo "$SHOULD_CONTINUE" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT  
+            echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "❌ Translation label does not exist, exit..."
             SHOULD_CONTINUE=false
@@ -64,14 +64,14 @@ jobs:
           path: |
             ~/.cache/yarn
             node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         if: steps.gate.outputs.should_continue == 'true'
         run: yarn install --frozen-lockfile
-        
+
       - name: GetChangedPackages
         if: steps.gate.outputs.should_continue == 'true'
         id: changed
@@ -94,7 +94,7 @@ jobs:
           CHANGED_PACKAGES=$(get_changed_packages)
           echo "Changed packages:"
           echo "$CHANGED_PACKAGES"
-      
+
           # Safe multiline output for next step
           echo "changed_packages<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED_PACKAGES" >> $GITHUB_OUTPUT
@@ -114,17 +114,17 @@ jobs:
             if [[ "$line" == "//" || -z "$line" ]]; then
               continue
             fi
-           
+
             # Remove prefix and suffix
             cleaned_package="${line#@ovh-ux/manager-}"   # remove prefix
             cleaned_package="${cleaned_package%-app}"    # remove suffix if exist
             echo "Checking: $cleaned_package"
-      
+
             # Check if cleaned_package is in available_apps
             if printf "%s\n" "${apps_array[@]}" | grep -qx "$cleaned_package"; then
               echo "✅ Found: $cleaned_package"
               yarn manager-cli duplicated-translations --app $cleaned_package
             fi
-            
+
 
           done <<< "${{ steps.changed.outputs.changed_packages }}"

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -37,7 +37,7 @@ jobs:
           path: |
             ~/.cache/yarn
             node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/run-bdd-tests.yml
+++ b/.github/workflows/run-bdd-tests.yml
@@ -1,5 +1,5 @@
 name: Run tests
-on: 
+on:
   push:
     branches-ignore: [master]
 
@@ -34,10 +34,10 @@ jobs:
           path: |
             ~/.cache/yarn
             node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-            
+
       - name: Install repository
         run: yarn install --frozen-lockfile
       - name: Build covered packages and dependencies


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

We have a recurring fail in some CI tasks post staff :
https://github.com/ovh/manager/actions/runs/20128143842/job/57774976021?pr=20989

`Error: The template is not valid. .github/workflows/linter.yaml (Line: 40, Col: 16): hashFiles('**/yarn.lock') couldn't finish within 120 seconds.`

The task itself is successful.

This is due to:
https://github.com/ovh/manager/blob/master/.github/workflows/linter.yaml#L40
https://github.com/ovh/manager/blob/master/.github/workflows/run-bdd-tests.yml#L37
https://github.com/ovh/manager/blob/master/.github/workflows/check-duplicates-translations.yml#L67

precisely: 
```
key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
```

After the job has run, the repo contains:
	•	.turbo/
	•	.eslintcache
	•	.cache/
	•	possibly thousands of build artifacts
	•	node_modules for multiple apps
The pattern **/yarn.lock triggers a full recursive filesystem scan.

GitHub Actions limits hashFiles() evaluation to 120 seconds, it times out.

"couldn't finish within 120 seconds."

So if we have chance it'll pass else it'll fail 😕 

I'll make a fix to change:
```
key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
```

To:
```
key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
```

We have a single yarn lock which is at the root.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference:  #MANAGER-20410

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->

https://github.com/actions/runner/issues/1840
https://github.com/actions/runner/issues/449
