### PR TITLE
fix(zimbra): display organizations label in redirections page and man…

### DIFF
--- a/packages/manager/apps/zimbra/src/data/hooks/redirection/useRedirections.ts
+++ b/packages/manager/apps/zimbra/src/data/hooks/redirection/useRedirections.ts
@@ -25,6 +25,7 @@ type UseRedirectionsParams = Omit<
   shouldFetchAll?: boolean;
 };
 
+// eslint-disable-next-line max-lines-per-function
 export const useRedirections = (props: UseRedirectionsParams = {}) => {
   const { destination, source, organizationId, shouldFetchAll, ...options } = props;
   const [allPages, setAllPages] = useState(!!shouldFetchAll);

--- a/packages/manager/apps/zimbra/src/pages/dashboard/redirections/ActionButton.spec.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/redirections/ActionButton.spec.tsx
@@ -18,8 +18,9 @@ describe('Redirections datagrid action menu', () => {
           id: '1',
           from: 'testFrom',
           to: 'testTo',
-          organization: 'TestOrganization',
+          organizationLabel: 'TestOrganization',
           status: ResourceStatus.READY,
+          organizationId: '1',
         }}
       />,
     );

--- a/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.types.ts
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/redirections/Redirections.types.ts
@@ -4,6 +4,7 @@ export type RedirectionItem = {
   id: string;
   from: string;
   to: string;
-  organization: string;
+  organizationLabel: string;
   status: keyof typeof ResourceStatus;
+  organizationId: string;
 };


### PR DESCRIPTION
ref: #PRDCOL-323


## Description
In Zimbra > redirections page :
- fix the display of organization label in the data grid.
- manage the filter by organization label.

<img width="557" height="360" alt="image" src="https://github.com/user-attachments/assets/1f2c29e2-e25b-4aed-913b-19ecfab53017" />
