### PR TITLE
feat(ips): impl ip search within ip blocks/byoip

### DIFF
--- a/packages/manager/apps/ips/src/pages/listing/ipListing/components/IpDatagrid/IpDatagrid.tsx
+++ b/packages/manager/apps/ips/src/pages/listing/ipListing/components/IpDatagrid/IpDatagrid.tsx
@@ -9,7 +9,7 @@ import { ODS_TABLE_SIZE } from '@ovhcloud/ods-components';
 import { useGetIpList } from '@/data/hooks/ip';
 import { ListingContext } from '../../../listingContext';
 import { urls } from '@/routes/routes.constant';
-import { ipFormatter } from '@/utils';
+import { ipFormatter, isIpMatchingSearch } from '@/utils';
 import { IpGroupDatagrid } from '../ipGroupDatagrid/ipGroupDatagrid';
 import { useIpDatagridColumns } from './useIpDatagridColumns';
 
@@ -45,7 +45,7 @@ export const IpDatagrid = () => {
 
     // filter by apiFilter.ip if exists
     const filtered = apiFilter?.ip
-      ? uniqueIpList.filter((ip) => ip.includes(apiFilter.ip))
+      ? uniqueIpList.filter((ip) => isIpMatchingSearch(ip, apiFilter.ip))
       : uniqueIpList;
     setFilteredIpList(filtered);
     setPaginatedIpList(

--- a/packages/manager/apps/ips/src/utils/validators.spec.ts
+++ b/packages/manager/apps/ips/src/utils/validators.spec.ts
@@ -4,6 +4,7 @@ import {
   isValidDomain,
   isValidSubDomain,
   isValidReverseDomain,
+  isIpMatchingSearch,
 } from './validators';
 
 describe('isValidIpv4Block', () => {
@@ -160,6 +161,39 @@ describe('isValidReverseDomain', () => {
           canBeginWithWildcard,
         }),
       ).toBe(isValid);
+    },
+  );
+});
+
+describe('isIpMatchingSearch', () => {
+  it.each([
+    // Exact IP match
+    { block: '10.0.0.6', search: '10.0.0.6', expected: true },
+    { block: '10.0.0.6/32', search: '10.0.0.6', expected: true },
+    // Subnet containment (IP inside CIDR block)
+    { block: '10.0.0.0/27', search: '10.0.0.5', expected: true },
+    { block: '10.0.0.32/27', search: '10.0.0.33', expected: true },
+    // No false positives for similar IPs
+    { block: '10.0.0.64', search: '10.0.0.6', expected: false },
+    { block: '10.0.0.64/32', search: '10.0.0.6', expected: false },
+    { block: '10.0.0.0/27', search: '10.0.0.32', expected: false },
+    // Partial search (substring matching)
+    { block: '10.0.0.6', search: '10.0.0', expected: true },
+    { block: '10.0.0.64', search: '10.0.0', expected: true },
+    { block: '10.0.0.0/27', search: '10.0.0', expected: true },
+    // CIDR search (IP with mask)
+    { block: '10.0.0.0/27', search: '10.0.0.5/27', expected: true },
+    { block: '10.0.0.5', search: '10.0.0.5/27', expected: true },
+    // IP 10.0.0.66 is inside 10.0.0.64/27 (.64-.95)
+    { block: '10.0.0.64/27', search: '10.0.0.66/29', expected: true },
+    { block: '10.0.0.64', search: '10.0.0.6/27', expected: false },
+    // Non-matching cases
+    { block: '10.0.0.6', search: '192.168.1.1', expected: false },
+    { block: '10.0.0.0/27', search: '192.168.1.1', expected: false },
+  ])(
+    'isIpMatchingSearch($block, $search) => $expected',
+    ({ block, search, expected }) => {
+      expect(isIpMatchingSearch(block, search)).toBe(expected);
     },
   );
 });

--- a/packages/manager/apps/ips/src/utils/validators.ts
+++ b/packages/manager/apps/ips/src/utils/validators.ts
@@ -99,3 +99,22 @@ export function isValidReverseDomain(domain?: string, opts?: DomainOptions) {
     isValidDomain(domain.slice(0, domain.length - 2), opts)
   );
 }
+
+/**
+ * Check if an IP block matches a search term.
+ * - For complete IP searches: exact match or subnet containment
+ * - For CIDR searches (e.g. 10.0.0.5/27): extract IP and match
+ * - For partial searches: substring matching
+ */
+export function isIpMatchingSearch(block: string, ip: string): boolean {
+  const blockSplit = block?.split('/');
+  const ipSplit = ip?.split('/');
+
+  // If search contains a valid IP, use exact match + subnet check
+  if (isValidIpv4(ipSplit[0])) {
+    return blockSplit[0] === ipSplit[0] || isIpInsideBlock(block, ipSplit[0]);
+  }
+
+  // For partial searches, use substring matching
+  return block.includes(ip);
+}


### PR DESCRIPTION
## Description

Implemented IP search for BYOIP or OVH Subnet blocks.
In the past when you search for an IP within a subnet it would result in No result, making it difficult, if you don't remember the slices made.

## Additional Information
- Included tests for new validator function

## Preview:
<img width="1732" height="555" alt="image" src="https://github.com/user-attachments/assets/fadec82e-dcc2-4de5-8f65-5d10f68ade05" />
