### PR TITLE
feat(container): hide mks load balancer navigation if empty

### DIFF
--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/navigation-tree/services/publicCloud.ts
@@ -341,7 +341,7 @@ pciNode.children = [
         },
         region: ['EU', 'CA'],
         features: ['load-balancer'],
-        forceVisibility: true,
+        hideIfEmpty: true,
       },
       {
         id: 'pci-kubernetes-load-balancer',
@@ -355,7 +355,7 @@ pciNode.children = [
         },
         region: ['US'],
         features: ['load-balancer'],
-        forceVisibility: true,
+        hideIfEmpty: true,
       },
     ],
   },


### PR DESCRIPTION
As per title the goal is to hide the navigation option when there is no load balancer resource present, account wide.

To be merged and prodded for 9th of July together with
- https://github.com/ovh/manager/pull/22883

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #TAPC-6823    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
