### PR TITLE
feat(zimbra): datagrid top actions

### DIFF
--- a/packages/manager/apps/zimbra/public/translations/services/Messages_fr_FR.json
+++ b/packages/manager/apps/zimbra/public/translations/services/Messages_fr_FR.json
@@ -1,6 +1,7 @@
 {
-  "zimbra_services_cost": "Coût / boîte mail",
+  "zimbra_services_cost": "Coût / boîte email",
   "zimbra_services_linked_service": "Service lié",
   "zimbra_services_service_reference": "Référence du service",
-  "zimbra_services_renew_date": "Date de renouvellement"
+  "zimbra_services_renew_date": "Date de renouvellement",
+  "zimbra_services_free": "Gratuit"
 }

--- a/packages/manager/apps/zimbra/src/components/exportCsv/ExportCsv.component.tsx
+++ b/packages/manager/apps/zimbra/src/components/exportCsv/ExportCsv.component.tsx
@@ -16,8 +16,7 @@ import {
 
 import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import { ButtonType, PageLocation, useOvhTracking } from '@ovh-ux/manager-react-shell-client';
-import { useBytes, useNotifications } from '@ovh-ux/muk';
-import { Button } from '@ovh-ux/muk';
+import { Button, useBytes, useNotifications } from '@ovh-ux/muk';
 
 import { AccountType } from '@/data/api';
 import { SlotWithService, useAccounts, usePlatform, useSlotsWithService } from '@/data/hooks';
@@ -35,7 +34,7 @@ type ItemCSV = {
   slot: SlotWithService;
 };
 
-export const EmailAccountsExportCsv = () => {
+export const ExportCsv = () => {
   const { t } = useTranslation([
     'accounts',
     'common',
@@ -230,7 +229,7 @@ export const EmailAccountsExportCsv = () => {
       .map((slot) => {
         return {
           account: accounts.find((account) => account.currentState.slotId === slot.id),
-          slot: slot,
+          slot,
         };
       })
       .sort((a: ItemCSV, b: ItemCSV) => {

--- a/packages/manager/apps/zimbra/src/components/exportCsv/ExportCsv.spec.tsx
+++ b/packages/manager/apps/zimbra/src/components/exportCsv/ExportCsv.spec.tsx
@@ -4,11 +4,11 @@ import actionsCommonTranslation from '@ovh-ux/manager-common-translations/dist/@
 
 import { render } from '@/utils/test.provider';
 
-import { EmailAccountsExportCsv } from './EmailAccountsExportCsv.component';
+import { ExportCsv } from './ExportCsv.component';
 
-describe('EmailAccountsExportCsv Component', () => {
+describe('ExportCsv Component', () => {
   test('renders Export CSV button', () => {
-    const { getByTestId } = render(<EmailAccountsExportCsv />);
+    const { getByTestId } = render(<ExportCsv />);
     expect(getByTestId('export-csv')).toHaveTextContent(
       actionsCommonTranslation.export_as.replace('{{ format }}', 'CSV'),
     );

--- a/packages/manager/apps/zimbra/src/components/index.ts
+++ b/packages/manager/apps/zimbra/src/components/index.ts
@@ -12,3 +12,4 @@ export * from './loading/Loading.component';
 export * from './tabsPanel/TabsPanel.component';
 export * from './priceCard/PriceCard.component';
 export * from './totalPriceCard/TotalPriceCard.component';
+export * from './exportCsv/ExportCsv.component';

--- a/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/DatagridTopBar.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/emailAccounts/DatagridTopBar.component.tsx
@@ -26,6 +26,7 @@ import {
 } from '@ovh-ux/manager-react-shell-client';
 import { Button } from '@ovh-ux/muk';
 
+import { ExportCsv } from '@/components';
 import { useDomains, usePlatform } from '@/data/hooks';
 import { GUIDES_LIST } from '@/guides.constants';
 import { useAccountsStatistics, useGenerateUrl } from '@/hooks';
@@ -37,7 +38,6 @@ import {
 import { IAM_ACTIONS } from '@/utils/iamAction.constants';
 
 import { EmailAccountItem } from './EmailAccounts.types';
-import { EmailAccountsExportCsv } from './EmailAccountsExportCsv.component';
 
 export type DatagridTopbarProps = {
   selectedRows?: EmailAccountItem[];
@@ -171,6 +171,7 @@ export const DatagridTopbar: React.FC<DatagridTopbarProps> = ({
           <Icon name={ICON_NAME.externalLink} />
         </>
       </Button>
+      <ExportCsv />
       {!!selectedRows?.length && (
         <Button
           id="ovh-mail-delete-selected-btn"
@@ -184,9 +185,6 @@ export const DatagridTopbar: React.FC<DatagridTopbarProps> = ({
           </>
         </Button>
       )}
-      <div className="ml-auto">
-        <EmailAccountsExportCsv />
-      </div>
     </div>
   );
 };

--- a/packages/manager/apps/zimbra/src/pages/dashboard/services/DatagridTopBar.component.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/services/DatagridTopBar.component.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { useTranslation } from 'react-i18next';
+
+import { BUTTON_COLOR, BUTTON_SIZE, ICON_NAME, Icon } from '@ovhcloud/ods-react';
+
+import { ButtonType, PageLocation, useOvhTracking } from '@ovh-ux/manager-react-shell-client';
+import { Button } from '@ovh-ux/muk';
+
+import { ExportCsv } from '@/components';
+import { SlotWithService, useDomains, usePlatform } from '@/data/hooks';
+import { useAccountsStatistics, useGenerateUrl } from '@/hooks';
+import { ADD_EMAIL_ACCOUNT } from '@/tracking.constants';
+import { IAM_ACTIONS } from '@/utils/iamAction.constants';
+
+export type DatagridTopbarProps = {
+  selectedRows?: SlotWithService[];
+};
+
+export const DatagridTopbar: React.FC<DatagridTopbarProps> = () => {
+  const { t } = useTranslation(['accounts', 'common']);
+  const { trackClick } = useOvhTracking();
+  const navigate = useNavigate();
+
+  const { platformUrn } = usePlatform();
+  const { accountsStatistics } = useAccountsStatistics();
+
+  const { data: domains, isLoading: isLoadingDomains } = useDomains();
+
+  const hrefAddEmailAccount = useGenerateUrl('../email_accounts/add', 'path');
+
+  const hasAvailableAccounts = useMemo(() => {
+    return accountsStatistics
+      ?.map((stats) => {
+        return stats.availableAccountsCount > 0;
+      })
+      .some(Boolean);
+  }, [accountsStatistics]);
+
+  const canCreateAccount = !isLoadingDomains && !!domains?.length && hasAvailableAccounts;
+
+  const handleAddEmailAccountClick = () => {
+    trackClick({
+      location: PageLocation.page,
+      buttonType: ButtonType.button,
+      actionType: 'navigation',
+      actions: [ADD_EMAIL_ACCOUNT],
+    });
+    navigate(hrefAddEmailAccount);
+  };
+
+  return (
+    <div className="flex gap-6">
+      <Button
+        id="add-account-btn"
+        color={BUTTON_COLOR.primary}
+        size={BUTTON_SIZE.sm}
+        urn={platformUrn}
+        iamActions={[IAM_ACTIONS.account.create]}
+        onClick={handleAddEmailAccountClick}
+        data-testid="add-account-btn"
+        disabled={!canCreateAccount}
+      >
+        <>
+          <Icon name={ICON_NAME.plus} />
+          {t('zimbra_account_account_add')}
+        </>
+      </Button>
+      <ExportCsv />
+    </div>
+  );
+};
+
+export default DatagridTopbar;

--- a/packages/manager/apps/zimbra/src/pages/dashboard/services/DatagridTopbar.spec.tsx
+++ b/packages/manager/apps/zimbra/src/pages/dashboard/services/DatagridTopbar.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { describe, expect } from 'vitest';
+
+import accountTranslation from '@/public/translations/accounts/Messages_fr_FR.json';
+import { render } from '@/utils/test.provider';
+
+import Services from './Services.page';
+
+describe('Services DatagridTopbar component', () => {
+  it('should display correctly', () => {
+    const { getByTestId } = render(<Services />);
+
+    const addButton = getByTestId('add-account-btn');
+    expect(addButton).toHaveTextContent(accountTranslation.zimbra_account_account_add);
+  });
+});

--- a/packages/manager/apps/zimbra/src/utils/price.ts
+++ b/packages/manager/apps/zimbra/src/utils/price.ts
@@ -1,4 +1,4 @@
-import { IntervalUnit } from "@ovh-ux/muk";
+import { IntervalUnit } from '@ovh-ux/muk';
 
 export const getPriceUnit = (duration?: string) => {
   switch (duration) {


### PR DESCRIPTION
ref: #PRDCOL-334

## Description
In zimbra > Services page :
- manage search input.
- manage top bar with including create account button and csv export button.

<img width="2422" height="140" alt="image" src="https://github.com/user-attachments/assets/966a3614-c184-4146-8219-41d0c3555af0" />

