### PR TITLE
fix(pci-object-storage): display Object Lock retention weeks as days

### DIFF
--- a/packages/manager/apps/pci-object-storage/src/lib/iso8601DurationHelper.spec.ts
+++ b/packages/manager/apps/pci-object-storage/src/lib/iso8601DurationHelper.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fromISO8601,
+  toISO8601,
+  isValidISO8601,
+  convertDuration,
+} from './iso8601DurationHelper';
+
+describe('iso8601DurationHelper', () => {
+  describe('fromISO8601', () => {
+    it('parses days', () => {
+      expect(fromISO8601('P8D')).toEqual({ value: 8, unit: 'D' });
+    });
+
+    it('parses months', () => {
+      expect(fromISO8601('P6M')).toEqual({ value: 6, unit: 'M' });
+    });
+
+    it('parses years', () => {
+      expect(fromISO8601('P1Y')).toEqual({ value: 1, unit: 'Y' });
+    });
+
+    // Regression: a 7-day retention is serialized as the ISO 8601 week form
+    // 'P1W' and previously fell back to the default '1 year' value.
+    it('normalizes weeks to days', () => {
+      expect(fromISO8601('P1W')).toEqual({ value: 7, unit: 'D' });
+      expect(fromISO8601('P3W')).toEqual({ value: 21, unit: 'D' });
+    });
+
+    it('returns the default value when period is missing', () => {
+      expect(fromISO8601()).toEqual({ value: 1, unit: 'Y' });
+    });
+
+    it('returns the default value when period is invalid', () => {
+      expect(fromISO8601('invalid')).toEqual({ value: 1, unit: 'Y' });
+    });
+
+    it('honors a custom default value', () => {
+      expect(fromISO8601(undefined, { value: 30, unit: 'D' })).toEqual({
+        value: 30,
+        unit: 'D',
+      });
+    });
+  });
+
+  describe('toISO8601', () => {
+    it('serializes a duration', () => {
+      expect(toISO8601(7, 'D')).toBe('P7D');
+      expect(toISO8601(1, 'Y')).toBe('P1Y');
+    });
+
+    it('throws for non-positive or non-integer values', () => {
+      expect(() => toISO8601(0, 'D')).toThrow();
+      expect(() => toISO8601(-1, 'Y')).toThrow();
+      expect(() => toISO8601(1.5, 'M')).toThrow();
+    });
+  });
+
+  describe('isValidISO8601', () => {
+    it('accepts days, weeks, months and years', () => {
+      expect(isValidISO8601('P7D')).toBe(true);
+      expect(isValidISO8601('P1W')).toBe(true);
+      expect(isValidISO8601('P6M')).toBe(true);
+      expect(isValidISO8601('P1Y')).toBe(true);
+    });
+
+    it('rejects invalid input', () => {
+      expect(isValidISO8601('invalid')).toBe(false);
+      expect(isValidISO8601('P1H')).toBe(false);
+    });
+  });
+
+  describe('convertDuration', () => {
+    it('converts years to days', () => {
+      expect(convertDuration({ value: 1, unit: 'Y' }, 'D')).toEqual({
+        value: 365,
+        unit: 'D',
+      });
+    });
+
+    it('converts days to months', () => {
+      expect(convertDuration({ value: 30, unit: 'D' }, 'M')).toEqual({
+        value: 1,
+        unit: 'M',
+      });
+    });
+
+    it('returns the same duration when units match', () => {
+      expect(convertDuration({ value: 7, unit: 'D' }, 'D')).toEqual({
+        value: 7,
+        unit: 'D',
+      });
+    });
+  });
+});

--- a/packages/manager/apps/pci-object-storage/src/lib/iso8601DurationHelper.ts
+++ b/packages/manager/apps/pci-object-storage/src/lib/iso8601DurationHelper.ts
@@ -13,13 +13,15 @@ export interface Duration {
 
 /**
  * Converts an ISO 8601 duration string to a value and unit object
- * Supports Days (D), Months (M), and Years (Y)
- * @param period - ISO 8601 duration string (e.g., 'P1Y', 'P30D', 'P6M')
+ * Supports Days (D), Weeks (W), Months (M), and Years (Y).
+ * Weeks are normalized to days (1W = 7D) since week is not a display unit.
+ * @param period - ISO 8601 duration string (e.g., 'P1Y', 'P30D', 'P6M', 'P1W')
  * @param defaultValue - Default duration to return if parsing fails (defaults to { value: 1, unit: 'Y' })
  * @returns Object with value and unit
  * @example
  * fromISO8601('P1Y') // { value: 1, unit: 'Y' }
  * fromISO8601('P30D') // { value: 30, unit: 'D' }
+ * fromISO8601('P1W') // { value: 7, unit: 'D' }
  * fromISO8601('invalid') // { value: 1, unit: 'Y' }
  */
 export const fromISO8601 = (
@@ -27,11 +29,18 @@ export const fromISO8601 = (
   defaultValue: Duration = { value: 1, unit: 'Y' },
 ): Duration => {
   if (!period) return defaultValue;
-  const match = period.match(/^P(\d+)([DMY])$/);
+  const match = period.match(/^P(\d+)([DWMY])$/);
   if (!match) return defaultValue;
 
+  const value = parseInt(match[1], 10);
+  // ISO 8601 represents an exact number of weeks (e.g. 7 days as 'P1W').
+  // Normalize to days since weeks are not a supported display unit.
+  if (match[2] === 'W') {
+    return { value: value * 7, unit: 'D' };
+  }
+
   const unit = match[2] as DurationUnit;
-  return { value: parseInt(match[1], 10), unit };
+  return { value, unit };
 };
 
 /**
@@ -58,10 +67,11 @@ export const toISO8601 = (value: number, unit: DurationUnit): string => {
  * @example
  * isValidISO8601('P1Y') // true
  * isValidISO8601('P30D') // true
+ * isValidISO8601('P1W') // true
  * isValidISO8601('invalid') // false
  */
 export const isValidISO8601 = (period: string): boolean => {
-  return /^P(\d+)([DMY])$/.test(period);
+  return /^P(\d+)([DWMY])$/.test(period);
 };
 
 /**


### PR DESCRIPTION
The Object Lock retention period was parsed with a regex accepting only D/M/Y units. A 7-day retention is serialized by the API as the ISO 8601 week form 'P1W', which did not match and fell back to the default '1 year' value, displaying "1 an" instead of "7 jours".

Parse the week unit and normalize it to days (1W = 7D), and accept it in the validator. Add unit tests covering the regression.

Closes #22840

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
