### PR TITLE
refactor(pci-instances): display local backup card items

### DIFF
--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_de_DE.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_de_DE.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} HT/Monat",
   "pci_instance_creation_backup_setting_local_label": "Automatische Sicherung (lokal)",
   "pci_instance_creation_backup_setting_distant_label": "Automatische Sicherung (fern)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Standorte"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Standorte",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Drehung 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Drehung 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Angepasst",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Ein Backup wird jeden Tag zwischen 22:00 und 6:00 Uhr (UTC) erstellt, und die Rotation hält einen Verlauf der letzten {{ numEntries }} Einträge. Wenn das neue Backup abgeschlossen ist, wird das älteste gelöscht.",
+    "custom": "Wählen Sie selbst die Planung (UNIX Cron-Format), die Anzahl der Rotationen und die maximalen Ausführungen, die Sie wünschen."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_en_GB.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_en_GB.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} ex VAT/month",
   "pci_instance_creation_backup_setting_local_label": "Auto backup (local)",
   "pci_instance_creation_backup_setting_distant_label": "Auto backup (remote)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Locations"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Locations",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotation 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotation 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Customised",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "A backup is performed every day between 10:00 PM and 6:00 AM (UTC) and the rotation maintains a history of the last {{ numEntries }} entries. When the new backup is complete, the oldest one is deleted.",
+    "custom": "Choose your own scheduling (UNIX Cron format), the number of rotations, and the maximum executions you want."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_es_ES.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_es_ES.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} HT/mes",
   "pci_instance_creation_backup_setting_local_label": "Copia de seguridad automática (local)",
   "pci_instance_creation_backup_setting_distant_label": "Copia de seguridad automática (remota)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Localizaciones"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Localizaciones",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotación 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotación 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Personalizado",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Una copia de seguridad se realiza todos los días entre las 22:00 y las 6:00 (UTC) y la rotación mantiene un historial de las {{ numEntries }} últimas entradas. Cuando se completa la nueva copia de seguridad, se elimina la más antigua.",
+    "custom": "Elija usted mismo la programación (formato UNIX Cron), el número de rotaciones y las ejecuciones máximas que desee."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_CA.json
@@ -133,5 +133,12 @@
   "pci_instance_creation_backup_setting_distant_backup_warning_message": "La sauvegarde distante suit la même rotation que la sauvegarde locale.",
   "pci_instance_creation_backup_setting_action_label": "Créer une sauvegarde automatisée d'une instance",
   "pci_instance_creation_backup_setting_local_label": "Sauvegarde auto (local)",
-  "pci_instance_creation_backup_setting_distant_label": "Sauvegarde auto (distant)"
+  "pci_instance_creation_backup_setting_distant_label": "Sauvegarde auto (distant)",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotation 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotation 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Personnalisé",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Une sauvegarde est effectuée tous les jours entre 22h00 et 6h00 (UTC) et la rotation maintient un historique des {{ numEntries }} dernières entrées. Lorsque la nouvelle sauvegarde est terminée, la plus ancienne est supprimée.",
+    "custom": "Choisissez vous-même l'ordonnancement (format UNIX Cron), le nombre de rotations et les exécutions maximales que vous souhaitez."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_fr_FR.json
@@ -133,5 +133,12 @@
   "pci_instance_creation_backup_setting_distant_backup_warning_message": "La sauvegarde distante suit la même rotation que la sauvegarde locale.",
   "pci_instance_creation_backup_setting_action_label": "Créer une sauvegarde automatisée d'une instance",
   "pci_instance_creation_backup_setting_local_label": "Sauvegarde auto (local)",
-  "pci_instance_creation_backup_setting_distant_label": "Sauvegarde auto (distant)"
+  "pci_instance_creation_backup_setting_distant_label": "Sauvegarde auto (distant)",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotation 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotation 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Personnalisé",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Une sauvegarde est effectuée tous les jours entre 22h00 et 6h00 (UTC) et la rotation maintient un historique des {{ numEntries }} dernières entrées. Lorsque la nouvelle sauvegarde est terminée, la plus ancienne est supprimée.",
+    "custom": "Choisissez vous-même l'ordonnancement (format UNIX Cron), le nombre de rotations et les exécutions maximales que vous souhaitez."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_it_IT.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_it_IT.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} HT/mese",
   "pci_instance_creation_backup_setting_local_label": "Backup automatico (locale)",
   "pci_instance_creation_backup_setting_distant_label": "Backup automatico (remoto)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Localizzazioni"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Localizzazioni",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotazione 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotazione 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Personalizzato",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Un backup viene eseguito ogni giorno tra le 22:00 e le 6:00 (UTC) e la rotazione mantiene una cronologia delle ultime {{ numEntries }} voci. Quando il nuovo backup è completato, il più vecchio viene eliminato.",
+    "custom": "Scegli tu stesso la pianificazione (formato UNIX Cron), il numero di rotazioni e le esecuzioni massime che desideri."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_pl_PL.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} HT/miesiąc",
   "pci_instance_creation_backup_setting_local_label": "Automatyczne kopie zapasowe (lokalne)",
   "pci_instance_creation_backup_setting_distant_label": "Automatyczne kopie zapasowe (zdalne)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Lokalizacje"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Lokalizacje",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotacja 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotacja 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Spersonalizowana",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Kopia zapasowa jest wykonywana codziennie między 22:00 a 6:00 (UTC) i rotacja utrzymuje historię ostatnich {{ numEntries }} wpisów. Gdy nowa kopia zapasowa jest zakończona, najstarsza jest usuwana.",
+    "custom": "Wybierz samodzielnie harmonogram (format UNIX Cron), liczbę rotacji i maksymalne wykonania, które chcesz."
+  }
 }

--- a/packages/manager/apps/pci-instances/public/translations/creation/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-instances/public/translations/creation/Messages_pt_PT.json
@@ -132,5 +132,12 @@
   "pci_instance_creation_windows_image_monthly_license_price": "+ {{ price }} HT/mês",
   "pci_instance_creation_backup_setting_local_label": "Backup automático (local)",
   "pci_instance_creation_backup_setting_distant_label": "Backup automático (remoto)",
-  "pci_instance_creation_select_deployment_mode_helper_title": "Localizações"
+  "pci_instance_creation_select_deployment_mode_helper_title": "Localizações",
+  "pci_instance_creation_backup_setting_rotation_7_label": "Rotação 7",
+  "pci_instance_creation_backup_setting_rotation_14_label": "Rotação 14",
+  "pci_instance_creation_backup_setting_rotation_custom_label": "Personalizado",
+  "pci_instance_creation_backup_setting_rotation_description": {
+    "predefined": "Um backup é realizado todos os dias entre as 22h00 e as 6h00 (UTC) e a rotação mantém um histórico das {{ numEntries }} últimas entradas. Quando o novo backup estiver concluído, o mais antigo será removido.",
+    "custom": "Escolha você mesmo a programação (formato UNIX Cron), o número de rotações e as execuções máximas que deseja."
+  }
 }

--- a/packages/manager/apps/pci-instances/src/__mocks__/instance/constants.ts
+++ b/packages/manager/apps/pci-instances/src/__mocks__/instance/constants.ts
@@ -1277,22 +1277,7 @@ export const mockedOvhPrivateNetwork = {
   enableDhcp: true,
 };
 
-export const mockedLocalBackups = [
-  {
-    label: 'Rotation 7',
-    value: 'rotation7-id',
-    description:
-      'A backup is taken every day between 22:00 and 06:00, and the rotation maintains a log of the 7 latest entries. When the new backup is taken, the previous one is deleted.',
-  },
-  {
-    label: 'Rotation 14',
-    value: 'rotation14-id',
-    description:
-      'A backup is taken every day between 22:00 and 06:00, and the rotation maintains a log of the 14 latest entries. When the new backup is taken, the previous one is deleted.',
-  },
-];
-
-export const mockedLocalizations = [
+export const mockedDistantBackupLocalizations = [
   {
     label: 'europe',
     options: [
@@ -1301,6 +1286,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'GRA9',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_GRA_micro',
         value: 'GRA9',
@@ -1310,6 +1296,7 @@ export const mockedLocalizations = [
           countryCode: 'uk',
           deploymentMode: 'region',
           regionId: 'UK1',
+          backupPrice: 20000,
         },
         label: 'regions:manager_components_region_UK_micro',
         value: 'UK1',
@@ -1319,6 +1306,7 @@ export const mockedLocalizations = [
           countryCode: 'pl',
           deploymentMode: 'region',
           regionId: 'WAW1',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_WAW_micro',
         value: 'WAW1',
@@ -1328,6 +1316,7 @@ export const mockedLocalizations = [
           countryCode: 'de',
           deploymentMode: 'region',
           regionId: 'DE1',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_DE_micro',
         value: 'DE1',
@@ -1337,6 +1326,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'INTERNAL.GRA1',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_GRA_micro',
         value: 'INTERNAL.GRA1',
@@ -1346,6 +1336,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'RBX-A',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_RBX_micro',
         value: 'RBX-A',
@@ -1355,6 +1346,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'GRA7',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_GRA_micro',
         value: 'GRA7',
@@ -1364,6 +1356,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'GRA11',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_GRA_micro',
         value: 'GRA11',
@@ -1373,6 +1366,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'GRA-STAGING-A',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_GRA_micro',
         value: 'GRA-STAGING-A',
@@ -1382,6 +1376,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'SBG5',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_SBG_micro',
         value: 'SBG5',
@@ -1391,6 +1386,7 @@ export const mockedLocalizations = [
           countryCode: 'fr',
           deploymentMode: 'region',
           regionId: 'SBG7',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_SBG_micro',
         value: 'SBG7',
@@ -1405,6 +1401,7 @@ export const mockedLocalizations = [
           countryCode: 'sg',
           deploymentMode: 'region',
           regionId: 'SGP1',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_SGP_micro',
         value: 'SGP1',
@@ -1414,6 +1411,7 @@ export const mockedLocalizations = [
           countryCode: 'au',
           deploymentMode: 'region',
           regionId: 'SYD1',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_SYD_micro',
         value: 'SYD1',
@@ -1428,6 +1426,7 @@ export const mockedLocalizations = [
           countryCode: 'ca',
           deploymentMode: 'region',
           regionId: 'BHS5',
+          backupPrice: 10000,
         },
         label: 'regions:manager_components_region_BHS_micro',
         value: 'BHS5',

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/CreateInstance.schema.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/CreateInstance.schema.ts
@@ -129,7 +129,7 @@ export const networkSchema = z
   })
   .nullable();
 
-export const localBackupSchema = z.string().nullable();
+export const localBackupRotationSchema = z.string().nullable();
 
 export const distantBackupLocalizationSchema = z.string().nullable();
 
@@ -155,6 +155,6 @@ export const instanceCreationSchema = z.object({
   networkId: networkIdSchema,
   newPrivateNetwork: networkSchema,
   billingType: billingTypeSelectionSchema,
-  localBackup: localBackupSchema,
+  localBackupRotation: localBackupRotationSchema,
   distantBackupLocalization: distantBackupLocalizationSchema,
 });

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/components/Backup.component.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/components/Backup.component.tsx
@@ -27,21 +27,21 @@ const Backup: FC = () => {
   const { t } = useTranslation(['creation', 'common']);
 
   const { control, setValue } = useFormContext<TInstanceCreationForm>();
-  const selectedLocalBackup = useWatch({
+  const selectedLocalBackupRotation = useWatch({
     control,
-    name: 'localBackup',
+    name: 'localBackupRotation',
   });
 
   const { price, items } = useMemo(() => selectLocalBackups(), []);
 
-  const handleSelectLocalBackup = (value: string | null) =>
-    setValue('localBackup', value);
+  const handleSelectLocalBackup = (rotation: string | null) =>
+    setValue('localBackupRotation', rotation);
 
   const handleDeactivateLocalBackup = ({
     checked,
   }: ToggleCheckedChangeDetail) => {
-    const localBackup = items[0]?.value ?? null;
-    handleSelectLocalBackup(checked ? localBackup : null);
+    const localBackupRotation = items[0]?.rotation ?? null;
+    handleSelectLocalBackup(checked ? localBackupRotation : null);
 
     if (!checked) setValue('distantBackupLocalization', null);
   };
@@ -63,7 +63,7 @@ const Backup: FC = () => {
         label={t(
           'creation:pci_instance_creation_backup_setting_auto_backup_checkbox_label',
         )}
-        checked={!!selectedLocalBackup}
+        checked={!!selectedLocalBackupRotation}
         badges={[
           {
             label: t('common:pci_instances_common_recommanded'),
@@ -71,59 +71,58 @@ const Backup: FC = () => {
         ]}
         onCheckedChange={handleDeactivateLocalBackup}
       />
-      {selectedLocalBackup && (
+      {selectedLocalBackupRotation && (
         <div className="mt-6">
           <Text className="font-semibold">
             {t('creation:pci_instance_creation_backup_billing_label')} {price}
           </Text>
           <RadioGroup
             className="mt-6 grid grid-cols-3 gap-6"
-            {...(selectedLocalBackup && { value: selectedLocalBackup })}
+            value={selectedLocalBackupRotation}
             onValueChange={({ value }) => handleSelectLocalBackup(value)}
           >
-            {items.map(({ value, label, description }) => (
+            {items.map(({ rotation, isEnabled, badge }) => (
               <PciCard
-                key={value}
+                key={rotation}
                 selectable
-                selected={selectedLocalBackup === value}
-                onClick={() => handleSelectLocalBackup(value)}
+                selected={selectedLocalBackupRotation === rotation}
+                onClick={() => handleSelectLocalBackup(rotation)}
+                disabled={!isEnabled}
               >
                 <PciCard.Header>
-                  <Radio value={value}>
+                  <Radio disabled={!isEnabled} value={rotation}>
                     <RadioControl />
                     <RadioLabel className={radioLabelClassname}>
-                      {label}
+                      {t(
+                        `creation:pci_instance_creation_backup_setting_rotation_${rotation}_label`,
+                      )}
                     </RadioLabel>
                   </Radio>
+                  {badge && (
+                    <Badge className={badgeClassname} color="neutral">
+                      {badge}
+                      <Icon
+                        className="!text-[--ods-color-element-text-selected]"
+                        name="circle-info"
+                      />
+                    </Badge>
+                  )}
                 </PciCard.Header>
                 <PciCard.Content>
-                  <Text>{description}</Text>
+                  <Text>
+                    {t(
+                      [
+                        `creation:pci_instance_creation_backup_setting_rotation_description.${rotation}`,
+                        'creation:pci_instance_creation_backup_setting_rotation_description.predefined',
+                      ],
+                      {
+                        numEntries: rotation,
+                      },
+                    )}
+                  </Text>
                 </PciCard.Content>
               </PciCard>
             ))}
-            <PciCard disabled>
-              <PciCard.Header>
-                <Radio disabled value="">
-                  <RadioControl />
-                  <RadioLabel className={radioLabelClassname}>
-                    Custom
-                  </RadioLabel>
-                </Radio>
-                <Badge className={badgeClassname} color="neutral">
-                  Coming soon
-                  <Icon
-                    className="!text-[--ods-color-element-text-selected]"
-                    name="circle-info"
-                  />
-                </Badge>
-              </PciCard.Header>
-              <PciCard.Content>
-                <Text>
-                  Choose the scheduling yourself (in UNIX Cron format), the
-                  number of rotations, and the maximum executions you want.
-                </Text>
-              </PciCard.Content>
-            </PciCard>
           </RadioGroup>
           <div className="mt-6">
             <BackupDistant />

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/components/__test__/BackupDistant.component.spec.tsx
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/components/__test__/BackupDistant.component.spec.tsx
@@ -7,13 +7,15 @@ import {
   selectDistantBackupLocalizations,
   TDistantBackupLocalizationItemData,
 } from '../../view-models/backupViewModel';
-import { mockedLocalizations } from '@/__mocks__/instance/constants';
+import { mockedDistantBackupLocalizations } from '@/__mocks__/instance/constants';
 import { SelectGroupItem } from '@ovhcloud/ods-react';
 import { TestCreateInstanceFormWrapper } from '@/__tests__/CreateInstanceFormWrapper';
 
 vi.mock('../../view-models/backupViewModel');
 vi.mocked(selectDistantBackupLocalizations).mockReturnValue(
-  mockedLocalizations as SelectGroupItem<TDistantBackupLocalizationItemData>[],
+  mockedDistantBackupLocalizations as SelectGroupItem<
+    TDistantBackupLocalizationItemData
+  >[],
 );
 
 describe('Considering BackupDistant component', () => {
@@ -47,7 +49,7 @@ describe('Considering BackupDistant component', () => {
         ),
       ).toBeVisible();
 
-      mockedLocalizations
+      mockedDistantBackupLocalizations
         // eslint-disable-next-line max-nested-callbacks
         .flatMap(({ options: localization }) => localization)
         // eslint-disable-next-line max-nested-callbacks

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useForm.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useForm.ts
@@ -13,11 +13,9 @@ import {
 import { selectFlavors } from '../view-models/flavorsViewModel';
 import { selectImages } from '../view-models/imagesViewModel';
 import { useMemo } from 'react';
-import {
-  mockedPrivateNetworks,
-  mockedLocalBackups,
-} from '@/__mocks__/instance/constants';
+import { mockedPrivateNetworks } from '@/__mocks__/instance/constants';
 import { instanceCreationSchema } from '../CreateInstance.schema';
+import { selectLocalBackups } from '../view-models/backupViewModel';
 
 const preselectedOs = 'linux';
 // eslint-disable-next-line max-lines-per-function
@@ -81,7 +79,8 @@ export const useForm = (projectId: string) => {
 
   const defaultNetworkId = defaultNetwork?.value ?? null;
 
-  const defaultLocalBackup = mockedLocalBackups[0]?.value ?? null;
+  const { items: localBackupItems } = selectLocalBackups();
+  const defaultLocalBackup = localBackupItems[0]?.rotation ?? null;
 
   const formMethods = useReactHookForm({
     resolver: zodResolver(instanceCreationSchema),
@@ -111,7 +110,7 @@ export const useForm = (projectId: string) => {
       networkId: defaultNetworkId,
       newPrivateNetwork: null,
       billingType: BILLING_TYPE.Hourly,
-      localBackup: defaultLocalBackup,
+      localBackupRotation: defaultLocalBackup,
       distantBackupLocalization: null,
     },
     mode: 'onChange',

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useInstanceCreation.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/hooks/useInstanceCreation.ts
@@ -67,7 +67,7 @@ export const useInstanceCreation = (): TInstanceCreation => {
     newSshPublicKey,
     newPrivateNetwork,
     billingType,
-    localBackup,
+    localBackupRotation,
     distantBackupLocalization,
   ] = useWatch({
     control,
@@ -86,7 +86,7 @@ export const useInstanceCreation = (): TInstanceCreation => {
       'newSshPublicKey',
       'newPrivateNetwork',
       'billingType',
-      'localBackup',
+      'localBackupRotation',
       'distantBackupLocalization',
     ],
   });
@@ -127,7 +127,7 @@ export const useInstanceCreation = (): TInstanceCreation => {
   );
 
   const backupSettingPrices = useMemo(() => {
-    if (!localBackup) return null;
+    if (!localBackupRotation) return null;
 
     const { price: localBackupPrice } = selectLocalBackups();
     const distantBackupLocalizations = selectDistantBackupLocalizations();
@@ -144,7 +144,11 @@ export const useInstanceCreation = (): TInstanceCreation => {
         ? getFormattedMonthlyCatalogPrice(distantBackupPrice)
         : null,
     };
-  }, [distantBackupLocalization, getFormattedMonthlyCatalogPrice, localBackup]);
+  }, [
+    distantBackupLocalization,
+    getFormattedMonthlyCatalogPrice,
+    localBackupRotation,
+  ]);
 
   const { networks } = useMemo(() => selectPrivateNetworks(microRegion), [
     microRegion,

--- a/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/backupViewModel.ts
+++ b/packages/manager/apps/pci-instances/src/pages/instances/create/view-models/backupViewModel.ts
@@ -1,7 +1,4 @@
-import {
-  mockedLocalBackups,
-  mockedLocalizations,
-} from '@/__mocks__/instance/constants';
+import { mockedDistantBackupLocalizations } from '@/__mocks__/instance/constants';
 import { TCustomRegionItemData } from '@/components/localizationCard/LocalizationSelect.component';
 import { SelectGroupItem } from '@ovhcloud/ods-react';
 
@@ -9,10 +6,29 @@ export type TDistantBackupLocalizationItemData = TCustomRegionItemData & {
   backupPrice: number;
 };
 
+const localBackupsItems = [
+  {
+    rotation: '7',
+    isEnabled: true,
+  },
+  {
+    rotation: '14',
+    isEnabled: true,
+  },
+  {
+    rotation: 'custom',
+    isEnabled: false,
+    badge: 'Coming soon',
+  },
+];
+
+// TODO: return price as number and let the component format it
 export const selectLocalBackups = () => ({
-  items: mockedLocalBackups,
+  items: localBackupsItems,
   price: '~0,011 € HT/mois/Go',
 });
 
 export const selectDistantBackupLocalizations = () =>
-  mockedLocalizations as SelectGroupItem<TDistantBackupLocalizationItemData>[];
+  mockedDistantBackupLocalizations as SelectGroupItem<
+    TDistantBackupLocalizationItemData
+  >[];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

This PR refactor the way we get local backup items. After discussing with api team items will be handle entirely in the front side. Then translations for the card description are added

## Additional Information

<img width="1875" height="868" alt="image" src="https://github.com/user-attachments/assets/9b70db63-071c-4546-9355-7930675a484d" />
