### PR TITLE
feat(pci-savings-plan): remove mention of storage on svp create

### DIFF
--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_de_DE.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_de_DE.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "Die B3, C3 und R3 Instanzen, die für Managed Kubernetes Service Nodes verwendet werden, werden ebenfalls berücksichtigt. Beachten Sie, dass in Local Zones bereitgestellte Instanzen nicht für Savings Plans infrage kommen.",
   "select_model": "Modell auswählen",
   "select_model_description_instance_b3": "Die General Purpose Instanzen verfügen über ausgewogene und garantierte Ressourcen in puncto CPU, Arbeitsspeicher, Storage und Netzwerk.",
+  "select_model_description_instance_b3_without_storage": "Die General Purpose Instanzen verfügen über ausgewogene und garantierte Ressourcen in puncto CPU, Arbeitsspeicher und Netzwerk.",
   "select_model_description_instance_c3": "Die Compute Optimized Instanzen wurden für hohe Anforderungen in Sachen Rechenleistung und rechenintensive Workloads entwickelt.",
   "select_model_description_instance_r3": "Memory Optimized Instanzen sind ideal für In-Memory-Datenbanken und -Anwendungen oder für RAM-intensive Prozesse geeignet.",
   "select_model_description_instance_publiccloud-rancher": "Managed Rancher Service vereinfacht die Verwaltung mehrerer Kubernetes-Cluster, darunter auch mit Managed Kubernetes Service erstellte Cluster.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_en_GB.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_en_GB.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "B3, C3, R3 instances used for Managed Kubernetes Service nodes are also eligible. Instances deployed in Local Zones are not eligible for Savings Plans.",
   "select_model": "Choose model",
   "select_model_description_instance_b3": "General Purpose instances have balanced and guaranteed resources between CPU, memory, storage and network.",
+  "select_model_description_instance_b3_without_storage": "General Purpose instances have balanced and guaranteed resources between CPU, memory and network.",
   "select_model_description_instance_c3": "Compute Optimized instances are designed for compute-intensive tasks and resource-intensive workloads.",
   "select_model_description_instance_r3": "Memory Optimized instances are ideal for databases and memory-intensive applications, or RAM-intensive usage.",
   "select_model_description_instance_publiccloud-rancher": "The Managed Rancher Service makes it easy to manage multiple Kubernetes clusters, including those created with the Managed Kubernetes Service.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_es_ES.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_es_ES.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "También se incluyen las instancias B3, C3 y R3 utilizadas para los nodos del servicio Managed Kubernetes. Tenga en cuenta que las instancias desplegadas en las Local Zones no pueden incluirse en los Savings Plans.",
   "select_model": "Elegir el modelo",
   "select_model_description_instance_b3": "Nuestras instancias General Purpose disponen de recursos equilibrados y garantizados en términos de CPU, memoria, almacenamiento y red.",
+  "select_model_description_instance_b3_without_storage": "Nuestras instancias General Purpose disponen de recursos equilibrados y garantizados en términos de CPU, memoria y red.",
   "select_model_description_instance_c3": "Las instancias Compute Optimized están especialmente diseñadas para tareas que requieren una gran potencia computacional y para cargas de trabajo intensivas en términos de cálculo.",
   "select_model_description_instance_r3": "Las instancias Memory Optimized son ideales para bases de datos y aplicaciones con un gran consumo de memoria o usos intensivos de RAM.",
   "select_model_description_instance_publiccloud-rancher": "El servicio Managed Rancher permite gestionar fácilmente varios clústeres Kubernetes, incluyendo los creados con el servicio Managed Kubernetes.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_fr_CA.json
@@ -5,6 +5,7 @@
   "choose_ressource_description_info": "Vous continuez à gérer vos services comme d'habitude. La plateforme calcule automatiquement votre utilisation en fonction des configurations de vos Savings Plans et de la consommation de vos ressources existantes ou futures.",
   "select_model": "Choisir le modèle",
   "select_model_description_instance_b3": "Les instances General Purpose disposent de ressources équilibrées et garanties entre le CPU, la mémoire, le stockage et le réseau.",
+  "select_model_description_instance_b3_without_storage": "Les instances General Purpose disposent de ressources équilibrées et garanties entre le CPU, la mémoire et le réseau.",
   "select_model_description_instance_c3": "Les instances Compute Optimized sont conçues pour des tâches exigeantes en matière de puissance de calcul et des charges de travail intensives en calcul.",
   "select_model_description_instance_r3": "Les instances Memory Optimized sont idéales pour les bases de données et les applications chargées en mémoire ou les utilisations intensives en RAM.",
   "select_model_description_instance_publiccloud-rancher": "Managed Rancher Service permet de faciliter la gestion de plusieurs clusters Kubernetes, dont ceux créés avec Managed Kubernetes Service.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_fr_FR.json
@@ -5,6 +5,7 @@
   "choose_ressource_description_info": "Vous continuez à gérer vos services comme d'habitude. La plateforme calcule automatiquement votre utilisation en fonction des configurations de vos Savings Plans et de la consommation de vos ressources existantes ou futures.",
   "select_model": "Choisir le modèle",
   "select_model_description_instance_b3": "Les instances General Purpose disposent de ressources équilibrées et garanties entre le CPU, la mémoire, le stockage et le réseau.",
+  "select_model_description_instance_b3_without_storage": "Les instances General Purpose disposent de ressources équilibrées et garanties entre le CPU, la mémoire et le réseau.",
   "select_model_description_instance_c3": "Les instances Compute Optimized sont conçues pour des tâches exigeantes en matière de puissance de calcul et des charges de travail intensives en calcul.",
   "select_model_description_instance_r3": "Les instances Memory Optimized sont idéales pour les bases de données et les applications chargées en mémoire ou les utilisations intensives en RAM.",
   "select_model_description_instance_publiccloud-rancher": "Managed Rancher Service permet de faciliter la gestion de plusieurs clusters Kubernetes, dont ceux créés avec Managed Kubernetes Service.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_it_IT.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_it_IT.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "Vengono considerate anche le istanze B3, C3, R3 utilizzate per i nodi Managed Kubernetes Service. Ricordiamo che le istanze eseguite nelle Local Zone non sono idonee ai Savings Plan.",
   "select_model": "Scegliere il modello",
   "select_model_description_instance_b3": "Le istanze General Purpose dispongono di risorse equilibrate e garantite tra CPU, memoria, storage e rete.",
+  "select_model_description_instance_b3_without_storage": "Le istanze General Purpose dispongono di risorse equilibrate e garantite tra CPU, memoria e rete.",
   "select_model_description_instance_c3": "Le istanze Compute Optimized sono progettate per attività che richiedono molta potenza di calcolo e carichi di lavoro intensivi.",
   "select_model_description_instance_r3": "Le istanze Memory Optimized sono ideali per database e applicazioni con un grande consumo di memoria o utilizzo intensivo di RAM.",
   "select_model_description_instance_publiccloud-rancher": "Managed Rancher Service permette di facilitare la gestione di più cluster Kubernetes, inclusi quelli creati con il servizio Managed Kubernetes.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_pl_PL.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "Planem objęte są również instancje B3, C3, R3 używane dla węzłów Managed Kubernetes Service. W przypadku instancji wdrażanych w Local Zones Savings Plans nie ma zastosowania.",
   "select_model": "Wybierz model",
   "select_model_description_instance_b3": "Instancje General Purpose dysponują zrównoważonymi i gwarantowanymi zasobami: CPU, pamięcią, przestrzenią dyskową i siecią.",
+  "select_model_description_instance_b3_without_storage": "Instancje General Purpose dysponują zrównoważonymi i gwarantowanymi zasobami: CPU, pamięcią i siecią.",
   "select_model_description_instance_c3": "Instancje Compute Optimized doskonale sprawdzają się w zadaniach wymagających dużej mocy obliczeniowej oraz intensywnych obliczeniach.",
   "select_model_description_instance_r3": "Instancje Memory Optimized są idealne do obsługi baz danych oraz aplikacji zużywających duże ilości pamięci. ",
   "select_model_description_instance_publiccloud-rancher": "Usługa Managed Rancher ułatwia zarządzanie wieloma klastrami Kubernetes, w tym klastrami utworzonymi za pomocą Managed Kubernetes Service.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/create/Messages_pt_PT.json
@@ -4,6 +4,7 @@
   "choose_ressource_description": "São igualmente tidas em conta as instâncias B3, C3, R3 utilizadas para nós do Managed Kubernetes Service. Atenção: as instâncias implementadas nas Local Zones não são elegíveis para os Savings Plans.",
   "select_model": "Escolher o modelo",
   "select_model_description_instance_b3": "As instâncias General Purpose dispõem de recursos equilibrados e garantidos entre CPU, memória, armazenamento e rede.",
+  "select_model_description_instance_b3_without_storage": "As instâncias General Purpose dispõem de recursos equilibrados e garantidos entre CPU, memória e rede.",
   "select_model_description_instance_c3": "As instâncias Compute Optimized foram concebidas para tarefas exigentes em termos de potência de cálculo e cargas de trabalho intensivas em cálculo.",
   "select_model_description_instance_r3": "As instâncias Memory Optimized são ideais para bases de dados e aplicações carregadas na memória ou para utilizações intensivas em RAM.",
   "select_model_description_instance_publiccloud-rancher": "O Managed Rancher Service facilita a gestão de vários clusters Kubernetes, incluindo os criados com o Managed Kubernetes Service.",

--- a/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/CreatePlanForm.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/CreatePlanForm.tsx
@@ -121,6 +121,7 @@ export type CreatePlanFormProps = {
   deploymentMode: DeploymentMode;
   deploymentModeOptions: TDeploymentOptions;
   isCreatePlanPending: boolean;
+  isStorageDisplayed?: boolean;
 };
 
 const CreatePlanForm: FC<CreatePlanFormProps> = ({
@@ -139,6 +140,7 @@ const CreatePlanForm: FC<CreatePlanFormProps> = ({
   deploymentMode,
   deploymentModeOptions,
   isCreatePlanPending,
+  isStorageDisplayed = true,
 }: CreatePlanFormProps) => {
   const { trackClick } = useOvhTracking();
   const navigate = useNavigate();
@@ -360,6 +362,7 @@ const CreatePlanForm: FC<CreatePlanFormProps> = ({
         isTechnicalInfoLoading={isTechnicalInfoLoading}
         technicalModel={technicalModel}
         onSelectModel={onSelectModel}
+        isStorageDisplayed={isStorageDisplayed}
       />
       <SelectQuantity
         isInstance={isInstance}
@@ -452,6 +455,7 @@ export const CreatePlanFormContainer = ({
   const {
     isDeployment3AZAvailable,
     isRancherServiceAvailable,
+    isInstancesRepricingAvailable,
   } = useSavingsPlanCreationOptionsFeatureAvailability();
 
   const [instanceCategory, setInstanceCategory] = useState<
@@ -557,6 +561,7 @@ export const CreatePlanFormContainer = ({
         deploymentMode={deploymentMode}
         deploymentModeOptions={availableDeploymentModeOptions}
         isCreatePlanPending={isCreatePlanPending}
+        isStorageDisplayed={!isInstancesRepricingAvailable}
       />
     </Suspense>
   );

--- a/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/SelectModel.test.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/SelectModel.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SelectModel from './SelectModel';
+import {
+  InstanceInfo,
+  InstanceTechnicalName,
+  TechnicalInfo,
+} from '@/types/CreatePlan.type';
+
+import { render } from '@/utils/testProvider';
+
+const defaultProps = {
+  technicalInfo: [] as TechnicalInfo[],
+  instanceCategory: InstanceTechnicalName.b3,
+  isInstance: true,
+  isTechnicalInfoLoading: false,
+  onSelectModel: vi.fn(),
+  setInstanceCategory: vi.fn(),
+  tabsList: [] as InstanceInfo[],
+  technicalModel: 'b3-8',
+};
+
+const setupSpecTest = (props = {}) =>
+  render(<SelectModel {...defaultProps} {...props} />);
+
+describe('SelectModel', () => {
+  it('should render the model description mentioning storage by default', () => {
+    setupSpecTest();
+
+    expect(
+      screen.getByText('select_model_description_instance_b3'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the storage free model description when storage is not displayed', () => {
+    setupSpecTest({ isStorageDisplayed: false });
+
+    expect(
+      screen.getByText('select_model_description_instance_b3_without_storage'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('select_model_description_instance_b3'),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    InstanceTechnicalName.c3,
+    InstanceTechnicalName.r3,
+    InstanceTechnicalName.rancher,
+  ])(
+    'should keep the standard description for %s when storage is not displayed',
+    (instanceCategory) => {
+      setupSpecTest({ instanceCategory, isStorageDisplayed: false });
+
+      expect(
+        screen.getByText(
+          `select_model_description_instance_${instanceCategory}`,
+        ),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/SelectModel.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/CreatePlanForm/SelectModel.tsx
@@ -21,6 +21,7 @@ type SelectModelProps = {
   setInstanceCategory: (category: InstanceTechnicalName) => void;
   tabsList: InstanceInfo[];
   technicalModel: string;
+  isStorageDisplayed?: boolean;
 };
 
 const SelectModel = ({
@@ -32,8 +33,13 @@ const SelectModel = ({
   setInstanceCategory,
   tabsList,
   technicalModel,
+  isStorageDisplayed = true,
 }: SelectModelProps) => {
   const { t } = useTranslation('create');
+
+  const modelDescriptionKey = `select_model_description_instance_${instanceCategory}`;
+  const hasStorageFreeDescription =
+    !isStorageDisplayed && instanceCategory === InstanceTechnicalName.b3;
 
   return (
     <Block>
@@ -54,7 +60,11 @@ const SelectModel = ({
         </div>
       )}
       <DescriptionWrapper>
-        {t(`select_model_description_instance_${instanceCategory}`)}
+        {t(
+          hasStorageFreeDescription
+            ? `${modelDescriptionKey}_without_storage`
+            : modelDescriptionKey,
+        )}
       </DescriptionWrapper>
       {!isTechnicalInfoLoading ? (
         <div className="flex flex-row w-full overflow-x-auto mb-[32px] gap-6">
@@ -65,6 +75,7 @@ const SelectModel = ({
               name={name}
               onClick={() => onSelectModel(name)}
               isActive={technicalModel === name}
+              isStorageDisplayed={isStorageDisplayed}
             />
           ))}
         </div>

--- a/packages/manager/apps/pci-savings-plan/src/components/TileTechnicalInfo/TileTechnicalInfo.test.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/TileTechnicalInfo/TileTechnicalInfo.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TileTechnicalInfo } from './TileTechnicalInfo';
+
+import { render } from '@/utils/testProvider';
+
+type TTechnical = React.ComponentProps<typeof TileTechnicalInfo>['technical'];
+
+const technical: TTechnical = {
+  bandwidth: { guaranteed: true, level: 1000, unlimited: false },
+  cpu: { cores: 8, frequency: 2.3, model: 'b3', type: 'shared' },
+  memory: { size: 32 },
+  storage: {
+    disks: [{ capacity: 50, number: 1, technology: 'NVMe' }],
+    raid: '0',
+  },
+};
+
+const setupSpecTest = ({
+  technicalInfo = technical,
+  isStorageDisplayed,
+}: {
+  technicalInfo?: TTechnical;
+  isStorageDisplayed?: boolean;
+} = {}) =>
+  render(
+    <TileTechnicalInfo
+      name="b3-8"
+      technical={technicalInfo}
+      isStorageDisplayed={isStorageDisplayed}
+    />,
+  );
+
+describe('TileTechnicalInfo', () => {
+  it('should render the model name', () => {
+    setupSpecTest();
+    expect(screen.getByText('b3-8')).toBeInTheDocument();
+  });
+
+  it('should render memory, cpu and bandwidth characteristics', () => {
+    setupSpecTest();
+
+    expect(
+      screen.getByText('resource_model_characteristics_gb'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('resource_model_characteristics_cpu'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('resource_model_characteristics_mbits'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the storage characteristic by default', () => {
+    setupSpecTest();
+
+    expect(
+      screen.getByText('resource_model_characteristics_disk'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the storage characteristic when storage is displayed', () => {
+    setupSpecTest({ isStorageDisplayed: true });
+
+    expect(
+      screen.getByText('resource_model_characteristics_disk'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render the storage characteristic when storage is not displayed', () => {
+    setupSpecTest({ isStorageDisplayed: false });
+
+    expect(
+      screen.queryByText('resource_model_characteristics_disk'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('resource_model_characteristics_gb'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a flavor that has no storage blob', () => {
+    const { storage, ...technicalWithoutStorage } = technical;
+    setupSpecTest({ technicalInfo: technicalWithoutStorage });
+
+    expect(screen.getByText('b3-8')).toBeInTheDocument();
+    expect(
+      screen.queryByText('resource_model_characteristics_disk'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/apps/pci-savings-plan/src/components/TileTechnicalInfo/TileTechnicalInfo.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/TileTechnicalInfo/TileTechnicalInfo.tsx
@@ -6,8 +6,10 @@ import { formatTechnicalInfo } from '@/utils/formatter/formatter';
 
 const DisplayTechnicalInfo = ({
   technical,
+  isStorageDisplayed,
 }: {
   technical: ReturnType<typeof formatTechnicalInfo>['technical'];
+  isStorageDisplayed: boolean;
 }) => {
   const { t } = useTranslation('create');
   const { memory, cpu, storage, bandwidth } = technical;
@@ -24,11 +26,13 @@ const DisplayTechnicalInfo = ({
           ghz: cpu.frequency,
         })}
       </OdsText>
-      <OdsText>
-        {t('resource_model_characteristics_disk', {
-          value: storage.disks[0].capacity,
-        })}
-      </OdsText>
+      {isStorageDisplayed && storage && (
+        <OdsText>
+          {t('resource_model_characteristics_disk', {
+            value: storage.disks[0].capacity,
+          })}
+        </OdsText>
+      )}
       <OdsText>
         {t('resource_model_characteristics_mbits', {
           value: bandwidth.level,
@@ -43,6 +47,7 @@ type TileTechnicalInfoProps = {
   onClick?: () => void;
   isActive?: boolean;
   name: string;
+  isStorageDisplayed?: boolean;
 };
 
 export const TileTechnicalInfo: React.FC<TileTechnicalInfoProps> = ({
@@ -50,13 +55,19 @@ export const TileTechnicalInfo: React.FC<TileTechnicalInfoProps> = ({
   technical,
   onClick,
   isActive,
+  isStorageDisplayed = true,
 }) => (
   <SimpleTile onClick={onClick} isActive={isActive}>
     <div className="flex flex-col items-center justify-center">
       <OdsText>
         <span className="font-bold">{name}</span>
       </OdsText>
-      {technical?.bandwidth && <DisplayTechnicalInfo technical={technical} />}
+      {technical?.bandwidth && (
+        <DisplayTechnicalInfo
+          technical={technical}
+          isStorageDisplayed={isStorageDisplayed}
+        />
+      )}
     </div>
   </SimpleTile>
 );

--- a/packages/manager/apps/pci-savings-plan/src/hooks/useSavingsPlanCreationOptionsFeatureAvailability.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/hooks/useSavingsPlanCreationOptionsFeatureAvailability.tsx
@@ -4,12 +4,18 @@ const svpApp = 'pci-savings-plan';
 
 const deployment3AZ = `${svpApp}:deployment-region-3-az`;
 const rancherService = `${svpApp}:rancher-service`;
+export const INSTANCES_REPRICING = `${svpApp}:repricing-instances-pre-com`;
 
 export const useSavingsPlanCreationOptionsFeatureAvailability = () => {
-  const { data } = useFeatureAvailability([deployment3AZ, rancherService]);
+  const { data } = useFeatureAvailability([
+    deployment3AZ,
+    rancherService,
+    INSTANCES_REPRICING,
+  ]);
 
   return {
     isDeployment3AZAvailable: data?.[deployment3AZ],
     isRancherServiceAvailable: data?.[rancherService],
+    isInstancesRepricingAvailable: data?.[INSTANCES_REPRICING],
   };
 };


### PR DESCRIPTION
Removes mentions of storage when creating a savings plan. controlled by feature flag "repricing-instances-pre-com"

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
before:
<img width="1104" height="346" alt="Capture d’écran 2026-08-03 à 13 55 00" src="https://github.com/user-attachments/assets/f6a75224-8930-41e7-b5bf-6334503d9725" />
after:
<img width="1041" height="320" alt="Capture d’écran 2026-08-03 à 13 54 49" src="https://github.com/user-attachments/assets/1add3233-d33a-422d-9e52-11bbf36dd2c5" />
