### PR TITLE
fix: Logs-to-Customer live-tail API parameters

### DIFF
--- a/packages/manager/modules/manager-pci-common/src/api/hook/useLogs.ts
+++ b/packages/manager/modules/manager-pci-common/src/api/hook/useLogs.ts
@@ -254,7 +254,7 @@ export function useTailLogs(
         };
       }[];
     }> =>
-      fetch(`${logsURL?.url}&sort=asc&limit=20`).then((response) =>
+      fetch(`${logsURL?.url}&limit=20`).then((response) =>
         response.json(),
       ),
     select: ({ messages: _msgs }) => _msgs?.map(({ message }) => message),


### PR DESCRIPTION
## Description

Logs-to-Customers live-tail API (`get.logs.ovh.com`) should not use the `sort=asc` query param. This cause displayed logs to be 5min late.

## Additional Information

Was already removed on other Logs-to-Customers live-tail modules (React/Angular), but was missed here
