### PR TITLE
fix(observability.logs): fix incorrect path for dep libraries

### DIFF
--- a/packages/manager/apps/hpc-vmware-vsphere/package.json
+++ b/packages/manager/apps/hpc-vmware-vsphere/package.json
@@ -32,6 +32,7 @@
     "@ovhcloud/ods-themes": "^18.6.2",
     "@tanstack/react-query": "^5.51.21",
     "@tanstack/react-virtual": "^3.10.9",
+    "date-fns": "~4.1.0",
     "i18next": "^23.8.2",
     "i18next-http-backend": "^2.4.3",
     "react": "^18.2.0",

--- a/packages/manager/apps/okms/package.json
+++ b/packages/manager/apps/okms/package.json
@@ -40,6 +40,7 @@
     "@tanstack/react-table": "^8.20.1",
     "@tanstack/react-virtual": "^3.10.9",
     "clsx": "2.1.1",
+    "date-fns": "~4.1.0",
     "file-saver": "^2.0.5",
     "i18next": "^23.8.2",
     "i18next-http-backend": "^2.4.3",

--- a/packages/manager/modules/logs-to-customer/package.json
+++ b/packages/manager/modules/logs-to-customer/package.json
@@ -37,9 +37,7 @@
     "test": "manager-test run",
     "test:coverage": "manager-test run --coverage"
   },
-  "dependencies": {
-    "date-fns": "4.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@ovh-ux/manager-core-api": "^0.20.1",
     "@ovh-ux/manager-core-test-utils": "^0.11.2",
@@ -50,6 +48,7 @@
     "@ovhcloud/ods-components": "18.6.4",
     "@ovhcloud/ods-themes": "18.6.4",
     "@tanstack/react-virtual": "3.10.9",
+    "date-fns": "~4.1.0",
     "element-internals-polyfill": "^1.3.11",
     "react-i18next": "^14.0.5",
     "tailwindcss": "^3.4.4",
@@ -65,6 +64,7 @@
     "@ovhcloud/ods-themes": "^18.6.4",
     "@tanstack/react-query": "^5.51.21",
     "@tanstack/react-virtual": "^3.10.9",
+    "date-fns": "~4.1.0",
     "i18next": "^23.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/manager/modules/logs-to-customer/vite.config.mjs
+++ b/packages/manager/modules/logs-to-customer/vite.config.mjs
@@ -4,15 +4,21 @@ import path from 'path';
 import tailwindcss from 'tailwindcss';
 import { getBaseConfig } from '@ovh-ux/manager-vite-config';
 import * as packageJson from './package.json' with { type: 'json' };
-import { viteStaticCopy } from 'vite-plugin-static-copy';
 
-const baseConfig = getBaseConfig({});
 const pathSrc = path.resolve(__dirname, 'src');
 const pathPublic = path.resolve(__dirname, 'public');
 const externalDeps = [
     ...Object.keys(packageJson.default.peerDependencies || {}),
     '@ovhcloud/ods-components/react',
 ];
+const baseConfig = getBaseConfig({
+    staticCopyTargets: [
+        {
+            src: `${pathPublic}/translations`,
+            dest: '@ovh-ux/logs-to-customer',
+        },
+    ],
+});
 
 export default defineConfig({
     ...baseConfig,
@@ -28,14 +34,6 @@ export default defineConfig({
             root: __dirname,
             insertTypesEntry: true,
             outDir: 'dist/types',
-        }),
-        viteStaticCopy({
-            targets: [
-                {
-                    src: `${pathPublic}/translations`,
-                    dest: '@ovh-ux/logs-to-customer',
-                },
-            ],
         }),
     ],
     css: {
@@ -56,7 +54,7 @@ export default defineConfig({
             entry: path.resolve(pathSrc, 'lib.ts'),
             name: 'LogsToCustomerLib',
             formats: ['esm'],
-            fileName: () => `src/lib.js`,
+            fileName: () => 'src/lib.js',
         },
         rollupOptions: {
             external: (id) =>


### PR DESCRIPTION
fixes: #MAOBS-136

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->

Fix build from published version
```sh
yarn run v1.22.22
$ tsc && vite build
vite v6.0.7 building for production...
(node:67947) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
transforming (10) ../../../../node_modules/@ovh-ux/manager-react-shell-client/dist/hooks/index.jsBrowserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
✓ 628 modules transformed.
x Build failed in 2.45s
error during build:
Could not resolve "../../node_modules/.pnpm/date-fns@4.1.0/node_modules/date-fns/locale/fr.js" from "node_modules/@ovh-ux/logs-to-customer/dist/src/components/data-streams/DataStreamRetention.component.js" 
```
