### PR TITLE
fix(billing-components): remove reactivate engagement on resiliation

### DIFF
--- a/packages/manager/modules/billing-components/src/components/resiliation/resiliation.controller.js
+++ b/packages/manager/modules/billing-components/src/components/resiliation/resiliation.controller.js
@@ -12,6 +12,9 @@ export default class BillingResiliationController {
 
   $onInit() {
     this.isUSRegion = this.coreConfig.isRegion('US');
+    this.availableStrategies = this.availableStrategies.filter(
+      ({ strategy }) => strategy !== 'REACTIVATE_ENGAGEMENT',
+    );
   }
 
   resiliate() {


### PR DESCRIPTION
## Description

Removed the "REACTIVATE_ENGAGEMENT" strategy if it's present since it make no sense to allow it on the commitment resiliation when it allow the cancellation of a commitment resiliation request


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20549, #INC0176084

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
