### PR TITLE
fix(pci-project): claim voucher twice when credits needed

### DIFF
--- a/packages/manager/apps/pci-project/src/pages/detail/activate/hooks/useActivateProject.tsx
+++ b/packages/manager/apps/pci-project/src/pages/detail/activate/hooks/useActivateProject.tsx
@@ -60,10 +60,14 @@ export const useProjectActivation = ({
   );
 
   const handleActivateProject = useCallback(
-    async ({ simulate = true, autoPay = true }: { simulate?: boolean; autoPay?: boolean } = {}) => {
+    async ({
+      simulate = true,
+      autoPay = true,
+      claimVoucher = true,
+    }: { simulate?: boolean; autoPay?: boolean; claimVoucher?: boolean } = {}) => {
       try {
         // Step 1: Claim voucher if we have a promotion amount
-        if (promotionVoucher) {
+        if (promotionVoucher && claimVoucher) {
           await claimDiscoveryVoucher({
             projectId,
             voucherCode: DISCOVERY_PROMOTION_VOUCHER,
@@ -124,7 +128,7 @@ export const useProjectActivation = ({
    * Handler for credit payment flow (when user needs to pay)
    */
   const handleCreditPayment = () => {
-    void handleActivateProject({ autoPay: false, simulate: false });
+    void handleActivateProject({ autoPay: false, simulate: false, claimVoucher: false });
   };
 
   const isSubmitting =


### PR DESCRIPTION
ref: #MANAGER-20735

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When credit deposit is required from the API we need to show a card to the user to warn him before we activate the project.
Once the user agrees and wants to validate the project we go through the validation process which claims the voucher a second time (it was already done during the first pass).
The fix skips this voucher claiming so that we continue where we left the process the first time.

<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
