### PR TITLE
feat(vcfaas): generic way to handle async ressource operations for vrack

### DIFF
--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/package.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/package.json
@@ -42,6 +42,7 @@
     "i18next": "^23.8.2",
     "i18next-http-backend": "^2.4.3",
     "ipaddr.js": "^2.2.0",
+    "lodash": "^4.17.15",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.56.1",

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/datacentres/vrack-segment/Messages_fr_FR.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/datacentres/vrack-segment/Messages_fr_FR.json
@@ -34,5 +34,8 @@
   "managed_vcd_dashboard_vrack_status_error": "Erreur",
   "managed_vcd_dashboard_vrack_status_ready": "Actif",
   "managed_vcd_dashboard_vrack_status_suspended": "Suspendu",
-  "managed_vcd_dashboard_vrack_status_updating": "Mis à jour"
+  "managed_vcd_dashboard_vrack_status_updating": "Mis à jour",
+  "managed_vcd_dashboard_vrack_status_operation_in_progress": "Une opération est en cours sur le segment vRack {{vlanId}}. Veuillez patienter.",
+  "managed_vcd_dashboard_vrack_status_operation_completed": "Opération terminée avec succès pour le segment vRack {{vlanId}}.",
+  "managed_vcd_dashboard_vrack_status_operation_error": "Une erreur est survenue pour le segment vRack {{vlanId}}."
 }

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/vrackSegment/VrackSegmentDatagrid.component.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/vrackSegment/VrackSegmentDatagrid.component.tsx
@@ -15,6 +15,8 @@ import { useQuery } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { useListUpdatedOperationsStatus } from '@/hooks/updatedOperationStatus/useUpdatedOperationStatus';
+import { useListUpdatedOperationBanner } from '@/hooks/updatedOperationBanner/useListUpdatedOperationBanner';
 import {
   isStatusTerminated,
   useVcdOrganization,
@@ -95,6 +97,52 @@ export const VrackSegmentDatagrid = ({
 
   const hasExtraSegments =
     (vrackSegments?.length ?? 0) > VRACK_SEGMENTS_MIN_LENGTH;
+
+  const {
+    updatingResources,
+    completedResources,
+    erroredResources,
+  } = useListUpdatedOperationsStatus(vrackSegments, {
+    ignoreFields: ['type'],
+  });
+
+  useListUpdatedOperationBanner({
+    updatingResources,
+    completedResources,
+    erroredResources,
+    getUpdatingMessage: (updating) => {
+      const vrackSegment = vrackSegments?.find(
+        (item) => item.id === updating.id,
+      );
+      if (!vrackSegment) return null;
+      return t(
+        'datacentres/vrack-segment:managed_vcd_dashboard_vrack_status_operation_in_progress',
+        {
+          vlanId: vrackSegment.targetSpec.vlanId,
+        },
+      );
+    },
+    getCompletedMessage: (completed) => {
+      const segment = vrackSegments?.find((s) => s.id === completed.id);
+      if (!segment) return null;
+      return t(
+        'datacentres/vrack-segment:managed_vcd_dashboard_vrack_status_operation_completed',
+        {
+          vlanId: segment.targetSpec.vlanId,
+        },
+      );
+    },
+    getErroredMessage: (errored) => {
+      const segment = vrackSegments?.find((s) => s.id === errored.id);
+      if (!segment) return null;
+      return t(
+        'datacentres/vrack-segment:managed_vcd_dashboard_vrack_status_operation_error',
+        {
+          vlanId: segment.targetSpec.vlanId,
+        },
+      );
+    },
+  });
 
   const columns = [
     {

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/context/Message.context.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/context/Message.context.tsx
@@ -9,6 +9,8 @@ import React, {
   useState,
 } from 'react';
 
+export type MessageColor = OdsMessageColor;
+
 export type MessageOptions = {
   isDismissible?: boolean;
   includedSubRoutes?: string[];
@@ -27,6 +29,7 @@ type AddMessageProps = Omit<AddGenericMessageProps, 'type'>;
 
 export type MessageContextType = {
   messages: MessageType[];
+  addMessage: (props: AddGenericMessageProps) => number;
   addSuccess: (props: AddMessageProps) => number;
   addError: (props: AddMessageProps) => number;
   addWarning: (props: AddMessageProps) => number;
@@ -38,6 +41,7 @@ export type MessageContextType = {
 
 const MessageContext = createContext<MessageContextType>({
   messages: [],
+  addMessage: () => null,
   addSuccess: () => null,
   addError: () => null,
   addWarning: () => null,
@@ -70,6 +74,7 @@ export const MessageContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const messageContextValue: MessageContextType = useMemo(
     () => ({
       messages,
+      addMessage,
       addSuccess: (props) => addMessage({ type: 'success', ...props }),
       addError: (props) => addMessage({ type: 'danger', ...props }),
       addInfo: (props) => addMessage({ type: 'information', ...props }),

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationBanner/useListUpdatedOperationBanner.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationBanner/useListUpdatedOperationBanner.ts
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useMemo } from 'react';
+import { useMessageContext, MessageColor } from '@/context/Message.context';
+import {
+  UpdatingInfo,
+  ChangedFieldInfo,
+} from '@/hooks/updatedOperationStatus/updatedOperationStatus.types';
+
+type UseListUpdatedOperationBannerParams = {
+  updatingResources: UpdatingInfo[];
+  completedResources: UpdatingInfo[];
+  erroredResources: UpdatingInfo[];
+  getUpdatingMessage: (updating: ChangedFieldInfo) => string | null;
+  getCompletedMessage?: (completed: ChangedFieldInfo) => string | null;
+  getErroredMessage?: (errored: ChangedFieldInfo) => string | null;
+  updatingMessageType?: MessageColor;
+  completedMessageType?: MessageColor;
+  erroredMessageType?: MessageColor;
+};
+
+const flattenChangedFields = (items: UpdatingInfo[]): ChangedFieldInfo[] => {
+  const map = new Map<string, ChangedFieldInfo>();
+
+  items.forEach(({ id, changedFields }) => {
+    if (changedFields.length === 0) {
+      const key = `${id}:null`;
+      if (!map.has(key)) map.set(key, { id, changedField: null });
+    } else {
+      changedFields.forEach((field) => {
+        const key = `${id}:${field}`;
+        if (!map.has(key)) map.set(key, { id, changedField: field });
+      });
+    }
+  });
+
+  return Array.from(map.values());
+};
+
+export const useListUpdatedOperationBanner = ({
+  updatingResources,
+  completedResources,
+  erroredResources,
+  getUpdatingMessage,
+  getCompletedMessage,
+  getErroredMessage,
+  updatingMessageType = 'information',
+  completedMessageType = 'success',
+  erroredMessageType = 'danger',
+}: UseListUpdatedOperationBannerParams): void => {
+  const { addMessage, clearMessage } = useMessageContext();
+  const updatingMsgUidsRef = useRef<Map<string, number>>(new Map());
+
+  const hasCompletedResources = completedResources.length > 0;
+  const hasErroredResources = erroredResources.length > 0;
+
+  const updating = useMemo<ChangedFieldInfo[]>(
+    () => flattenChangedFields(updatingResources),
+    [updatingResources],
+  );
+
+  const completed = useMemo<ChangedFieldInfo[]>(
+    () => flattenChangedFields(completedResources),
+    [completedResources],
+  );
+
+  const errored = useMemo<ChangedFieldInfo[]>(
+    () => flattenChangedFields(erroredResources),
+    [erroredResources],
+  );
+
+  useEffect(() => {
+    const currentKeys = new Set(
+      updating.map((item) => `${item.id}:${item.changedField}`),
+    );
+
+    const shownMessages = new Set<string>();
+    updating.forEach((item) => {
+      const key = `${item.id}:${item.changedField}`;
+      if (!updatingMsgUidsRef.current.has(key)) {
+        const message = getUpdatingMessage(item);
+        if (message && !shownMessages.has(message)) {
+          shownMessages.add(message);
+          const msgId = addMessage({
+            type: updatingMessageType,
+            content: message,
+            isDismissible: false,
+          });
+          updatingMsgUidsRef.current.set(key, msgId);
+        }
+      }
+    });
+
+    // Clear banners for items that finished updating
+    updatingMsgUidsRef.current.forEach((msgId, key) => {
+      if (!currentKeys.has(key)) {
+        clearMessage(msgId);
+        updatingMsgUidsRef.current.delete(key);
+      }
+    });
+  }, [updating]);
+
+  useEffect(() => {
+    if (hasCompletedResources && getCompletedMessage) {
+      const shownMessages = new Set<string>();
+      completed.forEach((item) => {
+        const message = getCompletedMessage(item);
+        if (message && !shownMessages.has(message)) {
+          shownMessages.add(message);
+          addMessage({
+            type: completedMessageType,
+            content: message,
+            isDismissible: true,
+          });
+        }
+      });
+    }
+  }, [hasCompletedResources, completed]);
+
+  useEffect(() => {
+    if (hasErroredResources && getErroredMessage) {
+      const shownMessages = new Set<string>();
+      errored.forEach((item) => {
+        const message = getErroredMessage(item);
+        if (message && !shownMessages.has(message)) {
+          shownMessages.add(message);
+          addMessage({
+            type: erroredMessageType,
+            content: message,
+            isDismissible: true,
+          });
+        }
+      });
+    }
+  }, [hasErroredResources, errored]);
+};

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/updatedOperationStatus.types.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/updatedOperationStatus.types.ts
@@ -1,0 +1,17 @@
+export type UpdatingInfo = {
+  id: string;
+  changedFields: string[];
+};
+
+export type ChangedFieldInfo = {
+  id: string;
+  changedField: string | null;
+};
+
+export type OperationsStatusResult = {
+  updatingResources: UpdatingInfo[];
+  completedResources: UpdatingInfo[];
+  erroredResources: UpdatingInfo[];
+};
+
+export const UPDATING_STATUSES = ['UPDATING', 'CREATING', 'DELETING'] as const;

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/updatedOperationStatus.utils.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/updatedOperationStatus.utils.ts
@@ -1,0 +1,48 @@
+import isEqual from 'lodash/isEqual';
+import { UPDATING_STATUSES } from './updatedOperationStatus.types';
+import { BaseResource } from '@ovh-ux/manager-module-vcd-api';
+
+export const isResourceUpdating = <
+  T extends BaseResource<Record<string, unknown>>
+>(
+  item: T | undefined,
+): boolean => {
+  if (!item) return false;
+  return UPDATING_STATUSES.includes(
+    item.resourceStatus as typeof UPDATING_STATUSES[number],
+  );
+};
+
+export const getChangedFields = (
+  currentState: Record<string, unknown> | undefined,
+  targetSpec: Record<string, unknown> | undefined,
+  ignoreFields: string[] = [],
+): string[] => {
+  if (!currentState || !targetSpec) return [];
+
+  const allKeys = new Set([
+    ...Object.keys(currentState),
+    ...Object.keys(targetSpec),
+  ]);
+
+  const changedFields: string[] = [];
+  allKeys.forEach((key) => {
+    if (
+      !ignoreFields.includes(key) &&
+      !isEqual(currentState[key], targetSpec[key])
+    ) {
+      changedFields.push(key);
+    }
+  });
+
+  return changedFields;
+};
+
+export const findUpdatingItems = <
+  T extends BaseResource<Record<string, unknown>>
+>(
+  items: T[] | undefined,
+): T[] => {
+  if (!items) return [];
+  return items.filter((item) => isResourceUpdating(item));
+};

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/useUpdatedOperationStatus.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/hooks/updatedOperationStatus/useUpdatedOperationStatus.ts
@@ -1,0 +1,131 @@
+import { useMemo, useRef, useEffect } from 'react';
+import {
+  UpdatingInfo,
+  OperationsStatusResult,
+  UPDATING_STATUSES,
+} from './updatedOperationStatus.types';
+import { BaseResource } from '@ovh-ux/manager-module-vcd-api';
+import {
+  isResourceUpdating,
+  getChangedFields,
+} from './updatedOperationStatus.utils';
+
+type UpdateStatusOptions = {
+  ignoreFields?: string[];
+};
+
+type PrevStatusInfo = {
+  status: string;
+  changedFields: string[];
+};
+
+export const useUpdatedOperationStatus = <
+  T extends BaseResource<Record<string, unknown>>
+>(
+  item: T | undefined,
+  options: UpdateStatusOptions = {},
+): UpdatingInfo | null => {
+  const { ignoreFields = [] } = options;
+
+  return useMemo(() => {
+    if (!isResourceUpdating(item)) return null;
+
+    const changedFields = getChangedFields(
+      item.currentState as Record<string, unknown>,
+      item.targetSpec as Record<string, unknown>,
+      ignoreFields,
+    );
+
+    return {
+      id: item.id,
+      changedFields,
+    };
+  }, [item, ignoreFields]);
+};
+
+export const useListUpdatedOperationsStatus = <
+  T extends BaseResource<Record<string, unknown>>
+>(
+  items: T[] | undefined,
+  options: UpdateStatusOptions = {},
+): OperationsStatusResult => {
+  const { ignoreFields = [] } = options;
+
+  // Track previous statuses for transition detection
+  const prevStatusMapRef = useRef<Map<string, PrevStatusInfo>>(new Map());
+
+  const result = useMemo(() => {
+    const updatingResources: UpdatingInfo[] = [];
+    const completedResources: UpdatingInfo[] = [];
+    const erroredResources: UpdatingInfo[] = [];
+
+    if (!items) {
+      return { updatingResources, completedResources, erroredResources };
+    }
+
+    items.forEach((item) => {
+      const prev = prevStatusMapRef.current.get(item.id);
+      const currentStatus = item.resourceStatus;
+      const changedFields = getChangedFields(
+        item.currentState as Record<string, unknown>,
+        item.targetSpec as Record<string, unknown>,
+        ignoreFields,
+      );
+
+      // Currently updating
+      if (
+        UPDATING_STATUSES.includes(
+          currentStatus as typeof UPDATING_STATUSES[number],
+        )
+      ) {
+        updatingResources.push({ id: item.id, changedFields });
+      }
+
+      // Transitioned: UPDATING => READY
+      if (
+        prev &&
+        UPDATING_STATUSES.includes(
+          prev.status as typeof UPDATING_STATUSES[number],
+        ) &&
+        currentStatus === 'READY'
+      ) {
+        completedResources.push({
+          id: item.id,
+          changedFields: prev.changedFields,
+        });
+      }
+
+      // Transitioned: UPDATING => ERROR
+      if (
+        prev &&
+        UPDATING_STATUSES.includes(
+          prev.status as typeof UPDATING_STATUSES[number],
+        ) &&
+        currentStatus === 'ERROR'
+      ) {
+        erroredResources.push({
+          id: item.id,
+          changedFields: prev.changedFields,
+        });
+      }
+    });
+
+    return { updatingResources, completedResources, erroredResources };
+  }, [items, ignoreFields]);
+
+  useEffect(() => {
+    if (!items) return;
+    const newMap = new Map<string, PrevStatusInfo>();
+    items.forEach((item) => {
+      const changedFields = getChangedFields(
+        item.currentState as Record<string, unknown>,
+        item.targetSpec as Record<string, unknown>,
+        ignoreFields,
+      );
+      newMap.set(item.id, { status: item.resourceStatus, changedFields });
+    });
+    prevStatusMapRef.current = newMap;
+  }, [items, ignoreFields]);
+
+  return result;
+};

--- a/packages/manager/modules/vcd-api/src/types/base-resource.type.ts
+++ b/packages/manager/modules/vcd-api/src/types/base-resource.type.ts
@@ -1,0 +1,20 @@
+export type ResourceStatus =
+  | 'CREATING'
+  | 'DELETING'
+  | 'ERROR'
+  | 'READY'
+  | 'SUSPENDED'
+  | 'UPDATING';
+
+export type BaseResource<
+  TState extends Record<string, unknown>,
+  TSpec extends Record<string, unknown> = TState
+> = {
+  id: string;
+  resourceStatus: ResourceStatus;
+  currentState: TState;
+  targetSpec: TSpec;
+  currentTasks: unknown[];
+};
+
+// TODO all other types file should inherit from this type

--- a/packages/manager/modules/vcd-api/src/types/index.ts
+++ b/packages/manager/modules/vcd-api/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './base-resource.type';
 export * from './veeam-backup.type';
 export * from './veeam-backup-catalog.type';
 export * from './vcd-catalog.type';

--- a/packages/manager/modules/vcd-api/src/types/vcd-vrack-segment.type.ts
+++ b/packages/manager/modules/vcd-api/src/types/vcd-vrack-segment.type.ts
@@ -1,22 +1,12 @@
-export interface VCDVrackSegmentSpec {
+import { BaseResource, ResourceStatus } from './base-resource.type';
+
+export type VCDVrackSegmentSpec = {
   vlanId: string;
-  type: 'DEFAULT' | 'MIGRATED';
+  type?: 'DEFAULT' | 'MIGRATED';
   mode: 'TAGGED' | 'TRUNK' | 'UNTAGGED' | 'PUBLIC';
   networks: string[];
-}
+};
 
-export type VrackSegmentResourceStatus =
-  | 'CREATING'
-  | 'DELETING'
-  | 'ERROR'
-  | 'READY'
-  | 'SUSPENDED'
-  | 'UPDATING';
+export type VrackSegmentResourceStatus = ResourceStatus;
 
-export interface VCDVrackSegment {
-  id: string;
-  resourceStatus: VrackSegmentResourceStatus;
-  targetSpec: VCDVrackSegmentSpec;
-  currentState: VCDVrackSegmentSpec;
-  currentTasks: unknown[];
-}
+export type VCDVrackSegment = BaseResource<VCDVrackSegmentSpec>;


### PR DESCRIPTION
ref: #MANAGER-20708

# Handle background operations notifications of OVH api

## Context

OVH APIs return resources with `currentState`, `targetSpec`, `resourceStatus` (`UPDATING`, `READY`, `ERROR`, etc.), and `currentTask`.

## Goal

Display persistent notifications (between user sessions) for async operations:

- Show notification while `resourceStatus` is in progress (`UPDATING`, `CREATING`, `DELETING`) with reference to the resource and which field (first level only) is being updated between `currentState` and `targetSpec`
- Show final notification when resource transitions to `READY` or `ERROR` with reference to the resource and updated field

## Hooks

**`useListUpdatedOperationsStatus`** — Monitors resources and detects status transitions. Returns `updatingResources`, `completedResources`, and `erroredResources` (each containing resource id and changed fields - first level only).

**`useListUpdatedOperationBanner`** — Displays notification banners based on the above hook's output.

## Usage

```typescript
const { updatingResources, completedResources, erroredResources } = 
  useListUpdatedOperationsStatus(vrackSegments, { ignoreFields: ['type'] });

useListUpdatedOperationBanner({
  updatingResources,
  completedResources,
  erroredResources,
  getUpdatingMessage: (updating) => {
    const segment = vrackSegments?.find((s) => s.id === updating.id);
    if (!segment) return null;
    if (updating.changedField === 'vlanId') {
      return `VLAN ID update in progress: ${segment.currentState.vlanId} → ${segment.targetSpec.vlanId}`;
    }
    return `Operation in progress on vRack segment ${segment.targetSpec.vlanId}...`;
  },
  getCompletedMessage: (completed) => {
    const segment = vrackSegments?.find((s) => s.id === completed.id);
    if (!segment) return null;
    return `Operation completed on vRack segment ${segment.targetSpec.vlanId}.`;
  },
  getErroredMessage: (errored) => {
    const segment = vrackSegments?.find((s) => s.id === errored.id);
    if (!segment) return null;
    return `An error occurred on vRack segment ${segment.targetSpec.vlanId}.`;
  },
});
```

## Limitations

Relies on diffing `currentState` vs `targetSpec` to identify changed fields. These objects don't always accurately reflect the actual resource state due to API inconsistencies (raised with Backend team).