### PR TITLE
feat(container): hide load balancer for mks navigation

### DIFF
--- a/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/public-cloud/PublicCloudSidebar.tsx
+++ b/packages/manager/apps/container/src/container/legacy/server-sidebar/universe/public-cloud/PublicCloudSidebar.tsx
@@ -4,12 +4,15 @@ import { useTranslation } from 'react-i18next';
 import { useFeatureAvailability } from '@ovh-ux/manager-react-components';
 import { useLegacyContainer } from '@/container/legacy/legacy.context';
 import { useShell } from '@/context';
+import { usePublicCloudLoadBalancer } from '@/container/nav-reshuffle/data/hooks/publicCloudLoadBalancer/usePublicCloudLoadBalancer';
 import useProjects from './useProjects';
 import { features, getPciProjectMenu } from './pci-menu';
 import style from './pci-sidebar.module.scss';
 
 import ProjectIdCopy from './ProjectIdCopy';
 import ProjectCreateButton from './ProjectCreateButton';
+
+const LOAD_BALANCER_MENU_ID = 'load-balancer';
 
 export default function PublicCloudSidebar() {
   const location = useLocation();
@@ -27,9 +30,11 @@ export default function PublicCloudSidebar() {
   const projectId = currentProject?.project_id;
 
   const { data: availability } = useFeatureAvailability(features);
+  const { data: loadBalancers } = usePublicCloudLoadBalancer(projectId);
 
   const menu = useMemo(() => {
     if (!availability) return [];
+    const hasLoadBalancer = (loadBalancers?.length ?? 0) > 0;
     const menuItems = getPciProjectMenu(
       projectId,
       region,
@@ -39,14 +44,19 @@ export default function PublicCloudSidebar() {
     return menuItems
       .map((item) => ({
         ...item,
-        subItems: item.subItems?.map((item) => ({
-          ...item,
-          selected:
-            location?.pathname?.indexOf(item.href?.replace(/^.*#/, '')) >= 0,
-        })),
+        subItems: item.subItems
+          ?.filter(
+            (subItem) => subItem.id !== LOAD_BALANCER_MENU_ID || hasLoadBalancer,
+          )
+          .map((subItem) => ({
+            ...subItem,
+            selected:
+              location?.pathname?.indexOf(subItem.href?.replace(/^.*#/, '')) >=
+              0,
+          })),
       }))
       .filter((menu) => menu.subItems?.length > 0);
-  }, [availability, location, projectId, navigation]);
+  }, [availability, location, projectId, navigation, loadBalancers]);
 
   const onShowAllProjectClick = useCallback(() => setShowAllProjects(true), []);
   const onHideAllProjectClick = useCallback(() => {
@@ -114,7 +124,7 @@ export default function PublicCloudSidebar() {
         </h2>
 
         <a
-          className={`oui-button oui-button_secondary m-2 d-block ${style.whiteButtonSecondary}`}
+          className={`oui-button oui-button_secondary d-block m-2 ${style.whiteButtonSecondary}`}
           href={navigation.getURL('public-cloud', '#/pci/projects')}
           onClick={onHideAllProjectClick}
         >

--- a/packages/manager/apps/container/src/container/nav-reshuffle/data/api/publicCloudLoadBalancer.ts
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/data/api/publicCloudLoadBalancer.ts
@@ -1,0 +1,11 @@
+import { v6 } from '@ovh-ux/manager-core-api';
+
+export const getPublicCloudLoadBalancers = async (
+  projectId: string,
+): Promise<unknown[]> => {
+  const { data } = await v6.get<unknown[]>(
+    `/cloud/project/${projectId}/loadbalancer`,
+  );
+
+  return data ?? [];
+};

--- a/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/publicCloudLoadBalancer/usePublicCloudLoadBalancer.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/data/hooks/publicCloudLoadBalancer/usePublicCloudLoadBalancer.tsx
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPublicCloudLoadBalancers } from '@/container/nav-reshuffle/data/api/publicCloudLoadBalancer';
+
+export const usePublicCloudLoadBalancer = (projectId?: string) =>
+  useQuery({
+    queryKey: ['pci-load-balancers', projectId],
+    queryFn: () => getPublicCloudLoadBalancers(projectId),
+    enabled: !!projectId,
+    retry: false,
+  });

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/SubTree/PublicCloudPanel.tsx
@@ -19,6 +19,9 @@ import style from '../style.module.scss';
 import SubTreeSection from '@/container/nav-reshuffle/sidebar/SubTree/SubTreeSection';
 import { PUBLICCLOUD_UNIVERSE_ID } from '../navigation-tree/services/publicCloud';
 import { useDefaultPublicCloudProject } from '@/container/nav-reshuffle/data/hooks/defaultPublicCloudProject/useDefaultPublicCloudProject';
+import { usePublicCloudLoadBalancer } from '@/container/nav-reshuffle/data/hooks/publicCloudLoadBalancer/usePublicCloudLoadBalancer';
+
+const LOAD_BALANCER_NODE_ID = 'pci-kubernetes-load-balancer';
 
 export interface PublicCloudPanelProps {
   rootNode: Node;
@@ -88,6 +91,21 @@ export const PublicCloudPanel: React.FC<ComponentProps<
       !selectedPciProject &&
       !pciProjects,
   });
+
+  const { data: loadBalancers } = usePublicCloudLoadBalancer(
+    selectedPciProject?.project_id,
+  );
+
+  const navigationNodes = useMemo(() => {
+    const hasLoadBalancer = (loadBalancers?.length ?? 0) > 0;
+    const resolveNode = (node: Node): Node => ({
+      ...node,
+      hasService:
+        node.id === LOAD_BALANCER_NODE_ID ? hasLoadBalancer : node.hasService,
+      children: node.children?.map(resolveNode),
+    });
+    return rootNode.children?.map(resolveNode);
+  }, [rootNode.children, loadBalancers]);
 
   /** Watch URL changes to update selected menu dynamically */
   useEffect(() => {
@@ -193,12 +211,12 @@ export const PublicCloudPanel: React.FC<ComponentProps<
             </span>
 
             <span
-              className={`oui-icon oui-icon-copy px-1 mx-1 ml-auto ${style.sidebar_clipboard_copy}`}
+              className={`oui-icon oui-icon-copy mx-1 ml-auto px-1 ${style.sidebar_clipboard_copy}`}
             ></span>
           </button>
         )}
       </li>
-      <li className="px-3 mt-3 flex">
+      <li className="mt-3 flex px-3">
         <OsdsButton
           color={ODS_THEME_COLOR_INTENT.primary}
           type={ODS_BUTTON_TYPE.button}
@@ -214,7 +232,7 @@ export const PublicCloudPanel: React.FC<ComponentProps<
         </OsdsButton>
       </li>
       {selectedPciProject !== null &&
-        rootNode.children
+        navigationNodes
           ?.filter((childNode) => !shouldHideElement(childNode, childNode.hasService ?? true))
           .map((node) => (
             <li


### PR DESCRIPTION
It seems as though the "hideIfEmpty" property in pci nav tree configuration does not work for pci resources, hence why all are forced visible. This PR implements a quick workaround for the load balancer so we can control the EOS deprecation.
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #TAPC-6823   <!-- prefix each issue number with "#", if any  -->

## Additional Information
Will add on a revert from the following branch once it's merged in master
- #22951
<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
