### PR TITLE
fix(billing-components): handle missing autorenewLink for US region r…

### DIFF
--- a/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
+++ b/packages/manager/modules/billing-components/src/components/utils/billing.links.service.js
@@ -95,12 +95,19 @@ export default class BillingLinksService {
         `${autorenewLink}/resiliation?serviceId=${service.id}&serviceName=${service.serviceId}${serviceTypeParam}`;
 
       if (this.coreConfig.isRegion('US')) {
-        if (service.serviceType !== 'VRACK')
+        if (service.serviceType !== 'VRACK') {
           // Currently vRack termination is not handled by backend for vRack
-          links.resiliateLink = this.buildResiliateModalLink(
-            autorenewLink,
-            service,
-          );
+          if (autorenewLink) {
+            links.resiliateLink = this.buildResiliateModalLink(
+              autorenewLink,
+              service,
+            );
+          } else if (service.serviceType === SERVICE_TYPE.VPS) {
+            links.resiliateLink = getResiliationLink && getResiliationLink();
+          } else if (service.canResiliateByEndRule()) {
+            links.resiliateLink = resiliationByEndRuleLink;
+          }
+        }
         return links;
       }
 


### PR DESCRIPTION
…esiliate link

ref: #MANAGER-21566

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

- Checking undefined autorenewLink before calling buildResiliateModalLink in the US region
- Fallback for VPS services to getResiliationLink coming from the main component
- Fallback to resilitation link for all services which are eligible for end-rule resilitation:



<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
