### PR TITLE
fix(bm-server-components): preserve all boolean inputs in OS install …

### DIFF
--- a/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
+++ b/packages/manager/modules/bm-server-components/src/general-information/installation/ovh/server-installation-ovh.controller.js
@@ -2156,7 +2156,7 @@ export default class ServerInstallationOvhCtrl {
   getCustomizations() {
     const customizations = {};
     Object.values(this.$scope.installation.inputs).forEach((input) => {
-      if (input.name === 'enableLacpBonding') {
+      if (input.type === 'boolean') {
         customizations[input.name] = !!this.$scope.installation.input[
           input.name
         ];


### PR DESCRIPTION
…customizations

Previous fix was scoped to enableLacpBonding by name. Replace name-based check with type-based check so all boolean inputs are preserved as native booleans in the API payload, not just enableLacpBonding. Future boolean inputs will be handled correctly without further changes.

ref: #PUBM-52327

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
