### PR TITLE
test(ovh-shell): add mock for fetchConfiguration in shell test

### DIFF
--- a/packages/components/ovh-shell/src/client/shell-client.spec.ts
+++ b/packages/components/ovh-shell/src/client/shell-client.spec.ts
@@ -13,6 +13,17 @@ vi.stubGlobal('window', {
   location: { href: '' },
 });
 
+vi.mock('@ovh-ux/manager-config', async (importOriginal) => {
+  const original: any = await importOriginal();
+  return {
+    ...original,
+    fetchConfiguration: () => {
+      const env = new original.Environment();
+      return Promise.resolve(env);
+    },
+  };
+});
+
 describe('Test shell client', () => {
   beforeEach(() => {
     delete window.location;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This Change fixes the flaky test in shell by mocking the fetchConfiguration call.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-20425    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
**Test case goal:** When user try to load a µ-app directly without Container (supposed to be loaded only in container), shell should redirect to container and then load the µ-app inside container.

**Steps involved:**
	1.	Get application registry with `/applications` BFF
	2.	Check if µ-app can/cannot be loaded outside of container.
	3.	If µ-app is not supposed be loaded outside container, replace the window.location.href to load the µ-app inside Container (Required URL is obtained from step 1)
	4.	Make a call to `/configuration` BFF and then initialise Environment using the fetchConfiguration utility provided by `@ovh-ux/manager-config` package.


In the above process, the flaky behaviour is occurred at step 4 but we can validate the required test scenario at step 3. So I am mocking the `fetchConfiguration` util from the package to avoid the trigger of flaky code.