### PR TITLE
feat: add warning when manual editing dns zone breaking terraform state

### DIFF
--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_de_DE.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_de_DE.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "Der Eintrag wurde in der DNS-Zone hinzugefügt. Bitte berücksichtigen Sie auch die Propagationszeit von höchstens 24 Stunden.",
   "domain_configuration_dns_entry_add_fail": "Beim Hinzufügen des Eintrags zur DNS-Zone ist ein Fehler aufgetreten.",
   "domain_configuration_dns_importtext_title": "Tragen Sie hier den entsprechenden Text für die DNS-Zonen ein, die Sie importieren möchten:",
+  "domain_configuration_dns_importtext_iacwarning": "Benutzer von Terraform oder IaC-Tools: Der Wechsel der Zone im Textmodus initialisiert die interne ID jedes DNS-Eintrags neu und macht damit den Terraform-Status ungültig.",
   "domain_configuration_dns_importtext_confirm": "Sie sind im Begriff, eine neue Konfiguration der DNS-Zone zu importieren.",
   "domain_configuration_dns_importtext_propagation_info": "Die Konfiguration wird in wenigen Sekunden importiert. Bitte berücksichtigen Sie auch die Propagationszeit von höchstens 24 Stunden.",
   "domain_configuration_dns_importtext_success": "Die Konfiguration wird in wenigen Augenblicken importiert. Sie können den Fortschritt des Imports der DNS-Zone im Bereich „Aktuelle Tasks“ nachverfolgen. Bitte beachten Sie die Propagationszeit von höchstens 24 Stunden.",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_en_GB.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_en_GB.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "The record has been added to the DNS zone, but please note that the change may take up to 24 hours to propagate.",
   "domain_configuration_dns_entry_add_fail": "An error has occurred adding the record to the DNS zone.",
   "domain_configuration_dns_importtext_title": "Enter below the text related to the DNS zones you want to import: ",
+  "domain_configuration_dns_importtext_iacwarning": "Users of Terraform or IaC tools: changing zones in text mode reinitializes the internal ID of each DNS record, thereby invalidating the Terraform state.",
   "domain_configuration_dns_importtext_confirm": "You are about to import a new DNS zone configuration.",
   "domain_configuration_dns_importtext_propagation_info": "The configuration will be imported in a few moments, but please note that the change may take up to 24 hours to propagate.",
   "domain_configuration_dns_importtext_success": "The configuration will be imported in a few moments. You can track the progress of the DNS zone import in the ‘Recent tasks’ section, but please note that the change may take up to 24 hours to propagate.",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_es_ES.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_es_ES.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "El registro se ha añadido a la zona DNS, pero deberá tener en cuenta el tiempo de propagación (máximo 24 horas).",
   "domain_configuration_dns_entry_add_fail": "Se ha producido un error al intentar añadir el registro a la zona DNS.",
   "domain_configuration_dns_importtext_title": "Introduzca a continuación el texto correspondiente a las zonas DNS que quiera importar:",
+  "domain_configuration_dns_importtext_iacwarning": "Usuarios de Terraform o herramientas de IaC: el cambio de zona en modo texto reinicia el ID interno de cada registro DNS, lo que invalida el estado de Terraform.",
   "domain_configuration_dns_importtext_confirm": "Va a importar una nueva configuración de zona DNS.",
   "domain_configuration_dns_importtext_propagation_info": "La configuración se importará enseguida, pero deberá tener en cuenta el tiempo de propagación (máximo 24 horas).",
   "domain_configuration_dns_importtext_success": "La configuración se importará enseguida. Puede consultar el progreso de la importación de la zona DNS en el apartado «Tareas recientes», pero deberá tener en cuenta el tiempo de propagación (máximo 24 horas).",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_CA.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_CA.json
@@ -497,6 +497,7 @@
   "domain_configuration_dns_entry_add_success": "L’entrée a été ajoutée dans la zone DNS, mais veuillez prendre en compte le temps de propagation (maximum 24h).",
   "domain_configuration_dns_entry_add_fail": "Une erreur est survenue lors de l'ajout de l'entrée à la zone DNS.",
   "domain_configuration_dns_importtext_title": "Entrez ci-dessous le texte correspondant aux zones DNS que vous souhaitez importer :",
+  "domain_configuration_dns_importtext_iacwarning": "Utilisateurs de Terraform ou outils d'IaC: le changement de zone en mode text re-initialise l'ID interne de chaque enregistrement DNS, et de ce fait invalide le state Terraform)",
   "domain_configuration_dns_importtext_confirm": "Vous aller importer une nouvelle configuration de zone DNS.",
   "domain_configuration_dns_importtext_propagation_info": "La configuration sera importée dans quelques instants, mais veuillez prendre en compte le temps de propagation (maximum 24h).",
   "domain_configuration_dns_importtext_success": "La configuration sera importée dans quelques instants. Vous pouvez suivre l'avancement de l'import de zone DNS dans la partie 'Tâches récentes', mais veuillez prendre en compte le temps de propagation (maximum 24h).",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_FR.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_fr_FR.json
@@ -497,6 +497,7 @@
   "domain_configuration_dns_entry_add_success": "L’entrée a été ajoutée dans la zone DNS, mais veuillez prendre en compte le temps de propagation (maximum 24h).",
   "domain_configuration_dns_entry_add_fail": "Une erreur est survenue lors de l'ajout de l'entrée à la zone DNS.",
   "domain_configuration_dns_importtext_title": "Entrez ci-dessous le texte correspondant aux zones DNS que vous souhaitez importer :",
+  "domain_configuration_dns_importtext_iacwarning": "Utilisateurs de Terraform ou outils d'IaC: le changement de zone en mode text re-initialise l'ID interne de chaque enregistrement DNS, et de ce fait invalide le state Terraform.",
   "domain_configuration_dns_importtext_confirm": "Vous aller importer une nouvelle configuration de zone DNS.",
   "domain_configuration_dns_importtext_propagation_info": "La configuration sera importée dans quelques instants, mais veuillez prendre en compte le temps de propagation (maximum 24h).",
   "domain_configuration_dns_importtext_success": "La configuration sera importée dans quelques instants. Vous pouvez suivre l'avancement de l'import de zone DNS dans la partie 'Tâches récentes', mais veuillez prendre en compte le temps de propagation (maximum 24h).",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_it_IT.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_it_IT.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "Il record è stato aggiunto nella zona DNS, ma la propagazione potrebbe richiedere fino a 24 ore.",
   "domain_configuration_dns_entry_add_fail": "Si è verificato un errore durante l'aggiunta del record alla zona DNS.",
   "domain_configuration_dns_importtext_title": "Inserisci qui sotto il nome delle zone DNS da importare:",
+  "domain_configuration_dns_importtext_iacwarning": "Utenti di Terraform o strumenti IaC: il cambio di zona in modalità testo reinizializza l'ID interno di ogni record DNS, invalidando così lo stato Terraform.",
   "domain_configuration_dns_importtext_confirm": "Stai per importare una nuova configurazione della zona DNS.",
   "domain_configuration_dns_importtext_propagation_info": "La configurazione sarà importata entro pochi minuti, ma la propagazione potrebbe richiedere fino a 24 ore.",
   "domain_configuration_dns_importtext_success": "La configurazione verrà importata tra pochi minuti. Lo stato di avanzamento dell'importazione della zona DNS è disponibile nella sezione \"Operazioni recenti\", ma ricordiamo che la propagazione potrebbe richiedere fino a 24 ore.",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_pl_PL.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_pl_PL.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "Rekord został dodany do strefy DNS, ale prosimy o uwzględnienie czasu propagacji (maksymalnie 24 godziny).",
   "domain_configuration_dns_entry_add_fail": "Wystąpił błąd podczas dodawania wpisu do strefy DNS.",
   "domain_configuration_dns_importtext_title": "Wpisz poniżej tekst odnoszący się do stref DNS, które chcesz zaimportować:",
+  "domain_configuration_dns_importtext_iacwarning": "Użytkownicy Terraform lub narzędzi IaC: zmiana strefy w trybie tekstowym powoduje ponowne zainicjowanie wewnętrznego identyfikatora każdego rekordu DNS, co powoduje unieważnienie stanu Terraform.",
   "domain_configuration_dns_importtext_confirm": "Chcesz zaimportować nową konfigurację strefy DNS.",
   "domain_configuration_dns_importtext_propagation_info": "Konfiguracja zostanie zaimportowana w ciągu kilku minut, ale prosimy o uwzględnienie czasu propagacji (maksymalnie 24 godziny).",
   "domain_configuration_dns_importtext_success": "Konfiguracja zostanie zaimportowana w ciągu kilku minut.  Możesz śledzić postęp importu strefy DNS w sekcji „Ostatnie zadania”, ale pamiętaj o czasie propagacji (maksymalnie 24 godziny).",

--- a/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_pt_PT.json
+++ b/packages/manager/apps/web/client/app/domain/dashboard/translations/Messages_pt_PT.json
@@ -491,6 +491,7 @@
   "domain_configuration_dns_entry_add_success": "A entrada foi adicionada à zona DNS, mas tenha em conta o tempo de propagação (máximo 24h).",
   "domain_configuration_dns_entry_add_fail": "Ocorreu um erro na adição da entrada à zona DNS.",
   "domain_configuration_dns_importtext_title": "Introduza abaixo o texto correspondente às zonas DNS que deseja importar:",
+  "domain_configuration_dns_importtext_iacwarning": "Utilizadores do Terraform ou ferramentas de IaC: a alteração da zona no modo texto reinicia o ID interno de cada registo DNS, invalidando assim o estado do Terraform.",
   "domain_configuration_dns_importtext_confirm": "Vai importar uma nova configuração da zona DNS.",
   "domain_configuration_dns_importtext_propagation_info": "A configuração será importada dentro de alguns instantes, mas tenha em conta o tempo de propagação (máximo 24h).",
   "domain_configuration_dns_importtext_success": "A configuração será importada dentro de alguns instantes. Pode acompanhar o progresso da importação da zona DNS na parte 'Operações recentes', mas tenha em conta o tempo de propagação (máximo 24h).",

--- a/packages/manager/apps/web/client/app/domain/zone/import-text/domain-zone-import-text.html
+++ b/packages/manager/apps/web/client/app/domain/zone/import-text/domain-zone-import-text.html
@@ -22,6 +22,11 @@
                             for="zoneDnsText"
                             data-translate="domain_configuration_dns_importtext_title"
                         ></label>
+                        <div
+                            class="alert alert-warning"
+                            role="alert"
+                            data-translate="domain_configuration_dns_importtext_iacwarning"
+                        ></div>
                         <textarea
                             class="mt-2 w-100"
                             id="zoneDnsText"


### PR DESCRIPTION

## Description

When using terraform to manage DNS zones, it's can be very (very) annoying to have our terraform state out-of-sync with the current status of the zone. It happens if we modify the zone in text mode.

This PR warns terraform (and other IaC tools) users for this, so they have a chance to abort and use terraform instead.

## Additional Information

This is more or less linked to the OVH terraform provider issue 275: https://github.com/ovh/terraform-provider-ovh/issues/275#issuecomment-1506798086

A warning has been added to the provider documentation (https://github.com/ovh/terraform-provider-ovh/pull/408/), but in my opinion having the warning directly on the OVH web console itself would prevent such issues more efficiently.
