### PR TITLE
fix(dedicated.download): open pdf in new tab to prevent cross origin …

### DIFF
--- a/packages/manager/apps/dedicated/client/app/download/download.controller.js
+++ b/packages/manager/apps/dedicated/client/app/download/download.controller.js
@@ -19,7 +19,10 @@ class DownloadCtrl {
       this.$stateParams.type,
       this.$stateParams.extension,
     )
-      .then((url) => this.$window.open(url, '_self'))
+      .then((url) => {
+        this.$window.open(url, '_blank', 'noopener');
+      })
+
       .catch((err) => {
         this.Alerter.error(this.$translate.instant('download_bill_error'));
         return this.$q.reject(err);


### PR DESCRIPTION
ref: #MANAGER-21462

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

Changed _self to _blank — the PDF will now open in a new tab by avoiding the cross-origin frame access error.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
