### PR TITLE
fix(vps): fix display of 10TB additional disk addon during order

### DIFF
--- a/packages/manager/modules/vps/src/additional-disk/order/vps-order-additional-disk-order.controller.js
+++ b/packages/manager/modules/vps/src/additional-disk/order/vps-order-additional-disk-order.controller.js
@@ -123,16 +123,20 @@ export default class VpsOrderDiskCtrl {
         // (e.g. blobs.commercial.name = "10000 GB" -> 10000), with a fallback
         // parsing the planCode trailing size (e.g. "option-additional-disk-100g" -> 100)
         diskOptions = diskOptions.map((diskOption) => {
-          const plan = this.catalog?.plans?.find(
+          const plan = this.catalog?.addons?.find(
             ({ planCode }) => planCode === diskOption.planCode,
+          );
+          const product = this.catalog?.products?.find(
+            ({ name }) => name === plan?.product,
           );
           set(diskOption, 'capacity', {
             value:
+              product?.blobs?.technical?.storage?.disks?.[0]?.capacity ||
               parseInt(
                 plan?.blobs?.commercial?.name?.replace(/[^\d]/g, ''),
                 10,
               ) ||
-              parseInt(diskOption.planCode.match(/-(\d+)g$/)?.[1], 10) ||
+              parseInt(diskOption.planCode.match(/-(\d+)g(-eu|-ca)?$/)?.[1], 10) ||
               0,
             unit: 'Go',
           });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fix the display of the VPS 10TB additional disk size when ordering a VPS additonal disk.


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: MANAGER-21891

## Additional Information

Works fine on EU side. Does not work on US side because of reseller plans having -eu/-ca suffix.
Fixed the code to look into the technical blob of product first and fallback to parsing the plan code.

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
