### PR TITLE
fix(pci-databases-analytics): support update & fork for EOS/EOL services

### DIFF
--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_de_DE.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_de_DE.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Ihr Dienst verwendet eine Konfiguration, die das Ende ihrer Lebensdauer erreicht hat. Wir empfehlen, sie so bald wie möglich auf eine unterstützte Version zu aktualisieren.",
+  "endOfSale": "Ihr Dienst verwendet eine Konfiguration, die sich dem Ende ihrer Lebensdauer nähert und nicht mehr für neue Bereitstellungen verfügbar ist. Wir empfehlen, sie auf eine unterstützte Version zu aktualisieren.",
+  "endOfLifeFork": "Dieser Dienst verwendet eine Konfiguration, die das Ende ihrer Lebensdauer erreicht hat. Wir empfehlen, für Ihren neuen Dienst eine unterstützte Version auszuwählen.",
+  "endOfSaleFork": "Dieser Dienst verwendet eine Konfiguration, die sich dem Ende ihrer Lebensdauer nähert und nicht mehr für neue Bereitstellungen verfügbar ist. Wir empfehlen, für Ihren neuen Dienst eine unterstützte Version auszuwählen."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_en_GB.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_en_GB.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Your service is running on a configuration that has reached its end of life. We recommend updating it to a supported version as soon as possible.",
+  "endOfSale": "Your service is running on a configuration that is approaching its end of life and is no longer available for new deployments. We recommend updating it to a supported version.",
+  "endOfLifeFork": "This service is running on a configuration that has reached its end of life. We recommend selecting a supported version for your new service.",
+  "endOfSaleFork": "This service is running on a configuration that is approaching its end of life and is no longer available for new deployments. We recommend selecting a supported version for your new service."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_es_ES.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_es_ES.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Su servicio utiliza una configuración que ha llegado al final de su vida útil. Le recomendamos que la actualice a una versión compatible lo antes posible.",
+  "endOfSale": "Su servicio utiliza una configuración que se acerca al final de su vida útil y ya no está disponible para nuevas implementaciones. Le recomendamos que la actualice a una versión compatible.",
+  "endOfLifeFork": "Este servicio utiliza una configuración que ha llegado al final de su vida útil. Le recomendamos que seleccione una versión compatible para su nuevo servicio.",
+  "endOfSaleFork": "Este servicio utiliza una configuración que se acerca al final de su vida útil y ya no está disponible para nuevas implementaciones. Le recomendamos que seleccione una versión compatible para su nuevo servicio."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_fr_CA.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Votre service utilise une configuration qui a atteint sa fin de vie. Nous vous recommandons de la mettre à jour vers une version prise en charge dès que possible.",
+  "endOfSale": "Votre service utilise une configuration qui approche de sa fin de vie et n'est plus disponible pour de nouveaux déploiements. Nous vous recommandons de la mettre à jour vers une version prise en charge.",
+  "endOfLifeFork": "Ce service utilise une configuration qui a atteint sa fin de vie. Nous vous recommandons de sélectionner une version prise en charge pour votre nouveau service.",
+  "endOfSaleFork": "Ce service utilise une configuration qui approche de sa fin de vie et n'est plus disponible pour de nouveaux déploiements. Nous vous recommandons de sélectionner une version prise en charge pour votre nouveau service."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_fr_FR.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Votre service utilise une configuration qui a atteint sa fin de vie. Nous vous recommandons de la mettre à jour vers une version prise en charge dès que possible.",
+  "endOfSale": "Votre service utilise une configuration qui approche de sa fin de vie et n'est plus disponible pour de nouveaux déploiements. Nous vous recommandons de la mettre à jour vers une version prise en charge.",
+  "endOfLifeFork": "Ce service utilise une configuration qui a atteint sa fin de vie. Nous vous recommandons de sélectionner une version prise en charge pour votre nouveau service.",
+  "endOfSaleFork": "Ce service utilise une configuration qui approche de sa fin de vie et n'est plus disponible pour de nouveaux déploiements. Nous vous recommandons de sélectionner une version prise en charge pour votre nouveau service."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_it_IT.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_it_IT.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Il tuo servizio utilizza una configurazione che ha raggiunto la fine del ciclo di vita. Ti consigliamo di aggiornarla a una versione supportata il prima possibile.",
+  "endOfSale": "Il tuo servizio utilizza una configurazione che si avvicina alla fine del ciclo di vita e non è più disponibile per nuove implementazioni. Ti consigliamo di aggiornarla a una versione supportata.",
+  "endOfLifeFork": "Questo servizio utilizza una configurazione che ha raggiunto la fine del ciclo di vita. Ti consigliamo di selezionare una versione supportata per il tuo nuovo servizio.",
+  "endOfSaleFork": "Questo servizio utilizza una configurazione che si avvicina alla fine del ciclo di vita e non è più disponibile per nuove implementazioni. Ti consigliamo di selezionare una versione supportata per il tuo nuovo servizio."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_pl_PL.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "Twoja usługa korzysta z konfiguracji, która osiągnęła koniec cyklu życia. Zalecamy jak najszybszą aktualizację do wspieranej wersji.",
+  "endOfSale": "Twoja usługa korzysta z konfiguracji, która zbliża się do końca cyklu życia i nie jest już dostępna dla nowych wdrożeń. Zalecamy aktualizację do wspieranej wersji.",
+  "endOfLifeFork": "Ta usługa korzysta z konfiguracji, która osiągnęła koniec cyklu życia. Zalecamy wybranie wspieranej wersji dla nowej usługi.",
+  "endOfSaleFork": "Ta usługa korzysta z konfiguracji, która zbliża się do końca cyklu życia i nie jest już dostępna dla nowych wdrożeń. Zalecamy wybranie wspieranej wersji dla nowej usługi."
+}

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/components/eos-banner/Messages_pt_PT.json
@@ -1,0 +1,6 @@
+{
+  "endOfLife": "O seu serviço utiliza uma configuração que atingiu o fim de vida. Recomendamos que a atualize para uma versão suportada o mais rapidamente possível.",
+  "endOfSale": "O seu serviço utiliza uma configuração que se aproxima do fim de vida e já não está disponível para novas implementações. Recomendamos que a atualize para uma versão suportada.",
+  "endOfLifeFork": "Este serviço utiliza uma configuração que atingiu o fim de vida. Recomendamos que selecione uma versão suportada para o seu novo serviço.",
+  "endOfSaleFork": "Este serviço utiliza uma configuração que se aproxima do fim de vida e já não está disponível para novas implementações. Recomendamos que selecione uma versão suportada para o seu novo serviço."
+}

--- a/packages/manager/apps/pci-databases-analytics/src/components/eos-banner/EosBanner.component.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/components/eos-banner/EosBanner.component.tsx
@@ -1,0 +1,43 @@
+import { Alert, AlertDescription } from '@datatr-ux/uxlib';
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import * as database from '@/types/cloud/project/database';
+import { isEndOfLifecycle } from '@/lib/availabilitiesHelper';
+
+interface EosBannerProps {
+  availability?: database.Availability;
+  /**
+   * Tailors the recommendation to the screen: 'update' invites the user to
+   * update the current service, 'fork' invites them to pick a supported version
+   * for the new forked service.
+   */
+  context?: 'update' | 'fork';
+}
+
+/**
+ * Warns the user when the current service configuration is no longer fully
+ * supported (deprecated / end of sale / end of life). Renders nothing for a
+ * healthy (STABLE/BETA) availability.
+ */
+const EosBanner = ({ availability, context = 'update' }: EosBannerProps) => {
+  const { t } = useTranslation('pci-databases-analytics/components/eos-banner');
+  if (!isEndOfLifecycle(availability)) {
+    return null;
+  }
+  const baseKey =
+    availability.lifecycle.status ===
+    database.availability.StatusEnum.END_OF_LIFE
+      ? 'endOfLife'
+      : 'endOfSale';
+  const message = context === 'fork' ? `${baseKey}Fork` : baseKey;
+  return (
+    <Alert variant="warning" data-testid="eos-banner" className="mb-4">
+      <div className="flex items-center gap-4">
+        <AlertTriangle className="h-4 w-4 shrink-0" />
+        <AlertDescription>{t(message)}</AlertDescription>
+      </div>
+    </Alert>
+  );
+};
+
+export default EosBanner;

--- a/packages/manager/apps/pci-databases-analytics/src/components/eos-banner/EosBanner.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/components/eos-banner/EosBanner.spec.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as database from '@/types/cloud/project/database';
+import { mockedAvailabilities } from '@/__tests__/helpers/mocks/availabilities';
+import { isEndOfLifecycle } from '@/lib/availabilitiesHelper';
+import EosBanner from './EosBanner.component';
+
+const availabilityWithStatus = (
+  status: database.availability.StatusEnum,
+): database.Availability => ({
+  ...mockedAvailabilities,
+  lifecycle: { ...mockedAvailabilities.lifecycle, status },
+});
+
+describe('EosBanner', () => {
+  it('renders nothing when no availability is provided', () => {
+    render(<EosBanner availability={undefined} />);
+    expect(screen.queryByTestId('eos-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a STABLE availability', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.STABLE,
+        )}
+      />,
+    );
+    expect(screen.queryByTestId('eos-banner')).not.toBeInTheDocument();
+  });
+
+  it('warns for an END_OF_SALE availability', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.END_OF_SALE,
+        )}
+      />,
+    );
+    expect(screen.getByTestId('eos-banner')).toBeInTheDocument();
+    expect(screen.getByText('endOfSale')).toBeInTheDocument();
+  });
+
+  it('warns for an END_OF_LIFE availability', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.END_OF_LIFE,
+        )}
+      />,
+    );
+    expect(screen.getByTestId('eos-banner')).toBeInTheDocument();
+    expect(screen.getByText('endOfLife')).toBeInTheDocument();
+  });
+
+  it('warns for a DEPRECATED availability', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.DEPRECATED,
+        )}
+      />,
+    );
+    expect(screen.getByTestId('eos-banner')).toBeInTheDocument();
+  });
+
+  it('uses fork-specific wording in the fork context', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.END_OF_LIFE,
+        )}
+        context="fork"
+      />,
+    );
+    expect(screen.getByText('endOfLifeFork')).toBeInTheDocument();
+  });
+
+  it('uses fork end-of-sale wording for a deprecated availability in the fork context', () => {
+    render(
+      <EosBanner
+        availability={availabilityWithStatus(
+          database.availability.StatusEnum.END_OF_SALE,
+        )}
+        context="fork"
+      />,
+    );
+    expect(screen.getByText('endOfSaleFork')).toBeInTheDocument();
+  });
+});
+
+describe('isEndOfLifecycle', () => {
+  it('is false for undefined and STABLE/BETA', () => {
+    expect(isEndOfLifecycle(undefined)).toBe(false);
+    expect(
+      isEndOfLifecycle(
+        availabilityWithStatus(database.availability.StatusEnum.STABLE),
+      ),
+    ).toBe(false);
+    expect(
+      isEndOfLifecycle(
+        availabilityWithStatus(database.availability.StatusEnum.BETA),
+      ),
+    ).toBe(false);
+  });
+
+  it('is true for deprecated / end of sale / end of life', () => {
+    expect(
+      isEndOfLifecycle(
+        availabilityWithStatus(database.availability.StatusEnum.DEPRECATED),
+      ),
+    ).toBe(true);
+    expect(
+      isEndOfLifecycle(
+        availabilityWithStatus(database.availability.StatusEnum.END_OF_SALE),
+      ),
+    ).toBe(true);
+    expect(
+      isEndOfLifecycle(
+        availabilityWithStatus(database.availability.StatusEnum.END_OF_LIFE),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetAvailabilities.hook.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetAvailabilities.hook.tsx
@@ -10,6 +10,7 @@ export function useGetAvailabilities(
   serviceId?: string,
   action?: database.availability.ActionEnum,
   target?: database.availability.TargetEnum,
+  status?: database.availability.StatusEnum[],
   options?: OptionsFor<typeof getAvailabilities>,
 ) {
   const queryKey = [
@@ -18,6 +19,7 @@ export function useGetAvailabilities(
     serviceId,
     action,
     target,
+    ...(status ? [`status:${status.join(',')}`] : []),
   ].filter(Boolean);
   return useQueryImmediateRefetch({
     queryKey,
@@ -27,6 +29,7 @@ export function useGetAvailabilities(
         ...(serviceId ? { serviceId } : {}),
         ...(action ? { action } : {}),
         ...(target ? { target } : {}),
+        ...(status ? { status } : {}),
       }),
     ...options,
   });

--- a/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetAvailabilities.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetAvailabilities.spec.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import * as databaseAPI from '@/data/api/database/availability.api';
+import * as database from '@/types/cloud/project/database';
 import { QueryClientWrapper } from '@/__tests__/helpers/wrappers/QueryClientWrapper';
 
 import { mockedAvailabilities } from '@/__tests__/helpers/mocks/availabilities';
@@ -30,6 +31,37 @@ describe('useGetAvailabilities', () => {
       expect(databaseAPI.getAvailabilities).toHaveBeenCalledWith({
         projectId,
         serviceId,
+      });
+    });
+  });
+
+  it('should forward the status filter (e.g. no filter for the self target)', async () => {
+    const projectId = 'projectId';
+    const serviceId = 'serviceId';
+
+    vi.mocked(databaseAPI.getAvailabilities).mockResolvedValue([
+      mockedAvailabilities,
+    ]);
+
+    const { result } = renderHook(
+      () =>
+        useGetAvailabilities(
+          projectId,
+          serviceId,
+          undefined,
+          database.availability.TargetEnum.self,
+          [],
+        ),
+      { wrapper: QueryClientWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+      expect(databaseAPI.getAvailabilities).toHaveBeenCalledWith({
+        projectId,
+        serviceId,
+        target: database.availability.TargetEnum.self,
+        status: [],
       });
     });
   });

--- a/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetCurrentAvailability.hook.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetCurrentAvailability.hook.tsx
@@ -1,0 +1,22 @@
+import * as database from '@/types/cloud/project/database';
+import { useGetAvailabilities } from './useGetAvailabilities.hook';
+
+/**
+ * Fetch the current service availability through the 'self' target with no
+ * status filter. Unlike the status-filtered availability queries, this always
+ * returns the current configuration, even when the service is EOS/EOL.
+ *
+ * The API requires an `action` alongside `target=self`. We always use `update`:
+ * its result set includes the current availability (which `target=self` narrows
+ * down to), and it is the combination the backend supports — `action=fork`
+ * with `target=self` returns a 500. All call sites therefore share one query.
+ */
+export function useGetCurrentAvailability(projectId: string, serviceId: string) {
+  return useGetAvailabilities(
+    projectId,
+    serviceId,
+    database.availability.ActionEnum.update,
+    database.availability.TargetEnum.self,
+    [],
+  );
+}

--- a/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetUpdateAvailabilities.hook.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/hooks/api/database/availability/useGetUpdateAvailabilities.hook.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import * as database from '@/types/cloud/project/database';
+import { mergeCurrentAvailability } from '@/lib/availabilitiesHelper';
+import { useGetAvailabilities } from './useGetAvailabilities.hook';
+import { useGetCurrentAvailability } from './useGetCurrentAvailability.hook';
+
+/**
+ * Fetch the availabilities for an update target and merge in the current
+ * service availability (fetched through the 'self' target with no status
+ * filter). The update endpoint only returns STABLE/BETA availabilities, so an
+ * EOS/EOL service is filtered out of its own results. Merging the 'self'
+ * availability guarantees the current configuration is always present, which
+ * the update modals need to display the current plan/flavor and compute the
+ * current price. The current availability is also returned so the caller can
+ * warn the user when it is EOS/EOL.
+ */
+export function useGetUpdateAvailabilities(
+  projectId: string,
+  serviceId: string,
+  target: database.availability.TargetEnum,
+) {
+  const availabilitiesQuery = useGetAvailabilities(
+    projectId,
+    serviceId,
+    database.availability.ActionEnum.update,
+    target,
+  );
+  const currentAvailabilityQuery = useGetCurrentAvailability(
+    projectId,
+    serviceId,
+  );
+  const availabilities = useMemo(() => {
+    if (!availabilitiesQuery.data) return availabilitiesQuery.data;
+    return mergeCurrentAvailability(
+      availabilitiesQuery.data,
+      currentAvailabilityQuery.data,
+    );
+  }, [availabilitiesQuery.data, currentAvailabilityQuery.data]);
+  return {
+    availabilities,
+    currentAvailability: currentAvailabilityQuery.data?.[0],
+  };
+}

--- a/packages/manager/apps/pci-databases-analytics/src/lib/availabilitiesHelper.ts
+++ b/packages/manager/apps/pci-databases-analytics/src/lib/availabilitiesHelper.ts
@@ -281,6 +281,47 @@ const setPrices = (
   }
 };
 
+const END_OF_LIFECYCLE_STATUSES = [
+  database.availability.StatusEnum.DEPRECATED,
+  database.availability.StatusEnum.END_OF_SALE,
+  database.availability.StatusEnum.END_OF_LIFE,
+];
+
+/**
+ * Whether an availability is past its supported lifecycle (deprecated, end of
+ * sale or end of life). Such offers cannot be modified (storage/nodes/flavor)
+ * server-side — the service must be migrated to a supported offer first.
+ */
+export const isEndOfLifecycle = (availability?: database.Availability) =>
+  !!availability &&
+  END_OF_LIFECYCLE_STATUSES.includes(availability.lifecycle.status);
+
+const isSameAvailability = (
+  a: database.Availability,
+  b: database.Availability,
+) =>
+  a.engine === b.engine &&
+  a.version === b.version &&
+  a.region === b.region &&
+  a.plan === b.plan &&
+  a.specifications.flavor === b.specifications.flavor;
+
+/**
+ * Merge the current service availabilities (fetched through the 'self' target
+ * with no status filter) into a status-filtered list of availabilities. When
+ * the current service is EOS/EOL it is filtered out of the status-filtered
+ * response, so this ensures the current configuration is always present.
+ */
+export function mergeCurrentAvailability(
+  availabilities: database.Availability[],
+  currentAvailabilities: database.Availability[] = [],
+) {
+  const missingCurrent = currentAvailabilities.filter(
+    (current) => !availabilities.some((a) => isSameAvailability(a, current)),
+  );
+  return [...availabilities, ...missingCurrent];
+}
+
 export function createTree(
   availabilities: database.Availability[],
   capabilities: FullCapabilities,

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/Fork.page.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/Fork.page.tsx
@@ -17,6 +17,9 @@ import {
 import { useGetBackups } from '@/hooks/api/database/backup/useGetBackups.hook';
 import { useGetCatalog } from '@/hooks/api/catalog/useGetCatalog.hook';
 import OrderSkeleton from '@/components/order/skeleton/OrderSkeleton.component';
+import { mergeCurrentAvailability } from '@/lib/availabilitiesHelper';
+import { useGetCurrentAvailability } from '@/hooks/api/database/availability/useGetCurrentAvailability.hook';
+import EosBanner from '@/components/eos-banner/EosBanner.component';
 
 export function breadcrumb() {
   return (
@@ -43,6 +46,15 @@ const Fork = () => {
     projectId,
     service.id,
     database.availability.ActionEnum.fork,
+  );
+  // The fork availabilities above are filtered to STABLE/BETA statuses. When the
+  // current service is EOS/EOL its own availability is missing from them, which
+  // prevents displaying the current configuration and crashes the funnel. Fetch
+  // it explicitly using the 'self' target with no status filter so it is always
+  // available as the fork default.
+  const currentAvailabilityQuery = useGetCurrentAvailability(
+    projectId,
+    service.id,
   );
   const capabilitiesQuery = useGetFullCapabilities(projectId);
   const backupsQuery = useGetBackups(projectId, service.engine, service.id);
@@ -90,10 +102,23 @@ const Fork = () => {
     !networkData.subnetQuery.isSuccess;
   const loading =
     availabilitiesQuery.isLoading ||
+    currentAvailabilityQuery.isLoading ||
     capabilitiesQuery.isLoading ||
     backupsQuery.isLoading ||
     isNetworkLoading ||
     catalogQuery.isLoading;
+
+  // Merge the current service availability into the fork availabilities so the
+  // current configuration can always be selected/displayed, even when it has
+  // been filtered out because of an EOS/EOL status.
+  const availabilities: database.Availability[] = useMemo(
+    () =>
+      mergeCurrentAvailability(
+        availabilitiesQuery.data ?? [],
+        currentAvailabilityQuery.data,
+      ),
+    [availabilitiesQuery.data, currentAvailabilityQuery.data],
+  );
 
   // Add the current tag to selected capabilities.
   const capabilities: FullCapabilities = useMemo(() => {
@@ -126,12 +151,16 @@ const Fork = () => {
     <>
       <h2>{t('title')}</h2>
       <p>{t('description')}</p>
+      <EosBanner
+        availability={currentAvailabilityQuery.data?.[0]}
+        context="fork"
+      />
 
       {loading ? (
         <OrderSkeleton />
       ) : (
         <ForkForm
-          availabilities={availabilitiesQuery.data}
+          availabilities={availabilities}
           capabilities={capabilities}
           initialValue={initialValue}
           catalog={catalogQuery.data}

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/Fork.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/Fork.spec.tsx
@@ -46,6 +46,7 @@ import {
 } from '@/types/cloud/network';
 import { apiErrorMock } from '@/__tests__/helpers/mocks/cdbError';
 import * as ServiceAPI from '@/data/api/database/service.api';
+import * as availabilityApi from '@/data/api/database/availability.api';
 
 const mockedFork = {
   source: {
@@ -238,6 +239,29 @@ describe('Fork funnel page', () => {
     await waitFor(() => {
       expect(useToast().toast).toHaveBeenCalledWith(errorMsg);
     });
+  });
+
+  it('renders without crashing when the current service is EOS/EOL', async () => {
+    // Simulate an EOS/EOL service: the status-filtered fork availabilities do
+    // not contain the current service, which is only returned by the unfiltered
+    // 'self' target. The funnel must still render using the current config.
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(
+      ({ target }) => {
+        if (target === database.availability.TargetEnum.self) {
+          return Promise.resolve([mockedAvailabilities]);
+        }
+        return Promise.resolve([]);
+      },
+    );
+    render(<Fork />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      expect(screen.getByTestId('fork-form-container')).toBeInTheDocument();
+      expect(screen.getByTestId('fork-submit-button')).toBeInTheDocument();
+    });
+    // Restore the default mock so this implementation does not leak to other tests.
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(() =>
+      Promise.resolve([mockedAvailabilities]),
+    );
   });
 
   it('Fork Submit button call Add Service and success toast', async () => {

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/_components/useFork.hook.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/backups/fork/_components/useFork.hook.tsx
@@ -293,6 +293,7 @@ export function useFork(
     const defaultEngine =
       listEngines.find((e) => e.name === suggestedEngine.engine) ??
       listEngines[0];
+    if (!defaultEngine) return;
     form.setValue('engine', defaultEngine.name);
   }, [listEngines, initialValue]);
   // update version

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/_components/UpdateTable.component.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/_components/UpdateTable.component.tsx
@@ -8,6 +8,8 @@ import * as database from '@/types/cloud/project/database';
 import { useServiceData } from '../../Service.context';
 import { compareStorage, formatStorage } from '@/lib/bytesHelper';
 import { useGetAvailabilities } from '@/hooks/api/database/availability/useGetAvailabilities.hook';
+import { useGetCurrentAvailability } from '@/hooks/api/database/availability/useGetCurrentAvailability.hook';
+import { isEndOfLifecycle } from '@/lib/availabilitiesHelper';
 import NavLink from '@/components/links/NavLink.component';
 import { isCapabilityDisabled } from '@/lib/capabilitiesHelper';
 
@@ -36,32 +38,56 @@ const UpdateTable = () => {
     database.availability.ActionEnum.update,
     database.availability.TargetEnum.flavor,
   );
+  // Fetch the current service availability using the 'self' target with no
+  // status filter. The queries above only return STABLE/BETA availabilities, so
+  // when the current service is EOS/EOL its own availability is missing from
+  // them. This 'self' query reliably provides the current specs (storage/nodes
+  // ranges) whatever the service status.
+  const currentAvailabilityQuery = useGetCurrentAvailability(
+    projectId,
+    service.id,
+  );
+  // Prefer the 'self' availability, but fall back to the current flavor in the
+  // (status-filtered) flavor availabilities so a healthy service keeps its
+  // storage/nodes controls even if the 'self' query returns nothing.
+  const currentAvailability =
+    currentAvailabilityQuery.data?.[0] ??
+    availabilitiesFlavorQuery.data?.find(
+      (availability) => availability.specifications.flavor === service.flavor,
+    );
   // refetch availabilities when service status changes
   useEffect(() => {
     availabilitiesVersionQuery.refetch();
     availabilitiesFlavorQuery.refetch();
     availabilitiesPlanQuery.refetch();
+    currentAvailabilityQuery.refetch();
   }, [service.status]);
   const rows = [
     {
       title: t('tableVersion'),
       cell: `${humanizeEngine(service.engine)} ${service.version}`,
       path: './update-version',
-      updateButtonDisplayed: availabilitiesVersionQuery.data?.length > 1,
+      updateButtonDisplayed: availabilitiesVersionQuery.data?.some(
+        (availability) => availability.version !== service.version,
+      ),
       disabled: isCapabilityDisabled(service, 'service', 'update'),
     },
     {
       title: t('tablePlan'),
       cell: service.plan,
       path: './update-plan',
-      updateButtonDisplayed: availabilitiesPlanQuery.data?.length > 1,
+      updateButtonDisplayed: availabilitiesPlanQuery.data?.some(
+        (availability) => availability.plan !== service.plan,
+      ),
       disabled: isCapabilityDisabled(service, 'service', 'update'),
     },
     {
       title: t('tableFlavor'),
       cell: service.flavor,
       path: './update-flavor',
-      updateButtonDisplayed: availabilitiesFlavorQuery.data?.length > 1,
+      updateButtonDisplayed: availabilitiesFlavorQuery.data?.some(
+        (availability) => availability.specifications.flavor !== service.flavor,
+      ),
       disabled: isCapabilityDisabled(service, 'serviceFlavor', 'update'),
     },
     service.storage?.size.value && {
@@ -69,13 +95,16 @@ const UpdateTable = () => {
       cell: `${formatStorage(service.storage.size)} ${service.storage.type}`,
       path: './update-flavor',
       disabled: isCapabilityDisabled(service, 'serviceDisk', 'update'),
+      // An EOS/EOL offer cannot be modified server-side, so storage scaling is
+      // not offered — the service must be migrated to a supported offer first.
       updateButtonDisplayed:
-        availabilitiesFlavorQuery.data?.length > 0 &&
-        availabilitiesFlavorQuery.data[0].specifications.storage &&
-        compareStorage(
-          availabilitiesFlavorQuery.data[0].specifications.storage.minimum,
-          availabilitiesFlavorQuery.data[0].specifications.storage.maximum,
-        ) !== 0,
+        !isEndOfLifecycle(currentAvailability) &&
+        (currentAvailability?.specifications.storage
+          ? compareStorage(
+              currentAvailability.specifications.storage.minimum,
+              currentAvailability.specifications.storage.maximum,
+            ) !== 0
+          : false),
     },
   ].filter((row) => Boolean(row));
   return (
@@ -103,7 +132,10 @@ const UpdateTable = () => {
           <td className="font-semibold px-4 py-2">{t('tableNodes')}</td>
           <td className="px-4 py-2">{service.nodes.length}</td>
           <td className="px-4 py-2 text-right">
-            {availabilitiesFlavorQuery.data?.length > 1 && (
+            {!isEndOfLifecycle(currentAvailability) &&
+              currentAvailability?.specifications.nodes &&
+              currentAvailability.specifications.nodes.maximum >
+                currentAvailability.specifications.nodes.minimum && (
               <div className="flex gap-2 justify-end">
                 {service.capabilities.nodes?.delete && (
                   <Button

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/_components/UpdateTable.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/_components/UpdateTable.spec.tsx
@@ -7,6 +7,7 @@ import {
 import { UseQueryResult } from '@tanstack/react-query';
 import * as ServiceContext from '@/pages/services/[serviceId]/Service.context';
 import * as database from '@/types/cloud/project/database';
+import * as availabilityApi from '@/data/api/database/availability.api';
 import { RouterWithQueryClientWrapper } from '@/__tests__/helpers/wrappers/RouterWithQueryClientWrapper';
 import { mockedService as mockedServiceOrig } from '@/__tests__/helpers/mocks/services';
 import {
@@ -15,6 +16,18 @@ import {
 } from '@/__tests__/helpers/mocks/availabilities';
 import { CdbError } from '@/data/api/database';
 import UpdateTable from './UpdateTable.component';
+
+// An availability the current service can migrate to: it differs from the
+// current service (mockedAvailabilities) on version, plan and flavor.
+const mockedAvailabilityTarget: database.Availability = {
+  ...mockedAvailabilitiesUpdate,
+  version: 'version2',
+  plan: 'plan2',
+  specifications: {
+    ...mockedAvailabilitiesUpdate.specifications,
+    flavor: 'flavor2',
+  },
+};
 
 // Override mock to add capabilities
 const mockedService = {
@@ -52,7 +65,15 @@ vi.mock('@/pages/services/[serviceId]/Service.context', () => ({
 vi.mock('@/data/api/database/availability.api', () => ({
   getAvailabilities: vi.fn(() => [
     mockedAvailabilities,
-    mockedAvailabilitiesUpdate,
+    {
+      ...mockedAvailabilitiesUpdate,
+      version: 'version2',
+      plan: 'plan2',
+      specifications: {
+        ...mockedAvailabilitiesUpdate.specifications,
+        flavor: 'flavor2',
+      },
+    },
   ]),
 }));
 
@@ -146,6 +167,109 @@ describe('Update table in settings page', () => {
       expect(createNodeButton.className).toContain('cursor-not-allowed');
       expect(deleteNodeButton).toBeInTheDocument();
       expect(deleteNodeButton.className).toContain('cursor-not-allowed');
+    });
+  });
+
+  it('still shows update buttons when the current service is EOS/EOL', async () => {
+    // Simulate an EOS/EOL service: it is filtered out of the status-filtered
+    // availabilities (version/plan/flavor), and is only returned by the 'self'
+    // target which has no status filter.
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(
+      ({ target }) => {
+        if (target === database.availability.TargetEnum.self) {
+          return Promise.resolve([mockedAvailabilities]);
+        }
+        return Promise.resolve([mockedAvailabilityTarget]);
+      },
+    );
+    vi.mocked(ServiceContext.useServiceData).mockReturnValue({
+      projectId: 'projectId',
+      service: mockedService,
+      category: 'operational',
+      serviceQuery: {} as UseQueryResult<database.Service, CdbError>,
+    });
+    render(<UpdateTable />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('update-button-tableVersion'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('update-button-tablePlan')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('update-button-tableFlavor'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('update-button-tableStorage'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('create-node-button')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-node-button')).toBeInTheDocument();
+    });
+  });
+
+  it('hides storage/nodes controls when the current offer is EOS/EOL', async () => {
+    // The current offer is end of sale: it cannot be modified server-side, so
+    // storage and node scaling controls must not be offered (only migration
+    // buttons remain). The current is returned by the 'self' target.
+    const eosCurrent: database.Availability = {
+      ...mockedAvailabilities,
+      lifecycle: {
+        ...mockedAvailabilities.lifecycle,
+        status: database.availability.StatusEnum.END_OF_SALE,
+      },
+    };
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(
+      ({ target }) => {
+        if (target === database.availability.TargetEnum.self) {
+          return Promise.resolve([eosCurrent]);
+        }
+        return Promise.resolve([mockedAvailabilityTarget]);
+      },
+    );
+    vi.mocked(ServiceContext.useServiceData).mockReturnValue({
+      projectId: 'projectId',
+      service: mockedService,
+      category: 'operational',
+      serviceQuery: {} as UseQueryResult<database.Service, CdbError>,
+    });
+    render(<UpdateTable />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      // migration buttons remain
+      expect(
+        screen.getByTestId('update-button-tableVersion'),
+      ).toBeInTheDocument();
+    });
+    // storage/nodes controls are hidden
+    expect(
+      screen.queryByTestId('update-button-tableStorage'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('create-node-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('delete-node-button')).not.toBeInTheDocument();
+  });
+
+  it('keeps storage/nodes controls when the self query returns nothing (fallback to flavor list)', async () => {
+    // Healthy service, but the 'self' availability query yields nothing: the
+    // storage/nodes controls must fall back to the current flavor found in the
+    // status-filtered flavor availabilities instead of disappearing.
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(
+      ({ target }) => {
+        if (target === database.availability.TargetEnum.self) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([mockedAvailabilities, mockedAvailabilityTarget]);
+      },
+    );
+    vi.mocked(ServiceContext.useServiceData).mockReturnValue({
+      projectId: 'projectId',
+      service: mockedService,
+      category: 'operational',
+      serviceQuery: {} as UseQueryResult<database.Service, CdbError>,
+    });
+    render(<UpdateTable />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('update-button-tableStorage'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('create-node-button')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-node-button')).toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateFlavor/UpdateFlavor.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateFlavor/UpdateFlavor.modal.tsx
@@ -26,9 +26,11 @@ import StorageConfig from '@/components/order/cluster-configuration/StorageConfi
 import { formatStorage } from '@/lib/bytesHelper';
 import PricingDetails from '../_components/PricingDetails.component';
 import { getCdbApiErrorMessage } from '@/lib/apiHelper';
-import { useGetAvailabilities } from '@/hooks/api/database/availability/useGetAvailabilities.hook';
+import { useGetUpdateAvailabilities } from '@/hooks/api/database/availability/useGetUpdateAvailabilities.hook';
 import { useUpdateFlavor } from './useUpdateFlavor.hook';
 import RouteModal from '@/components/route-modal/RouteModal';
+import EosBanner from '@/components/eos-banner/EosBanner.component';
+import { isEndOfLifecycle } from '@/lib/availabilitiesHelper';
 
 const UpdateFlavor = () => {
   const navigate = useNavigate();
@@ -37,10 +39,9 @@ const UpdateFlavor = () => {
   const { t } = useTranslation(
     'pci-databases-analytics/services/service/settings/update',
   );
-  const availabilitiesQuery = useGetAvailabilities(
+  const { availabilities, currentAvailability } = useGetUpdateAvailabilities(
     projectId,
     service.id,
-    database.availability.ActionEnum.update,
     database.availability.TargetEnum.flavor,
   );
   const {
@@ -51,7 +52,7 @@ const UpdateFlavor = () => {
     initialFlavorObject,
     oldPrice,
     newPrice,
-  } = useUpdateFlavor({ availabilities: availabilitiesQuery.data, service });
+  } = useUpdateFlavor({ availabilities, service });
   const { editService, isPending } = useEditService({
     onError: (err) => {
       toast.toast({
@@ -105,6 +106,7 @@ const UpdateFlavor = () => {
           </DialogTitle>
         </DialogHeader>
         <DialogBody>
+          <EosBanner availability={currentAvailability} />
           <Form {...form}>
             <form onSubmit={onSubmit} id="updateFlavorForm">
               <FormField
@@ -187,7 +189,7 @@ const UpdateFlavor = () => {
               </DialogClose>
               <Button
                 form="updateFlavorForm"
-                disabled={isPending}
+                disabled={isPending || isEndOfLifecycle(availability)}
                 data-testid="update-flavor-submit-button"
               >
                 {t('updateFlavorSubmitButton')}

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateFlavor/UpdateFlavor.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateFlavor/UpdateFlavor.spec.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@datatr-ux/uxlib';
 import { RouterWithQueryClientWrapper } from '@/__tests__/helpers/wrappers/RouterWithQueryClientWrapper';
 import * as database from '@/types/cloud/project/database';
 import * as serviceApi from '@/data/api/database/service.api';
+import * as availabilityApi from '@/data/api/database/availability.api';
 import { apiErrorMock } from '@/__tests__/helpers/mocks/cdbError';
 import { setMockedUseParams } from '@/__tests__/helpers/mockRouterDomHelper';
 import UpdateFlavor from './UpdateFlavor.modal';
@@ -154,5 +155,32 @@ describe('Update Flavor modal', () => {
         description: 'updateFlavorAndStorageToastSuccessDescription',
       });
     });
+  });
+
+  it('disables submit when the selected (current) flavor is EOS/EOL', async () => {
+    // Current flavor (db1-4) is end of sale: filtered out of the status-filtered
+    // flavor list, present only via 'self'. Submitting a change that stays on
+    // this offer is rejected server-side, so the submit must be disabled.
+    const eosCurrent: database.Availability = {
+      ...mockedAvailabilitiesFlavor,
+      lifecycle: {
+        ...mockedAvailabilitiesFlavor.lifecycle,
+        status: database.availability.StatusEnum.END_OF_SALE,
+      },
+    };
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(
+      ({ target }) =>
+        target === database.availability.TargetEnum.self
+          ? Promise.resolve([eosCurrent])
+          : Promise.resolve([mockedAvailabilitiesFlavorBis]),
+    );
+    render(<UpdateFlavor />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      expect(screen.getByTestId('update-flavor-submit-button')).toBeDisabled();
+    });
+    // restore default mock so it does not leak
+    vi.mocked(availabilityApi.getAvailabilities).mockImplementation(() =>
+      Promise.resolve([mockedAvailabilitiesFlavor, mockedAvailabilitiesFlavorBis]),
+    );
   });
 });

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updatePlan/UpdatePlan.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updatePlan/UpdatePlan.modal.tsx
@@ -25,9 +25,10 @@ import { useEditService } from '@/hooks/api/database/service/useEditService.hook
 import Price from '@/components/price/Price.component';
 import PricingDetails from '../_components/PricingDetails.component';
 import { getCdbApiErrorMessage } from '@/lib/apiHelper';
-import { useGetAvailabilities } from '@/hooks/api/database/availability/useGetAvailabilities.hook';
+import { useGetUpdateAvailabilities } from '@/hooks/api/database/availability/useGetUpdateAvailabilities.hook';
 import { useUpdatePlan } from './useUpdatePlan.hook';
 import RouteModal from '@/components/route-modal/RouteModal';
+import EosBanner from '@/components/eos-banner/EosBanner.component';
 
 const UpdatePlan = () => {
   const navigate = useNavigate();
@@ -37,10 +38,9 @@ const UpdatePlan = () => {
   const { t } = useTranslation(
     'pci-databases-analytics/services/service/settings/update',
   );
-  const availabilitiesQuery = useGetAvailabilities(
+  const { availabilities, currentAvailability } = useGetUpdateAvailabilities(
     projectId,
     service.id,
-    database.availability.ActionEnum.update,
     database.availability.TargetEnum.plan,
   );
 
@@ -50,7 +50,7 @@ const UpdatePlan = () => {
     initialFlavorObject,
     oldPrice,
     newPrice,
-  } = useUpdatePlan({ availabilities: availabilitiesQuery.data, service });
+  } = useUpdatePlan({ availabilities, service });
 
   const { editService, isPending } = useEditService({
     onError: (err) => {
@@ -107,6 +107,7 @@ const UpdatePlan = () => {
           </DialogTitle>
         </DialogHeader>
         <DialogBody>
+          <EosBanner availability={currentAvailability} />
           <Form {...form}>
             <form onSubmit={onSubmit} id="updatePlanForm">
               <FormField

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
@@ -24,10 +24,11 @@ import { Engine } from '@/types/orderFunnel';
 import { useServiceData } from '@/pages/services/[serviceId]/Service.context';
 import { useEditService } from '@/hooks/api/database/service/useEditService.hook';
 import { getCdbApiErrorMessage } from '@/lib/apiHelper';
-import { useGetAvailabilities } from '@/hooks/api/database/availability/useGetAvailabilities.hook';
+import { useGetUpdateAvailabilities } from '@/hooks/api/database/availability/useGetUpdateAvailabilities.hook';
 import { useUpdateTree } from '../_components/useUpdateTree';
 import RouteModal from '@/components/route-modal/RouteModal';
 import VersionSelect from '@/components/order/version/VersionSelect.component';
+import EosBanner from '@/components/eos-banner/EosBanner.component';
 
 const UpdateVersion = () => {
   const { service, projectId } = useServiceData();
@@ -36,10 +37,9 @@ const UpdateVersion = () => {
   const { t } = useTranslation(
     'pci-databases-analytics/services/service/settings/update',
   );
-  const availabilitiesQuery = useGetAvailabilities(
+  const { availabilities, currentAvailability } = useGetUpdateAvailabilities(
     projectId,
     service.id,
-    database.availability.ActionEnum.update,
     database.availability.TargetEnum.version,
   );
   const { editService, isPending } = useEditService({
@@ -62,7 +62,7 @@ const UpdateVersion = () => {
   });
 
   const listVersions =
-    useUpdateTree(availabilitiesQuery.data)?.find(
+    useUpdateTree(availabilities)?.find(
       (e: Engine) => e.name === service.engine,
     )?.versions || [];
 
@@ -102,6 +102,7 @@ const UpdateVersion = () => {
           </DialogTitle>
         </DialogHeader>
         <DialogBody>
+          <EosBanner availability={currentAvailability} />
           <Form {...form}>
             <form onSubmit={onSubmit} id="updateVersionForm">
               <FormField

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/create/Create.page.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/create/Create.page.tsx
@@ -31,6 +31,7 @@ const Service = () => {
     null,
     null,
     null,
+    null,
     { refetchOnWindowFocus: false },
   );
   const suggestionsQuery = useGetSuggestions(projectId, {


### PR DESCRIPTION
Availabilities are fetched filtered by lifecycle status (STABLE/BETA), so an EOS/EOL service's own availability is excluded from the response. This hid the update buttons (which relied on the availability count), left the update modals unable to resolve the current plan/flavor to compute a price, and crashed the fork funnel because the current config was missing from the option tree.

- Fetch the current availability via the 'self' target with no status filter (action=update, the backend-supported combination; action=fork+self 500s) and merge it into the update/fork option lists.
- Show update buttons when a differing availability exists rather than by count; derive the storage/nodes controls from the current availability.
- Warn the user with an EOS banner in the update modals and on the fork page, with fork-specific wording.
- Prevent modifying an EOS offer, which the API rejects: hide the storage and node controls and disable the flavor-update submit while on the EOS offer.

ref: #DATATR-1234