### PR TITLE
fix(ips): allow byoip slices to show edge/game fw badges

### DIFF
--- a/packages/manager/apps/ips/src/pages/listing/ipListing/components/DatagridCells/IpEdgeFirewall/IpEdgeFirewall.tsx
+++ b/packages/manager/apps/ips/src/pages/listing/ipListing/components/DatagridCells/IpEdgeFirewall/IpEdgeFirewall.tsx
@@ -8,7 +8,6 @@ import { IpEdgeFirewallDisplay } from './IpEdgeFirewallDisplay';
 export type IpEdgeFirewallProps = {
   ip: string;
   ipOnFirewall?: string;
-  isByoipSlice?: boolean;
 };
 
 /**
@@ -20,19 +19,14 @@ export type IpEdgeFirewallProps = {
  * @param ip the ip with mask
  * @returns React component
  */
-export const IpEdgeFirewall = ({
-  ip,
-  ipOnFirewall,
-  isByoipSlice,
-}: IpEdgeFirewallProps) => {
+export const IpEdgeFirewall = ({ ip, ipOnFirewall }: IpEdgeFirewallProps) => {
   const { expiredIps } = useContext(ListingContext);
   const { isGroup, ipAddress } = ipFormatter(ip);
 
   const enabled = React.useMemo(
     () =>
       ((isGroup && !!ipOnFirewall) || !isGroup) &&
-      expiredIps.indexOf(ip) === -1 &&
-      !isByoipSlice,
+      expiredIps.indexOf(ip) === -1,
     [isGroup, ipOnFirewall, ip, expiredIps],
   );
 

--- a/packages/manager/apps/ips/src/pages/listing/ipListing/components/ipGroupDatagrid/ipGroupDatagrid.tsx
+++ b/packages/manager/apps/ips/src/pages/listing/ipListing/components/ipGroupDatagrid/ipGroupDatagrid.tsx
@@ -51,7 +51,10 @@ export const IpGroupDatagrid: React.FC<IpGroupDatagridProps> = ({
   const ipList = React.useMemo(() => {
     if (ipDetails?.bringYourOwnIp) {
       return (
-        slice?.find(({ slicingSize }) => slicingSize === 32)?.childrenIps || []
+        // get the /32 ips from the byoip slice and remove the mask
+        slice
+          ?.find(({ slicingSize }) => slicingSize === 32)
+          ?.childrenIps.map((ip) => ip.replace('/32', '')) || []
       );
     }
 

--- a/packages/manager/apps/ips/src/pages/listing/ipListing/components/ipGroupDatagrid/useIpGroupDatagridColumns.tsx
+++ b/packages/manager/apps/ips/src/pages/listing/ipListing/components/ipGroupDatagrid/useIpGroupDatagridColumns.tsx
@@ -122,13 +122,7 @@ export const useIpGroupDatagridColumns = ({
     {
       id: 'ip-edge-firewall',
       label: t('listingColumnsIpEdgeFirewall'),
-      cell: (ip: string) => (
-        <IpEdgeFirewall
-          ip={parentIp}
-          ipOnFirewall={ip}
-          isByoipSlice={isByoipSlice}
-        />
-      ),
+      cell: (ip: string) => <IpEdgeFirewall ip={parentIp} ipOnFirewall={ip} />,
       size: parentHeaders.current['ip-edge-firewall'].clientWidth,
     },
     {
@@ -138,7 +132,7 @@ export const useIpGroupDatagridColumns = ({
         <IpGameFirewallDisplay
           ip={parentIp}
           ipOnGame={ip}
-          enabled={isGameFirewallAvailable && !isByoipSlice}
+          enabled={isGameFirewallAvailable}
         />
       ),
       size: parentHeaders.current['ip-game-firewall'].clientWidth,


### PR DESCRIPTION
## Description
Added back BYOIP badges for Edge & Game Firewall. After the new release made on 5 January, with the new dashboard for IPs Management, BYOIP lost it's badges, being unable to configure the Game or Edge FW only through generated links.

So I took it personal, at 6 AM after a no sleep night and fix it myself, as I know it would take ages until it will be fixed.

Before:
<img width="1562" height="947" alt="image" src="https://github.com/user-attachments/assets/a7038caf-5413-4dee-b265-e40c08390e39" />

After:
<img width="1545" height="937" alt="image" src="https://github.com/user-attachments/assets/10dc2432-2f2e-4d13-bff8-0e48a36e5efb" />
