### PR TITLE
fix(muk): link component polymorphism ability

### DIFF
--- a/packages/manager-ui-kit/src/components/link/Link.component.tsx
+++ b/packages/manager-ui-kit/src/components/link/Link.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ElementType } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -12,35 +12,26 @@ import {
 
 import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 
-import { LinkProps } from '@/components/link/Link.props';
 import { useAuthorizationIam } from '@/hooks/iam/useOvhIam';
 
+import { LinkProps } from './Link.props';
 import { LinkIcons } from './LinkIcons.component';
 
-export const Link: React.FC<LinkProps> = ({
+export const Link = <T extends ElementType = 'a'>({
   children,
   type,
-  href,
-  className = '',
   iamActions,
   urn,
   disableIamCheck = false,
   displayTooltip = true,
-  ...props
-}) => {
+  ...odsLinkProps
+}: LinkProps<T>) => {
   const { t } = useTranslation(NAMESPACES.IAM);
   const { isAuthorized } = useAuthorizationIam(iamActions || [], urn || '', !disableIamCheck);
 
-  const getLinkProps = (isDisabled = false) => ({
-    className,
-    href,
-    disabled: isDisabled,
-    ...props,
-  });
-
   if (isAuthorized || iamActions === undefined) {
     return (
-      <OdsLink {...getLinkProps()}>
+      <OdsLink {...odsLinkProps}>
         <LinkIcons type={type}>{children}</LinkIcons>
       </OdsLink>
     );
@@ -48,7 +39,7 @@ export const Link: React.FC<LinkProps> = ({
 
   if (!displayTooltip) {
     return (
-      <OdsLink {...getLinkProps(true)}>
+      <OdsLink {...odsLinkProps} disabled={true}>
         <LinkIcons type={type}>{children}</LinkIcons>
       </OdsLink>
     );
@@ -57,7 +48,7 @@ export const Link: React.FC<LinkProps> = ({
   return (
     <Tooltip position={TOOLTIP_POSITION.bottom}>
       <TooltipTrigger asChild>
-        <OdsLink {...getLinkProps(true)} disabled={true}>
+        <OdsLink {...odsLinkProps} disabled={true}>
           <LinkIcons type={type}>{children}</LinkIcons>
         </OdsLink>
       </TooltipTrigger>

--- a/packages/manager-ui-kit/src/components/link/Link.props.ts
+++ b/packages/manager-ui-kit/src/components/link/Link.props.ts
@@ -1,6 +1,6 @@
-import { DOMAttributes, JSX, ReactNode } from 'react';
+import { ComponentPropsWithRef, ElementType, ReactNode } from 'react';
 
-import { LinkProp } from '@ovhcloud/ods-react';
+import { LinkProp as OdsLinkProp } from '@ovhcloud/ods-react';
 
 export enum LinkType {
   back = 'back',
@@ -8,23 +8,21 @@ export enum LinkType {
   external = 'external',
 }
 
-export interface LinkProps extends LinkProp, DOMAttributes<HTMLAnchorElement> {
-  className?: string;
-  download?: string;
-  label?: string;
-  children?: string | JSX.Element;
-  href?: string;
-  rel?: string;
-  target?: string;
+interface CustomLinkProps {
+  // Customization props
   type?: LinkType;
-  // Iam trigger
+  // IAM trigger props
   iamActions?: string[];
   urn?: string;
   displayTooltip?: boolean;
-  isIamTrigger?: boolean;
   disableIamCheck?: boolean;
 }
 
+export type LinkProps<T extends ElementType = 'a'> = CustomLinkProps &
+  OdsLinkProp<T> &
+  Omit<ComponentPropsWithRef<T>, keyof OdsLinkProp<T> | keyof CustomLinkProps>;
+
+// Icon props types
 type BackLinkProps = { type?: LinkType.back; children: ReactNode };
 type ExternalLinkProps = { type?: LinkType.external; children: ReactNode };
 type NextLinkProps = { type?: LinkType.next; children: ReactNode };


### PR DESCRIPTION
## Description

As detailed in [the ODS19 documentation](https://ovh.github.io/design-system/latest/?path=%2Fdocs%2Freact-components-link--technical-information#react-router-integration), the Link component has a polymorphism feature that enables the use of the `react-router` `RouterLink` component to implement client side navigation.

This feature is broken in the `MUK` `Link` component.

This PR fixes the types on the `Link` component to allow doing something like this:

```tsx 
import { type ComponentPropsWithRef } from 'react';

import { Link as RouterLink } from 'react-router-dom';

import { Link as MukLink, LinkProps as MukLinkProps, LinkType as MukLinkType } from '@ovh-ux/muk';

type InternalLinkProps = Omit<ComponentPropsWithRef<typeof RouterLink>, 'as'> & MukLinkProps;

/**
 * InternalLink
 * Wrapper around the design-system Link component that uses React Router for client-side navigation.
 */
export function InternalLink({ ...props }: InternalLinkProps) {
  return <MukLink as={RouterLink} {...props} />;
}
```

The core fix is in the code: 
```ts
export type LinkProps<T extends ElementType = 'a'> = CustomLinkProps &
  LinkProp<T> &
  Omit<ComponentPropsWithRef<T>, keyof LinkProp<T> | keyof CustomLinkProps>;
```

Which: 
- Adds a generic type to the `Link` component. And defaults it to 'a' if not provided. (`<T extends ElementType = 'a'>`)
- Adds the new props added with `MUK` (`CustomLinkProps`)
- Keeps the props of the `ODS` `Link` (`LinkProp<T>`)
- Adds the props of the generic component (ie: a or RouterLink), while omitting the ones already defined (`Omit<ComponentPropsWithRef<T>, keyof LinkProp<T> | keyof CustomLinkProps>`)