### PR TITLE
fix(pci-databases-analytics): use /topicAcl endpoint for Kafka topic ACLs

### DIFF
--- a/packages/manager/apps/pci-databases-analytics/src/data/api/database/topicAcl.api.ts
+++ b/packages/manager/apps/pci-databases-analytics/src/data/api/database/topicAcl.api.ts
@@ -14,7 +14,7 @@ export const getTopicAcls = async ({
   serviceId,
 }: ServiceData) =>
   apiClient.v6.get<database.kafka.TopicAcl[]>(
-    `/cloud/project/${projectId}/database/${engine}/${serviceId}/acl`,
+    `/cloud/project/${projectId}/database/${engine}/${serviceId}/topicAcl`,
     { headers: createHeaders(NoCacheHeaders, IcebergPaginationHeaders) },
   );
 
@@ -28,7 +28,7 @@ export const addTopicAcl = async ({
   topicAcl,
 }: AddTopicAcl) =>
   apiClient.v6.post<database.kafka.TopicAcl>(
-    `/cloud/project/${projectId}/database/${engine}/${serviceId}/acl`,
+    `/cloud/project/${projectId}/database/${engine}/${serviceId}/topicAcl`,
     topicAcl,
   );
 
@@ -42,5 +42,5 @@ export const deleteTopicAcl = async ({
   serviceId,
 }: DeleteTopicAcl) =>
   apiClient.v6.delete(
-    `/cloud/project/${projectId}/database/${engine}/${serviceId}/acl/${topicAclId}`,
+    `/cloud/project/${projectId}/database/${engine}/${serviceId}/topicAcl/${topicAclId}`,
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

The Public Cloud Databases / Analytics app failed to load Kafka Topic ACLs: the data layer (`topicAcl.api.ts`) called the removed `/cloud/project/{projectId}/database/{engine}/{serviceId}/acl` endpoint.

This updates the three calls (`getTopicAcls`, `addTopicAcl`, `deleteTopicAcl`) to `/topicAcl`. The response model is unchanged, so nothing else changes.

Ticket Reference: Fixes #23066

## Additional Information

- Evidence: the current API only documents `/topicAcl` ([console](https://api.eu.ovhcloud.com/console/?section=%2Fcloud&branch=v1#post-/cloud/project/-serviceName-/database/kafka/-clusterId-/topicAcl));
  OVH's schema marks the legacy `/acl` path deprecated/deleted with `x-replacement-route: .../topicAcl`. The official `ovhcloud-cli` already uses `/topicAcl`.
- Tested locally against a real Kafka cluster: the Topic ACLs tab lists existing ACLs and add/delete work.

<img width="547" height="778" alt="image" src="https://github.com/user-attachments/assets/61dd9c6e-a9af-4aa9-9555-9078d71837b3" />