### PR TITLE
fix(network-vrack): fixing the crash of the vrack bandwidth page when any ip's region is null

### DIFF
--- a/packages/manager/apps/network-vrack/src/hooks/useGetEligibleServices.tsx
+++ b/packages/manager/apps/network-vrack/src/hooks/useGetEligibleServices.tsx
@@ -60,10 +60,10 @@ export const useGetEligibleServices = (serviceName: string = '', region: string)
 
   return {
     ipv4List: ipv4Results
-      .filter((result) => result.data?.regions.includes(region))
+      .filter((result) => result.data?.regions?.includes(region) ?? false)
       .map(({ data }) => data ?? defaultIpDetailValue),
     ipv6List: ipv6Results
-      .filter((result) => result.data?.regions.includes(region))
+      .filter((result) => result.data?.regions?.includes(region) ?? false)
       .map(({ data }) => data ?? defaultIpDetailValue),
     isComplete: data?.status !== 'pending',
     isLoading:


### PR DESCRIPTION

ref: #MANAGER-21445

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #MANAGER-21445

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
