### PR TITLE
fix(billing-components): callback to go back from exchange renew

### DIFF
--- a/packages/manager/modules/billing-components/src/components/exchange-renew/renew.component.js
+++ b/packages/manager/modules/billing-components/src/components/exchange-renew/renew.component.js
@@ -5,7 +5,7 @@ export default {
   bindings: {
     exchange: '<',
     getAccounts: '<',
-    goBack: '<',
+    goToAutorenew: '<',
     updateRenew: '<',
   },
   controller,

--- a/packages/manager/modules/billing-components/src/components/exchange-renew/renew.controller.js
+++ b/packages/manager/modules/billing-components/src/components/exchange-renew/renew.controller.js
@@ -126,7 +126,7 @@ export default class ExchangeUpdateRenewCtrl {
         };
       })
       .catch((failure) => {
-        this.goBack(
+        this.goToAutorenew(
           `${this.$translate.instant(
             'exchange_tab_ACCOUNTS_error_message',
           )} ${failure}`,
@@ -191,10 +191,10 @@ export default class ExchangeUpdateRenewCtrl {
           ),
         };
 
-        this.goBack(updateRenewMessages[state]);
+        this.goToAutorenew(updateRenewMessages[state]);
       })
       .catch((failure) => {
-        this.goBack(
+        this.goToAutorenew(
           `${this.$translate.instant(
             'exchange_update_billing_periode_failure',
           )} ${failure}`,

--- a/packages/manager/modules/billing-components/src/components/exchange-renew/renew.html
+++ b/packages/manager/modules/billing-components/src/components/exchange-renew/renew.html
@@ -1,5 +1,5 @@
 <div class="p-5" data-ui-view>
-    <oui-back-button data-on-click="$ctrl.goBack()">
+    <oui-back-button data-on-click="$ctrl.goToAutorenew()">
         <span data-translate="exchange_update_billing_action_title"></span>
     </oui-back-button>
 
@@ -8,7 +8,7 @@
             data-header="{{::'exchange_update_billing_button_title' | translate}}"
             data-description="{{::'exchange_update_billing_periode_intro' | translate}}"
             data-loading="!$ctrl.exchange"
-            data-on-cancel="$ctrl.goBack()"
+            data-on-cancel="$ctrl.goToAutorenew()"
             data-valid="$ctrl.buffer.hasChanged"
             data-prevent-next
         >


### PR DESCRIPTION
## Description

Replaced removed goBack callback with goToAutorenew to fix the back link and cancel button

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20665

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
