### PR TITLE
fix(mxplan): remove upgrade button in general information and clean code

### DIFF
--- a/packages/manager/modules/emailpro/src/information/emailpro-information-tab.js
+++ b/packages/manager/modules/emailpro/src/information/emailpro-information-tab.js
@@ -8,7 +8,6 @@ export default class EmailProTabInformationCtrl {
   constructor(
     $q,
     $scope,
-    $state,
     $stateParams,
     $translate,
     coreURLBuilder,
@@ -19,7 +18,6 @@ export default class EmailProTabInformationCtrl {
   ) {
     this.$q = $q;
     this.$scope = $scope;
-    this.$state = $state;
     this.$stateParams = $stateParams;
     this.$translate = $translate;
     this.coreURLBuilder = coreURLBuilder;
@@ -54,11 +52,6 @@ export default class EmailProTabInformationCtrl {
         redirections: this.$scope.currentRegionCA
           ? this.$q.when({})
           : this.getRedirections(),
-      });
-
-      this.upgradeLink = this.$state.href('mxplan.dashboard.upgrade', {
-        productId: this.$stateParams.productId,
-        domain: this.$scope.exchange.associatedDomainName,
       });
     }
 

--- a/packages/manager/modules/emailpro/src/information/emailpro-information.html
+++ b/packages/manager/modules/emailpro/src/information/emailpro-information.html
@@ -188,19 +188,6 @@
                                                 data-ng-if="!exchange.isMXPlan"
                                                 data-ng-bind="exchange.accountsNumber"
                                             ></span>
-                                            <oui-action-menu
-                                                data-ng-if="exchange.isMXPlan && exchange.accountsNumber <= 100 && !currentRegionCA"
-                                                data-compact
-                                                data-placement="end"
-                                            >
-                                                <oui-action-menu-item
-                                                    data-href="{{ $ctrl.upgradeLink }}"
-                                                >
-                                                    <span
-                                                        data-translate="emailpro_dashboard_accounts_upgrade_mxPlan"
-                                                    ></span>
-                                                </oui-action-menu-item>
-                                            </oui-action-menu>
                                         </div>
                                     </div>
                                 </li>


### PR DESCRIPTION
ref: #PRDCOL-308

## Description

In manager > web cloud > mx plan > general information > statistics :
- Remove upgrade button in email accounts line.
- clean code.

<img width="798" height="244" alt="image" src="https://github.com/user-attachments/assets/7be9206c-fd4d-4cde-967c-6eb195d1045d" />
