### PR TITLE
fix(telephony): manage translation keys in added value numbers

### DIFF
--- a/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/order/orderAlias/special/index.js
+++ b/packages/manager/apps/telecom/src/app/telecom/telephony/billingAccount/order/orderAlias/special/index.js
@@ -25,6 +25,6 @@ angular
     retractation,
   ])
   .config(routing)
-  .run(/* @ngTranslationsInject:json ./translations ./../../../alias/special/rsva/translations */);
+  .run(/* @ngTranslationsInject:json ./translations ./../../../../alias/special/rsva/translations */);
 
 export default moduleName;


### PR DESCRIPTION
ref: #PRDCOL-497

## Description
In Telecom > Order a number > Added-value numbers :
- Fix the translations listed in Type field.

