### PR TITLE
chore(migration-cli): add src/common to resolve route path

### DIFF
--- a/packages/manager-tools/manager-migration-cli/utils/AppUtils.mjs
+++ b/packages/manager-tools/manager-migration-cli/utils/AppUtils.mjs
@@ -46,6 +46,7 @@ export const resolveRoutePath = (appName, { verbose = false } = {}) => {
     join(applicationsBasePath, appName, 'src/alldoms/routes/routes.tsx'),
     join(applicationsBasePath, appName, 'src/core/routing/redirections.tsx'),
     join(applicationsBasePath, appName, 'src/core/routing/iframe-app-router.tsx'),
+    join(applicationsBasePath, appName, 'src/common/routes/routes.tsx'),
   ];
 
   for (const path of candidates) {


### PR DESCRIPTION
Okms application has its routes in: 
- `root`: `src/common/routes/routes.tsx`
- `kms`: `src/modules/key-management-service/routes/routes.tsx`
- `secrets`: `src/modules/secret-manager/routes/routes.tsx`

This PR adds `src/common/routes/routes.tsx` to the candidate paths to check if the route migration has been done