### PR TITLE
fix(i18n): remove extra space before exclamation mark

### DIFF
--- a/packages/manager/apps/hub/public/translations/hub/Messages_fr_FR.json
+++ b/packages/manager/apps/hub/public/translations/hub/Messages_fr_FR.json
@@ -1,5 +1,5 @@
 {
-  "manager_hub_dashboard_welcome": "Bienvenue {{ name }} !",
+  "manager_hub_dashboard_welcome": "Bienvenue {{ name }}!",
   "ovh_trusted_nic_label": "Zone de confiance",
   "manager_hub_skip_to_main_content": "Aller au contenu principal",
   "manager_hub_dashboard_overview": "Vue d'ensemble de mon activité",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

Fix a minor punctuation issue in the manager hub dashboard welcome message by removing an extra space before the exclamation mark.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: N/A

## Additional Information

Text-only change, no functional impact.
