### PR TITLE
feat(hpc-vmware-public-vcf-aas): VCDA migration tile, routing & data foundation

### DIFF
--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_de_DE.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_de_DE.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migration",
+    "cta": {
+      "order": "Bestellen",
+      "orderDisabledTooltip": {
+        "noPermission": "Sie sind nicht berechtigt, diesen Dienst zu bestellen."
+      }
+    },
+    "badge": {
+      "actif": "Aktiv",
+      "provisioning": "Wird bereitgestellt…",
+      "deleting": "Wird gelöscht…",
+      "suspended": "Ausgesetzt",
+      "error": "Fehler",
+      "updateInProgress": "Aktualisierung läuft"
+    },
+    "error": {
+      "fetch": "Status nicht verfügbar.",
+      "retry": "Erneut versuchen"
+    },
+    "ariaLabel": {
+      "active": "VCDA-Migration: aktiv",
+      "inactive": "VCDA-Migration: nicht aktiv. Klicken Sie auf Bestellen, um zu abonnieren.",
+      "provisioning": "VCDA-Migration: wird bereitgestellt."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_en_GB.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_en_GB.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migration",
+    "cta": {
+      "order": "Order",
+      "orderDisabledTooltip": {
+        "noPermission": "You do not have permission to order this service."
+      }
+    },
+    "badge": {
+      "actif": "Active",
+      "provisioning": "Provisioning…",
+      "deleting": "Deleting…",
+      "suspended": "Suspended",
+      "error": "Error",
+      "updateInProgress": "Update in progress"
+    },
+    "error": {
+      "fetch": "Status unavailable.",
+      "retry": "Retry"
+    },
+    "ariaLabel": {
+      "active": "VCDA migration: active",
+      "inactive": "VCDA migration: not active. Click Order to subscribe.",
+      "provisioning": "VCDA migration: provisioning."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_es_ES.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_es_ES.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migración",
+    "cta": {
+      "order": "Solicitar",
+      "orderDisabledTooltip": {
+        "noPermission": "No tiene permiso para solicitar este servicio."
+      }
+    },
+    "badge": {
+      "actif": "Activo",
+      "provisioning": "Aprovisionando…",
+      "deleting": "Eliminando…",
+      "suspended": "Suspendido",
+      "error": "Error",
+      "updateInProgress": "Actualización en curso"
+    },
+    "error": {
+      "fetch": "Estado no disponible.",
+      "retry": "Reintentar"
+    },
+    "ariaLabel": {
+      "active": "Migración VCDA: activa",
+      "inactive": "Migración VCDA: no activa. Haga clic en Solicitar para suscribirse.",
+      "provisioning": "Migración VCDA: aprovisionando."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_fr_CA.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_fr_CA.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migration",
+    "cta": {
+      "order": "Commander",
+      "orderDisabledTooltip": {
+        "noPermission": "Vous n'avez pas l'autorisation de commander ce service."
+      }
+    },
+    "badge": {
+      "actif": "Actif",
+      "provisioning": "Provisionnement…",
+      "deleting": "Suppression…",
+      "suspended": "Suspendu",
+      "error": "Erreur",
+      "updateInProgress": "Mise à jour en cours"
+    },
+    "error": {
+      "fetch": "Statut indisponible.",
+      "retry": "Réessayer"
+    },
+    "ariaLabel": {
+      "active": "Migration VCDA : active",
+      "inactive": "Migration VCDA : non active. Cliquez sur Commander pour souscrire.",
+      "provisioning": "Migration VCDA : provisionnement en cours."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Résilier le service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_fr_FR.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_fr_FR.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migration",
+    "cta": {
+      "order": "Commander",
+      "orderDisabledTooltip": {
+        "noPermission": "Vous n'avez pas l'autorisation de commander ce service."
+      }
+    },
+    "badge": {
+      "actif": "Actif",
+      "provisioning": "Provisionnement…",
+      "deleting": "Suppression…",
+      "suspended": "Suspendu",
+      "error": "Erreur",
+      "updateInProgress": "Mise à jour en cours"
+    },
+    "error": {
+      "fetch": "Statut indisponible.",
+      "retry": "Réessayer"
+    },
+    "ariaLabel": {
+      "active": "Migration VCDA : active",
+      "inactive": "Migration VCDA : non active. Cliquez sur Commander pour souscrire.",
+      "provisioning": "Migration VCDA : provisionnement en cours."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Résilier le service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_it_IT.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_it_IT.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migrazione",
+    "cta": {
+      "order": "Ordina",
+      "orderDisabledTooltip": {
+        "noPermission": "Non disponi dell'autorizzazione per ordinare questo servizio."
+      }
+    },
+    "badge": {
+      "actif": "Attivo",
+      "provisioning": "Provisioning in corso…",
+      "deleting": "Eliminazione in corso…",
+      "suspended": "Sospeso",
+      "error": "Errore",
+      "updateInProgress": "Aggiornamento in corso"
+    },
+    "error": {
+      "fetch": "Stato non disponibile.",
+      "retry": "Riprova"
+    },
+    "ariaLabel": {
+      "active": "Migrazione VCDA: attiva",
+      "inactive": "Migrazione VCDA: non attiva. Clicca su Ordina per sottoscrivere.",
+      "provisioning": "Migrazione VCDA: provisioning in corso."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_pl_PL.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_pl_PL.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migracja",
+    "cta": {
+      "order": "Zamów",
+      "orderDisabledTooltip": {
+        "noPermission": "Nie masz uprawnień do zamówienia tej usługi."
+      }
+    },
+    "badge": {
+      "actif": "Aktywna",
+      "provisioning": "Przygotowywanie…",
+      "deleting": "Usuwanie…",
+      "suspended": "Zawieszona",
+      "error": "Błąd",
+      "updateInProgress": "Aktualizacja w toku"
+    },
+    "error": {
+      "fetch": "Status niedostępny.",
+      "retry": "Ponów"
+    },
+    "ariaLabel": {
+      "active": "Migracja VCDA: aktywna",
+      "inactive": "Migracja VCDA: nieaktywna. Kliknij Zamów, aby wykupić usługę.",
+      "provisioning": "Migracja VCDA: przygotowywanie."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_pt_PT.json
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/public/translations/vcda/Messages_pt_PT.json
@@ -1,0 +1,31 @@
+{
+  "tile": {
+    "title": "Migração",
+    "cta": {
+      "order": "Encomendar",
+      "orderDisabledTooltip": {
+        "noPermission": "Não tem permissão para encomendar este serviço."
+      }
+    },
+    "badge": {
+      "actif": "Ativo",
+      "provisioning": "A aprovisionar…",
+      "deleting": "A eliminar…",
+      "suspended": "Suspenso",
+      "error": "Erro",
+      "updateInProgress": "Atualização em curso"
+    },
+    "error": {
+      "fetch": "Estado indisponível.",
+      "retry": "Tentar novamente"
+    },
+    "ariaLabel": {
+      "active": "Migração VCDA: ativa",
+      "inactive": "Migração VCDA: não ativa. Clique em Encomendar para subscrever.",
+      "provisioning": "Migração VCDA: a aprovisionar."
+    }
+  },
+  "serviceTermination": {
+    "cta": "Terminate service"
+  }
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/MigrationTile.component.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/MigrationTile.component.tsx
@@ -1,0 +1,112 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { DashboardTile } from '@ovh-ux/manager-react-components';
+import {
+  OdsBadge,
+  OdsButton,
+  OdsMessage,
+  OdsSkeleton,
+  OdsText,
+} from '@ovhcloud/ods-components/react';
+import {
+  ODS_BADGE_COLOR,
+  ODS_BUTTON_COLOR,
+  ODS_BUTTON_SIZE,
+  ODS_BUTTON_VARIANT,
+} from '@ovhcloud/ods-components';
+import { useVcdaStatus } from '@/data/hooks/vcda/useVcdaStatus.hook';
+import TEST_IDS from '@/utils/testIds.constants';
+import ComingSoonButton from './_components/ComingSoonButton.component';
+import ActiveBody from './_components/ActiveBody.component';
+
+const MIGRATION_TILE_ID = 'migration';
+
+export default function MigrationTile() {
+  const { t } = useTranslation('vcda');
+  const { id } = useParams();
+  const { data: status, isPending, isError, refetch } = useVcdaStatus(id);
+
+  const renderBody = () => {
+    if (isPending) {
+      return <OdsSkeleton data-testid={TEST_IDS.migrationTileSkeleton} />;
+    }
+
+    if (isError || !status) {
+      return (
+        <OdsMessage
+          color="critical"
+          isDismissible={false}
+          role="alert"
+          data-testid={TEST_IDS.migrationTileError}
+        >
+          <div className="flex items-center justify-between gap-4 w-full">
+            <OdsText>{t('tile.error.fetch')}</OdsText>
+            <OdsButton
+              data-testid={TEST_IDS.migrationTileRetryCta}
+              variant={ODS_BUTTON_VARIANT.ghost}
+              size={ODS_BUTTON_SIZE.sm}
+              label={t('tile.error.retry')}
+              onClick={() => refetch()}
+            />
+          </div>
+        </OdsMessage>
+      );
+    }
+
+    switch (status.kind) {
+      case 'inactive':
+        return (
+          <ComingSoonButton
+            triggerId="migration-tile-order"
+            label={t('tile.cta.order')}
+          />
+        );
+      case 'provisioning':
+        return (
+          <OdsBadge
+            color={ODS_BADGE_COLOR.information}
+            label={t('tile.badge.provisioning')}
+            aria-label={t('tile.ariaLabel.provisioning')}
+            data-testid={TEST_IDS.migrationTileProvisioningBadge}
+          />
+        );
+      case 'deleting':
+        return (
+          <div className="flex flex-col gap-3">
+            <OdsBadge
+              color={ODS_BADGE_COLOR.neutral}
+              label={t('tile.badge.deleting')}
+              data-testid={TEST_IDS.migrationTileDeletingBadge}
+            />
+            <ComingSoonButton
+              triggerId="migration-terminate"
+              label={t('serviceTermination.cta')}
+              color={ODS_BUTTON_COLOR.critical}
+            />
+          </div>
+        );
+      case 'active':
+      default:
+        return <ActiveBody status={status} />;
+    }
+  };
+
+  return (
+    <div className="h-fit">
+      <DashboardTile
+        title={t('tile.title')}
+        items={[
+          {
+            id: MIGRATION_TILE_ID,
+            label: t('tile.title'),
+            value: (
+              <div aria-live="polite" aria-busy={isPending}>
+                {renderBody()}
+              </div>
+            ),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/MigrationTile.spec.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/MigrationTile.spec.tsx
@@ -1,0 +1,202 @@
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, beforeAll } from 'vitest';
+import React from 'react';
+import { i18n } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  ShellContext,
+  ShellContextType,
+} from '@ovh-ux/manager-react-shell-client';
+import { useVcdOrganization } from '@ovh-ux/manager-module-vcd-api';
+import {
+  assertElementLabel,
+  assertElementVisibility,
+  getElementByTestId,
+  initTestI18n,
+} from '@ovh-ux/manager-core-test-utils';
+import userEvent from '@testing-library/user-event';
+import MigrationTile from './MigrationTile.component';
+import { useVcdaStatus } from '../../../data/hooks/vcda/useVcdaStatus.hook';
+import { labels, translations } from '../../../test-utils/test-i18n';
+import vcdaMessages from '../../../../public/translations/vcda/Messages_fr_FR.json';
+import TEST_IDS from '../../../utils/testIds.constants';
+import { APP_NAME } from '../../../tracking.constants';
+
+const navigateMock = vi.fn();
+const trackClickMock = vi.fn();
+const refetchMock = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const original: typeof import('react-router-dom') = await importOriginal();
+  return {
+    ...original,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ id: 'org-123' }),
+  };
+});
+
+vi.mock('@ovh-ux/manager-react-shell-client', async (importOriginal) => {
+  const original: typeof import('@ovh-ux/manager-react-shell-client') = await importOriginal();
+  return {
+    ...original,
+    useOvhTracking: () => ({ trackClick: trackClickMock }),
+  };
+});
+
+vi.mock('@ovh-ux/manager-module-vcd-api', async (importOriginal) => {
+  const original: typeof import('@ovh-ux/manager-module-vcd-api') = await importOriginal();
+  return {
+    ...original,
+    useVcdOrganization: vi.fn(),
+  };
+});
+
+vi.mock('../../../data/hooks/vcda/useVcdaStatus.hook', () => ({
+  useVcdaStatus: vi.fn(),
+}));
+
+vi.mock('@ovh-ux/manager-react-components', async (importOriginal) => {
+  const original: typeof import('@ovh-ux/manager-react-components') = await importOriginal();
+  return {
+    ...original,
+    ManagerButton: ({
+      label,
+      onClick,
+      'data-testid': dataTestId,
+      'aria-label': ariaLabel,
+    }: {
+      label: string;
+      onClick?: () => void;
+      'data-testid'?: string;
+      'aria-label'?: string;
+    }) =>
+      React.createElement('ods-button', {
+        label,
+        'data-testid': dataTestId,
+        'aria-label': ariaLabel,
+        onClick,
+      }),
+  };
+});
+
+let i18nState: i18n;
+
+const shellContext = {
+  shell: {
+    navigation: { getURL: vi.fn().mockResolvedValue('https://www.ovh.com') },
+  },
+};
+
+const mockStatus = (overrides: Partial<ReturnType<typeof useVcdaStatus>>) => {
+  vi.mocked(useVcdaStatus).mockReturnValue({
+    data: undefined,
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    refetch: refetchMock,
+    ...overrides,
+  });
+};
+
+const renderComponent = () => {
+  const queryClient = new QueryClient();
+  return render(
+    <I18nextProvider i18n={i18nState}>
+      <QueryClientProvider client={queryClient}>
+        <ShellContext.Provider
+          value={(shellContext as unknown) as ShellContextType}
+        >
+          <MigrationTile />
+        </ShellContext.Provider>
+      </QueryClientProvider>
+    </I18nextProvider>,
+  );
+};
+
+describe('MigrationTile', () => {
+  beforeAll(async () => {
+    i18nState = await initTestI18n(APP_NAME, translations);
+    i18nState.addResourceBundle('fr_FR', 'vcda', vcdaMessages, true, true);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useVcdOrganization).mockReturnValue({
+      data: { data: { iam: { urn: 'urn:org-123' } } },
+    } as ReturnType<typeof useVcdOrganization>);
+  });
+
+  it('renders the loading skeleton while the status is in flight', async () => {
+    mockStatus({ isPending: true });
+    renderComponent();
+    const skeleton = await getElementByTestId(TEST_IDS.migrationTileSkeleton);
+    await assertElementVisibility(skeleton);
+  });
+
+  it('renders the inline error with a retry action and refetches on click', async () => {
+    const user = userEvent.setup();
+    mockStatus({ isError: true });
+    renderComponent();
+
+    const error = await getElementByTestId(TEST_IDS.migrationTileError);
+    await assertElementVisibility(error);
+
+    const retry = await getElementByTestId(TEST_IDS.migrationTileRetryCta);
+    await act(() => user.click(retry));
+    expect(refetchMock).toHaveBeenCalled();
+  });
+
+
+  it('renders the provisioning badge for CREATING', async () => {
+    mockStatus({ data: { kind: 'provisioning' } });
+    renderComponent();
+    const badge = await getElementByTestId(
+      TEST_IDS.migrationTileProvisioningBadge,
+    );
+    await assertElementLabel({
+      element: badge,
+      label: labels.vcda.tile.badge.provisioning,
+    });
+  });
+
+  it('renders the deleting badge for DELETING', async () => {
+    mockStatus({ data: { kind: 'deleting' } });
+    renderComponent();
+    const badge = await getElementByTestId(TEST_IDS.migrationTileDeletingBadge);
+    await assertElementLabel({
+      element: badge,
+      label: labels.vcda.tile.badge.deleting,
+    });
+  });
+
+  it('renders the Actif badge for READY', async () => {
+    mockStatus({ data: { kind: 'active', resourceStatus: 'READY' } });
+    renderComponent();
+    const badge = await getElementByTestId(TEST_IDS.migrationTileStatusBadge);
+    await assertElementLabel({
+      element: badge,
+      label: labels.vcda.tile.badge.actif,
+    });
+  });
+
+  it('renders the Suspendu badge for SUSPENDED', async () => {
+    mockStatus({ data: { kind: 'active', resourceStatus: 'SUSPENDED' } });
+    renderComponent();
+    const badge = await getElementByTestId(TEST_IDS.migrationTileStatusBadge);
+    await assertElementLabel({
+      element: badge,
+      label: labels.vcda.tile.badge.suspended,
+    });
+  });
+
+  it('renders the Erreur badge for ERROR', async () => {
+    mockStatus({ data: { kind: 'active', resourceStatus: 'ERROR' } });
+    renderComponent();
+    const badge = await getElementByTestId(TEST_IDS.migrationTileStatusBadge);
+    await assertElementLabel({
+      element: badge,
+      label: labels.vcda.tile.badge.error,
+    });
+  });
+});

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/_components/ActiveBody.component.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/_components/ActiveBody.component.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next';
+import { OdsBadge, OdsText } from '@ovhcloud/ods-components/react';
+import { ODS_BADGE_COLOR, ODS_BUTTON_COLOR } from '@ovhcloud/ods-components';
+import {
+  VcdaResourceStatus,
+  VcdaTileStatus,
+} from '@ovh-ux/manager-module-vcd-api';
+import TEST_IDS from '@/utils/testIds.constants';
+import ComingSoonButton from './ComingSoonButton.component';
+
+type BadgeConfig = {
+  color: ODS_BADGE_COLOR;
+  labelKey: string;
+  ariaKey?: string;
+  captionKey?: string;
+};
+
+const STATUS_BADGE: Partial<Record<VcdaResourceStatus, BadgeConfig>> = {
+  SUSPENDED: {
+    color: ODS_BADGE_COLOR.warning,
+    labelKey: 'tile.badge.suspended',
+  },
+  ERROR: { color: ODS_BADGE_COLOR.critical, labelKey: 'tile.badge.error' },
+  UPDATING: {
+    color: ODS_BADGE_COLOR.success,
+    labelKey: 'tile.badge.actif',
+    ariaKey: 'tile.ariaLabel.active',
+    captionKey: 'tile.badge.updateInProgress',
+  },
+};
+
+const DEFAULT_BADGE: BadgeConfig = {
+  color: ODS_BADGE_COLOR.success,
+  labelKey: 'tile.badge.actif',
+  ariaKey: 'tile.ariaLabel.active',
+};
+
+export default function ActiveBody({
+  status,
+}: Readonly<{ status: VcdaTileStatus }>) {
+  const { t } = useTranslation('vcda');
+  if (status.kind !== 'active') return null;
+
+  const cfg = STATUS_BADGE[status.resourceStatus] ?? DEFAULT_BADGE;
+
+  const badge = (
+    <OdsBadge
+      color={cfg.color}
+      label={t(cfg.labelKey)}
+      aria-label={cfg.ariaKey ? t(cfg.ariaKey) : undefined}
+      data-testid={TEST_IDS.migrationTileStatusBadge}
+    />
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {cfg.captionKey ? (
+        <div className="flex flex-col gap-2">
+          {badge}
+          <OdsText preset="caption">{t(cfg.captionKey)}</OdsText>
+        </div>
+      ) : (
+        badge
+      )}
+      <ComingSoonButton
+        triggerId="migration-terminate"
+        label={t('serviceTermination.cta')}
+        color={ODS_BUTTON_COLOR.critical}
+      />
+    </div>
+  );
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/_components/ComingSoonButton.component.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/tiles/migration-tile/_components/ComingSoonButton.component.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { OdsButton, OdsTooltip } from '@ovhcloud/ods-components/react';
+import {
+  ODS_BUTTON_COLOR,
+  ODS_BUTTON_SIZE,
+  ODS_BUTTON_VARIANT,
+} from '@ovhcloud/ods-components';
+
+// Disabled placeholder CTA. The dashboard tile is complete & previewable, but the
+// Order and Terminate actions are wired by the order / service-termination feature
+// PRs — until then they are inert and flagged "coming soon" (not production-ready).
+export default function ComingSoonButton({
+  triggerId,
+  label,
+  color,
+}: Readonly<{
+  triggerId: string;
+  label: string;
+  color?: ODS_BUTTON_COLOR;
+}>) {
+  const { t: tDashboard } = useTranslation('dashboard');
+  return (
+    <>
+      <OdsButton
+        id={triggerId}
+        variant={ODS_BUTTON_VARIANT.ghost}
+        size={ODS_BUTTON_SIZE.sm}
+        color={color}
+        label={label}
+        isDisabled
+      />
+      <OdsTooltip triggerId={triggerId}>
+        {tDashboard('managed_vcd_dashboard_coming_soon')}
+      </OdsTooltip>
+    </>
+  );
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/vcda/VcdaFeatureGuard.component.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/components/vcda/VcdaFeatureGuard.component.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  RedirectionGuard,
+  useFeatureAvailability,
+} from '@ovh-ux/manager-react-components';
+import { FEATURES } from '@/utils/features.constants';
+import { urls } from '@/routes/routes.constant';
+
+export default function VcdaFeatureGuard({
+  children,
+}: Readonly<PropsWithChildren>) {
+  const { id } = useParams();
+  const { data: features, isLoading } = useFeatureAvailability([
+    FEATURES.HPC_VCFAAS_VCDA,
+  ]);
+
+  return (
+    <RedirectionGuard
+      route={urls.dashboard.replace(':id', id ?? '')}
+      isLoading={isLoading}
+      condition={!features?.[FEATURES.HPC_VCFAAS_VCDA]}
+    >
+      {children}
+    </RedirectionGuard>
+  );
+}

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/data/hooks/vcda/useVcdaStatus.hook.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/data/hooks/vcda/useVcdaStatus.hook.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getVcdaMigrationList,
+  matchesVcdaOrg,
+  PublicVcda,
+  VcdaResourceStatus,
+  VcdaTileStatus,
+} from '@ovh-ux/manager-module-vcd-api';
+
+export const getVcdaStatusQueryKey = (orgId: string) => [
+  'public-vcf',
+  orgId,
+  'vcda-status',
+];
+
+const POLLED_STATUSES: VcdaResourceStatus[] = [
+  'CREATING',
+  'UPDATING',
+  'DELETING',
+];
+
+export const deriveTileStatus = (
+  entity: PublicVcda | undefined,
+): VcdaTileStatus => {
+  if (!entity) {
+    return { kind: 'inactive' };
+  }
+  switch (entity.resourceStatus) {
+    case 'CREATING':
+      return { kind: 'provisioning' };
+    case 'DELETING':
+      return { kind: 'deleting' };
+    default:
+      return { kind: 'active', resourceStatus: entity.resourceStatus };
+  }
+};
+
+export interface UseVcdaStatusResult {
+  data: VcdaTileStatus | undefined;
+  isPending: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+export const useVcdaStatus = (
+  orgId: string,
+  enabled = true,
+): UseVcdaStatusResult => {
+  const { data, isPending, isLoading, isError, refetch } = useQuery({
+    queryKey: getVcdaStatusQueryKey(orgId),
+    queryFn: getVcdaMigrationList,
+    enabled: enabled && !!orgId,
+    staleTime: 30_000,
+    select: (migrations: PublicVcda[]) =>
+      deriveTileStatus(
+        migrations.find((migration) =>
+          matchesVcdaOrg(migration.currentState?.organizationId, orgId),
+        ),
+      ),
+    refetchInterval: (query) => {
+      const matched = query.state.data?.find((migration) =>
+        matchesVcdaOrg(migration.currentState?.organizationId, orgId),
+      );
+      return matched && POLLED_STATUSES.includes(matched.resourceStatus)
+        ? 30_000
+        : false;
+    },
+  });
+
+  return { data, isPending, isLoading, isError, refetch };
+};

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/data/hooks/vcda/useVcdaStatus.spec.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/data/hooks/vcda/useVcdaStatus.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTileStatus, getVcdaStatusQueryKey } from './useVcdaStatus.hook';
+import { PublicVcda, VcdaResourceStatus } from '@ovh-ux/manager-module-vcd-api';
+
+const makeEntity = (resourceStatus: VcdaResourceStatus): PublicVcda => ({
+  id: 'mig-1',
+  resourceStatus,
+  currentState: { organizationId: 'org-123' },
+  targetSpec: { ips: [] },
+  createdAt: '2026-06-01',
+  updatedAt: '2026-06-01',
+});
+
+describe('useVcdaStatus query key', () => {
+  it('builds a hierarchical key scoped to the org', () => {
+    expect(getVcdaStatusQueryKey('org-123')).toEqual([
+      'public-vcf',
+      'org-123',
+      'vcda-status',
+    ]);
+  });
+});
+
+describe('deriveTileStatus (R6bis / R8 mapping)', () => {
+  it('maps an absent org to inactive', () => {
+    expect(deriveTileStatus(undefined)).toEqual({ kind: 'inactive' });
+  });
+
+  it('maps CREATING to provisioning', () => {
+    expect(deriveTileStatus(makeEntity('CREATING'))).toEqual({
+      kind: 'provisioning',
+    });
+  });
+
+  it('maps DELETING to deleting', () => {
+    expect(deriveTileStatus(makeEntity('DELETING'))).toEqual({
+      kind: 'deleting',
+    });
+  });
+
+  it.each(['READY', 'UPDATING', 'SUSPENDED', 'ERROR'] as VcdaResourceStatus[])(
+    'maps %s to active with its resourceStatus',
+    (resourceStatus) => {
+      expect(deriveTileStatus(makeEntity(resourceStatus))).toEqual({
+        kind: 'active',
+        resourceStatus,
+      });
+    },
+  );
+});

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/index.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/index.tsx
@@ -32,7 +32,7 @@ const init = async (appName: string) => {
     context,
     reloadOnLocaleChange: true,
     defaultNS: appName,
-    ns: ['listing', 'dashboard', 'onboarding'],
+    ns: ['listing', 'dashboard', 'onboarding', 'vcda'],
   });
 
   const region = context.environment.getRegion();

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/pages/dashboard/organization/general-information/OrganizationGeneralInformation.page.tsx
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/pages/dashboard/organization/general-information/OrganizationGeneralInformation.page.tsx
@@ -3,12 +3,15 @@ import {
   isStatusTerminated,
   useVcdOrganization,
 } from '@ovh-ux/manager-module-vcd-api';
+import { useFeatureAvailability } from '@ovh-ux/manager-react-components';
 import Errors from '@/components/error/Error.component';
 import Loading from '@/components/loading/Loading.component';
 import OrganizationGenerationInformationTile from '@/components/tiles/organization-general-information-tile/OrganizationGeneralInformationTile.component';
 import OrganizationOptionsTile from '@/components/tiles/organization-options-tile/OrganizationOptionsTile.component';
 import OrganizationDataProtectionTile from '@/components/tiles/organization-data-tile/OrganizationDataProtectionTile.component';
 import OrganizationServiceManagementTile from '@/components/tiles/organization-service-tile/OrganizationServiceManagementTile.component';
+import MigrationTile from '@/components/tiles/migration-tile/MigrationTile.component';
+import { FEATURES } from '@/utils/features.constants';
 
 export default function GeneralInformation() {
   const { id } = useParams();
@@ -22,6 +25,8 @@ export default function GeneralInformation() {
     id,
     refetchInterval: 60 * 1000,
   });
+  const { data: features } = useFeatureAvailability([FEATURES.HPC_VCFAAS_VCDA]);
+  const isVcdaEnabled = !!features?.[FEATURES.HPC_VCFAAS_VCDA];
 
   if (isError || isRefetchError) {
     return <Errors error={error?.response} />;
@@ -48,6 +53,7 @@ export default function GeneralInformation() {
         <OrganizationDataProtectionTile
           vcdOrganization={vcdOrganization.data}
         />
+        {isVcdaEnabled && <MigrationTile />}
       </div>
       <OrganizationServiceManagementTile />
       <Outlet />

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/test-utils/test-i18n.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/test-utils/test-i18n.ts
@@ -9,6 +9,7 @@ import datacentresVrackSegment from '../../public/translations/datacentres/vrack
 import terminate from '../../public/translations/terminate/Messages_fr_FR.json';
 import networkAcl from '../../public/translations/networkAcl/Messages_fr_FR.json';
 import zodError from '../../public/translations/zodError/Messages_fr_FR.json';
+import vcda from '../../public/translations/vcda/Messages_fr_FR.json';
 
 const error = {
   manager_error_page_title: 'Oops …!',
@@ -89,4 +90,5 @@ export const labels = {
   networkAcl,
   commun,
   zodError,
+  vcda,
 };

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/utils/features.constants.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/utils/features.constants.ts
@@ -3,4 +3,5 @@ import { APP_NAME } from '@/tracking.constants';
 export const FEATURES = {
   APP: APP_NAME,
   COMPUTE_SPECIAL_OFFER_BANNER: `${APP_NAME}:compute-special-offer-banner`,
+  HPC_VCFAAS_VCDA: `${APP_NAME}:vcda`,
 };

--- a/packages/manager/apps/hpc-vmware-public-vcf-aas/src/utils/testIds.constants.ts
+++ b/packages/manager/apps/hpc-vmware-public-vcf-aas/src/utils/testIds.constants.ts
@@ -20,6 +20,12 @@ const TEST_IDS = {
   networkAclCta: 'network-acl-cta',
   networkAclAddCurrentIpAction: 'add-current-ip-button',
   networkAclfromAnywhereIpAction: 'from-anywhere-ip-button',
+  migrationTileStatusBadge: 'migration-tile-status-badge',
+  migrationTileProvisioningBadge: 'migration-tile-provisioning-badge',
+  migrationTileDeletingBadge: 'migration-tile-deleting-badge',
+  migrationTileSkeleton: 'migration-tile-skeleton',
+  migrationTileError: 'migration-tile-error',
+  migrationTileRetryCta: 'migration-tile-retry-cta',
 } as const;
 
 export default TEST_IDS;

--- a/packages/manager/modules/vcd-api/src/api/index.ts
+++ b/packages/manager/modules/vcd-api/src/api/index.ts
@@ -4,3 +4,5 @@ export * from './vcd-organization';
 export * from './vcd-reset-password';
 export * from './veeam-backup';
 export * from './vcd-network-acl';
+export * from './vcda-migration';
+export * from './vcda-migration-order';

--- a/packages/manager/modules/vcd-api/src/api/vcda-migration-order.ts
+++ b/packages/manager/modules/vcd-api/src/api/vcda-migration-order.ts
@@ -1,0 +1,87 @@
+import {
+  createCart,
+  postOrderCartCartIdCheckout,
+} from '@ovh-ux/manager-module-order';
+import { VCDOrganization } from '../types';
+
+export const VCDA_ORDER = {
+  PLAN_CODE: 'vcda-migration',
+  PRODUCT_FAMILY: 'vcdaMigration',
+  PRICING_MODE: 'default',
+  DURATION: 'P1M',
+  QUANTITY: 1,
+} as const;
+
+export const VCDA_ORDER_CONFIG_LABEL = {
+  ORG_ID: 'org-id',
+  EXTERNAL_IPS: 'external-ips',
+  DATACENTER_ZONE: 'datacenter-zone',
+} as const;
+
+export interface OrderVcdaConfig {
+  orgId: string;
+  externalIp: string;
+  datacenterZone: string;
+}
+
+export type SubmitVcdaOrderParams = {
+  ovhSubsidiary: string;
+  config: OrderVcdaConfig;
+};
+
+export type VcdaContract = {
+  name: string;
+  url: string;
+  content?: string;
+};
+
+export type PreparedVcdaOrder = {
+  cartId: string;
+  contractList: VcdaContract[];
+};
+
+export const getVcdaDatacenterZone = (organization?: VCDOrganization): string =>
+  organization?.currentState?.region?.toLowerCase() ?? '';
+
+export const prepareVcdaOrder = async ({
+  ovhSubsidiary,
+  config,
+}: SubmitVcdaOrderParams): Promise<PreparedVcdaOrder> => {
+  const { cartId, contractList } = await createCart({
+    ovhSubsidiary,
+    items: [
+      {
+        itemEndpoint: VCDA_ORDER.PRODUCT_FAMILY,
+        options: {
+          planCode: VCDA_ORDER.PLAN_CODE,
+          pricingMode: VCDA_ORDER.PRICING_MODE,
+          duration: VCDA_ORDER.DURATION,
+          quantity: VCDA_ORDER.QUANTITY,
+        },
+        configurations: [
+          { label: VCDA_ORDER_CONFIG_LABEL.ORG_ID, value: config.orgId },
+          {
+            label: VCDA_ORDER_CONFIG_LABEL.EXTERNAL_IPS,
+            value: config.externalIp,
+          },
+          {
+            label: VCDA_ORDER_CONFIG_LABEL.DATACENTER_ZONE,
+            value: config.datacenterZone,
+          },
+        ],
+      },
+    ],
+  });
+
+  return { cartId, contractList: contractList ?? [] };
+};
+
+export const checkoutVcdaOrder = async (cartId: string) => {
+  const { data } = await postOrderCartCartIdCheckout({
+    cartId,
+    autoPayWithPreferredPaymentMethod: true,
+    waiveRetractationPeriod: true,
+  });
+
+  return data;
+};

--- a/packages/manager/modules/vcd-api/src/api/vcda-migration.ts
+++ b/packages/manager/modules/vcd-api/src/api/vcda-migration.ts
@@ -1,0 +1,24 @@
+import { ApiResponse, apiClient } from '@ovh-ux/manager-core-api';
+import { PublicVcda, PublicVcdaTargetSpec } from '../types/vcda-migration.type';
+
+export const VCDA_MIGRATION_ROUTE = '/vmwareCloudDirector/migration';
+
+export const getVcdaMigrationList = async (): Promise<PublicVcda[]> => {
+  const { data } = await apiClient.v2.get<PublicVcda[]>(VCDA_MIGRATION_ROUTE);
+  return data;
+};
+
+export const getVcdaMigration = async (
+  migrationId: string,
+): Promise<PublicVcda> => {
+  const { data } = await apiClient.v2.get<PublicVcda>(
+    `${VCDA_MIGRATION_ROUTE}/${migrationId}`,
+  );
+  return data;
+};
+
+export const updateVcdaMigrationWhitelist = (
+  migrationId: string,
+  targetSpec: PublicVcdaTargetSpec,
+): Promise<ApiResponse<PublicVcda>> =>
+  apiClient.v2.put(`${VCDA_MIGRATION_ROUTE}/${migrationId}`, { targetSpec });

--- a/packages/manager/modules/vcd-api/src/types/index.ts
+++ b/packages/manager/modules/vcd-api/src/types/index.ts
@@ -10,3 +10,4 @@ export * from './vcd-storage.type';
 export * from './vcd-utility.type';
 export * from './vcd-vrack-segment.type';
 export * from './vcd-network-acl.type';
+export * from './vcda-migration.type';

--- a/packages/manager/modules/vcd-api/src/types/vcda-migration.type.ts
+++ b/packages/manager/modules/vcd-api/src/types/vcda-migration.type.ts
@@ -1,0 +1,54 @@
+export type VcdaResourceStatus =
+  | 'CREATING'
+  | 'READY'
+  | 'UPDATING'
+  | 'DELETING'
+  | 'SUSPENDED'
+  | 'ERROR'
+  | 'OUT_OF_SYNC'
+  | 'UNKNOWN';
+
+export interface PublicCurrentTask {
+  id: string;
+  status: string;
+  type?: string;
+}
+
+export interface PublicVcdaCurrentState {
+  organizationId: string;
+  migrationCloudUrl?: string;
+  ips?: string[];
+  azName?: string;
+  id?: string;
+}
+
+export interface PublicVcdaTargetSpec {
+  ips: string[];
+}
+
+export interface PublicVcda {
+  id: string;
+  resourceStatus: VcdaResourceStatus;
+  currentState: PublicVcdaCurrentState;
+  currentTasks?: PublicCurrentTask[] | null;
+  targetSpec: PublicVcdaTargetSpec;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VcdaWhitelistEntry {
+  ip: string;
+}
+
+export type VcdaTileStatus =
+  | { kind: 'inactive' }
+  | { kind: 'provisioning' }
+  | { kind: 'deleting' }
+  | { kind: 'active'; resourceStatus: VcdaResourceStatus };
+
+export const matchesVcdaOrg = (
+  organizationId: string | undefined,
+  routeOrgId: string,
+): boolean =>
+  !!organizationId &&
+  (organizationId === routeOrgId || routeOrgId.endsWith(`-${organizationId}`));


### PR DESCRIPTION
Part 1/4 of the VCDA migration stack (base of the stack → `feat/vcda`).

Adds the VCDA migration entry point on the Public VCF organization dashboard: a feature-flagged migration tile, the VCDA status read (`useVcdaStatus`) and the shared foundation — route constants, types, data API, IAM/feature constants, tracking, test-ids and i18n.

Spec: vcda/dashboard-tile. Stack: dashboard-tile → migration-tab → order → service-termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)