### PR TITLE
feat(account): warn and block the "Autre" category for FR e-invoicing

### DIFF
--- a/packages/manager/apps/container/src/components/modal-container/ModalContainer.component.tsx
+++ b/packages/manager/apps/container/src/components/modal-container/ModalContainer.component.tsx
@@ -14,12 +14,14 @@ import PaymentModal from '@/components/payment-modal/PaymentModal.component';
 import { IdentityDocumentsModal } from '@/components/identity-documents-modal/IdentityDocumentsModal.component';
 import { CommunicationAnnounceModal } from '../communication-announce-modal/CommunicationAnnounceModal.component';
 import CompanyInformationModal from '../company-information-modal/CompanyInformationModal.component';
+import OtherCategoryModal from '../other-category-modal/OtherCategoryModal.component';
 
 const MODALS: FC[] = [
   IdentityDocumentsModal,
   PaymentModal,
   AgreementsUpdateModal,
   CompanyInformationModal,
+  OtherCategoryModal,
   SuggestionModal,
   CommunicationAnnounceModal,
 ];

--- a/packages/manager/apps/container/src/components/other-category-modal/OtherCategoryModal.component.tsx
+++ b/packages/manager/apps/container/src/components/other-category-modal/OtherCategoryModal.component.tsx
@@ -1,0 +1,119 @@
+import { FC, useCallback, useEffect, useState } from "react";
+import { OsdsButton, OsdsModal, OsdsText, OsdsLink } from "@ovhcloud/ods-components/react";
+import { ODS_THEME_TYPOGRAPHY_SIZE, ODS_THEME_COLOR_INTENT } from "@ovhcloud/ods-common-theming";
+import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT } from "@ovhcloud/ods-components";
+import { OdsHTMLAnchorElementRel, OdsHTMLAnchorElementTarget } from "@ovhcloud/ods-common-core";
+import { Trans, useTranslation } from "react-i18next";
+import {
+  ELECTRONIC_BILLING_REGULATION_LINK,
+  LEGALFORM_FIELD_TO_FOCUS,
+  OTHER_CATEGORY_FEATURE,
+  TRACKING_CONTEXT,
+  TRACKING_PREFIX,
+} from "./otherCategoryModal.constants";
+import { isUserCategoryOther } from "./otherCategoryModal.helpers";
+import { useCheckModalDisplay } from "@/hooks/modal/useModal";
+import { useSuggestionTargetUrl } from "@/data/hooks/suggestion/useSuggestion";
+import { useApplication } from "@/context";
+
+const OtherCategoryModal: FC = () => {
+  const { shell } = useApplication();
+  const ux = shell.getPlugin('ux');
+  const tracking = shell.getPlugin('tracking');
+  const { t } = useTranslation('other-category-modal');
+
+  const accountEditionLink = useSuggestionTargetUrl();
+
+  // No preference/interval throttling: the modal is displayed at every login as
+  // long as the category remains "Autre" (RG1). It is skipped on the account
+  // edition page itself so it does not overlap the form the CTA leads to.
+  const shouldDisplayModal = useCheckModalDisplay(
+    undefined,
+    undefined,
+    [OTHER_CATEGORY_FEATURE],
+    undefined,
+    undefined,
+    isUserCategoryOther,
+    [accountEditionLink],
+  );
+
+  const [showModal, setShowModal] = useState(shouldDisplayModal);
+
+  const closeModal = useCallback(() => {
+    setShowModal(false);
+    ux.notifyModalActionDone(OtherCategoryModal.name);
+    tracking.trackClick({
+      name: `${TRACKING_PREFIX}::pop-up::button::other_category::dismiss`,
+      type: 'action',
+      ...TRACKING_CONTEXT,
+    });
+  }, [ux]);
+
+  const goToCategoryEdition = useCallback(() => {
+    setShowModal(false);
+    ux.notifyModalActionDone(OtherCategoryModal.name);
+    tracking.trackClick({
+      name: `${TRACKING_PREFIX}::pop-up::button::other_category::update`,
+      type: 'action',
+      ...TRACKING_CONTEXT,
+    });
+    window.top.location.href = `${accountEditionLink}?fieldToFocus=${LEGALFORM_FIELD_TO_FOCUS}`;
+  }, [accountEditionLink]);
+
+  useEffect(() => {
+    if (shouldDisplayModal !== undefined) {
+      setShowModal(shouldDisplayModal);
+      if (!shouldDisplayModal) {
+        ux.notifyModalActionDone(OtherCategoryModal.name);
+      } else {
+        tracking.trackPage({
+          name: `${TRACKING_PREFIX}::pop-up::other_category`,
+          ...TRACKING_CONTEXT,
+        });
+      }
+    }
+  }, [shouldDisplayModal]);
+
+  return (
+    showModal && (
+      <OsdsModal
+        dismissible={true}
+        onOdsModalClose={closeModal}
+        headline={t('other_category_modal_title')}
+        color={ODS_THEME_COLOR_INTENT.info}
+        data-testid="other-category-modal"
+      >
+        <OsdsText
+          color={ODS_THEME_COLOR_INTENT.text}
+          size={ODS_THEME_TYPOGRAPHY_SIZE._400}
+        >
+          <Trans
+            i18nKey="other_category_modal_description"
+            t={t}
+            components={{
+              anchor: (
+                <OsdsLink
+                  href={ELECTRONIC_BILLING_REGULATION_LINK}
+                  color={ODS_THEME_COLOR_INTENT.primary}
+                  target={OdsHTMLAnchorElementTarget._blank}
+                  rel={OdsHTMLAnchorElementRel.noopener}
+                />
+              ),
+            }}
+          />
+        </OsdsText>
+        <OsdsButton
+          onClick={goToCategoryEdition}
+          slot="actions"
+          color={ODS_THEME_COLOR_INTENT.primary}
+          variant={ODS_BUTTON_VARIANT.flat}
+          size={ODS_BUTTON_SIZE.sm}
+        >
+          {t('other_category_modal_action_modify')}
+        </OsdsButton>
+      </OsdsModal>
+    )
+  );
+};
+
+export default OtherCategoryModal;

--- a/packages/manager/apps/container/src/components/other-category-modal/OtherCategoryModal.spec.tsx
+++ b/packages/manager/apps/container/src/components/other-category-modal/OtherCategoryModal.spec.tsx
@@ -1,0 +1,87 @@
+import { vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import * as useModalModule from '@/hooks/modal/useModal';
+import OtherCategoryModal from './OtherCategoryModal.component';
+
+const ACCOUNT_EDITION_LINK =
+  'https://fake-manager.com/manager/account/#/useraccount/infos';
+
+const notifyModalActionDone = vi.fn();
+const trackClick = vi.fn();
+const trackPage = vi.fn();
+
+vi.mock('@/data/hooks/suggestion/useSuggestion', () => ({
+  useSuggestionTargetUrl: () => ACCOUNT_EDITION_LINK,
+}));
+
+vi.mock('@/context', () => ({
+  useApplication: () => ({
+    shell: {
+      getPlugin: (plugin: string) => {
+        switch (plugin) {
+          case 'ux':
+            return { notifyModalActionDone };
+          case 'tracking':
+            return { trackClick, trackPage };
+          default:
+            return {};
+        }
+      },
+    },
+  }),
+}));
+
+const renderComponent = () => render(<OtherCategoryModal />);
+
+describe('OtherCategoryModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'top', {
+      value: { location: { href: '' } },
+      writable: true,
+    });
+  });
+
+  it('renders when the display check resolves to true', async () => {
+    vi.spyOn(useModalModule, 'useCheckModalDisplay').mockReturnValue(true);
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('other-category-modal')).not.toBeNull();
+    });
+  });
+
+  it('does not render when the display check resolves to false', async () => {
+    vi.spyOn(useModalModule, 'useCheckModalDisplay').mockReturnValue(false);
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('other-category-modal')).toBeNull();
+    });
+  });
+
+  it('does not render while the display check is undefined', async () => {
+    vi.spyOn(useModalModule, 'useCheckModalDisplay').mockReturnValue(undefined);
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('other-category-modal')).toBeNull();
+    });
+  });
+
+  it('redirects to the legalform select of the account edition form on CTA click', async () => {
+    vi.spyOn(useModalModule, 'useCheckModalDisplay').mockReturnValue(true);
+
+    const { getByText } = renderComponent();
+
+    fireEvent.click(getByText('other_category_modal_action_modify'));
+
+    expect(window.top.location.href).toBe(
+      `${ACCOUNT_EDITION_LINK}?fieldToFocus=ovh_field_legalform`,
+    );
+    expect(notifyModalActionDone).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.constants.ts
+++ b/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.constants.ts
@@ -1,0 +1,19 @@
+// Reuse the shared "tout savoir sur la facturation électronique" documentation
+// link declared for the company information modal so both e-invoicing modals point
+// to the same official page.
+export { ELECTRONIC_BILLING_REGULATION_LINK } from '../company-information-modal/companyInformationModal.constants';
+
+export const MODAL_NAME = 'OtherCategoryModal';
+// Feature flag gating the whole "Autre" category e-invoicing flow (FR only).
+export const OTHER_CATEGORY_FEATURE = 'account:fr-e-invoicing-other-category';
+// Field id of the legalform select in the account edition form, used so the CTA
+// lands directly on the category select.
+export const LEGALFORM_FIELD_TO_FOCUS = 'ovh_field_legalform';
+export const TRACKING_PREFIX = 'Hub::account::user';
+export const TRACKING_CONTEXT = {
+  chapter1: 'Hub',
+  chapter2: 'account',
+  chapter3: 'user',
+  level2: 'Manager-Account',
+  page: 'user::pop-up::other_category',
+};

--- a/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.helpers.spec.ts
+++ b/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.helpers.spec.ts
@@ -1,0 +1,21 @@
+import { User } from '@ovh-ux/manager-config';
+import { isUserCategoryOther } from './otherCategoryModal.helpers';
+
+const buildUser = (overrides: Partial<User>): User =>
+  ({ legalform: 'other', country: 'FR', ...overrides } as User);
+
+describe('isUserCategoryOther', () => {
+  it('returns true for a FR customer whose category is "other"', () => {
+    expect(isUserCategoryOther(buildUser({}))).toBe(true);
+  });
+
+  it('returns false when the category is not "other"', () => {
+    expect(isUserCategoryOther(buildUser({ legalform: 'corporation' }))).toBe(
+      false,
+    );
+  });
+
+  it('returns false when the customer is not in France', () => {
+    expect(isUserCategoryOther(buildUser({ country: 'DE' }))).toBe(false);
+  });
+});

--- a/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.helpers.ts
+++ b/packages/manager/apps/container/src/components/other-category-modal/otherCategoryModal.helpers.ts
@@ -1,0 +1,6 @@
+import { User } from "@ovh-ux/manager-config";
+
+// The "Autre" category (legalform === 'other') is not compatible with the French
+// e-invoicing reform: FR customers holding it must update their category.
+export const isUserCategoryOther = (user: User) =>
+  user.legalform === 'other' && user.country === 'FR';

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_de_DE.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_de_DE.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "OBLIGATORISCHE AKTION",
+  "other_category_modal_description": "Ihre Kontokategorie ist auf „Sonstige“ eingestellt. Um die Konformität Ihrer nächsten Rechnungen zu gewährleisten, ist eine Aktualisierung im Rahmen der Reform der elektronischen Rechnungsstellung <anchor>alles über die elektronische Rechnungsstellung erfahren</anchor> erforderlich. Bitte aktualisieren Sie Ihre Kategorie (Unternehmen, Verwaltung, Verein, Privatperson) in Ihren Kontoeinstellungen.",
+  "other_category_modal_action_modify": "Meine Kategorie aktualisieren"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_en_GB.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_en_GB.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "MANDATORY ACTION",
+  "other_category_modal_description": "Your account category is set to 'Other'. To ensure the compliance of your future invoices, updating it is mandatory as part of the electronic invoicing reform <anchor>find out everything about electronic invoicing</anchor>. Please update your category (business, administration, association, individual) in your account settings.",
+  "other_category_modal_action_modify": "Update my category"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_es_ES.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_es_ES.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "ACCIÓN OBLIGATORIA",
+  "other_category_modal_description": "Su categoría de cuenta está definida como «Otro». Para garantizar la conformidad de sus próximas facturas, su actualización es obligatoria en el marco de la reforma de la facturación electrónica <anchor>todo sobre la facturación electrónica</anchor>. Actualice su categoría (empresa, administración, asociación, particular) en los ajustes de su cuenta.",
+  "other_category_modal_action_modify": "Actualizar mi categoría"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_fr_CA.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_fr_CA.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "ACTION OBLIGATOIRE",
+  "other_category_modal_description": "Votre catégorie de compte est définie sur « Autre ». Pour assurer la conformité de vos prochaines factures, sa mise à jour est obligatoire dans le cadre de la réforme de la facturation électronique <anchor>tout savoir sur la facturation électronique</anchor>. Veuillez mettre à jour votre catégorie (entreprise, administration, association, particulier) dans les paramètres de votre compte.",
+  "other_category_modal_action_modify": "Mettre à jour ma catégorie"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_fr_FR.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "ACTION OBLIGATOIRE",
+  "other_category_modal_description": "Votre catégorie de compte est définie sur « Autre ». Pour assurer la conformité de vos prochaines factures, sa mise à jour est obligatoire dans le cadre de la réforme de la facturation électronique <anchor>tout savoir sur la facturation électronique</anchor>. Veuillez mettre à jour votre catégorie (entreprise, administration, association, particulier) dans les paramètres de votre compte.",
+  "other_category_modal_action_modify": "Mettre à jour ma catégorie"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_it_IT.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_it_IT.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "AZIONE OBBLIGATORIA",
+  "other_category_modal_description": "La categoria del tuo account è impostata su «Altro». Per garantire la conformità delle tue prossime fatture, l'aggiornamento è obbligatorio nell'ambito della riforma della fatturazione elettronica <anchor>scopri tutto sulla fatturazione elettronica</anchor>. Ti preghiamo di aggiornare la tua categoria (azienda, amministrazione, associazione, privato) nelle impostazioni del tuo account.",
+  "other_category_modal_action_modify": "Aggiorna la mia categoria"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_pl_PL.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_pl_PL.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "DZIAŁANIE OBOWIĄZKOWE",
+  "other_category_modal_description": "Twoja kategoria konta jest ustawiona na „Inne”. Aby zapewnić zgodność przyszłych faktur, jej aktualizacja jest obowiązkowa w ramach reformy fakturowania elektronicznego <anchor>dowiedz się więcej o fakturowaniu elektronicznym</anchor>. Prosimy o aktualizację swojej kategorii (przedsiębiorstwo, administracja, stowarzyszenie, osoba prywatna) w ustawieniach konta.",
+  "other_category_modal_action_modify": "Zaktualizuj moją kategorię"
+}

--- a/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_pt_PT.json
+++ b/packages/manager/apps/container/src/public/translations/other-category-modal/Messages_pt_PT.json
@@ -1,0 +1,5 @@
+{
+  "other_category_modal_title": "AÇÃO OBRIGATÓRIA",
+  "other_category_modal_description": "A sua categoria de conta está definida como «Outra». Para garantir a conformidade das suas próximas faturas, a sua atualização é obrigatória no âmbito da reforma da faturação eletrónica <anchor>saiba tudo sobre a faturação eletrónica</anchor>. Por favor, atualize a sua categoria (empresa, administração, associação, particular) nas definições da sua conta.",
+  "other_category_modal_action_modify": "Atualizar a minha categoria"
+}

--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -223,6 +223,27 @@ export default class NewAccountFormFieldController {
         return true;
       },
     };
+
+    // RG1: when the customer is redirected here from the "Autre" category modal
+    // (fieldToFocus === legalform select), open the select directly so they can
+    // pick a valid category right away. The parent controller already scrolls to
+    // the field; this focuses/opens it once rendered (best-effort on oui-select).
+    if (
+      this.newAccountForm.fieldToFocus === this.id &&
+      this.rule.fieldName === FIELD_NAME_LIST.legalform &&
+      this.getFieldType() === 'select'
+    ) {
+      this.$timeout(() => {
+        const element = document.getElementById(this.id);
+        if (!element) {
+          return;
+        }
+        const trigger =
+          element.querySelector('button, [role="button"], input') || element;
+        trigger.focus();
+        trigger.click();
+      }, 500);
+    }
   }
 
   $onChanges({ isEditionDisabledByKyc }) {

--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.html
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.html
@@ -185,5 +185,13 @@
             data-translate="{{ 'common_field_error_' + error }}"
             data-translate-values="{ minlength: $ctrl.rule.minLength, maxlength: $ctrl.rule.maxLength }"
         ></span>
+
+        <!-- RG2: informational error when the "Autre" category is selected -->
+        <span
+            class="help-block text-danger"
+            data-ng-if="$ctrl.rule.fieldName === $ctrl.FIELD_NAME_LIST.legalform && $ctrl.newAccountForm.isOtherCategorySelected()"
+            role="alert"
+            data-translate="signup_legalform_other_invalid"
+        ></span>
     </div>
 </div>

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.constants.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.constants.js
@@ -391,6 +391,7 @@ export const TRACKING_PREFIX = 'accountmodification';
 export const FEATURES = {
   emailConsent: 'account:email-consent',
   smsConsent: 'account:sms-consent',
+  otherCategory: 'account:fr-e-invoicing-other-category',
 };
 
 export const IN_SUBSIDIARY = 'IN';
@@ -399,6 +400,7 @@ export const USER_TYPE_ENTERPRISE = 'corporation';
 export const USER_TYPE_ASSOCIATION = 'association';
 export const USER_TYPE_ADMINISTRATION = 'administration';
 export const USER_TYPE_INDIVIDUAL = 'individual';
+export const USER_TYPE_OTHER = 'other';
 
 export default {
   ENUM_TRANSLATION_RULES,
@@ -420,4 +422,5 @@ export default {
   USER_TYPE_ASSOCIATION,
   USER_TYPE_ADMINISTRATION,
   USER_TYPE_INDIVIDUAL,
+  USER_TYPE_OTHER,
 };

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.html
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.html
@@ -100,6 +100,23 @@
 
     <!-- FOOTER BUTTONS -->
     <div class="mb-5">
+        <!-- RG4: switching from "Autre" to a company category prompts a company data check -->
+        <oui-message
+            class="mb-2"
+            type="warning"
+            data-ng-if="$ctrl.shouldShowCategorySwitchWarning()"
+        >
+            <span
+                data-translate="signup_legalform_other_switch_company"
+                data-translate-values="{ category: ('signup_enum_legalform_' + $ctrl.model.legalform | translate) }"
+            ></span>
+            <button
+                class="oui-button oui-button_secondary mt-2"
+                type="button"
+                data-ng-click="$ctrl.scrollToCompanyData()"
+                data-translate="signup_legalform_other_switch_company_cta"
+            ></button>
+        </oui-message>
         <oui-message
             class="mb-2"
             type="warning"

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.js
@@ -20,6 +20,7 @@ import {
   USER_TYPE_ASSOCIATION,
   USER_TYPE_ADMINISTRATION,
   USER_TYPE_INDIVIDUAL,
+  USER_TYPE_OTHER,
   SUBSIDIARIES_VAT_FIELD_OVERRIDE,
 } from './new-account-form-component.constants';
 import { KYC_STATUS } from '../../../identity-documents/user-identity-documents.constant';
@@ -85,13 +86,21 @@ export default class NewAccountFormController {
     this.smsConsentDecision = null;
 
     return this.ovhFeatureFlipping
-      .checkFeatureAvailability([FEATURES.emailConsent, FEATURES.smsConsent])
+      .checkFeatureAvailability([
+        FEATURES.emailConsent,
+        FEATURES.smsConsent,
+        FEATURES.otherCategory,
+      ])
       .then((result) => {
         this.isEmailConsentAvailable = result.isFeatureAvailable(
           FEATURES.emailConsent,
         );
         this.isSmsConsentAvailable = result.isFeatureAvailable(
           FEATURES.smsConsent,
+        );
+        // Gates the FR e-invoicing "Autre" category controls (RG2/RG3/RG4)
+        this.isOtherCategoryControlEnabled = result.isFeatureAvailable(
+          FEATURES.otherCategory,
         );
       })
       .then(() => this.fetchRules(this.model))
@@ -308,6 +317,17 @@ export default class NewAccountFormController {
       name: 'dedicated::account::user::infos::save',
       type: 'action',
     });
+
+    // RG3: saving is blocked while the category is still "Autre".
+    if (this.isOtherCategorySelected()) {
+      this.Alerter.alertFromSWS(
+        this.$translate.instant('signup_legalform_other_save_blocked'),
+        'ERROR',
+        'InfoErrors',
+      );
+      return null;
+    }
+
     this.isSubmitting = true;
     this.submitError = null;
 
@@ -673,6 +693,42 @@ export default class NewAccountFormController {
       ].includes(this.model?.legalform) &&
       FR_COUNTRIES.includes(this.model?.country)
     );
+  }
+
+  // The FR e-invoicing "Autre" category controls (RG2/RG3/RG4) are gated by a
+  // feature flag and restricted to French customers.
+  isOtherCategoryControlActive() {
+    return (
+      this.isOtherCategoryControlEnabled &&
+      FR_COUNTRIES.includes(this.model?.country)
+    );
+  }
+
+  // RG2/RG3: the currently selected category is the invalid "Autre" value.
+  isOtherCategorySelected() {
+    return (
+      this.isOtherCategoryControlActive() &&
+      this.model?.legalform === USER_TYPE_OTHER
+    );
+  }
+
+  // RG4: the saved category was "Autre" and the customer switched to a category
+  // holding company data (B2B/B2G/association). B2C (individual) is excluded (RG5).
+  shouldShowCategorySwitchWarning() {
+    return (
+      this.isOtherCategoryControlActive() &&
+      this.originalModel?.legalform === USER_TYPE_OTHER &&
+      [
+        USER_TYPE_ENTERPRISE,
+        USER_TYPE_ASSOCIATION,
+        USER_TYPE_ADMINISTRATION,
+      ].includes(this.model?.legalform)
+    );
+  }
+
+  // RG4: bring the customer to the company data (SIRET) section of the form.
+  scrollToCompanyData() {
+    this.$anchorScroll('ovh_form_content_activity');
   }
 
   isFieldHiddenForFr(rule) {

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_de_DE.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_de_DE.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "Sie können auch eine andere in Ihrem Rechnungsstellungsbereich konfigurieren.",
   "signup_einvoicing_stale_address": "Die ausgewählte Adresse ist nicht mehr aktiv. Bitte wählen Sie eine neue aus.",
   "signup_einvoicing_multi_b2b": "Bitte wählen Sie Ihre Standardadresse für die elektronische Rechnungsstellung aus.",
-  "signup_einvoicing_multi_b2g": "Bitte wählen Sie Ihre Standardadresse für die elektronische Rechnungsstellung aus. Falls Ihre SIREN für die Rechnungsstellung von der SIREN Ihrer Einheit abweicht, können Sie den Support kontaktieren, um eine andere anzugeben."
+  "signup_einvoicing_multi_b2g": "Bitte wählen Sie Ihre Standardadresse für die elektronische Rechnungsstellung aus. Falls Ihre SIREN für die Rechnungsstellung von der SIREN Ihrer Einheit abweicht, können Sie den Support kontaktieren, um eine andere anzugeben.",
+  "signup_legalform_other_invalid": "Die Kategorie „Sonstige“ ist nicht gültig. Bitte wählen Sie eine andere Kategorie aus.",
+  "signup_legalform_other_save_blocked": "Speichern mit der Kategorie „Sonstige“ nicht möglich. Bitte wählen Sie eine gültige Kategorie aus, bevor Sie fortfahren.",
+  "signup_legalform_other_switch_company": "Sie haben Ihre Kategorie geändert. Bitte aktualisieren Sie die Daten Ihrer {{ category }}, bevor Sie speichern.",
+  "signup_legalform_other_switch_company_cta": "Meine Unternehmensdaten aktualisieren"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_en_GB.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_en_GB.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "You will also be able to configure another one from your invoicing area.",
   "signup_einvoicing_stale_address": "The selected address is no longer active. Please select a new one.",
   "signup_einvoicing_multi_b2b": "Please select your default electronic invoicing address.",
-  "signup_einvoicing_multi_b2g": "Please select your default electronic invoicing address. If your invoicing SIREN is different from your entity's SIREN, you can contact support to provide another one."
+  "signup_einvoicing_multi_b2g": "Please select your default electronic invoicing address. If your invoicing SIREN is different from your entity's SIREN, you can contact support to provide another one.",
+  "signup_legalform_other_invalid": "The \"Other\" category is not valid. Please select another category.",
+  "signup_legalform_other_save_blocked": "Unable to save with the \"Other\" category. Please select a valid category before continuing.",
+  "signup_legalform_other_switch_company": "You have changed your category. Please update your {{ category }} data before saving.",
+  "signup_legalform_other_switch_company_cta": "Update my company data"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_es_ES.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_es_ES.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "También podrá configurar otra desde su espacio de facturación.",
   "signup_einvoicing_stale_address": "La dirección seleccionada ya no está activa. Por favor, seleccione una nueva.",
   "signup_einvoicing_multi_b2b": "Por favor, seleccione su dirección de facturación electrónica por defecto.",
-  "signup_einvoicing_multi_b2g": "Por favor, seleccione su dirección de facturación electrónica por defecto. Si su SIREN de facturación es diferente al SIREN de su entidad, puede contactar con el soporte para indicar otra."
+  "signup_einvoicing_multi_b2g": "Por favor, seleccione su dirección de facturación electrónica por defecto. Si su SIREN de facturación es diferente al SIREN de su entidad, puede contactar con el soporte para indicar otra.",
+  "signup_legalform_other_invalid": "La categoría «Otro» no es válida. Seleccione otra categoría.",
+  "signup_legalform_other_save_blocked": "No es posible guardar con la categoría «Otro». Seleccione una categoría válida antes de continuar.",
+  "signup_legalform_other_switch_company": "Ha modificado su categoría. Actualice los datos de su {{ category }} antes de guardar.",
+  "signup_legalform_other_switch_company_cta": "Actualizar mis datos de empresa"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -785,5 +785,9 @@
   "signup_einvoicing_single_b2g": "L'adresse {{address}} sera utilisée comme adresse de facturation électronique par défaut. Si votre SIREN de facturation est différent du SIREN de votre entité, vous pouvez contacter le support pour en renseigner une autre.",
   "signup_einvoicing_multi_b2b": "Veuillez sélectionner votre adresse de facturation électronique par défaut.",
   "signup_einvoicing_multi_b2g": "Veuillez sélectionner votre adresse de facturation électronique par défaut. Si votre SIREN de facturation est différent du SIREN de votre entité, vous pouvez contacter le support pour en renseigner une autre.",
-  "signup_einvoicing_stale_address": "L'adresse sélectionnée n'est plus active. Veuillez en sélectionner une nouvelle."
+  "signup_einvoicing_stale_address": "L'adresse sélectionnée n'est plus active. Veuillez en sélectionner une nouvelle.",
+  "signup_legalform_other_invalid": "La catégorie « Autre » n'est pas valide. Veuillez sélectionner une autre catégorie.",
+  "signup_legalform_other_save_blocked": "Impossible d'enregistrer avec la catégorie « Autre ». Veuillez sélectionner une catégorie valide avant de continuer.",
+  "signup_legalform_other_switch_company": "Vous avez modifié votre catégorie. Veuillez mettre à jour les données de votre {{ category }} avant d'enregistrer.",
+  "signup_legalform_other_switch_company_cta": "Mettre à jour mes données société"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -785,5 +785,9 @@
   "signup_einvoicing_single_b2g": "L'adresse {{address}} sera utilisée comme adresse de facturation électronique par défaut. Si votre SIREN de facturation est différent du SIREN de votre entité, vous pouvez contacter le support pour en renseigner une autre.",
   "signup_einvoicing_multi_b2b": "Veuillez sélectionner votre adresse de facturation électronique par défaut.",
   "signup_einvoicing_multi_b2g": "Veuillez sélectionner votre adresse de facturation électronique par défaut. Si votre SIREN de facturation est différent du SIREN de votre entité, vous pouvez contacter le support pour en renseigner une autre.",
-  "signup_einvoicing_stale_address": "L'adresse sélectionnée n'est plus active. Veuillez en sélectionner une nouvelle."
+  "signup_einvoicing_stale_address": "L'adresse sélectionnée n'est plus active. Veuillez en sélectionner une nouvelle.",
+  "signup_legalform_other_invalid": "La catégorie « Autre » n'est pas valide. Veuillez sélectionner une autre catégorie.",
+  "signup_legalform_other_save_blocked": "Impossible d'enregistrer avec la catégorie « Autre ». Veuillez sélectionner une catégorie valide avant de continuer.",
+  "signup_legalform_other_switch_company": "Vous avez modifié votre catégorie. Veuillez mettre à jour les données de votre {{ category }} avant d'enregistrer.",
+  "signup_legalform_other_switch_company_cta": "Mettre à jour mes données société"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_it_IT.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_it_IT.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "Potrà inoltre configurarne un altro dal Suo spazio di fatturazione.",
   "signup_einvoicing_stale_address": "L'indirizzo selezionato non è più attivo. La preghiamo di selezionarne uno nuovo.",
   "signup_einvoicing_multi_b2b": "La preghiamo di selezionare il Suo indirizzo di fatturazione elettronica predefinito.",
-  "signup_einvoicing_multi_b2g": "La preghiamo di selezionare il Suo indirizzo di fatturazione elettronica predefinito. Se il Suo SIREN di fatturazione è diverso dal SIREN della Sua entità, può contattare l'assistenza per indicarne un altro."
+  "signup_einvoicing_multi_b2g": "La preghiamo di selezionare il Suo indirizzo di fatturazione elettronica predefinito. Se il Suo SIREN di fatturazione è diverso dal SIREN della Sua entità, può contattare l'assistenza per indicarne un altro.",
+  "signup_legalform_other_invalid": "La categoria \"Altro\" non è valida. Seleziona un'altra categoria.",
+  "signup_legalform_other_save_blocked": "Impossibile salvare con la categoria \"Altro\". Seleziona una categoria valida prima di continuare.",
+  "signup_legalform_other_switch_company": "Hai modificato la tua categoria. Aggiorna i dati della tua {{ category }} prima di salvare.",
+  "signup_legalform_other_switch_company_cta": "Aggiorna i miei dati aziendali"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pl_PL.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "Będziesz mógł również skonfigurować inny w swoim panelu fakturowania.",
   "signup_einvoicing_stale_address": "Wybrany adres nie jest już aktywny. Proszę wybrać nowy.",
   "signup_einvoicing_multi_b2b": "Proszę wybrać domyślny adres faktur elektronicznych.",
-  "signup_einvoicing_multi_b2g": "Proszę wybrać domyślny adres faktur elektronicznych. Jeśli Państwa numer SIREN do faktur różni się od numeru SIREN Państwa podmiotu, mogą Państwo skontaktować się z działem wsparcia, aby podać inny."
+  "signup_einvoicing_multi_b2g": "Proszę wybrać domyślny adres faktur elektronicznych. Jeśli Państwa numer SIREN do faktur różni się od numeru SIREN Państwa podmiotu, mogą Państwo skontaktować się z działem wsparcia, aby podać inny.",
+  "signup_legalform_other_invalid": "Kategoria „Inne” jest nieprawidłowa. Wybierz inną kategorię.",
+  "signup_legalform_other_save_blocked": "Zapisanie z kategorią „Inne” jest niemożliwe. Przed kontynuowaniem wybierz prawidłową kategorię.",
+  "signup_legalform_other_switch_company": "Zmieniono kategorię. Przed zapisaniem zaktualizuj dane {{ category }}.",
+  "signup_legalform_other_switch_company_cta": "Zaktualizuj moje dane firmy"
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pt_PT.json
@@ -786,5 +786,9 @@
   "signup_einvoicing_multi_b2g_hint": "Poderá igualmente configurar outro a partir da sua área de faturação.",
   "signup_einvoicing_stale_address": "O endereço selecionado já não está ativo. Por favor, selecione um novo.",
   "signup_einvoicing_multi_b2b": "Por favor, selecione o seu endereço de faturação eletrónica por defeito.",
-  "signup_einvoicing_multi_b2g": "Por favor, selecione o seu endereço de faturação eletrónica por defeito. Se o seu SIREN de faturação for diferente do SIREN da sua entidade, pode contactar o suporte para indicar outro."
+  "signup_einvoicing_multi_b2g": "Por favor, selecione o seu endereço de faturação eletrónica por defeito. Se o seu SIREN de faturação for diferente do SIREN da sua entidade, pode contactar o suporte para indicar outro.",
+  "signup_legalform_other_invalid": "A categoria «Outro» não é válida. Queira selecionar outra categoria.",
+  "signup_legalform_other_save_blocked": "Impossível guardar com a categoria «Outro». Queira selecionar uma categoria válida antes de continuar.",
+  "signup_legalform_other_switch_company": "Alterou a sua categoria. Queira atualizar os dados da sua {{ category }} antes de guardar.",
+  "signup_legalform_other_switch_company_cta": "Atualizar os meus dados de empresa"
 }


### PR DESCRIPTION
The "Autre" (other) account category is not compatible with the French e-invoicing reform. This adds, gated by the account:fr-e-invoicing-other-category feature flag (FR only):
- a dismissible home modal shown at every login inviting the customer to update their category (container modal-container);
- an informational error below the category select when it is set to "Autre";
- a blocking error on save while the category is still "Autre";
- a non-blocking warning with a company-data shortcut when switching from "Autre" to a company category (corporation/administration/association).

ref: #MANAGER-22014

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
