### PR TITLE
fix(web-domains): align cancel-resiliation redirect params

### DIFF
--- a/packages/manager/apps/web-domains/src/domain/components/DatagridColumns/Domain/DatagridColumnActions.tsx
+++ b/packages/manager/apps/web-domains/src/domain/components/DatagridColumns/Domain/DatagridColumnActions.tsx
@@ -151,9 +151,9 @@ export default function DatagridColumnActions({
         label: t('domain_action_cancel_terminate'),
         onClick: () =>
           navigateTo('billing', '/autorenew/services/cancel-resiliation', {
-            selectedType: DOMAIN,
+            serviceId: serviceName,
+            serviceType: DOMAIN,
             searchText: serviceName,
-            serviceId: serviceInfo?.serviceId,
           }),
       });
     }


### PR DESCRIPTION
## Description

Redirect the domain listing "cancel terminate" action to billing/autorenew/services/cancel-resiliation using serviceId (domain name) and serviceType=DOMAIN, matching the billing route query params.

Ticket Reference: #DCE-231

