### PR TITLE
fix(module-federation): update WillPayment URLs from /order/payment/ to /payment/

### DIFF
--- a/packages/manager/apps/pci-project/src/utils/module-federation-runtime.ts
+++ b/packages/manager/apps/pci-project/src/utils/module-federation-runtime.ts
@@ -5,15 +5,16 @@ import { isLabeuEnvironment, isProdEnvironment } from './environment';
 export { isProdEnvironment };
 
 const getWillPaymentUrl = (): string => {
-  /** In preprod and prod environments, use a relative path to mitigate potential DDOS attacks */
-  if (isProdEnvironment()) {
-    return '/order/payment/assets/remoteEntry.js';
+  // ISO date prefix truncated to the minute: "2026-06-26T14:30"
+  // Used as CDN cache-busting query parameter (duplicated from Manager/billing pattern)
+  const minute = new Date().toISOString().slice(0, 16);
+
+  /** In known OVHcloud environments (production and labeu), use a relative path to mitigate potential DDOS attacks */
+  if (isProdEnvironment() || isLabeuEnvironment()) {
+    return `/payment/assets/remoteEntry.js?v=${minute}`;
   }
 
-  return (
-    (isLabeuEnvironment() && import.meta.env.VITE_WP_LABEU_ENTRY_POINT) ||
-    'https://www.ovhcloud.com/order/payment/assets/remoteEntry.js'
-  );
+  return `https://www.ovhcloud.com/payment/assets/remoteEntry.js?v=${minute}`;
 };
 
 /**

--- a/packages/manager/modules/billing/src/common/module-federation-helper.js
+++ b/packages/manager/modules/billing/src/common/module-federation-helper.js
@@ -18,11 +18,11 @@ const getWillPaymentUrl = () => {
   if (isLabeuEnvironment()) {
     return (
       getLabeuEntryPoint() ||
-      'https://www.ovhcloud.com/order/payment/assets/remoteEntry.js'
+      'https://www.ovhcloud.com/payment/assets/remoteEntry.js'
     );
   }
 
-  return 'https://www.ovhcloud.com/order/payment/assets/remoteEntry.js';
+  return 'https://www.ovhcloud.com/payment/assets/remoteEntry.js';
 };
 
 exports.isLabeuEnvironment = isLabeuEnvironment;


### PR DESCRIPTION
## What

- Update WillPayment federated module URLs from `/order/payment/` to `/payment/` in both billing and PCI modules (MANAGER-21788)
- PCI: merge prod and labeu environment branches into a single relative-path branch, remove obsolete `VITE_WP_LABEU_ENTRY_POINT` env var
- PCI: add CDN cache-busting (`?v=ISO-minute`) duplicating the existing Manager/billing pattern (commit 21b16997db)

## Files changed

- `packages/manager/modules/billing/src/common/module-federation-helper.js` — fallback URLs
- `packages/manager/apps/pci-project/src/utils/module-federation-runtime.ts` — URL migration + env merge + cache-busting

## References

- MANAGER-21788