### PR TITLE
fix(telecom): add a banner in sms order when no sms account exists

### DIFF
--- a/packages/manager/modules/sms/src/sms/order/telecom-sms-order-service.html
+++ b/packages/manager/modules/sms/src/sms/order/telecom-sms-order-service.html
@@ -20,6 +20,29 @@
         </oui-header>
 
         <form name="smsOrderForm">
+            <div
+                class="d-inline-block mb-2"
+                data-ng-if="$ctrl.smsFeatureAvailability.isFeatureAvailable('sms:time2chat') && $ctrl.availableAccounts.length === 1"
+            >
+                <oui-message data-type="warning">
+                    <p data-translate="sms_order_info_message"></p>
+                    <div
+                        class="oui-link_icon"
+                        data-ng-repeat="action in $ctrl.actions track by action.name"
+                    >
+                        <a
+                            class="oui-link"
+                            data-ng-href="{{ action.href }}"
+                            target="_blank"
+                        >
+                            <span data-translate="{{ action.text }}"></span>
+                            <span
+                                class="oui-icon oui-icon-external-link"
+                            ></span>
+                        </a>
+                    </div>
+                </oui-message>
+            </div>
             <div class="row">
                 <!-- ACCOUNT -->
                 <div class="col-sm-12">

--- a/packages/manager/modules/sms/src/sms/order/telecom-sms-order.component.js
+++ b/packages/manager/modules/sms/src/sms/order/telecom-sms-order.component.js
@@ -36,6 +36,7 @@ angular
     template: templateService,
     bindings: {
       headerGuideLink: '<',
+      smsFeatureAvailability: '<',
     },
   })
   .config(($stateProvider) => {
@@ -70,6 +71,8 @@ angular
             ),
             url: url[coreConfig.getUser().ovhSubsidiary] || url.DEFAULT,
           })),
+        smsFeatureAvailability: /* @ngInject */ (ovhFeatureFlipping) =>
+          ovhFeatureFlipping.checkFeatureAvailability(['sms:time2chat']),
         breadcrumb: /* @ngInject */ ($translate) =>
           $translate.instant('sms_order_title'),
       },

--- a/packages/manager/modules/sms/src/sms/order/telecom-sms-order.controller.js
+++ b/packages/manager/modules/sms/src/sms/order/telecom-sms-order.controller.js
@@ -72,6 +72,20 @@ export default class {
       }
     });
 
+    this.actions = [
+      {
+        name: 'sms_order_info_welcome',
+        href: 'https://www.ovhtelecom.fr/sms20free.xml',
+        text: this.$translate.instant('sms_order_info_welcome_link'),
+      },
+      {
+        name: 'sms_order_info_guide',
+        href:
+          'https://help.ovhcloud.com/csm/fr-sms-time-2-chat?id=kb_article_view&sysparm_article=KB0073733',
+        text: this.$translate.instant('sms_order_info_guide_link'),
+      },
+    ];
+
     this.loading.init = true;
     this.TucSmsMediator.initAll()
       .then(() => {

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_de_DE.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_de_DE.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "Der transaktionale Kanal ist für den Versand von SMS über das SMPP-Protokoll zu nichtkommerziellen Zwecken (2FA, Benachrichtigungen, Termine usw.) bestimmt",
   "sms_order_account_channel_transactional_footer": "Sie unterliegt weniger strengen Vorschriften als der Marketing-Kanal (e.g. Versand zu jeder Stunde des möglichen Tages)",
   "sms_order_header_guide": "Anleitungen",
-  "sms_order_header_guide_start_with_sms": "Erste SMS von OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Erste SMS von OVHcloud",
+  "sms_order_info_message": "Achtung: Ein Konto ist für Time2Chat erforderlich. Wenn Sie keins haben, aktivieren Sie das Willkommensangebot von 20 kostenlosen SMS, um Ihr Konto zu erstellen, und abonnieren Sie dann Time2Chat.",
+  "sms_order_info_welcome_link": "Erhalten Sie jetzt Ihre 20 kostenlosen SMS",
+  "sms_order_info_guide_link": "Sie brauchen Hilfe? Zur Anleitung"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_en_GB.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_en_GB.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "The transactional channel is dedicated to sending SMS messages using the SMPP protocol for non-commercial purposes (2FA, notifications, appointments, etc.)",
   "sms_order_account_channel_transactional_footer": "It is subject to less restrictive regulations than the marketing channel (e.g. sending at any time of day possible)",
   "sms_order_header_guide": "Guides",
-  "sms_order_header_guide_start_with_sms": "Getting started with OVHcloud SMS"
+  "sms_order_header_guide_start_with_sms": "Getting started with OVHcloud SMS",
+  "sms_order_info_message": "Attention: an account is required for Time2Chat. If you don't have one, activate the welcome offer of 20 free SMS to create your account, then subscribe to Time2Chat.",
+  "sms_order_info_welcome_link": "Receive your 20 free SMS now",
+  "sms_order_info_guide_link": "Need help? See the guide"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_es_ES.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_es_ES.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "El canal transaccional está dedicado al envío de SMS mediante el protocolo SMPP con fines no comerciales (2FA, notificaciones, citas, etc.).",
   "sms_order_account_channel_transactional_footer": "Está sujeto a una regulación menos restrictiva que el canal de marketing (e.g envío a cualquier hora del día posible)",
   "sms_order_header_guide": "Guías",
-  "sms_order_header_guide_start_with_sms": "Empezar con los SMS de OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Empezar con los SMS de OVHcloud",
+  "sms_order_info_message": "Atención: se necesita una cuenta para Time2Chat. Si no tiene una, active la oferta de bienvenida de 20 SMS gratis para crear su cuenta y luego suscríbase a Time2Chat.",
+  "sms_order_info_welcome_link": "Reciba sus 20 SMS gratis ahora",
+  "sms_order_info_guide_link": "¿Necesitas ayuda? Consultar la guía"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_fr_CA.json
@@ -27,5 +27,8 @@
   "sms_order_more_info": "En savoir plus",
   "sms_order_retract_info": "Vous pouvez exercer votre droit de rétractation, sans avoir à justifier de motifs ni à payer de pénalités, dans un délai de quatorze (14) jours à compter de la souscription du contrat, par courrier postal ou par message adressé au Service client OVH par le biais de votre Interface de gestion.",
   "sms_order_header_guide": "Guides",
-  "sms_order_header_guide_start_with_sms": "Débuter avec les SMS OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Débuter avec les SMS OVHcloud",
+  "sms_order_info_message": "Attention : un compte est nécessaire pour Time2Chat. Si vous n'en avez pas, activez l'offre de bienvenue 20 SMS offerts pour créer votre compte, puis souscrivez à Time2Chat.",
+  "sms_order_info_welcome_link": "Recevez vos 20 SMS gratuits maintenant",
+  "sms_order_info_guide_link": "Besoin d'aide ? Suivez le guide"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_fr_FR.json
@@ -27,5 +27,8 @@
   "sms_order_more_info": "En savoir plus",
   "sms_order_retract_info": "Vous pouvez exercer votre droit de rétractation, sans avoir à justifier de motifs ni à payer de pénalités, dans un délai de quatorze (14) jours à compter de la souscription du contrat, par courrier postal ou par message adressé au Service client OVH par le biais de votre Interface de gestion.",
   "sms_order_header_guide": "Guides",
-  "sms_order_header_guide_start_with_sms": "Débuter avec les SMS OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Débuter avec les SMS OVHcloud",
+  "sms_order_info_message": "Attention : un compte est nécessaire pour Time2Chat. Si vous n'en avez pas, activez l'offre de bienvenue 20 SMS offerts pour créer votre compte, puis souscrivez à Time2Chat.",
+  "sms_order_info_welcome_link": "Recevez vos 20 SMS gratuits maintenant",
+  "sms_order_info_guide_link": "Besoin d'aide ? Suivez le guide"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_it_IT.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_it_IT.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "Il canale transazionale è dedicato all'invio di SMS tramite il protocollo SMPP non commerciale (2FA, notifiche, appuntamenti, ecc...)",
   "sms_order_account_channel_transactional_footer": "Esso è soggetto a una regolamentazione meno restrittiva del canale di marketing (e.g invio a qualsiasi ora del giorno possibile)",
   "sms_order_header_guide": "Guide",
-  "sms_order_header_guide_start_with_sms": "Come utilizzare gli SMS OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Come utilizzare gli SMS OVHcloud",
+  "sms_order_info_message": "Attenzione: è necessario un account per Time2Chat. Se non ne hai uno, attiva l'offerta di benvenuto di 20 SMS gratuiti per creare il tuo account, quindi abbonati a Time2Chat.",
+  "sms_order_info_welcome_link": "Ricevi i tuoi 20 SMS gratuiti ora",
+  "sms_order_info_guide_link": "Hai bisogno di aiuto? Consulta le nostre guide"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_pl_PL.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "Kanał transakcyjny jest przeznaczony do wysyłania wiadomości SMS przy użyciu protokołu SMPP o charakterze niehandlowym (2FA, powiadomienia, spotkania, itp.)",
   "sms_order_account_channel_transactional_footer": "Podlega ono mniej restrykcyjnej regulacji niż kanał marketingowy (e.g wysyłka o dowolnej porze dnia)",
   "sms_order_header_guide": "Przewodniki",
-  "sms_order_header_guide_start_with_sms": "Pierwsze kroki z SMS OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Pierwsze kroki z SMS OVHcloud",
+  "sms_order_info_message": "Uwaga: konto jest wymagane do Time2Chat. Jeśli go nie masz, aktywuj ofertę powitalną 20 darmowych SMS-ów, aby utworzyć swoje konto, a następnie subskrybuj Time2Chat.",
+  "sms_order_info_welcome_link": "Odbierz swoje 20 darmowych SMS-ów teraz",
+  "sms_order_info_guide_link": "Potrzebujesz pomocy? Skorzystaj z przewodnika"
 }

--- a/packages/manager/modules/sms/src/sms/order/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/sms/src/sms/order/translations/Messages_pt_PT.json
@@ -27,5 +27,8 @@
   "sms_order_account_channel_transactional_description": "O canal transacional é dedicado ao envio de SMS com a ajuda do protocolo SMPP com finalidade não comercial (2FA, notificações, encontros, etc.)",
   "sms_order_account_channel_transactional_footer": "Está sujeito a uma regulamentação menos restritiva do que o canal de marketing (e.g. envio a qualquer hora do dia possível)",
   "sms_order_header_guide": "Manuais",
-  "sms_order_header_guide_start_with_sms": "Dar os primeiros passos com as SMS OVHcloud"
+  "sms_order_header_guide_start_with_sms": "Dar os primeiros passos com as SMS OVHcloud",
+  "sms_order_info_message": "Atenção: é necessária uma conta para o Time2Chat. Se não tiver uma, ative a oferta de boas-vindas de 20 SMS gratuitos para criar a sua conta e, em seguida, subscreva o Time2Chat.",
+  "sms_order_info_welcome_link": "Receba agora os seus 20 SMS gratuitos",
+  "sms_order_info_guide_link": "Necessita de ajuda? Consulte o manual"
 }


### PR DESCRIPTION
ref: #PRDCOL-321

## Description
In Telecom > SMS > Order :
- Add a banner when the user has NOT an SMS account or is Not an fr customer

<img width="1170" height="360" alt="image" src="https://github.com/user-attachments/assets/f137b130-cbdd-4be2-942f-cec9b3f28548" />

