### PR TITLE
feat(*): start ci checks on pr main events (opened, synchronize, reopened)

### DIFF
--- a/.github/workflows/check-duplicates-translations.yml
+++ b/.github/workflows/check-duplicates-translations.yml
@@ -1,8 +1,6 @@
 name: Duplicate translation
 
 on:
-  push:
-    branches-ignore: [master]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -12,9 +10,6 @@ concurrency:
 
 jobs:
   duplicate-translation:
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.pull_request == null)
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/check-medata.yaml
+++ b/.github/workflows/check-medata.yaml
@@ -1,7 +1,6 @@
 name: Check package.json metadatas
 
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -11,9 +10,6 @@ concurrency:
 
 jobs:
   check-regions:
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,7 +1,6 @@
 name: Lint Code Base
 
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -12,9 +11,6 @@ concurrency:
 jobs:
   lint:
     name: Lint Code Base
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.pull_request == null)
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/merge_conflict_finder.yml
+++ b/.github/workflows/merge_conflict_finder.yml
@@ -1,7 +1,6 @@
 name: "Merge Conflict Finder"
 
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -11,12 +10,8 @@ concurrency:
 
 jobs:
   merge_conflict_job:
-    name: Find merge conflicts
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.pull_request == null)
     runs-on: ubuntu-latest
-
+    name: Find merge conflicts
     steps:
       # Checkout the source code so we have some files to look at.
       - uses: actions/checkout@v4

--- a/.github/workflows/run-bdd-tests.yml
+++ b/.github/workflows/run-bdd-tests.yml
@@ -1,8 +1,6 @@
 name: Run tests
 
 on:
-  push:
-    branches-ignore: [master]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -12,9 +10,6 @@ concurrency:
 
 jobs:
   test:
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' && github.event.pull_request == null)
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## Description

Start CI checks on Pull Request lifecycle events (`opened`, `synchronize`, `reopened`) to fix missing checks on automated PRs and avoid duplicated CI runs.

Related workflow:
https://github.com/ovh/manager/actions/workflows/pnpm-migration.yml

Ticket Reference: **#MANAGER-20690**

### Original issue

Pull Requests created automatically (e.g. by GitHub Actions or scripts) did not trigger CI checks at creation time.  
As a result, checks were missing until a manual push was performed on the PR branch.

This happened because the workflows were triggered on `push`, and:
- the initial commits already existed before the PR was created
- creating a PR does **not** emit a `push` event
- therefore, no CI was triggered at PR creation

### What changed

Main workflows are now aligned with GitHub’s Pull Request lifecycle:

- ✅ CI checks start when a PR is opened
- ✅ Checks rerun automatically on every new commit pushed to the PR
- ❌ Checks no longer run before a PR exists
- ❌ Avoid duplicated `(push)` / `(pull_request)` checks in the PR UI

GitHub already provides the exact semantics we need:
- `opened` → first CI run at PR creation
- `synchronize` → rerun CI on every push to the PR branch
- `reopened` → rerun if the PR is reopened

### Why not using both `push` and `pull_request`

GitHub Actions creates a **separate workflow run per trigger event**.  
When a workflow listens to both `push` and `pull_request`:

- a push to a PR branch triggers a `push` workflow run
- the same push also triggers a `pull_request` (`synchronize`) workflow run
- both runs appear as separate checks in the PR UI

This behavior is inherent to GitHub Actions:
- workflow runs are created **before** job-level conditions are evaluated
- concurrency and conditional logic cannot prevent check creation
- required checks are matched by name, leading to duplicated required checks

As a result, mixing `push` and `pull_request` for PR checks causes:
- duplicated checks in PRs
- confusing branch protection configuration
- unnecessary CI executions

Using `pull_request` only avoids these limitations while still covering:
- PR creation
- subsequent pushes to the PR branch
- PR reopening