### PR TITLE
fix(zimbra): rename email account by email address

### DIFF
--- a/packages/manager/apps/zimbra/public/translations/common/Messages_de_DE.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_de_DE.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "Land",
   "redirections": "Weiterleitungen",
   "delete_redirections": "Weiterleitungen entfernen",
-  "delete_email_accounts": "Accounts löschen"
+  "delete_email_accounts": "Accounts löschen",
+  "email_address": "E-Mail-Adresse"
 }

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_en_GB.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_en_GB.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "Country",
   "redirections": "Redirects",
   "delete_redirections": "Delete redirects",
-  "delete_email_accounts": "Delete accounts"
+  "delete_email_accounts": "Delete accounts",
+  "email_address": "Email address"
 }

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_es_ES.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_es_ES.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "País",
   "redirections": "Redirecciones",
   "delete_redirections": "Eliminar las redirecciones",
-  "delete_email_accounts": "Eliminar las cuentas"
+  "delete_email_accounts": "Eliminar las cuentas",
+  "email_address": "Dirección email"
 }

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_fr_CA.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_fr_CA.json
@@ -45,6 +45,7 @@
   "configure_another_account": "Configurer un autre compte",
   "configure_account": "Configurer le compte",
   "email_account": "Compte email",
+  "email_address": "Adresse email",
   "add_email_account": "Créer un compte email",
   "email_account_settings": "Paramètres du compte",
   "delete_email_account": "Supprimer le compte",

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_fr_FR.json
@@ -45,6 +45,7 @@
   "configure_another_account": "Configurer un autre compte",
   "configure_account": "Configurer le compte",
   "email_account": "Compte email",
+  "email_address": "Adresse email",
   "add_email_account": "Créer un compte email",
   "email_account_settings": "Paramètres du compte",
   "delete_email_account": "Supprimer le compte",

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_it_IT.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_it_IT.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "Paese",
   "redirections": "Reindirizzamenti",
   "delete_redirections": "Eliminare i reindirizzamenti",
-  "delete_email_accounts": "Eliminare gli account"
+  "delete_email_accounts": "Eliminare gli account",
+  "email_address": "Indirizzo email"
 }

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_pl_PL.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_pl_PL.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "Kraj",
   "redirections": "Przekierowania",
   "delete_redirections": "Usuń przekierowania",
-  "delete_email_accounts": "Usuń konta"
+  "delete_email_accounts": "Usuń konta",
+  "email_address": "Adres email"
 }

--- a/packages/manager/apps/zimbra/public/translations/common/Messages_pt_PT.json
+++ b/packages/manager/apps/zimbra/public/translations/common/Messages_pt_PT.json
@@ -148,5 +148,6 @@
   "contactInformation_country": "País",
   "redirections": "Reencaminhamentos",
   "delete_redirections": "Eliminar os reencaminhamentos",
-  "delete_email_accounts": "Eliminar as contas"
+  "delete_email_accounts": "Eliminar as contas",
+  "email_address": "Endereço de e-mail"
 }

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccountForm.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/EmailAccountForm.component.tsx
@@ -242,7 +242,7 @@ export const EmailAccountForm = () => {
         }) => (
           <FormField className="w-full" invalid={(isDirty || isTouched) && !!errors?.[name]}>
             <label htmlFor={name} slot="label">
-              {t('common:email_account')} *
+              {t('common:email_address')} *
             </label>
             <div className="flex">
               <Input


### PR DESCRIPTION
ref: #PRDCOL-300

## Description
In Zimbra > Email account > Create email account:
- Rename email account by email address.
- 
<img width="640" height="323" alt="image" src="https://github.com/user-attachments/assets/0234748f-a252-47fb-b14c-f6c3d77cff95" />
