### PR TITLE
fix(billing): properly manage messages and button state on bulk autorenew

### DIFF
--- a/packages/manager/modules/billing/src/autoRenew/bulk/bulk.controller.js
+++ b/packages/manager/modules/billing/src/autoRenew/bulk/bulk.controller.js
@@ -7,7 +7,7 @@ export default class {
   $onInit() {
     this.expand = {};
 
-    this.availableServices = this.services.available;
+    this.availableServices = this.services.available || [];
     this.unavailableServices = omit(this.services, 'available');
 
     this.servicesCount = flatten(values(this.services)).length;

--- a/packages/manager/modules/billing/src/autoRenew/bulk/bulk.html
+++ b/packages/manager/modules/billing/src/autoRenew/bulk/bulk.html
@@ -11,13 +11,14 @@
             data-ng-pluralize
             data-count="$ctrl.servicesCount"
             data-when="{
+                '0': ('billing_autorenew_bulk' | translate:{ count: $ctrl.servicesCount }),
                 'one': ('billing_autorenew_bulk_one' | translate),
                 'other': ('billing_autorenew_bulk' | translate:{ count: $ctrl.servicesCount })
             }"
         >
         </strong>
         <p
-            data-ng-if="$ctrl.unavailableServicesCount === 0"
+            data-ng-if="$ctrl.unavailableServicesCount === 0 && $ctrl.availableServices.length"
             data-ng-pluralize
             data-count="$ctrl.availableServices.length"
             data-when="{
@@ -65,6 +66,7 @@
             <button
                 type="button"
                 class="oui-link"
+                data-ng-if="$ctrl.availableServices.length"
                 data-ng-click="$ctrl.expand.available = !$ctrl.expand.available"
                 data-ng-bind="($ctrl.expand.available ? 'billing_autorenew_bulk_available_less' : 'billing_autorenew_bulk_available_more') | translate"
             ></button>
@@ -82,7 +84,7 @@
             <oui-button
                 data-variant="primary"
                 data-on-click="$ctrl.updateRenew({ services: $ctrl.availableServices })"
-                data-disabled="!$ctrl.availableServices"
+                data-disabled="!$ctrl.availableServices.length"
             >
                 <span data-translate="billing_autorenew_bulk_confirm"></span>
             </oui-button>

--- a/packages/manager/modules/billing/src/autoRenew/disable/disable.routing.js
+++ b/packages/manager/modules/billing/src/autoRenew/disable/disable.routing.js
@@ -14,6 +14,8 @@ export default /* @ngInject */ ($stateProvider) => {
     resolve: {
       servicesId: /* @ngInject */ ($transition$) =>
         $transition$.params().services.split(','),
+      // This might not work if you try to access the url directly: since we rely on the billingServices (fetched on services route) if the ids we pass here are not present in billingServices we'll have an empty servicesList
+      // We probably should request /services using iceberg to fetch services, however the result from the API is currently not compatible with the BillingService model we're expecting the services to be.
       servicesList: /* @ngInject */ (
         BillingAutorenewDisable,
         billingServices,

--- a/packages/manager/modules/billing/src/autoRenew/helpers/bulk-action-message.helper.js
+++ b/packages/manager/modules/billing/src/autoRenew/helpers/bulk-action-message.helper.js
@@ -23,10 +23,9 @@ export const mapErrorsForBulkActions = (results) => {
   const errors = results.filter((result) => result?.type === 'ERROR');
 
   if (errors.length > 0) {
-    return this.$q.reject({
-      messages: errors,
-      state: 'PARTIAL',
-    });
+    const error = new Error();
+    error.messages = errors;
+    return Promise.reject(error);
   }
 
   return {


### PR DESCRIPTION
## Description

Ensure to properly display messages regarding services selected for bulk autorenew disabling / enabling
Ensure action is possible if at least one service is elligible


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20667

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
