### PR TITLE
feat(backup-licenses): list the vaults of the service (BKP-1221)

### DIFF
--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "Dieser Vault verfügt über kein Bucket, das S3-Zugangsdaten bereitstellen kann."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "S3-Zugangsdaten",
+    "field": {
+      "endpoint": "S3-Endpunkt"
+    },
+    "hide": "Ausblenden",
+    "copied_toast": "In die Zwischenablage kopiert",
+    "error": "Die S3-Zugangsdaten konnten nicht abgerufen werden. Bitte versuchen Sie es in einigen Augenblicken erneut.",
+    "loading": "S3-Zugangsdaten werden abgerufen",
+    "a11y": {
+      "show_secret": "Geheimen Schlüssel anzeigen",
+      "hide_secret": "Geheimen Schlüssel ausblenden",
+      "copy_field": "Feld {{field}} kopieren",
+      "value_hidden": "Wert ausgeblendet"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "This vault has no bucket able to provide S3 credentials."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "S3 credentials",
+    "field": {
+      "endpoint": "S3 Endpoint"
+    },
+    "hide": "Hide",
+    "copied_toast": "Copied to clipboard",
+    "error": "The S3 credentials could not be retrieved. Please try again in a few moments.",
+    "loading": "Retrieving the S3 credentials",
+    "a11y": {
+      "show_secret": "Show the secret key",
+      "hide_secret": "Hide the secret key",
+      "copy_field": "Copy the {{field}} field",
+      "value_hidden": "Value hidden"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "Este vault no tiene ningún bucket capaz de proporcionar credenciales S3."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "Credenciales S3",
+    "field": {
+      "endpoint": "Endpoint S3"
+    },
+    "hide": "Ocultar",
+    "copied_toast": "Copiado al portapapeles",
+    "error": "No se han podido recuperar las credenciales S3. Vuelva a intentarlo en unos instantes.",
+    "loading": "Recuperando las credenciales S3",
+    "a11y": {
+      "show_secret": "Mostrar la clave secreta",
+      "hide_secret": "Ocultar la clave secreta",
+      "copy_field": "Copiar el campo {{field}}",
+      "value_hidden": "Valor oculto"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Commander un vault"
+  },
+  "column": {
+    "immutability": "Immuabilité",
+    "encryption": "Chiffrement"
+  },
+  "immutability_value_one": "Activée - {{count}} jour",
+  "immutability_value_other": "Activée - {{count}} jours",
+  "encryption_value": "Activé - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Actions du vault",
+    "show_credentials": "Afficher les identifiants",
+    "credentials_disabled_tooltip": "Ce vault n'a aucun bucket en mesure de fournir des identifiants S3."
+  },
+  "state": {
+    "empty": {
+      "title": "Aucun vault à afficher",
+      "description": "Aucun vault de stockage n'est rattaché à ce service pour le moment. Un vault commandé à l'instant peut être encore en cours de création : rechargez la page dans quelques minutes."
+    },
+    "error": {
+      "message": "La liste des vaults n'a pas pu être chargée.",
+      "retry": "Réessayer"
+    }
+  },
+  "terminate": {
+    "message": "Êtes-vous sûr de vouloir résilier le vault {{name}} (région : {{region}}) ? Toutes les données qu'il contient seront définitivement perdues. Cette action est irréversible.",
+    "success": "Le vault a bien été résilié.",
+    "included_tooltip": "Le vault inclus ne peut pas être résilié.",
+    "error": "La résiliation du vault a échoué. Veuillez réessayer dans quelques instants."
+  },
+  "credentials": {
+    "title": "Identifiants S3",
+    "field": {
+      "endpoint": "Point d'accès S3"
+    },
+    "hide": "Masquer",
+    "copied_toast": "Copié dans le presse-papiers",
+    "error": "Les identifiants S3 n'ont pas pu être récupérés. Veuillez réessayer dans quelques instants.",
+    "loading": "Récupération des identifiants S3",
+    "a11y": {
+      "show_secret": "Afficher la clé secrète",
+      "hide_secret": "Masquer la clé secrète",
+      "copy_field": "Copier le champ {{field}}",
+      "value_hidden": "Valeur masquée"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Commander un vault"
+  },
+  "column": {
+    "immutability": "Immuabilité",
+    "encryption": "Chiffrement"
+  },
+  "immutability_value_one": "Activée - {{count}} jour",
+  "immutability_value_other": "Activée - {{count}} jours",
+  "encryption_value": "Activé - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Actions du vault",
+    "show_credentials": "Afficher les identifiants",
+    "credentials_disabled_tooltip": "Ce vault n'a aucun bucket en mesure de fournir des identifiants S3."
+  },
+  "state": {
+    "empty": {
+      "title": "Aucun vault à afficher",
+      "description": "Aucun vault de stockage n'est rattaché à ce service pour le moment. Un vault commandé à l'instant peut être encore en cours de création : rechargez la page dans quelques minutes."
+    },
+    "error": {
+      "message": "La liste des vaults n'a pas pu être chargée.",
+      "retry": "Réessayer"
+    }
+  },
+  "terminate": {
+    "message": "Êtes-vous sûr de vouloir résilier le vault {{name}} (région : {{region}}) ? Toutes les données qu'il contient seront définitivement perdues. Cette action est irréversible.",
+    "success": "Le vault a bien été résilié.",
+    "included_tooltip": "Le vault inclus ne peut pas être résilié.",
+    "error": "La résiliation du vault a échoué. Veuillez réessayer dans quelques instants."
+  },
+  "credentials": {
+    "title": "Identifiants S3",
+    "field": {
+      "endpoint": "Point d'accès S3"
+    },
+    "hide": "Masquer",
+    "copied_toast": "Copié dans le presse-papiers",
+    "error": "Les identifiants S3 n'ont pas pu être récupérés. Veuillez réessayer dans quelques instants.",
+    "loading": "Récupération des identifiants S3",
+    "a11y": {
+      "show_secret": "Afficher la clé secrète",
+      "hide_secret": "Masquer la clé secrète",
+      "copy_field": "Copier le champ {{field}}",
+      "value_hidden": "Valeur masquée"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "Questo vault non ha alcun bucket in grado di fornire credenziali S3."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "Credenziali S3",
+    "field": {
+      "endpoint": "Endpoint S3"
+    },
+    "hide": "Nascondi",
+    "copied_toast": "Copiato negli appunti",
+    "error": "Non è stato possibile recuperare le credenziali S3. Riprova tra qualche istante.",
+    "loading": "Recupero delle credenziali S3",
+    "a11y": {
+      "show_secret": "Mostra la chiave segreta",
+      "hide_secret": "Nascondi la chiave segreta",
+      "copy_field": "Copia il campo {{field}}",
+      "value_hidden": "Valore nascosto"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
@@ -1,0 +1,53 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_few": "Enabled - {{count}} days",
+  "immutability_value_many": "Enabled - {{count}} days",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "Ten vault nie ma żadnego bucketa, który mógłby udostępnić dane uwierzytelniające S3."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "Dane uwierzytelniające S3",
+    "field": {
+      "endpoint": "Punkt końcowy S3"
+    },
+    "hide": "Ukryj",
+    "copied_toast": "Skopiowano do schowka",
+    "error": "Nie udało się pobrać danych uwierzytelniających S3. Spróbuj ponownie za chwilę.",
+    "loading": "Pobieranie danych uwierzytelniających S3",
+    "a11y": {
+      "show_secret": "Pokaż klucz tajny",
+      "hide_secret": "Ukryj klucz tajny",
+      "copy_field": "Skopiuj pole {{field}}",
+      "value_hidden": "Wartość ukryta"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
@@ -1,0 +1,51 @@
+{
+  "service_type": "vault",
+  "cta": {
+    "order": "Order a vault"
+  },
+  "column": {
+    "immutability": "Immutability",
+    "encryption": "Encryption"
+  },
+  "immutability_value_one": "Enabled - {{count}} day",
+  "immutability_value_other": "Enabled - {{count}} days",
+  "encryption_value": "Enabled - SSE OMK",
+  "region_single": "{{city}} ({{code}})",
+  "action": {
+    "menu_label": "Vault actions",
+    "show_credentials": "Show credentials",
+    "credentials_disabled_tooltip": "Este vault não tem nenhum bucket capaz de fornecer credenciais S3."
+  },
+  "state": {
+    "empty": {
+      "title": "No vault to display",
+      "description": "No storage vault is attached to this service yet. A vault ordered a few moments ago may still be being created: reload the page in a few minutes."
+    },
+    "error": {
+      "message": "The vault list could not be loaded.",
+      "retry": "Retry"
+    }
+  },
+  "terminate": {
+    "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
+    "success": "Vault terminated successfully.",
+    "included_tooltip": "The included vault cannot be terminated.",
+    "error": "Terminating the vault failed. Please try again in a few moments."
+  },
+  "credentials": {
+    "title": "Credenciais S3",
+    "field": {
+      "endpoint": "Endpoint S3"
+    },
+    "hide": "Ocultar",
+    "copied_toast": "Copiado para a área de transferência",
+    "error": "Não foi possível obter as credenciais S3. Tente novamente dentro de alguns instantes.",
+    "loading": "A obter as credenciais S3",
+    "a11y": {
+      "show_secret": "Mostrar a chave secreta",
+      "hide_secret": "Ocultar a chave secreta",
+      "copy_field": "Copiar o campo {{field}}",
+      "value_hidden": "Valor oculto"
+    }
+  }
+}

--- a/packages/manager/modules/backup-licenses/src/BackupLicenses.translations.ts
+++ b/packages/manager/modules/backup-licenses/src/BackupLicenses.translations.ts
@@ -8,4 +8,5 @@ export const BACKUP_LICENSES_NAMESPACES = {
   LINKED_SERVERS: `${NAMESPACE_PREFIX}/linked-servers`,
   GENERAL_INFORMATION: `${NAMESPACE_PREFIX}/general-information`,
   BILLING: `${NAMESPACE_PREFIX}/billing`,
+  VAULTS: `${NAMESPACE_PREFIX}/vaults`,
 };

--- a/packages/manager/modules/backup-licenses/src/components/ActionButton/ActionButton.component.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/ActionButton/ActionButton.component.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ODS_ICON_NAME } from '@ovhcloud/ods-components';
+
+import { renderWithProviders } from '@/test-utils/renderWithProviders';
+
+import { ActionButton } from './ActionButton.component';
+
+const renderActionButton = (props: Partial<React.ComponentProps<typeof ActionButton>> = {}) =>
+  renderWithProviders(
+    <ActionButton
+      testId="copy-thing"
+      icon={ODS_ICON_NAME.fileCopy}
+      accessibleName="Copy the Region field"
+      onClick={vi.fn()}
+      {...props}
+    />,
+  );
+
+describe('ActionButton', () => {
+  it('exposes its accessible name on the focusable control itself', async () => {
+    await renderActionButton();
+
+    const button = screen.getByRole('button', { name: 'Copy the Region field' });
+    expect(button).toHaveAttribute('type', 'button');
+    expect(button).toBe(screen.getByTestId('copy-thing'));
+  });
+
+  it('keeps the icon out of the accessibility tree', async () => {
+    const { container } = await renderActionButton();
+
+    expect(container.querySelector(`ods-icon[name="${ODS_ICON_NAME.fileCopy}"]`)).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    await expect(container).toBeAccessible();
+  });
+
+  it('is named by the label it displays, and only described by the rest', async () => {
+    const { container } = await renderActionButton({
+      accessibleName: 'Show the secret key',
+      visibleLabel: 'Show',
+    });
+
+    // WCAG 2.1 SC 2.5.3: a speech-input user says what they read, so nothing may override the label.
+    const button = screen.getByRole('button', { name: 'Show' });
+    expect(button).toHaveAccessibleDescription('Show the secret key');
+    expect(screen.getByText('Show the secret key')).toHaveClass('sr-only');
+    await expect(container).toBeAccessible();
+  });
+
+  it('reports the click to its caller', async () => {
+    const onClick = vi.fn();
+    await renderActionButton({ onClick });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy the Region field' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/components/ActionButton/ActionButton.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/ActionButton/ActionButton.component.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import { ODS_ICON_NAME, ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
+import { OdsIcon, OdsText } from '@ovhcloud/ods-components/react';
+
+export type ActionButtonProps = {
+  id?: string;
+  testId: string;
+  icon: ODS_ICON_NAME;
+  accessibleName: string;
+  visibleLabel?: string;
+  className?: string;
+  onClick: () => void;
+  disclosedOverlayId?: string;
+  isExpanded?: boolean;
+  popupRole?: 'menu' | 'dialog';
+};
+
+const ACTION_BUTTON_CLASS = [
+  // Tailwind's preflight is off in the consuming apps and nothing else resets `button`, so the
+  // user-agent background, border and 13.3px font survive unless they are cleared here.
+  'cursor-pointer appearance-none border-0 bg-transparent [font:inherit]',
+  // Explicit rem, because manager-tailwind-config remaps the spacing scale onto the ODS tokens
+  // (`gap-1` is 0.0625rem, `p-2` 0.125rem) — far too small for a hit area.
+  'inline-flex shrink-0 items-center justify-center gap-[0.25rem] rounded',
+  'min-h-[1.5rem] min-w-[1.5rem]',
+  'text-[var(--ods-color-primary-500)] hover:bg-[var(--ods-color-primary-050)]',
+  'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+  'focus-visible:outline-[var(--ods-color-primary-500)]',
+].join(' ');
+
+const ICON_ONLY_PADDING_CLASS = 'p-[0.25rem]';
+const LABELLED_PADDING_CLASS = 'px-[0.5rem] py-[0.25rem]';
+
+/**
+ * ODS 18's `ods-button` renders its real `<button>` inside a shadow root and names it from the
+ * `label` prop alone: an `aria-label` set on the host never becomes the control's accessible name.
+ * An icon-driven action therefore has to be a native button here, dressed with the ODS icon and
+ * the ODS colour tokens.
+ *
+ * `accessibleName` names the control only while it is icon-only. Once a `visibleLabel` is rendered the
+ * name is that same string — WCAG 2.1 SC 2.5.3 (Label in Name): the two texts come from two translation
+ * keys and diverge per locale (it_IT displays "Mostrare", named "Mostra la chiave segreta"), and a name
+ * that overrides the visible text leaves a speech-input user unable to activate what they read. The
+ * `aria-label` is kept, bound to the variable the label renders: the two cannot desynchronise, and the
+ * name does not depend on `ods-text` exposing its slotted text. The extra context becomes the
+ * accessible *description*, announced after the name.
+ */
+export const ActionButton = ({
+  id,
+  testId,
+  icon,
+  accessibleName,
+  visibleLabel,
+  className = '',
+  onClick,
+  disclosedOverlayId,
+  isExpanded,
+  popupRole,
+}: ActionButtonProps) => {
+  const isLabelled = !!visibleLabel;
+  const descriptionId = isLabelled ? `${testId}-description` : undefined;
+  const paddingClass = isLabelled ? LABELLED_PADDING_CLASS : ICON_ONLY_PADDING_CLASS;
+
+  return (
+    <button
+      id={id}
+      type="button"
+      data-testid={testId}
+      aria-label={isLabelled ? visibleLabel : accessibleName}
+      aria-describedby={descriptionId}
+      aria-haspopup={popupRole}
+      aria-expanded={popupRole ? !!isExpanded : undefined}
+      aria-controls={disclosedOverlayId}
+      className={`${ACTION_BUTTON_CLASS} ${paddingClass} ${className}`.trim()}
+      onClick={onClick}
+    >
+      <OdsIcon name={icon} aria-hidden="true" />
+      {isLabelled && (
+        <>
+          <OdsText preset={ODS_TEXT_PRESET.span}>{visibleLabel}</OdsText>
+          <span id={descriptionId} className="sr-only">
+            {accessibleName}
+          </span>
+        </>
+      )}
+    </button>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/components/billing/BillingPeriodNotice/BillingPeriodNotice.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/billing/BillingPeriodNotice/BillingPeriodNotice.component.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { useTranslation } from 'react-i18next';
-
 import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
 
 import { ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
 import { OdsText } from '@ovhcloud/ods-components/react';

--- a/packages/manager/modules/backup-licenses/src/components/billing/VaultPriceCell/VaultPriceCell.component.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/billing/VaultPriceCell/VaultPriceCell.component.spec.tsx
@@ -17,7 +17,9 @@ describe('VaultPriceCell', () => {
   });
 
   it('renders the formatted price text when it is defined and non-zero', async () => {
-    await renderWithProviders(<VaultPriceCell storagePriceValue={5000000} storagePriceText="0,05 €" />);
+    await renderWithProviders(
+      <VaultPriceCell storagePriceValue={5000000} storagePriceText="0,05 €" />,
+    );
     expect(screen.getByText('0,05 €')).toBeInTheDocument();
   });
 

--- a/packages/manager/modules/backup-licenses/src/components/billing/VaultPriceCell/VaultPriceCell.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/billing/VaultPriceCell/VaultPriceCell.component.tsx
@@ -19,7 +19,10 @@ interface VaultPriceCellProps {
  * le type de vault : un bundle en dépassement de ses 500 Go est facturé (§7 de la spec
  * BKP-1225).
  */
-export default function VaultPriceCell({ storagePriceValue, storagePriceText }: VaultPriceCellProps) {
+export default function VaultPriceCell({
+  storagePriceValue,
+  storagePriceText,
+}: VaultPriceCellProps) {
   const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.BILLING);
 
   if (storagePriceValue === 0) {

--- a/packages/manager/modules/backup-licenses/src/components/linked-servers/BackupServerActionsCell/BackupServerActionsCell.component.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/linked-servers/BackupServerActionsCell/BackupServerActionsCell.component.spec.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ActionMenuProps } from '@ovh-ux/manager-react-components';
 
+import { labels } from '@/test-utils/i18ntest.utils';
 import { renderWithProviders } from '@/test-utils/renderWithProviders';
 
 import BackupServerActionsCell from './BackupServerActionsCell.component';
@@ -35,7 +36,7 @@ describe('BackupServerActionsCell', () => {
       <BackupServerActionsCell backupServerId="server-1" isDisabled={false} />,
     );
 
-    expect(screen.getByRole('button', { name: 'modify' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: labels.actions.modify })).toHaveAttribute(
       'data-href',
       '/edit/server-1',
     );
@@ -54,7 +55,7 @@ describe('BackupServerActionsCell', () => {
       { initialEntries: ['/linked-servers'] },
     );
 
-    expect(screen.getByRole('button', { name: 'delete' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: labels.actions.delete })).toHaveAttribute(
       'data-href',
       '/linked-servers/delete/server-1',
     );

--- a/packages/manager/modules/backup-licenses/src/data/api/backupLicenses/backupLicenses.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/backupLicenses/backupLicenses.requests.ts
@@ -1,7 +1,10 @@
 import { fetchIcebergV2 } from '@ovh-ux/manager-core-api';
 
 import { postJSON } from '@/data/api/Client.api';
-import { mockBackupLicenses, mockCreateBackupLicense } from '@/mocks/backupLicenses/backupLicenses.mock';
+import {
+  mockBackupLicenses,
+  mockCreateBackupLicense,
+} from '@/mocks/backupLicenses/backupLicenses.mock';
 import { USE_API_MOCKS } from '@/mocks/mocks.config';
 import { BackupLicenseResource, CreateBackupLicenseParams } from '@/types/BackupLicense.type';
 import { BackupServerResource } from '@/types/BackupServer.type';

--- a/packages/manager/modules/backup-licenses/src/data/api/services/consumption.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/services/consumption.requests.ts
@@ -1,12 +1,15 @@
 import { v6 } from '@ovh-ux/manager-core-api';
 
-import { USE_API_MOCKS } from '@/mocks/mocks.config';
 import {
   mockLicenseConsumptions,
   mockStorageConsumptions,
 } from '@/mocks/consumptions/consumptions.mock';
+import { USE_API_MOCKS } from '@/mocks/mocks.config';
 import { ServiceConsumption } from '@/types/Consumption.type';
-import { getLicenseConsumptionRoute, getServiceConsumptionRoute } from '@/utils/apiRoutes/apiRoutes';
+import {
+  getLicenseConsumptionRoute,
+  getServiceConsumptionRoute,
+} from '@/utils/apiRoutes/apiRoutes';
 
 /** Stockage d'un vault (§3.1 de la spec BKP-1225) : `quantity` et `price` en un seul appel. */
 export const getServiceConsumption = async (serviceId: string): Promise<ServiceConsumption[]> => {

--- a/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
@@ -13,7 +13,7 @@ export const getVaults = async (backupServicesId: string): Promise<VaultResource
 };
 
 /** Secrets : le contrat interdit de les journaliser ou de les cacher, d'où `Pragma: no-cache`. */
-export const getVaultBucketAccess = async (
+export const getVaultBucketCredentials = async (
   backupServicesId: string,
   vaultId: string,
   bucketId: string,

--- a/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
@@ -1,9 +1,9 @@
 import { v2 } from '@ovh-ux/manager-core-api';
 
 import { USE_API_MOCKS } from '@/mocks/mocks.config';
-import { mockVaults } from '@/mocks/vaults/vaults.mock';
-import { VaultResource } from '@/types/Vault.type';
-import { getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
+import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
+import { VaultBucketAccess, VaultResource } from '@/types/Vault.type';
+import { getVaultBucketAccessRoute, getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
 
 /**
  * Route empruntée à `@ovh-ux/backup-agent`, non vérifiée pour ce produit (cf. §14 de la
@@ -13,5 +13,20 @@ export const getVaults = async (backupServicesId: string): Promise<VaultResource
   if (USE_API_MOCKS) return mockVaults;
 
   const { data } = await v2.get<VaultResource[]>(getVaultsRoute(backupServicesId));
+  return data;
+};
+
+/** Même statut que `getVaults` : route supposée, non publiée (BKP-1222). */
+export const getVaultBucketAccess = async (
+  backupServicesId: string,
+  vaultId: string,
+  bucketId: string,
+): Promise<VaultBucketAccess> => {
+  if (USE_API_MOCKS) return mockVaultBucketAccess;
+
+  const { data } = await v2.get<VaultBucketAccess>(
+    getVaultBucketAccessRoute(backupServicesId, vaultId, bucketId),
+    { headers: { Pragma: 'no-cache' } },
+  );
   return data;
 };

--- a/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
@@ -3,12 +3,8 @@ import { v2 } from '@ovh-ux/manager-core-api';
 import { USE_API_MOCKS } from '@/mocks/mocks.config';
 import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
 import { VaultBucketAccess, VaultResource } from '@/types/Vault.type';
-import { getVaultBucketAccessRoute, getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
+import { getVaultBucketCredentialsRoute, getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
 
-/**
- * Route empruntée à `@ovh-ux/backup-agent`, non vérifiée pour ce produit (cf. §14 de la
- * spec BKP-1225). `USE_API_MOCKS` permet de développer sans.
- */
 export const getVaults = async (backupServicesId: string): Promise<VaultResource[]> => {
   if (USE_API_MOCKS) return mockVaults;
 
@@ -16,7 +12,7 @@ export const getVaults = async (backupServicesId: string): Promise<VaultResource
   return data;
 };
 
-/** Même statut que `getVaults` : route supposée, non publiée (BKP-1222). */
+/** Secrets : le contrat interdit de les journaliser ou de les cacher, d'où `Pragma: no-cache`. */
 export const getVaultBucketAccess = async (
   backupServicesId: string,
   vaultId: string,
@@ -25,7 +21,7 @@ export const getVaultBucketAccess = async (
   if (USE_API_MOCKS) return mockVaultBucketAccess;
 
   const { data } = await v2.get<VaultBucketAccess>(
-    getVaultBucketAccessRoute(backupServicesId, vaultId, bucketId),
+    getVaultBucketCredentialsRoute(backupServicesId, vaultId, bucketId),
     { headers: { Pragma: 'no-cache' } },
   );
   return data;

--- a/packages/manager/modules/backup-licenses/src/data/queries/billing.queries.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/billing.queries.spec.ts
@@ -35,13 +35,21 @@ const buildVault = (id: string, resourceName: string): VaultResource => ({
   },
 });
 
-const buildLicense = (id: string, resourceName: string, vaultId: string): BackupLicenseResource => ({
+const buildLicense = (
+  id: string,
+  resourceName: string,
+  vaultId: string,
+): BackupLicenseResource => ({
   id,
   resourceStatus: 'READY',
   currentState: { id, resourceName, vaultId },
 });
 
-const buildConsumption = (planCode: string, quantity: number, priceText: string): ServiceConsumption => ({
+const buildConsumption = (
+  planCode: string,
+  quantity: number,
+  priceText: string,
+): ServiceConsumption => ({
   beginDate: '2026-07-01T00:00:00Z',
   endDate: '2026-07-31T23:59:59Z',
   pricingMode: 'consumption',
@@ -78,7 +86,8 @@ describe('billingQueries', () => {
     ]);
   });
 
-  const fetchRows = () => queryClient.fetchQuery(billingQueries.withClient(queryClient).consumptionRows());
+  const fetchRows = () =>
+    queryClient.fetchQuery(billingQueries.withClient(queryClient).consumptionRows());
 
   it('builds a row with both storage and license prices when both resolve', async () => {
     vi.mocked(getVaults).mockResolvedValue([buildVault('vault-1', 'resource-1')]);

--- a/packages/manager/modules/backup-licenses/src/data/queries/billing.queries.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/billing.queries.ts
@@ -3,7 +3,10 @@ import { QueryClient, queryOptions } from '@tanstack/react-query';
 import { getResourceServiceId } from '@ovh-ux/manager-module-common-api';
 
 import { getBackupLicenses } from '@/data/api/backupLicenses/backupLicenses.requests';
-import { getLicenseConsumption, getServiceConsumption } from '@/data/api/services/consumption.requests';
+import {
+  getLicenseConsumption,
+  getServiceConsumption,
+} from '@/data/api/services/consumption.requests';
 import { getVaults } from '@/data/api/vaults/vaults.requests';
 import { matchLicenseToVault } from '@/data/selectors/licenses.selectors';
 import { selectVaultConsumptionElement } from '@/data/selectors/vaultConsumption.selectors';
@@ -15,8 +18,8 @@ import {
 } from '@/module.constants';
 import { BackupLicenseResource } from '@/types/BackupLicense.type';
 import { ServiceConsumption } from '@/types/Consumption.type';
-import { BillingPeriod, VaultConsumptionRow } from '@/types/VaultConsumption.type';
 import { VaultResource } from '@/types/Vault.type';
+import { BillingPeriod, VaultConsumptionRow } from '@/types/VaultConsumption.type';
 
 import { queryKeys } from './queryKeys';
 import { tenantsQueries } from './tenants.queries';

--- a/packages/manager/modules/backup-licenses/src/data/queries/queryKeys.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/queryKeys.ts
@@ -23,4 +23,14 @@ export const queryKeys = {
     all: () => ['backup-licenses', 'billing'],
     consumptionRows: () => [...queryKeys.billing.all(), 'consumption-rows'],
   },
+  vaults: {
+    all: () => ['backup-licenses', 'vaults'],
+    bucketAccess: (vaultId: string, bucketId: string) => [
+      ...queryKeys.vaults.all(),
+      vaultId,
+      'bucket',
+      bucketId,
+      'access',
+    ],
+  },
 } as const;

--- a/packages/manager/modules/backup-licenses/src/data/queries/queryKeys.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/queryKeys.ts
@@ -25,12 +25,12 @@ export const queryKeys = {
   },
   vaults: {
     all: () => ['backup-licenses', 'vaults'],
-    bucketAccess: (vaultId: string, bucketId: string) => [
+    bucketCredentials: (vaultId: string, bucketId: string) => [
       ...queryKeys.vaults.all(),
       vaultId,
       'bucket',
       bucketId,
-      'access',
+      'credentials',
     ],
   },
 } as const;

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
@@ -1,0 +1,82 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+
+import { mockEdgeCaseVaults, mockVaultBucketAccess } from '@/mocks/vaults/vaults.mock';
+import { setupMswMock } from '@/test-utils/setupMsw';
+import { VaultResource } from '@/types/Vault.type';
+
+import { vaultsQueries } from './vaults.queries';
+
+/**
+ * `USE_API_MOCKS` renvoie les jeux de données sans passer par le réseau : le module l'utilise pour
+ * développer sans API. Ces tests-ci portent justement sur la couche réseau (erreurs, polling), donc
+ * ils la laissent s'exécuter et servent les réponses par MSW.
+ */
+vi.mock('@/mocks/mocks.config', () => ({ USE_API_MOCKS: false }));
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+describe('vaultsQueries.list', () => {
+  it('resolves the tenant, then lists its vaults', async () => {
+    setupMswMock();
+    const queryClient = createQueryClient();
+
+    const vaults = await queryClient.fetchQuery(vaultsQueries.withClient(queryClient).list());
+
+    expect(vaults[0]?.currentState.name).toBe('vault-veeam-multi-region');
+  });
+
+  it('rejects when the listing fails, so the error state can be rendered', async () => {
+    setupMswMock({ isVaultListError: true });
+    const queryClient = createQueryClient();
+
+    await expect(
+      queryClient.fetchQuery(vaultsQueries.withClient(queryClient).list()),
+    ).rejects.toThrow();
+  });
+
+  const creatingVault = mockEdgeCaseVaults.filter(({ id }) => id === 'vault-status-creating');
+  const statusOfCreating = (vaults: VaultResource[]) =>
+    vaults.find(({ id }) => id === 'vault-status-creating')?.currentState.status;
+
+  it('flips a creating vault to ready once polling has run, so polling can stop', async () => {
+    setupMswMock({ vaults: creatingVault, vaultCreatingCallsBeforeReady: 1 });
+    const queryClient = createQueryClient();
+    const getVaults = () => queryClient.fetchQuery(vaultsQueries.withClient(queryClient).list());
+
+    expect(statusOfCreating(await getVaults())).toBe('CREATING');
+    expect(statusOfCreating(await getVaults())).toBe('READY');
+  });
+
+  it('keeps a stuck vault creating, so the timeout path can be exercised', async () => {
+    setupMswMock({ vaults: creatingVault, vaultCreatingCallsBeforeReady: Infinity });
+    const queryClient = createQueryClient();
+    const list = vaultsQueries.withClient(queryClient).list();
+
+    await queryClient.fetchQuery(list);
+
+    expect(statusOfCreating(await queryClient.fetchQuery(list))).toBe('CREATING');
+  });
+});
+
+describe('vaultsQueries.bucketAccess', () => {
+  it('returns the S3 keys of the requested bucket', async () => {
+    setupMswMock();
+    const queryClient = createQueryClient();
+
+    const access = await queryClient.fetchQuery(
+      vaultsQueries.withClient(queryClient).bucketAccess('0001', '0001-b1'),
+    );
+
+    expect(access).toEqual(mockVaultBucketAccess);
+  });
+
+  it('rejects when the credentials call fails', async () => {
+    setupMswMock({ isVaultAccessError: true });
+    const queryClient = createQueryClient();
+
+    await expect(
+      queryClient.fetchQuery(vaultsQueries.withClient(queryClient).bucketAccess('0001', '0001-b1')),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
@@ -59,24 +59,26 @@ describe('vaultsQueries.list', () => {
   });
 });
 
-describe('vaultsQueries.bucketAccess', () => {
+describe('vaultsQueries.bucketCredentials', () => {
   it('returns the S3 keys of the requested bucket', async () => {
     setupMswMock();
     const queryClient = createQueryClient();
 
-    const access = await queryClient.fetchQuery(
-      vaultsQueries.withClient(queryClient).bucketAccess('0001', '0001-b1'),
+    const credentials = await queryClient.fetchQuery(
+      vaultsQueries.withClient(queryClient).bucketCredentials('0001', '0001-b1'),
     );
 
-    expect(access).toEqual(mockVaultBucketAccess);
+    expect(credentials).toEqual(mockVaultBucketAccess);
   });
 
   it('rejects when the credentials call fails', async () => {
-    setupMswMock({ isVaultAccessError: true });
+    setupMswMock({ isVaultCredentialsError: true });
     const queryClient = createQueryClient();
 
     await expect(
-      queryClient.fetchQuery(vaultsQueries.withClient(queryClient).bucketAccess('0001', '0001-b1')),
+      queryClient.fetchQuery(
+        vaultsQueries.withClient(queryClient).bucketCredentials('0001', '0001-b1'),
+      ),
     ).rejects.toThrow();
   });
 });

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
@@ -1,0 +1,36 @@
+import { QueryClient, queryOptions } from '@tanstack/react-query';
+
+import { getVaultBucketAccess, getVaults } from '@/data/api/vaults/vaults.requests';
+
+import { queryKeys } from './queryKeys';
+import { tenantsQueries } from './tenants.queries';
+
+const list = (queryClient: QueryClient) => () =>
+  queryOptions({
+    queryKey: queryKeys.vaults.all(),
+    queryFn: async () => getVaults(await tenantsQueries.withClient(queryClient).backupServicesId()),
+  });
+
+const bucketAccess =
+  (queryClient: QueryClient) =>
+  (vaultId: string, bucketId: string, { enabled = true }: { enabled?: boolean } = {}) =>
+    queryOptions({
+      queryKey: queryKeys.vaults.bucketAccess(vaultId, bucketId),
+      queryFn: async () =>
+        getVaultBucketAccess(
+          await tenantsQueries.withClient(queryClient).backupServicesId(),
+          vaultId,
+          bucketId,
+        ),
+      enabled: enabled && !!vaultId && !!bucketId,
+      // Secrets : lus à l'ouverture de la modale, jamais resservis depuis le cache.
+      staleTime: 0,
+      gcTime: 0,
+    });
+
+const withClient = (queryClient: QueryClient) => ({
+  list: list(queryClient),
+  bucketAccess: bucketAccess(queryClient),
+});
+
+export const vaultsQueries = { withClient };

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
@@ -1,6 +1,6 @@
 import { QueryClient, queryOptions } from '@tanstack/react-query';
 
-import { getVaultBucketAccess, getVaults } from '@/data/api/vaults/vaults.requests';
+import { getVaultBucketCredentials, getVaults } from '@/data/api/vaults/vaults.requests';
 
 import { queryKeys } from './queryKeys';
 import { tenantsQueries } from './tenants.queries';
@@ -11,13 +11,13 @@ const list = (queryClient: QueryClient) => () =>
     queryFn: async () => getVaults(await tenantsQueries.withClient(queryClient).backupServicesId()),
   });
 
-const bucketAccess =
+const bucketCredentials =
   (queryClient: QueryClient) =>
   (vaultId: string, bucketId: string, { enabled = true }: { enabled?: boolean } = {}) =>
     queryOptions({
-      queryKey: queryKeys.vaults.bucketAccess(vaultId, bucketId),
+      queryKey: queryKeys.vaults.bucketCredentials(vaultId, bucketId),
       queryFn: async () =>
-        getVaultBucketAccess(
+        getVaultBucketCredentials(
           await tenantsQueries.withClient(queryClient).backupServicesId(),
           vaultId,
           bucketId,
@@ -30,7 +30,7 @@ const bucketAccess =
 
 const withClient = (queryClient: QueryClient) => ({
   list: list(queryClient),
-  bucketAccess: bucketAccess(queryClient),
+  bucketCredentials: bucketCredentials(queryClient),
 });
 
 export const vaultsQueries = { withClient };

--- a/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { VaultResource } from '@/types/Vault.type';
+import { VaultProductLine, VaultResource } from '@/types/Vault.type';
 
 import { selectBackupLicensesVaults } from './vaults.selectors';
 
-const buildVault = (id: string, vaultProductLine?: string): VaultResource => ({
+const buildVault = (id: string, vaultProductLine?: VaultProductLine | null): VaultResource => ({
   id,
   resourceStatus: 'READY',
   currentState: {
@@ -23,13 +23,16 @@ describe('selectBackupLicensesVaults', () => {
     expect(selectBackupLicensesVaults(vaults)).toEqual(vaults);
   });
 
-  it('discards vaults whose vaultProductLine is another value', () => {
-    const vaults = [buildVault('v1', 'ICEBERG')];
+  it('discards vaults of the other product line', () => {
+    const vaults = [buildVault('v1', 'BACKUP_AGENT')];
     expect(selectBackupLicensesVaults(vaults)).toEqual([]);
   });
 
-  it('keeps vaults whose vaultProductLine field is absent (BE tolerance, §14)', () => {
-    const vaults = [buildVault('v1', undefined)];
-    expect(selectBackupLicensesVaults(vaults)).toEqual(vaults);
-  });
+  it.each([['absent', undefined] as const, ['null, as the contract allows', null] as const])(
+    'keeps vaults whose vaultProductLine is %s',
+    (_, vaultProductLine) => {
+      const vaults = [buildVault('v1', vaultProductLine)];
+      expect(selectBackupLicensesVaults(vaults)).toEqual(vaults);
+    },
+  );
 });

--- a/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
+++ b/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
@@ -1,15 +1,14 @@
 import { VaultBucket, VaultResource } from '@/types/Vault.type';
 
 /**
- * `vaultProductLine` n'a 0 occurrence dans aucun contrat API connu (cf. §14 de la spec
- * BKP-1225) : les vaults dont le champ est absent sont conservés, sinon l'écran serait
- * vide tant que le BE ne le renvoie pas encore.
+ * `vaultProductLine` est nullable au contrat, « until existing vaults are backfilled » : les vaults
+ * dont il n'est pas renseigné sont conservés, sinon l'écran serait vide tant que le BE n'a pas
+ * rétro-rempli le champ.
  */
 export const selectBackupLicensesVaults = (vaults: VaultResource[]): VaultResource[] =>
   vaults.filter(
-    ({ currentState }) =>
-      currentState.vaultProductLine === undefined ||
-      currentState.vaultProductLine === 'BACKUP_LICENSES',
+    ({ currentState: { vaultProductLine } }) =>
+      !vaultProductLine || vaultProductLine === 'BACKUP_LICENSES',
   );
 
 /**
@@ -19,6 +18,7 @@ export const selectBackupLicensesVaults = (vaults: VaultResource[]): VaultResour
 export const selectVaultCredentialsBucket = (vault: VaultResource): VaultBucket | undefined =>
   vault.currentState.buckets?.find(({ role, status }) => role === 'PRIMARY' && status === 'READY');
 
+/** `type` et non `includedSoftQuotaGb` : ce champ est aussi null « when not applicable ». */
 export const selectIsIncludedVault = (vault: VaultResource): boolean =>
   vault.currentState.type === 'BUNDLE';
 

--- a/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
+++ b/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
@@ -1,4 +1,4 @@
-import { VaultResource } from '@/types/Vault.type';
+import { VaultBucket, VaultResource } from '@/types/Vault.type';
 
 /**
  * `vaultProductLine` n'a 0 occurrence dans aucun contrat API connu (cf. §14 de la spec
@@ -11,3 +11,19 @@ export const selectBackupLicensesVaults = (vaults: VaultResource[]): VaultResour
       currentState.vaultProductLine === undefined ||
       currentState.vaultProductLine === 'BACKUP_LICENSES',
   );
+
+/**
+ * Bucket dont la modale d'identifiants montre les clés (BKP-1222). C'est le statut qui compte,
+ * pas l'ordre : un vault peut porter plusieurs buckets PRIMARY dont le premier est suspendu.
+ */
+export const selectVaultCredentialsBucket = (vault: VaultResource): VaultBucket | undefined =>
+  vault.currentState.buckets?.find(({ role, status }) => role === 'PRIMARY' && status === 'READY');
+
+export const selectIsIncludedVault = (vault: VaultResource): boolean =>
+  vault.currentState.type === 'BUNDLE';
+
+export const selectCanTerminateVault = (vault: VaultResource): boolean =>
+  vault.currentState.type === 'PAYGO';
+
+export const selectIsVaultSettled = (vault: VaultResource): boolean =>
+  vault.resourceStatus === 'READY';

--- a/packages/manager/modules/backup-licenses/src/hooks/useReturnFocus/useReturnFocus.ts
+++ b/packages/manager/modules/backup-licenses/src/hooks/useReturnFocus/useReturnFocus.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+
+/**
+ * Gives keyboard focus back to the control that opened a route-driven overlay.
+ *
+ * The trigger is named by id rather than captured from `document.activeElement`: the row menu closes
+ * as the overlay opens, and a menu item that is no longer displayed cannot take focus back. The call
+ * is deferred by one task because a modal `<dialog>` makes the rest of the document inert — the
+ * trigger becomes focusable again only once the dialog has left the DOM.
+ */
+export const useReturnFocus = (triggerId: string) =>
+  useCallback(() => {
+    window.setTimeout(() => document.getElementById(triggerId)?.focus(), 0);
+  }, [triggerId]);

--- a/packages/manager/modules/backup-licenses/src/hooks/useServiceTabs/useServiceTabs.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/hooks/useServiceTabs/useServiceTabs.spec.tsx
@@ -39,11 +39,13 @@ describe('useServiceTabs', () => {
     expect(await activeTabNames(routeUrls.onboarding)).toEqual([]);
   });
 
-  it('never marks a disabled tab as active, even on its own pathname', async () => {
+  // L'onglet Vaults était affiché désactivé en attendant sa route ; BKP-1221 la livre, donc il est
+  // désormais navigable et actif sur son propre pathname.
+  it('marks the vaults tab as active on its own pathname', async () => {
     const tabs = await renderTabs(routeUrls.vaults);
     const vaultsTab = tabs.find((tab) => tab.name === 'vaults');
 
-    expect(vaultsTab?.isDisabled).toBe(true);
-    expect(vaultsTab?.isActive).toBe(false);
+    expect(vaultsTab?.isDisabled).toBeFalsy();
+    expect(vaultsTab?.isActive).toBe(true);
   });
 });

--- a/packages/manager/modules/backup-licenses/src/hooks/useTerminateIamActions/useTerminateIamActions.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/hooks/useTerminateIamActions/useTerminateIamActions.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ShellContext, ShellContextType } from '@ovh-ux/manager-react-shell-client';
+
+import { IAM_ACTIONS } from '@/utils/iam.constants';
+
+import { useTerminateIamActions } from './useTerminateIamActions';
+
+const renderWithSubsidiary = (ovhSubsidiary?: string) => {
+  const context = {
+    environment: { getUser: () => ({ ovhSubsidiary }) },
+  } as unknown as ShellContextType;
+
+  return renderHook(() => useTerminateIamActions(), {
+    wrapper: ({ children }) => (
+      <ShellContext.Provider value={context}>{children}</ShellContext.Provider>
+    ),
+  });
+};
+
+describe('useTerminateIamActions', () => {
+  it('asks for the action guarding the DELETE form served to the US subsidiary', () => {
+    const { result } = renderWithSubsidiary('US');
+
+    expect(result.current).toContain(IAM_ACTIONS.servicesTerminateWithoutConfirmation);
+    expect(result.current).toContain(IAM_ACTIONS.servicesGet);
+  });
+
+  it('asks for the action guarding the POST form served everywhere else', () => {
+    const { result } = renderWithSubsidiary('FR');
+
+    expect(result.current).toContain(IAM_ACTIONS.servicesTerminate);
+    expect(result.current).not.toContain(IAM_ACTIONS.servicesTerminateWithoutConfirmation);
+  });
+
+  it('falls back to the POST form when no shell provides the subsidiary', () => {
+    const { result } = renderHook(() => useTerminateIamActions());
+
+    expect(result.current).toEqual([IAM_ACTIONS.servicesGet, IAM_ACTIONS.servicesTerminate]);
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/hooks/useTerminateIamActions/useTerminateIamActions.ts
+++ b/packages/manager/modules/backup-licenses/src/hooks/useTerminateIamActions/useTerminateIamActions.ts
@@ -1,0 +1,12 @@
+import { useContext, useMemo } from 'react';
+
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+
+import { getTerminateIamActions } from '@/utils/iam.constants';
+
+export const useTerminateIamActions = (): string[] => {
+  // `getUser` is absent from the ShellContext default value, so the call has to stay optional.
+  const ovhSubsidiary = useContext(ShellContext)?.environment?.getUser?.()?.ovhSubsidiary;
+
+  return useMemo(() => getTerminateIamActions(ovhSubsidiary), [ovhSubsidiary]);
+};

--- a/packages/manager/modules/backup-licenses/src/mocks/iam/iam.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/iam/iam.handler.ts
@@ -1,0 +1,27 @@
+import { PathParams } from 'msw';
+
+import { Handler } from '@ovh-ux/manager-core-test-utils';
+
+import { VAULT_IAM_ACTIONS } from '@/mocks/iam/iam.mock';
+
+export type TIamMockParams = {
+  /** Denied actions; every other published action is granted. */
+  unauthorizedIamActions?: string[];
+};
+
+export const getIamMocks = ({ unauthorizedIamActions = [] }: TIamMockParams): Handler[] => [
+  {
+    url: '/iam/resource/:urn/authorization/check',
+    response: (_: unknown, params: PathParams) => ({
+      urn: String(params.urn),
+      authorizedActions: VAULT_IAM_ACTIONS.filter(
+        (action) => !unauthorizedIamActions.includes(action),
+      ),
+      unauthorizedActions: unauthorizedIamActions,
+    }),
+    api: 'v2',
+    method: 'post',
+    status: 200,
+    delay: 0,
+  },
+];

--- a/packages/manager/modules/backup-licenses/src/mocks/iam/iam.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/iam/iam.mock.ts
@@ -1,0 +1,6 @@
+import { IAM_ACTIONS } from '@/utils/iam.constants';
+
+export const VAULT_IAM_ACTIONS = Object.values(IAM_ACTIONS);
+
+export const getVaultIamUrn = (vaultId: string) =>
+  `urn:v1:eu:resource:backupServices:vault:${vaultId}`;

--- a/packages/manager/modules/backup-licenses/src/mocks/tenants/tenants.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/tenants/tenants.handler.ts
@@ -1,0 +1,27 @@
+import { Handler } from '@ovh-ux/manager-core-test-utils';
+
+import { mockBackupServicesTenants } from '@/mocks/tenants/tenants.mock';
+import { BackupServicesTenant } from '@/types/BackupServicesTenant.type';
+import { Resource } from '@/types/Resource.type';
+
+export type TTenantMockParams = {
+  backupServicesTenants?: Resource<BackupServicesTenant>[];
+  isBackupServicesTenantsError?: boolean;
+};
+
+export const getTenantMocks = ({
+  backupServicesTenants,
+  isBackupServicesTenantsError,
+}: TTenantMockParams): Handler[] => [
+  {
+    url: '/backupServices/tenant',
+    response: () =>
+      isBackupServicesTenantsError
+        ? { message: 'Internal server error' }
+        : (backupServicesTenants ?? mockBackupServicesTenants),
+    api: 'v2',
+    method: 'get',
+    status: isBackupServicesTenantsError ? 500 : 200,
+    delay: 0,
+  },
+];

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
@@ -1,0 +1,81 @@
+import { PathParams } from 'msw';
+
+import { Handler } from '@ovh-ux/manager-core-test-utils';
+
+import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
+import { VaultResource } from '@/types/Vault.type';
+
+export type TVaultMockParams = {
+  vaults?: VaultResource[];
+  isVaultListError?: boolean;
+  isVaultAccessError?: boolean;
+  /** Holds the credentials answer back, so the in-modal loading state can be observed. */
+  vaultAccessDelay?: number;
+  /**
+   * Number of list calls a CREATING vault stays CREATING before flipping to READY. A static fixture
+   * cannot prove that polling stops, so the handler has to change its answer over time.
+   * `Infinity` keeps it CREATING forever, which is how the timeout path gets tested.
+   */
+  vaultCreatingCallsBeforeReady?: number;
+};
+
+const settleCreatingVaults = (vaults: VaultResource[]): VaultResource[] =>
+  vaults.map((vault) =>
+    vault.currentState.status === 'CREATING'
+      ? {
+          ...vault,
+          resourceStatus: 'READY',
+          currentTasks: [],
+          currentState: { ...vault.currentState, status: 'READY' },
+        }
+      : vault,
+  );
+
+export const getVaultMocks = ({
+  vaults,
+  isVaultListError,
+  isVaultAccessError,
+  vaultAccessDelay = 0,
+  vaultCreatingCallsBeforeReady,
+}: TVaultMockParams): Handler[] => {
+  let listCalls = 0;
+
+  return [
+    {
+      url: '/backupServices/tenant/:backupServicesId/vault',
+      response: () => {
+        if (isVaultListError) return { message: 'Internal server error' };
+
+        listCalls += 1;
+        const list = vaults ?? mockVaults;
+
+        return vaultCreatingCallsBeforeReady !== undefined &&
+          listCalls > vaultCreatingCallsBeforeReady
+          ? settleCreatingVaults(list)
+          : list;
+      },
+      api: 'v2',
+      method: 'get',
+      status: isVaultListError ? 500 : 200,
+      delay: 0,
+    },
+    {
+      url: '/backupServices/tenant/:backupServicesId/vault/:vaultId',
+      response: (_: unknown, params: PathParams) =>
+        (vaults ?? mockVaults).find(({ id }) => id === params.vaultId),
+      api: 'v2',
+      method: 'get',
+      status: 200,
+      delay: 0,
+    },
+    {
+      url: '/backupServices/tenant/:backupServicesId/vault/:vaultId/bucket/:bucketId/access',
+      response: () =>
+        isVaultAccessError ? { message: 'Internal server error' } : mockVaultBucketAccess,
+      api: 'v2',
+      method: 'get',
+      status: isVaultAccessError ? 500 : 200,
+      delay: vaultAccessDelay,
+    },
+  ];
+};

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
@@ -8,9 +8,9 @@ import { VaultResource } from '@/types/Vault.type';
 export type TVaultMockParams = {
   vaults?: VaultResource[];
   isVaultListError?: boolean;
-  isVaultAccessError?: boolean;
+  isVaultCredentialsError?: boolean;
   /** Holds the credentials answer back, so the in-modal loading state can be observed. */
-  vaultAccessDelay?: number;
+  vaultCredentialsDelay?: number;
   /**
    * Number of list calls a CREATING vault stays CREATING before flipping to READY. A static fixture
    * cannot prove that polling stops, so the handler has to change its answer over time.
@@ -34,8 +34,8 @@ const settleCreatingVaults = (vaults: VaultResource[]): VaultResource[] =>
 export const getVaultMocks = ({
   vaults,
   isVaultListError,
-  isVaultAccessError,
-  vaultAccessDelay = 0,
+  isVaultCredentialsError,
+  vaultCredentialsDelay = 0,
   vaultCreatingCallsBeforeReady,
 }: TVaultMockParams): Handler[] => {
   let listCalls = 0;
@@ -71,11 +71,11 @@ export const getVaultMocks = ({
     {
       url: '/backupServices/tenant/:backupServicesId/vault/:vaultId/bucket/:bucketId/credentials',
       response: () =>
-        isVaultAccessError ? { message: 'Internal server error' } : mockVaultBucketAccess,
+        isVaultCredentialsError ? { message: 'Internal server error' } : mockVaultBucketAccess,
       api: 'v2',
       method: 'get',
-      status: isVaultAccessError ? 500 : 200,
-      delay: vaultAccessDelay,
+      status: isVaultCredentialsError ? 500 : 200,
+      delay: vaultCredentialsDelay,
     },
   ];
 };

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
@@ -69,7 +69,7 @@ export const getVaultMocks = ({
       delay: 0,
     },
     {
-      url: '/backupServices/tenant/:backupServicesId/vault/:vaultId/bucket/:bucketId/access',
+      url: '/backupServices/tenant/:backupServicesId/vault/:vaultId/bucket/:bucketId/credentials',
       response: () =>
         isVaultAccessError ? { message: 'Internal server error' } : mockVaultBucketAccess,
       api: 'v2',

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
@@ -2,10 +2,35 @@
  * Jeux de données de développement pour l'onglet « Facturation » (BKP-1225), calqués sur
  * la maquette : un vault inclus (bundle, 487 Go) et deux vaults paygo.
  * À supprimer une fois l'endpoint déployé (cf. §15 de la spec).
+ *
+ * Les vaults (BKP-1221/1222) réutilisent ces trois lignes — d'où l'ajout de `status` et
+ * `buckets`, que la facturation ne lit pas — et ajoutent leurs propres cas limites plus bas.
  */
-import { VaultResource } from '@/types/Vault.type';
+import { getVaultIamUrn } from '@/mocks/iam/iam.mock';
+import { ResourceStatus } from '@/types/Resource.type';
+import { VaultBucket, VaultResource } from '@/types/Vault.type';
 
-export const mockVaults: VaultResource[] = [
+/**
+ * L'API sert chaque vault avec son enveloppe IAM : sans elle, les entrées du menu d'action restent
+ * désactivées, faute d'URN à autoriser.
+ */
+const withIam = (vaults: VaultResource[]): VaultResource[] =>
+  vaults.map((vault) => ({
+    ...vault,
+    iam: { id: `iam-${vault.id}`, urn: getVaultIamUrn(vault.id) },
+  }));
+
+const buildBucket = (overrides: Partial<VaultBucket> & Pick<VaultBucket, 'id'>): VaultBucket => ({
+  name: `bucket-${overrides.id}`,
+  performance: 'HIGH_PERF',
+  region: 'eu-west-rbx',
+  role: 'PRIMARY',
+  status: 'READY',
+  endPoint: `s3.${overrides.region ?? 'eu-west-rbx'}.io.cloud.ovh.net`,
+  ...overrides,
+});
+
+export const mockVaults: VaultResource[] = withIam([
   {
     id: 'vault-1',
     resourceStatus: 'READY',
@@ -16,6 +41,17 @@ export const mockVaults: VaultResource[] = [
       region: 'EU-WEST-PAR',
       type: 'BUNDLE',
       vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      vspcTenants: ['vspc-tenant-backuplicenses-01'],
+      buckets: [
+        buildBucket({ id: 'vault-1-b1', region: 'eu-west-rbx' }),
+        buildBucket({
+          id: 'vault-1-b2',
+          region: 'eu-west-gra',
+          role: 'REPLICA',
+          performance: 'STANDARD',
+        }),
+      ],
     },
   },
   {
@@ -28,6 +64,9 @@ export const mockVaults: VaultResource[] = [
       region: 'EU-WEST-PAR',
       type: 'PAYGO',
       vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      vspcTenants: ['vspc-tenant-backuplicenses-01'],
+      buckets: [buildBucket({ id: 'vault-2-b1', region: 'eu-west-par' })],
     },
   },
   {
@@ -40,6 +79,147 @@ export const mockVaults: VaultResource[] = [
       region: 'UK-LONDON',
       type: 'PAYGO',
       vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      vspcTenants: ['vspc-tenant-backuplicenses-01'],
+      buckets: [buildBucket({ id: 'vault-3-b1', region: 'eu-west-lz-lon' })],
     },
   },
-];
+]);
+
+/** Les trois lignes de la maquette BKP-1221, pour comparer l'UI mockée au design. */
+export const mockVaultsFromDesign = mockVaults;
+
+/** Servi sans enveloppe IAM : il n'y a alors aucun URN à autoriser, donc aucune action possible. */
+const vaultWithoutIamEnvelope: VaultResource = {
+  id: 'vault-without-iam-envelope',
+  resourceStatus: 'READY',
+  currentState: {
+    id: 'vault-without-iam-envelope',
+    name: 'vault-without-iam-envelope',
+    resourceName: 'vault-without-iam-envelope',
+    region: 'EU-WEST-PAR',
+    type: 'PAYGO',
+    vaultProductLine: 'BACKUP_LICENSES',
+    status: 'READY',
+    buckets: [buildBucket({ id: 'vault-without-iam-envelope-b1' })],
+  },
+};
+
+/** Cas que la maquette ne montre pas — les noms disent lequel. */
+export const mockEdgeCaseVaults: VaultResource[] = withIam([
+  {
+    id: 'vault-foreign',
+    resourceStatus: 'READY',
+    currentState: {
+      id: 'vault-foreign',
+      name: 'vault-of-backup-agent',
+      resourceName: 'vault-of-backup-agent',
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO',
+      vaultProductLine: 'BACKUP_AGENT',
+      status: 'READY',
+      buckets: [buildBucket({ id: 'vault-foreign-b1' })],
+    },
+  },
+  ...(
+    [
+      ['ERROR', 'vault-status-error'],
+      ['SUSPENDED', 'vault-status-suspended'],
+      ['UPDATING', 'vault-status-updating'],
+      ['DELETING', 'vault-status-deleting'],
+      ['OUT_OF_SYNC', 'vault-status-out-of-sync'],
+      ['CREATING', 'vault-status-creating'],
+    ] as [ResourceStatus, string][]
+  ).map(([status, name]) => ({
+    id: name,
+    resourceStatus: status,
+    currentState: {
+      id: name,
+      name,
+      resourceName: name,
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO' as const,
+      vaultProductLine: 'BACKUP_LICENSES',
+      status,
+      buckets: [buildBucket({ id: `${name}-b1` })],
+    },
+  })),
+  {
+    id: 'vault-bundle-purchased',
+    resourceStatus: 'READY',
+    currentState: {
+      id: 'vault-bundle-purchased',
+      name: 'vault-bundle-purchased',
+      resourceName: 'vault-bundle-purchased',
+      region: 'EU-WEST-PAR',
+      type: 'BUNDLE',
+      vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      buckets: [buildBucket({ id: 'vault-bundle-purchased-b1' })],
+    },
+  },
+  {
+    id: 'vault-primary-suspended',
+    resourceStatus: 'READY',
+    currentState: {
+      id: 'vault-primary-suspended',
+      name: 'vault-primary-suspended',
+      resourceName: 'vault-primary-suspended',
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO',
+      vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      buckets: [buildBucket({ id: 'vault-primary-suspended-b1', status: 'SUSPENDED' })],
+    },
+  },
+  {
+    id: 'vault-two-primaries',
+    resourceStatus: 'READY',
+    currentState: {
+      id: 'vault-two-primaries',
+      name: 'vault-two-primaries',
+      resourceName: 'vault-two-primaries',
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO',
+      vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      buckets: [
+        buildBucket({ id: '0109-b1', status: 'SUSPENDED' }),
+        buildBucket({ id: '0109-b2', status: 'READY', region: 'eu-west-gra' }),
+      ],
+    },
+  },
+  {
+    id: 'vault-without-bucket',
+    resourceStatus: 'READY',
+    currentState: {
+      id: 'vault-without-bucket',
+      name: 'vault-without-bucket',
+      resourceName: 'vault-without-bucket',
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO',
+      vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      buckets: [],
+    },
+  },
+  {
+    id: 'vault-not-ready-yet',
+    resourceStatus: 'UPDATING',
+    currentState: {
+      id: 'vault-not-ready-yet',
+      name: 'vault-not-ready-yet',
+      resourceName: 'vault-not-ready-yet',
+      region: 'EU-WEST-PAR',
+      type: 'PAYGO',
+      vaultProductLine: 'BACKUP_LICENSES',
+      status: 'READY',
+      buckets: [buildBucket({ id: 'vault-not-ready-yet-b1' })],
+    },
+  },
+]).concat(vaultWithoutIamEnvelope);
+
+export const mockVaultBucketAccess = {
+  accessKey: 'AKIAMOCKACCESSKEY',
+  secretKey: 'wJalrXUtnFEMIMOCKSECRETKEY',
+};

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
@@ -8,7 +8,7 @@
  */
 import { getVaultIamUrn } from '@/mocks/iam/iam.mock';
 import { ResourceStatus } from '@/types/Resource.type';
-import { VaultBucket, VaultResource } from '@/types/Vault.type';
+import { VaultBucket, VaultBucketAccess, VaultResource } from '@/types/Vault.type';
 
 /**
  * L'API sert chaque vault avec son enveloppe IAM : sans elle, les entrées du menu d'action restent
@@ -26,7 +26,6 @@ const buildBucket = (overrides: Partial<VaultBucket> & Pick<VaultBucket, 'id'>):
   region: 'eu-west-rbx',
   role: 'PRIMARY',
   status: 'READY',
-  endPoint: `s3.${overrides.region ?? 'eu-west-rbx'}.io.cloud.ovh.net`,
   ...overrides,
 });
 
@@ -40,6 +39,7 @@ export const mockVaults: VaultResource[] = withIam([
       resourceName: 'vault-veeam-multi-region',
       region: 'EU-WEST-PAR',
       type: 'BUNDLE',
+      includedSoftQuotaGb: 487,
       vaultProductLine: 'BACKUP_LICENSES',
       status: 'READY',
       vspcTenants: ['vspc-tenant-backuplicenses-01'],
@@ -130,20 +130,22 @@ export const mockEdgeCaseVaults: VaultResource[] = withIam([
       ['OUT_OF_SYNC', 'vault-status-out-of-sync'],
       ['CREATING', 'vault-status-creating'],
     ] as [ResourceStatus, string][]
-  ).map(([status, name]) => ({
-    id: name,
-    resourceStatus: status,
-    currentState: {
+  ).map(
+    ([status, name]): VaultResource => ({
       id: name,
-      name,
-      resourceName: name,
-      region: 'EU-WEST-PAR',
-      type: 'PAYGO' as const,
-      vaultProductLine: 'BACKUP_LICENSES',
-      status,
-      buckets: [buildBucket({ id: `${name}-b1` })],
-    },
-  })),
+      resourceStatus: status,
+      currentState: {
+        id: name,
+        name,
+        resourceName: name,
+        region: 'EU-WEST-PAR',
+        type: 'PAYGO',
+        vaultProductLine: 'BACKUP_LICENSES',
+        status,
+        buckets: [buildBucket({ id: `${name}-b1` })],
+      },
+    }),
+  ),
   {
     id: 'vault-bundle-purchased',
     resourceStatus: 'READY',
@@ -153,6 +155,7 @@ export const mockEdgeCaseVaults: VaultResource[] = withIam([
       resourceName: 'vault-bundle-purchased',
       region: 'EU-WEST-PAR',
       type: 'BUNDLE',
+      includedSoftQuotaGb: 1024,
       vaultProductLine: 'BACKUP_LICENSES',
       status: 'READY',
       buckets: [buildBucket({ id: 'vault-bundle-purchased-b1' })],
@@ -219,7 +222,10 @@ export const mockEdgeCaseVaults: VaultResource[] = withIam([
   },
 ]).concat(vaultWithoutIamEnvelope);
 
-export const mockVaultBucketAccess = {
+export const mockVaultBucketAccess: VaultBucketAccess = {
   accessKey: 'AKIAMOCKACCESSKEY',
+  bucketName: 'bucket-vault-2-b1',
+  endpoint: 's3.eu-west-par.io.cloud.ovh.net',
+  regionCode: 'eu-west-par',
   secretKey: 'wJalrXUtnFEMIMOCKSECRETKEY',
 };

--- a/packages/manager/modules/backup-licenses/src/module.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/module.constants.ts
@@ -37,6 +37,9 @@ export const VAULT_DEFAULT_IMMUTABILITY = {
   encryption: 'SSE-OMK',
 };
 
+/** Masque de la clé secrète : longueur fixe, pour ne pas révéler celle du secret (BKP-1222). */
+export const VAULT_SECRET_MASK = '••••••••••••';
+
 export const BACKUP_LICENSES_IAM_RULES = {
   'vault/edit': 'backupServices:apiovh:vault/edit',
   'vspc/edit': 'backupServices:apiovh:vspc/edit',

--- a/packages/manager/modules/backup-licenses/src/pages/general-information/GeneralInformation.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/general-information/GeneralInformation.page.spec.tsx
@@ -69,7 +69,11 @@ describe('GeneralInformationPage', () => {
 
     await renderWithProviders(<GeneralInformationPage />);
 
-    await waitFor(() => expect(screen.getByText("Les informations du service n'ont pas pu être chargées.")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText("Les informations du service n'ont pas pu être chargées."),
+      ).toBeInTheDocument(),
+    );
 
     vi.mocked(getBackupLicenses).mockResolvedValue([
       {
@@ -88,8 +92,14 @@ describe('GeneralInformationPage', () => {
 
     await renderWithProviders(<GeneralInformationPage />);
 
-    await waitFor(() => expect(screen.getByText("Les informations du service n'ont pas pu être chargées.")).toBeInTheDocument(), {
-      timeout: 5000,
-    });
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText("Les informations du service n'ont pas pu être chargées."),
+        ).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    );
   });
 });

--- a/packages/manager/modules/backup-licenses/src/pages/linked-servers/edit/EditBackupServer.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/linked-servers/edit/EditBackupServer.page.spec.tsx
@@ -233,11 +233,19 @@ describe('EditBackupServerPage', () => {
     await renderPage();
     await waitFor(() => expect(screen.getByTestId('step-1-content')).toBeInTheDocument());
 
-    expect(screen.queryByText("Le changement de licence prendra effet le 1er du mois prochain. D'ici là, la licence actuelle reste active.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Le changement de licence prendra effet le 1er du mois prochain. D'ici là, la licence actuelle reste active.",
+      ),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('radio', { name: /Veeam Enterprise Plus/ }));
 
-    expect(screen.getByText("Le changement de licence prendra effet le 1er du mois prochain. D'ici là, la licence actuelle reste active.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Le changement de licence prendra effet le 1er du mois prochain. D'ici là, la licence actuelle reste active.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it('shows the before/after recap only once a field has changed', async () => {

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.spec.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+
+import { RenderResult, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockEdgeCaseVaults, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { VAULT_DEFAULT_IMMUTABILITY } from '@/module.constants';
+import { renderTest } from '@/test-utils/Test.utils';
+import { labels } from '@/test-utils/i18ntest.utils';
+import { renderWithProviders } from '@/test-utils/renderWithProviders';
+import { MockParams, setupMswMock } from '@/test-utils/setupMsw';
+import { VaultResource } from '@/types/Vault.type';
+
+import VaultsPage from './Vaults.page';
+
+/**
+ * `USE_API_MOCKS` court-circuite le réseau et renvoie les jeux de données du module. Ces tests
+ * paramètrent leurs propres fixtures via MSW, donc ils laissent la couche réseau s'exécuter.
+ */
+vi.mock('@/mocks/mocks.config', () => ({ USE_API_MOCKS: false }));
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const [includedVault, paygoVault] = mockVaultsFromDesign as [VaultResource, VaultResource];
+
+// Les trois lignes de la maquette sont toutes READY : le vault en cours de création vient des cas
+// limites, qui couvrent les statuts que la maquette ne montre pas.
+const creatingVault = mockEdgeCaseVaults.find(
+  ({ id }) => id === 'vault-status-creating',
+) as VaultResource;
+
+const renderPage = async (mockParams: MockParams = {}): Promise<RenderResult> => {
+  setupMswMock(mockParams);
+  return renderWithProviders(<VaultsPage />);
+};
+
+const dataRows = () => screen.getAllByRole('row').slice(1);
+
+const badge = (container: HTMLElement, label: string) =>
+  container.querySelector(`ods-badge[label="${label}"]`);
+
+const waitForRows = (expectedCount: number) =>
+  waitFor(() => {
+    expect(screen.queryAllByTestId('loading-row')).toHaveLength(0);
+    expect(dataRows()).toHaveLength(expectedCount);
+  });
+
+describe('Vaults page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading rows in place of the data while the list is in flight', async () => {
+    const { container } = await renderPage();
+
+    expect(screen.getAllByTestId('loading-row').length).toBeGreaterThan(0);
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('renders one row per vault of this product line once the list resolves', async () => {
+    const { container } = await renderPage({ vaults: mockVaultsFromDesign });
+
+    await waitForRows(mockVaultsFromDesign.length);
+    expect(screen.getByText(includedVault.currentState.name)).toBeVisible();
+    expect(screen.getByText(paygoVault.currentState.name)).toBeVisible();
+    expect(container.querySelector('[aria-busy="false"]')).toBeInTheDocument();
+  });
+
+  it('hides the vaults served by another product line from the same route', async () => {
+    const foreignVault: VaultResource = {
+      ...paygoVault,
+      id: 'foreign',
+      currentState: {
+        ...paygoVault.currentState,
+        name: 'vault-of-backup-agent',
+        vaultProductLine: 'BACKUP_AGENT',
+      },
+    };
+
+    await renderPage({ vaults: [paygoVault, foreignVault] });
+
+    await waitForRows(1);
+    expect(screen.getByText(paygoVault.currentState.name)).toBeVisible();
+    expect(screen.queryByText('vault-of-backup-agent')).not.toBeInTheDocument();
+  });
+
+  it('keeps a vault that carries no product line, rather than emptying the screen', async () => {
+    const unscopedVault: VaultResource = {
+      ...paygoVault,
+      currentState: { ...paygoVault.currentState, vaultProductLine: undefined },
+    };
+
+    await renderPage({ vaults: [unscopedVault] });
+
+    // `vaultProductLine` n'est publié par aucun contrat : le filtre du module garde les vaults qui
+    // ne le portent pas, sinon l'onglet serait vide pour tout le monde jusqu'à sa livraison.
+    expect(await screen.findByText(unscopedVault.currentState.name)).toBeVisible();
+    expect(screen.queryByText(labels.vaults.state.empty.title)).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when the list comes back with no entry', async () => {
+    await renderPage({ vaults: [] });
+
+    expect(await screen.findByText(labels.vaults.state.empty.title)).toBeVisible();
+  });
+
+  it('exposes the five specified columns plus the row-action column', async () => {
+    await renderPage({ vaults: [paygoVault] });
+
+    await waitForRows(1);
+    expect(screen.getByTestId('header-name')).toHaveTextContent(labels.commonDashboard.name);
+    expect(screen.getByTestId('header-region')).toHaveTextContent(labels.region.region);
+    expect(screen.getByTestId('header-immutability')).toHaveTextContent(
+      labels.vaults.column.immutability,
+    );
+    expect(screen.getByTestId('header-encryption')).toHaveTextContent(
+      labels.vaults.column.encryption,
+    );
+    expect(screen.getByTestId('header-status')).toHaveTextContent(labels.status.status);
+    expect(screen.getByTestId('header-actions')).toBeInTheDocument();
+  });
+
+  it('renders the hardcoded immutability retention and the encryption invariant on every row', async () => {
+    await renderPage({ vaults: mockVaultsFromDesign });
+
+    await waitForRows(mockVaultsFromDesign.length);
+    const immutability = labels.vaults.immutability_value_other.replace(
+      '{{count}}',
+      String(VAULT_DEFAULT_IMMUTABILITY.duration),
+    );
+    expect(screen.getAllByText(immutability)).toHaveLength(mockVaultsFromDesign.length);
+    expect(screen.getAllByText(labels.vaults.encryption_value)).toHaveLength(
+      mockVaultsFromDesign.length,
+    );
+  });
+
+  it('renders the region of the vault itself, ignoring the regions of its buckets', async () => {
+    await renderPage({ vaults: [includedVault] });
+
+    await waitForRows(1);
+    const [row] = dataRows() as [HTMLElement];
+    expect(within(row).getByText('Paris (PAR)')).toBeVisible();
+    expect(within(row).queryByText(/GRA|SBG/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw region code when the code is outside the mapped subset', async () => {
+    const unmappedRegionVault: VaultResource = {
+      ...paygoVault,
+      currentState: { ...paygoVault.currentState, region: 'ap-southeast-syd' },
+    };
+
+    await renderPage({ vaults: [unmappedRegionVault] });
+
+    await waitForRows(1);
+    expect(screen.getByText('ap-southeast-syd')).toBeVisible();
+  });
+
+  it('reads the badge off the top-level resourceStatus, not off currentState.status', async () => {
+    const updatingVault: VaultResource = {
+      ...paygoVault,
+      resourceStatus: 'UPDATING',
+      currentState: { ...paygoVault.currentState, status: 'READY' },
+    };
+
+    const { container } = await renderPage({ vaults: [updatingVault] });
+
+    await waitForRows(1);
+    expect(badge(container, labels.status.error)).toBeInTheDocument();
+    expect(badge(container, labels.status.ready)).not.toBeInTheDocument();
+  });
+
+  it('marks a provisioning vault as creating and a ready one as active', async () => {
+    const { container } = await renderPage({ vaults: [paygoVault, creatingVault] });
+
+    await waitForRows(2);
+    expect(badge(container, labels.status.ready)).toBeInTheDocument();
+    expect(badge(container, labels.status.creating)).toBeInTheDocument();
+    expect(container.querySelector('ods-spinner')).toBeInTheDocument();
+  });
+
+  it('shows an error with a Retry control, and recovers the list when the retry succeeds', async () => {
+    const { container } = await renderPage({ isVaultListError: true });
+
+    expect(await screen.findByText(labels.vaults.state.error.message)).toBeVisible();
+    expect(screen.getByTestId('vaults-retry')).toHaveAttribute(
+      'label',
+      labels.vaults.state.error.retry,
+    );
+    expect(container.querySelector('table')).not.toBeInTheDocument();
+
+    setupMswMock({ vaults: [paygoVault] });
+    await userEvent.click(screen.getByTestId('vaults-retry'));
+
+    await waitForRows(1);
+    expect(screen.queryByText(labels.vaults.state.error.message)).not.toBeInTheDocument();
+    expect(screen.getByText(paygoVault.currentState.name)).toBeVisible();
+  });
+
+  it('offers the "Order a vault" control above the table', async () => {
+    await renderPage({ vaults: [paygoVault] });
+
+    await waitForRows(1);
+    const orderButton = screen.getByTestId('order-vault');
+    expect(orderButton).toHaveAttribute('label', labels.vaults.cta.order);
+
+    await userEvent.click(orderButton);
+    expect(navigateMock).toHaveBeenCalledWith('/vaults/order');
+  });
+});
+
+describe('[INTEGRATION] Vaults route', () => {
+  it('is reachable at /vaults', async () => {
+    const { container } = await renderTest({
+      initialRoute: '/vaults',
+      vaults: [paygoVault],
+    });
+
+    await waitFor(() => expect(container.querySelector('table')).toBeInTheDocument(), {
+      timeout: 20_000,
+    });
+    expect(await screen.findByText(paygoVault.currentState.name)).toBeVisible();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { Outlet, useNavigate } from 'react-router-dom';
+
+import { useTranslation } from 'react-i18next';
+
+import { ODS_BUTTON_SIZE } from '@ovhcloud/ods-components';
+import { OdsButton } from '@ovhcloud/ods-components/react';
+
+import { Datagrid, Notifications } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { routeUrls } from '@/routes/routes.constants';
+
+import { VaultsEmptyState } from './_components/VaultsEmptyState.component';
+import { VaultsErrorState } from './_components/VaultsErrorState.component';
+import { useVaultColumns } from './_hooks/useVaultColumns.hook';
+import { useVaultsList } from './_hooks/useVaultsList.hook';
+
+export default function VaultsPage() {
+  const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.VAULTS);
+  const navigate = useNavigate();
+  const columns = useVaultColumns();
+  const { vaults, isPending, isError, refetch } = useVaultsList();
+
+  const renderVaults = () => {
+    if (isError) {
+      return <VaultsErrorState onRetry={() => void refetch()} />;
+    }
+
+    if (!isPending && vaults.length === 0) {
+      return <VaultsEmptyState />;
+    }
+
+    return (
+      <Datagrid
+        columns={columns}
+        items={vaults}
+        totalItems={vaults.length}
+        isLoading={isPending}
+        contentAlignLeft
+      />
+    );
+  };
+
+  return (
+    <section className="flex flex-col gap-6">
+      {/* DEFERRED: BKP-1215 owns the tab shell that renders <Notifications /> once for every tab, and
+          is not delivered — the module's MainLayout is still a two-placeholder-tab stub this route
+          must not mount under. Until then the tab hosts its own, or the termination toast
+          (ux.md § Notifications) is added to a store nothing reads. Drop it when the shell lands. */}
+      <Notifications />
+      <div className="flex">
+        <OdsButton
+          data-testid="order-vault"
+          size={ODS_BUTTON_SIZE.sm}
+          label={t('cta.order')}
+          onClick={() => navigate(routeUrls.orderVault)}
+        />
+      </div>
+      <div aria-live="polite" aria-busy={isPending}>
+        {renderVaults()}
+      </div>
+      <Outlet />
+    </section>
+  );
+}

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.spec.tsx
@@ -161,6 +161,17 @@ describe('VaultActionsCell', () => {
     expect(screen.queryByTestId(`vault-credentials-disabled-${vault.id}`)).not.toBeInTheDocument();
   });
 
+  it('disables the credentials entry when the account lacks the credentials action', async () => {
+    setupMswMock({ unauthorizedIamActions: [IAM_ACTIONS.vaultCredentialsGet] });
+
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await waitForEntryEnabled(`vault-terminate-${paygoVault.id}`);
+
+    expect(entry(`vault-credentials-${paygoVault.id}`)).toHaveAttribute('is-disabled', 'true');
+  });
+
   it('disables the terminate entry when the account lacks the termination action', async () => {
     setupMswMock({ unauthorizedIamActions: [IAM_ACTIONS.servicesTerminate] });
 

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.spec.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockEdgeCaseVaults, mockVaults, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { labels } from '@/test-utils/i18ntest.utils';
+import { renderWithProviders } from '@/test-utils/renderWithProviders';
+import { setupMswMock } from '@/test-utils/setupMsw';
+import { VaultResource } from '@/types/Vault.type';
+import { IAM_ACTIONS } from '@/utils/iam.constants';
+
+import { getVaultActionsMenuId } from '../vaults.constants';
+import { VaultActionsCell } from './VaultActionsCell.component';
+
+/**
+ * `USE_API_MOCKS` court-circuite le réseau et renvoie les jeux de données du module. Ces tests
+ * paramètrent leurs propres fixtures via MSW, donc ils laissent la couche réseau s'exécuter.
+ */
+vi.mock('@/mocks/mocks.config', () => ({ USE_API_MOCKS: false }));
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+const [includedVault, paygoVault] = mockVaultsFromDesign as [VaultResource, VaultResource];
+const findVault = (name: string) =>
+  [...mockVaults, ...mockEdgeCaseVaults].find(
+    ({ currentState }) => currentState.name === name,
+  ) as VaultResource;
+
+const openMenu = (vaultId: string) =>
+  userEvent.click(screen.getByTestId(`vault-actions-trigger-${vaultId}`));
+
+// `is-disabled` is reflected synchronously, `disabled` is dropped on the next ODS render — and only the
+// latter decides whether a pointer event reaches the entry, so both have to settle.
+const waitForEntryEnabled = async (testId: string) => {
+  await waitFor(() => {
+    expect(screen.getByTestId(testId)).toHaveAttribute('is-disabled', 'false');
+    expect(screen.getByTestId(testId)).not.toHaveAttribute('disabled');
+  });
+  return screen.getByTestId(testId);
+};
+
+const entry = (testId: string) => screen.getByTestId(testId);
+
+describe('VaultActionsCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMswMock();
+  });
+
+  it('offers exactly the credentials and terminate entries', async () => {
+    const { container } = await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('ods-popover ods-button')).toHaveLength(2),
+    );
+    expect(
+      container.querySelector(`ods-button[label="${labels.vaults.action.show_credentials}"]`),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(`ods-button[label="${labels.actions.terminate}"]`),
+    ).toBeInTheDocument();
+  });
+
+  it('names the icon-only trigger for assistive technology', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    expect(await screen.findByRole('button', { name: labels.vaults.action.menu_label })).toBe(
+      screen.getByTestId(`vault-actions-trigger-${paygoVault.id}`),
+    );
+  });
+
+  it('opens the termination modal of the row on a PAYGO vault', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await userEvent.click(await waitForEntryEnabled(`vault-terminate-${paygoVault.id}`));
+
+    expect(navigateMock).toHaveBeenCalledWith(`/vaults/${paygoVault.id}/terminate`);
+  });
+
+  it('opens the credentials modal of the row', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await userEvent.click(await waitForEntryEnabled(`vault-credentials-${paygoVault.id}`));
+
+    expect(navigateMock).toHaveBeenCalledWith(`/vaults/${paygoVault.id}/credentials`);
+  });
+
+  it('offers the terminate entry of the included vault as a named, unavailable control', async () => {
+    const { container } = await renderWithProviders(<VaultActionsCell vault={includedVault} />);
+
+    await openMenu(includedVault.id);
+
+    const disabledEntry = screen.getByRole('button', { name: labels.actions.terminate });
+    expect(disabledEntry).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByTestId(`vault-terminate-${includedVault.id}`)).not.toBeInTheDocument();
+    // The ODS button is the visual shell of the entry, not a second control announced after it.
+    expect(entry(`vault-terminate-disabled-${includedVault.id}`)).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+
+    const tooltipId = `vault-terminate-tooltip-${includedVault.id}`;
+    expect(disabledEntry).toHaveAttribute('aria-describedby', tooltipId);
+    await waitFor(() =>
+      expect(container.querySelector(`#${tooltipId}`)).toHaveTextContent(
+        labels.vaults.terminate.included_tooltip,
+      ),
+    );
+  });
+
+  it.each([
+    ['whose only PRIMARY bucket is not ready', 'vault-primary-suspended'],
+    ['that carries no bucket at all', 'vault-without-bucket'],
+  ])(
+    'offers the credentials entry of a vault %s as a named, unavailable control',
+    async (_, vaultName) => {
+      const vault = findVault(vaultName);
+
+      const { container } = await renderWithProviders(<VaultActionsCell vault={vault} />);
+
+      await openMenu(vault.id);
+
+      const disabledEntry = await screen.findByRole('button', {
+        name: labels.vaults.action.show_credentials,
+      });
+      expect(disabledEntry).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.queryByTestId(`vault-credentials-${vault.id}`)).not.toBeInTheDocument();
+      expect(entry(`vault-credentials-disabled-${vault.id}`)).toHaveAttribute(
+        'aria-hidden',
+        'true',
+      );
+
+      const tooltipId = `vault-credentials-tooltip-${vault.id}`;
+      expect(disabledEntry).toHaveAttribute('aria-describedby', tooltipId);
+      await waitFor(() =>
+        expect(container.querySelector(`#${tooltipId}`)).toHaveTextContent(
+          labels.vaults.action.credentials_disabled_tooltip,
+        ),
+      );
+    },
+  );
+
+  it('keeps the credentials entry on a vault whose PRIMARY bucket is ready', async () => {
+    const vault = findVault('vault-two-primaries');
+
+    await renderWithProviders(<VaultActionsCell vault={vault} />);
+    await openMenu(vault.id);
+
+    expect(screen.getByTestId(`vault-credentials-${vault.id}`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`vault-credentials-disabled-${vault.id}`)).not.toBeInTheDocument();
+  });
+
+  it('disables the terminate entry when the account lacks the termination action', async () => {
+    setupMswMock({ unauthorizedIamActions: [IAM_ACTIONS.servicesTerminate] });
+
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await waitForEntryEnabled(`vault-credentials-${paygoVault.id}`);
+
+    expect(entry(`vault-terminate-${paygoVault.id}`)).toHaveAttribute('is-disabled', 'true');
+  });
+
+  it('defers the authorization check until the menu is opened', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    expect(entry(`vault-credentials-${paygoVault.id}`)).toHaveAttribute('is-disabled', 'true');
+
+    await openMenu(paygoVault.id);
+
+    await waitForEntryEnabled(`vault-credentials-${paygoVault.id}`);
+  });
+
+  it('advertises no permission error, and adds no wrapper, on an unauthorized entry', async () => {
+    setupMswMock({ unauthorizedIamActions: [IAM_ACTIONS.servicesTerminate] });
+
+    const { container } = await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await waitFor(() =>
+      expect(entry(`vault-terminate-${paygoVault.id}`)).toHaveAttribute('is-disabled', 'true'),
+    );
+    expect(container.querySelector('ods-popover ods-tooltip')).not.toBeInTheDocument();
+    expect(container.querySelector('ods-popover div.w-fit')).not.toBeInTheDocument();
+  });
+
+  it('keeps both entries disabled on a vault the API serves without an IAM envelope', async () => {
+    const vault = findVault('vault-without-iam-envelope');
+    expect(vault.iam).toBeUndefined();
+
+    await renderWithProviders(<VaultActionsCell vault={vault} />);
+
+    await openMenu(vault.id);
+
+    await waitFor(() =>
+      expect(entry(`vault-credentials-${vault.id}`)).toHaveAttribute('is-disabled', 'true'),
+    );
+    expect(entry(`vault-terminate-${vault.id}`)).toHaveAttribute('is-disabled', 'true');
+  });
+
+  it('does not gate a non-US customer on the action guarding the US-only DELETE form', async () => {
+    setupMswMock({
+      unauthorizedIamActions: [IAM_ACTIONS.servicesTerminateWithoutConfirmation],
+    });
+
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+
+    expect(await waitForEntryEnabled(`vault-terminate-${paygoVault.id}`)).toHaveAttribute(
+      'is-disabled',
+      'false',
+    );
+  });
+
+  it('disables the terminate entry when the serviceId resolution is not granted', async () => {
+    setupMswMock({ unauthorizedIamActions: [IAM_ACTIONS.servicesGet] });
+
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await waitForEntryEnabled(`vault-credentials-${paygoVault.id}`);
+
+    expect(entry(`vault-terminate-${paygoVault.id}`)).toHaveAttribute('is-disabled', 'true');
+  });
+});
+
+describe('VaultActionsCell menu disclosure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMswMock();
+  });
+
+  const trigger = () => screen.getByTestId(`vault-actions-trigger-${paygoVault.id}`);
+
+  it('announces itself as a collapsed menu button owning the popover', async () => {
+    const { container } = await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    const menuId = getVaultActionsMenuId(paygoVault.id);
+    expect(trigger()).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger()).toHaveAttribute('aria-controls', menuId);
+    expect(container.querySelector(`ods-popover#${menuId}`)).toBeInTheDocument();
+  });
+
+  it('follows the open state the popover reports', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    await waitFor(() => expect(trigger()).toHaveAttribute('aria-expanded', 'true'));
+
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => expect(trigger()).toHaveAttribute('aria-expanded', 'false'));
+  });
+
+  it('gives focus back to the trigger when Escape closes the menu on a focused entry', async () => {
+    await renderWithProviders(<VaultActionsCell vault={paygoVault} />);
+
+    await openMenu(paygoVault.id);
+    (await waitForEntryEnabled(`vault-credentials-${paygoVault.id}`)).focus();
+
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => expect(trigger()).toHaveFocus());
+  });
+
+  it('leaves focus where a click outside the menu put it', async () => {
+    await renderWithProviders(
+      <>
+        <button type="button" data-testid="outside" />
+        <VaultActionsCell vault={paygoVault} />
+      </>,
+    );
+
+    await openMenu(paygoVault.id);
+    await waitFor(() => expect(trigger()).toHaveAttribute('aria-expanded', 'true'));
+
+    await userEvent.click(screen.getByTestId('outside'));
+
+    await waitFor(() => expect(trigger()).toHaveAttribute('aria-expanded', 'false'));
+    expect(screen.getByTestId('outside')).toHaveFocus();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.tsx
@@ -1,0 +1,158 @@
+import React, { useRef, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { useTranslation } from 'react-i18next';
+
+import {
+  ODS_BUTTON_SIZE,
+  ODS_BUTTON_VARIANT,
+  ODS_ICON_NAME,
+  ODS_POPOVER_POSITION,
+} from '@ovhcloud/ods-components';
+import { OdsPopover } from '@ovhcloud/ods-components/react';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { DataGridTextCell, ManagerButton } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { ActionButton } from '@/components/ActionButton/ActionButton.component';
+import {
+  selectCanTerminateVault,
+  selectVaultCredentialsBucket,
+} from '@/data/selectors/vaults.selectors';
+import { useReturnFocus } from '@/hooks/useReturnFocus/useReturnFocus';
+import { useTerminateIamActions } from '@/hooks/useTerminateIamActions/useTerminateIamActions';
+import { getTerminateVaultUrl, getVaultCredentialsUrl } from '@/routes/routes.constants';
+import { VaultResource } from '@/types/Vault.type';
+import { IAM_ACTIONS } from '@/utils/iam.constants';
+
+import { getVaultActionsMenuId, getVaultActionsTriggerId } from '../vaults.constants';
+import { VaultDisabledAction } from './VaultDisabledAction.component';
+
+export type VaultActionsCellProps = {
+  vault: VaultResource;
+};
+
+export const VaultActionsCell = ({ vault }: VaultActionsCellProps) => {
+  const { t } = useTranslation([BACKUP_LICENSES_NAMESPACES.VAULTS, NAMESPACES.ACTIONS]);
+  const navigate = useNavigate();
+  const [isMenuTriggered, setIsMenuTriggered] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const popoverRef = useRef<HTMLOdsPopoverElement>(null);
+  const terminateIamActions = useTerminateIamActions();
+
+  const triggerId = getVaultActionsTriggerId(vault.id);
+  const menuId = getVaultActionsMenuId(vault.id);
+  const returnFocusToTrigger = useReturnFocus(triggerId);
+
+  /**
+   * `OdsPopover.hide()` only hides its host, so the focused entry leaves the accessibility tree and
+   * focus lands on `<body>` — a keyboard user would have to tab from the top of the page again. Focus
+   * is only taken back when it went down with the menu: an outside click has already moved it
+   * somewhere the customer chose.
+   */
+  const handleMenuHidden = () => {
+    setIsMenuOpen(false);
+    const focused = document.activeElement;
+    if (!focused || focused === document.body || popoverRef.current?.contains(focused)) {
+      returnFocusToTrigger();
+    }
+  };
+
+  /**
+   * `displayTooltip: false` mirrors MRC's own `ActionMenu`: its default wraps an unauthorized entry in
+   * an extra `w-fit` div (defeating `w-full`) and mounts a "you lack the permission" tooltip in the DOM
+   * before the menu is ever opened. `ActionMenu` itself is not reused because it offers no per-item
+   * tooltip for the disabled-BUNDLE case, and names its icon-only trigger with an `aria-label` the ODS
+   * shadow root never exposes (see ActionButton).
+   */
+  const menuItemProps = {
+    size: ODS_BUTTON_SIZE.sm,
+    variant: ODS_BUTTON_VARIANT.ghost,
+    displayTooltip: false,
+    className: 'w-full',
+  };
+  const credentialsLabel = t('action.show_credentials');
+  const terminateLabel = t(`${NAMESPACES.ACTIONS}:terminate`);
+
+  /**
+   * `iam` is nullable on `backup.tenant.vaultWithIAM`, and `ManagerButton` renders an ungated, enabled
+   * button when it gets no URN (`isAuthorized || !(iamActions && urn)`). Without an envelope there is
+   * nothing to check the actions against, so the entries fail closed rather than open.
+   */
+  const iamUrn = vault.iam?.urn;
+
+  return (
+    <DataGridTextCell>
+      <ActionButton
+        id={triggerId}
+        testId={triggerId}
+        icon={ODS_ICON_NAME.ellipsisVertical}
+        accessibleName={t('action.menu_label')}
+        disclosedOverlayId={menuId}
+        isExpanded={isMenuOpen}
+        popupRole="menu"
+        onClick={() => setIsMenuTriggered(true)}
+      />
+      <OdsPopover
+        ref={popoverRef}
+        id={menuId}
+        triggerId={triggerId}
+        position={ODS_POPOVER_POSITION.bottomEnd}
+        withArrow
+        className="py-2 px-0 w-max"
+        onOdsShow={() => setIsMenuOpen(true)}
+        onOdsHide={handleMenuHidden}
+      >
+        {/* DEFERRED: no menu/menuitem roles nor arrow-key roving — the focusable node of an ODS 18
+            entry lives in a shadow root this component cannot reach or re-role. Tab moves between
+            the two entries in DOM order, Enter/Space opens and Escape closes (ux.md § Accessibility). */}
+        <div className="flex flex-col">
+          {selectVaultCredentialsBucket(vault) ? (
+            <ManagerButton
+              {...menuItemProps}
+              id={`vault-credentials-${vault.id}`}
+              data-testid={`vault-credentials-${vault.id}`}
+              iamActions={[IAM_ACTIONS.vaultGet]}
+              urn={iamUrn}
+              isDisabled={!iamUrn}
+              isIamTrigger={isMenuTriggered}
+              label={credentialsLabel}
+              onClick={() => navigate(getVaultCredentialsUrl(vault.id))}
+            />
+          ) : (
+            <VaultDisabledAction
+              id={`vault-credentials-disabled-${vault.id}`}
+              tooltipId={`vault-credentials-tooltip-${vault.id}`}
+              testId={`vault-credentials-disabled-${vault.id}`}
+              label={credentialsLabel}
+              tooltip={t('action.credentials_disabled_tooltip')}
+            />
+          )}
+          {selectCanTerminateVault(vault) ? (
+            <ManagerButton
+              {...menuItemProps}
+              id={`vault-terminate-${vault.id}`}
+              data-testid={`vault-terminate-${vault.id}`}
+              iamActions={terminateIamActions}
+              urn={iamUrn}
+              isDisabled={!iamUrn}
+              isIamTrigger={isMenuTriggered}
+              label={terminateLabel}
+              onClick={() => navigate(getTerminateVaultUrl(vault.id))}
+            />
+          ) : (
+            <VaultDisabledAction
+              id={`vault-terminate-disabled-${vault.id}`}
+              tooltipId={`vault-terminate-tooltip-${vault.id}`}
+              testId={`vault-terminate-disabled-${vault.id}`}
+              label={terminateLabel}
+              tooltip={t('terminate.included_tooltip')}
+            />
+          )}
+        </div>
+      </OdsPopover>
+    </DataGridTextCell>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultActionsCell.component.tsx
@@ -114,7 +114,7 @@ export const VaultActionsCell = ({ vault }: VaultActionsCellProps) => {
               {...menuItemProps}
               id={`vault-credentials-${vault.id}`}
               data-testid={`vault-credentials-${vault.id}`}
-              iamActions={[IAM_ACTIONS.vaultGet]}
+              iamActions={[IAM_ACTIONS.vaultCredentialsGet]}
               urn={iamUrn}
               isDisabled={!iamUrn}
               isIamTrigger={isMenuTriggered}

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultDisabledAction.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultDisabledAction.component.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT } from '@ovhcloud/ods-components';
+import { OdsButton, OdsTooltip } from '@ovhcloud/ods-components/react';
+
+export type VaultDisabledActionProps = {
+  id: string;
+  tooltipId: string;
+  testId: string;
+  label: string;
+  tooltip: string;
+};
+
+export const VaultDisabledAction = ({
+  id,
+  tooltipId,
+  testId,
+  label,
+  tooltip,
+}: VaultDisabledActionProps) => (
+  <>
+    {/* A disabled ODS button neither takes focus nor exposes its shadow-root name (see ActionButton),
+        so the entry itself is the wrapper: it carries the role, the accessible name and the
+        unavailable state, leaving the ODS button as the visual shell only. */}
+    <span
+      id={id}
+      role="button"
+      aria-disabled="true"
+      aria-label={label}
+      tabIndex={0}
+      aria-describedby={tooltipId}
+      className="w-full"
+    >
+      <OdsButton
+        data-testid={testId}
+        size={ODS_BUTTON_SIZE.sm}
+        variant={ODS_BUTTON_VARIANT.ghost}
+        className="w-full"
+        aria-hidden="true"
+        isDisabled
+        label={label}
+      />
+    </span>
+    <OdsTooltip id={tooltipId} triggerId={id} withArrow>
+      {tooltip}
+    </OdsTooltip>
+  </>
+);

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultRegionCell.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultRegionCell.component.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { DataGridTextCell } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { getVaultRegionI18nKey } from '@/utils/vault/vaultRegion';
+
+export type VaultRegionCellProps = {
+  region: string;
+};
+
+export const VaultRegionCell = ({ region }: VaultRegionCellProps) => {
+  const { t } = useTranslation([BACKUP_LICENSES_NAMESPACES.VAULTS, NAMESPACES.REGION]);
+  const datacenterKey = getVaultRegionI18nKey(region);
+
+  if (!datacenterKey) {
+    return <DataGridTextCell>{region}</DataGridTextCell>;
+  }
+
+  const datacenterCode = datacenterKey.toUpperCase();
+
+  return (
+    <DataGridTextCell>
+      {t('region_single', {
+        city: t(`${NAMESPACES.REGION}:region_${datacenterCode}`),
+        code: datacenterCode,
+      })}
+    </DataGridTextCell>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultStatusCell.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultStatusCell.component.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { ODS_SPINNER_SIZE } from '@ovhcloud/ods-components';
+import { OdsBadge, OdsSpinner } from '@ovhcloud/ods-components/react';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { DataGridTextCell } from '@ovh-ux/manager-react-components';
+
+import {
+  getVaultStatusBadgeColor,
+  getVaultStatusLabel,
+  getVaultStatusTranslationKey,
+} from '@/utils/vault/vaultStatus';
+
+export type VaultStatusCellProps = {
+  resourceStatus: string;
+};
+
+export const VaultStatusCell = ({ resourceStatus }: VaultStatusCellProps) => {
+  const { t } = useTranslation(NAMESPACES.STATUS);
+  const isCreating = getVaultStatusLabel(resourceStatus) === 'creating';
+
+  return (
+    <DataGridTextCell>
+      <span className="flex items-center gap-2">
+        {isCreating && (
+          <span aria-hidden="true">
+            <OdsSpinner size={ODS_SPINNER_SIZE.xs} />
+          </span>
+        )}
+        <OdsBadge
+          color={getVaultStatusBadgeColor(resourceStatus)}
+          label={t(getVaultStatusTranslationKey(resourceStatus))}
+        />
+      </span>
+    </DataGridTextCell>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultsEmptyState.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultsEmptyState.component.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
+import { OdsText } from '@ovhcloud/ods-components/react';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+
+export const VaultsEmptyState = () => {
+  const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.VAULTS);
+
+  return (
+    <div className="flex flex-col items-center gap-2 py-10 text-center">
+      <OdsText preset={ODS_TEXT_PRESET.heading4}>{t('state.empty.title')}</OdsText>
+      <OdsText preset={ODS_TEXT_PRESET.paragraph}>{t('state.empty.description')}</OdsText>
+    </div>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultsErrorState.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_components/VaultsErrorState.component.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT, ODS_MESSAGE_COLOR } from '@ovhcloud/ods-components';
+import { OdsButton, OdsMessage } from '@ovhcloud/ods-components/react';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+
+export type VaultsErrorStateProps = {
+  onRetry: () => void;
+};
+
+export const VaultsErrorState = ({ onRetry }: VaultsErrorStateProps) => {
+  const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.VAULTS);
+
+  return (
+    <OdsMessage color={ODS_MESSAGE_COLOR.critical} isDismissible={false}>
+      <div className="flex flex-wrap items-center gap-4">
+        <span>{t('state.error.message')}</span>
+        <OdsButton
+          data-testid="vaults-retry"
+          size={ODS_BUTTON_SIZE.sm}
+          variant={ODS_BUTTON_VARIANT.outline}
+          label={t('state.error.retry')}
+          onClick={onRetry}
+        />
+      </div>
+    </OdsMessage>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_hooks/useVaultColumns.hook.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_hooks/useVaultColumns.hook.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { DataGridTextCell, DatagridColumn } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { VAULT_DEFAULT_IMMUTABILITY } from '@/module.constants';
+import { VaultActionsCell } from '@/pages/vaults/_components/VaultActionsCell.component';
+import { VaultRegionCell } from '@/pages/vaults/_components/VaultRegionCell.component';
+import { VaultStatusCell } from '@/pages/vaults/_components/VaultStatusCell.component';
+import { VaultResource } from '@/types/Vault.type';
+
+export const useVaultColumns = (): DatagridColumn<VaultResource>[] => {
+  const { t } = useTranslation([
+    BACKUP_LICENSES_NAMESPACES.VAULTS,
+    NAMESPACES.DASHBOARD,
+    NAMESPACES.REGION,
+    NAMESPACES.STATUS,
+  ]);
+
+  return [
+    {
+      id: 'name',
+      label: t(`${NAMESPACES.DASHBOARD}:name`),
+      isSortable: false,
+      cell: ({ currentState }: VaultResource) => (
+        <DataGridTextCell>{currentState.name}</DataGridTextCell>
+      ),
+    },
+    {
+      id: 'region',
+      label: t(`${NAMESPACES.REGION}:region`),
+      isSortable: false,
+      cell: ({ currentState }: VaultResource) => <VaultRegionCell region={currentState.region} />,
+    },
+    {
+      id: 'immutability',
+      label: t('column.immutability'),
+      isSortable: false,
+      cell: () => (
+        <DataGridTextCell>
+          {t('immutability_value', { count: VAULT_DEFAULT_IMMUTABILITY.duration })}
+        </DataGridTextCell>
+      ),
+    },
+    {
+      id: 'encryption',
+      label: t('column.encryption'),
+      isSortable: false,
+      cell: () => <DataGridTextCell>{t('encryption_value')}</DataGridTextCell>,
+    },
+    {
+      id: 'status',
+      label: t(`${NAMESPACES.STATUS}:status`),
+      isSortable: false,
+      cell: ({ resourceStatus }: VaultResource) => (
+        <VaultStatusCell resourceStatus={resourceStatus} />
+      ),
+    },
+    {
+      id: 'actions',
+      label: '',
+      isSortable: false,
+      cell: (vault: VaultResource) => <VaultActionsCell vault={vault} />,
+    },
+  ];
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/_hooks/useVaultsList.hook.ts
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/_hooks/useVaultsList.hook.ts
@@ -1,0 +1,15 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { vaultsQueries } from '@/data/queries/vaults.queries';
+import { selectBackupLicensesVaults } from '@/data/selectors/vaults.selectors';
+
+export const useVaultsList = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isPending, isError, refetch } = useQuery({
+    ...vaultsQueries.withClient(queryClient).list(),
+    select: selectBackupLicensesVaults,
+  });
+
+  return { vaults: data ?? [], isPending, isError, refetch };
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/vaults.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/vaults.constants.ts
@@ -1,0 +1,4 @@
+/** Shared with the modal routes, which send focus back to this control when they close. */
+export const getVaultActionsTriggerId = (vaultId: string) => `vault-actions-trigger-${vaultId}`;
+
+export const getVaultActionsMenuId = (vaultId: string) => `vault-actions-menu-${vaultId}`;

--- a/packages/manager/modules/backup-licenses/src/routes/routes.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/routes/routes.constants.ts
@@ -13,10 +13,12 @@ export const subRoutes = {
   terminate: 'terminate' as const,
   edit: 'edit' as const,
   delete: 'delete' as const,
+  credentials: 'credentials' as const,
 } as const;
 
 export const urlParams = {
   backupServerId: ':backupServerId' as const,
+  vaultId: ':vaultId' as const,
 } as const;
 
 export const urls = {
@@ -35,7 +37,21 @@ export const routeUrls = {
   generalInformation: `/${subRoutes.generalInformation}`,
   /** Page pleine (sœur de `order`), pas une modale : BKP-1218 reprend le tunnel de commande. */
   edit: (backupServerId: string) => `/${subRoutes.edit}/${backupServerId}`,
+  orderVault: `/${subRoutes.vaults}/${subRoutes.order}`,
 } as const;
+
+// Modales de l'onglet Vaults : routes enfants de la liste, comme `delete` sous `linked-servers`.
+export const terminateVaultRoutePath = `${urlParams.vaultId}/${subRoutes.terminate}`;
+export const vaultCredentialsRoutePath = `${urlParams.vaultId}/${subRoutes.credentials}`;
+export const orderVaultRoutePath = subRoutes.order;
+
+export const getTerminateVaultUrl = (vaultId: string) =>
+  `${routeUrls.vaults}/${vaultId}/${subRoutes.terminate}`;
+
+export const getVaultCredentialsUrl = (vaultId: string) =>
+  `${routeUrls.vaults}/${vaultId}/${subRoutes.credentials}`;
+
+export const getOrderVaultUrl = () => `${routeUrls.vaults}/${subRoutes.order}`;
 
 export type ServiceNavTab = {
   name: string;
@@ -66,7 +82,7 @@ export const SERVICE_NAV_TABS: readonly ServiceNavTab[] = Object.freeze([
     name: 'vaults',
     title: `${BACKUP_LICENSES_NAMESPACES.DASHBOARD}:tab.vaults`,
     to: routeUrls.vaults,
-    isDisabled: true,
+    trackingActions: ['click::vaults-tab'],
   },
   {
     name: 'billing',

--- a/packages/manager/modules/backup-licenses/src/routes/routes.tsx
+++ b/packages/manager/modules/backup-licenses/src/routes/routes.tsx
@@ -24,6 +24,7 @@ const DeleteBackupServerPage = React.lazy(
   () => import('@/pages/linked-servers/delete/DeleteBackupServer.page'),
 );
 const BillingPage = React.lazy(() => import('@/pages/billing/Billing.page'));
+const VaultsPage = React.lazy(() => import('@/pages/vaults/Vaults.page'));
 
 export default (
   <>
@@ -94,7 +95,13 @@ export default (
       >
         <Route path={subRoutes.terminate} Component={TerminateServicePage} />
       </Route>
-      {/* TODO(1.2) : route vaults. */}
+      <Route
+        path={subRoutes.vaults}
+        Component={VaultsPage}
+        handle={{
+          tracking: { pageName: 'vaults', pageType: PageType.listing },
+        }}
+      />
     </Route>
   </>
 );

--- a/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.spec.ts
@@ -1,0 +1,43 @@
+import i18next from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+
+import {
+  defaultLocale,
+  initTestI18n,
+  labels,
+  moduleResources,
+  sharedResources,
+} from './i18ntest.utils';
+
+const allResources = { ...moduleResources, ...sharedResources };
+
+describe('i18n test harness', () => {
+  beforeAll(async () => {
+    await initTestI18n();
+  });
+
+  it('registers every namespace it exposes', () => {
+    const unregistered = Object.keys(allResources).filter(
+      (namespace) => !i18next.hasResourceBundle(defaultLocale, namespace),
+    );
+
+    expect(unregistered).toEqual([]);
+  });
+
+  it('covers every namespace declared by the module', () => {
+    expect(Object.keys(moduleResources).sort()).toEqual(
+      Object.values(BACKUP_LICENSES_NAMESPACES).sort(),
+    );
+  });
+
+  it('registers every bundle exposed in labels', () => {
+    const registered = Object.values(allResources);
+    const unregistered = Object.entries(labels)
+      .filter(([, resources]) => !registered.includes(resources))
+      .map(([name]) => `labels.${name}`);
+
+    expect(unregistered).toEqual([]);
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
@@ -8,7 +8,7 @@ import region from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-com
 import status from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/status/Messages_fr_FR.json';
 import system from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/system/Messages_fr_FR.json';
 
-import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { NAMESPACE_PREFIX } from '@/BackupLicenses.translations';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -37,6 +37,37 @@ import vaults from '../../public/translations/vaults/Messages_fr_FR.json';
 
 export const defaultLocale = 'fr_FR';
 export const defaultAvailableLocales = [defaultLocale];
+
+/**
+ * Le glob évite qu'un dossier de traduction ajouté soit oublié ici. Le namespace se déduit du nom
+ * du dossier parce que les applis copient `public/translations/*` sous
+ * `translations/<NAMESPACE_PREFIX>/` (staticCopy de leur vite.config).
+ */
+export const moduleResources: Record<string, unknown> = Object.fromEntries(
+  Object.entries(
+    import.meta.glob('../../public/translations/*/Messages_fr_FR.json', {
+      eager: true,
+      import: 'default',
+    }),
+  ).map(([file, resources]) => [
+    file.replace('../../public/translations', NAMESPACE_PREFIX).replace('/Messages_fr_FR.json', ''),
+    resources,
+  ]),
+);
+
+/**
+ * Namespaces partagés : les composants les résolvent par `t('region:…')`, donc ils doivent être
+ * enregistrés dans i18next, et pas seulement exposés dans `labels` pour les assertions.
+ */
+export const sharedResources: Record<string, unknown> = {
+  [NAMESPACES.ACTIONS]: actions,
+  [NAMESPACES.BILLING]: billing,
+  [NAMESPACES.DASHBOARD]: commonDashboard,
+  [NAMESPACES.REGION]: region,
+  [NAMESPACES.STATUS]: status,
+  [NAMESPACES.SYSTEM]: system,
+};
+
 /**
  * `addResources` ignore silencieusement toute valeur imbriquée (seules les chaînes/tableaux
  * de premier niveau sont pris en compte) : nos JSON de traduction ont des clés imbriquées
@@ -44,38 +75,15 @@ export const defaultAvailableLocales = [defaultLocale];
  * profonde pour que les tests résolvent les vrais libellés plutôt que la clé brute.
  */
 function addTranslations() {
-  i18next
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.COMMON, common, true)
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.ONBOARDING, onboarding, true)
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.ORDER, order, true)
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.DASHBOARD, dashboard, true)
-    .addResourceBundle(
-      defaultLocale,
-      BACKUP_LICENSES_NAMESPACES.LINKED_SERVERS,
-      linkedServers,
-      true,
-    )
-    .addResourceBundle(
-      defaultLocale,
-      BACKUP_LICENSES_NAMESPACES.GENERAL_INFORMATION,
-      generalInformation,
-      true,
-    )
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.BILLING, billingTab, true)
-    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.VAULTS, vaults, true)
-    // Namespaces partagés : les composants les résolvent par `t('region:…')`, donc ils doivent être
-    // enregistrés dans i18next, et pas seulement exposés dans `labels` pour les assertions.
-    .addResourceBundle(defaultLocale, NAMESPACES.REGION, region, true)
-    .addResourceBundle(defaultLocale, NAMESPACES.STATUS, status, true)
-    .addResourceBundle(defaultLocale, NAMESPACES.ACTIONS, actions, true)
-    .addResourceBundle(defaultLocale, NAMESPACES.DASHBOARD, commonDashboard, true)
-    .addResourceBundle(defaultLocale, NAMESPACES.SYSTEM, system, true)
-    .addResourceBundle(defaultLocale, NAMESPACES.BILLING, billing, true)
-    .use({
-      type: 'postProcessor',
-      name: 'normalize',
-      process: (value: string) => (value ? value.replace(/&amp;/g, '&') : value),
-    });
+  Object.entries({ ...moduleResources, ...sharedResources }).forEach(([namespace, resources]) => {
+    i18next.addResourceBundle(defaultLocale, namespace, resources, true);
+  });
+  // eslint-disable-next-line import/no-named-as-default-member
+  i18next.use({
+    type: 'postProcessor',
+    name: 'normalize',
+    process: (value: string) => (value ? value.replace(/&amp;/g, '&') : value),
+  });
 }
 export const getTesti18nParams = (): InitOptions<unknown> => ({
   lng: defaultLocale,

--- a/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
@@ -1,5 +1,6 @@
 import i18next, { InitOptions, i18n } from 'i18next';
 
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import actions from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/actions/Messages_fr_FR.json';
 import billing from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/billing/Messages_fr_FR.json';
 import commonDashboard from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/dashboard/Messages_fr_FR.json';
@@ -11,10 +12,10 @@ import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import common from '../../public/translations/common/Messages_fr_FR.json';
+import billingTab from '../../public/translations/billing/Messages_fr_FR.json';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import billingTab from '../../public/translations/billing/Messages_fr_FR.json';
+import common from '../../public/translations/common/Messages_fr_FR.json';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import dashboard from '../../public/translations/dashboard/Messages_fr_FR.json';
@@ -30,6 +31,9 @@ import onboarding from '../../public/translations/onboarding/Messages_fr_FR.json
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import order from '../../public/translations/order/Messages_fr_FR.json';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import vaults from '../../public/translations/vaults/Messages_fr_FR.json';
 
 export const defaultLocale = 'fr_FR';
 export const defaultAvailableLocales = [defaultLocale];
@@ -58,6 +62,15 @@ function addTranslations() {
       true,
     )
     .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.BILLING, billingTab, true)
+    .addResourceBundle(defaultLocale, BACKUP_LICENSES_NAMESPACES.VAULTS, vaults, true)
+    // Namespaces partagés : les composants les résolvent par `t('region:…')`, donc ils doivent être
+    // enregistrés dans i18next, et pas seulement exposés dans `labels` pour les assertions.
+    .addResourceBundle(defaultLocale, NAMESPACES.REGION, region, true)
+    .addResourceBundle(defaultLocale, NAMESPACES.STATUS, status, true)
+    .addResourceBundle(defaultLocale, NAMESPACES.ACTIONS, actions, true)
+    .addResourceBundle(defaultLocale, NAMESPACES.DASHBOARD, commonDashboard, true)
+    .addResourceBundle(defaultLocale, NAMESPACES.SYSTEM, system, true)
+    .addResourceBundle(defaultLocale, NAMESPACES.BILLING, billing, true)
     .use({
       type: 'postProcessor',
       name: 'normalize',
@@ -97,4 +110,5 @@ export const labels = {
   linkedServers,
   generalInformation,
   billingTab,
+  vaults,
 };

--- a/packages/manager/modules/backup-licenses/src/test-utils/setupMsw.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/setupMsw.ts
@@ -3,7 +3,14 @@ import { SetupServer } from 'msw/node';
 import { getAuthenticationMocks, toMswHandlers } from '@ovh-ux/manager-core-test-utils';
 import { GetServicesMocksParams, getServicesMocks } from '@ovh-ux/manager-module-common-api';
 
-export type MockParams = GetServicesMocksParams;
+import { TIamMockParams, getIamMocks } from '@/mocks/iam/iam.handler';
+import { TTenantMockParams, getTenantMocks } from '@/mocks/tenants/tenants.handler';
+import { TVaultMockParams, getVaultMocks } from '@/mocks/vaults/vaults.handler';
+
+export type MockParams = GetServicesMocksParams &
+  TTenantMockParams &
+  TVaultMockParams &
+  TIamMockParams;
 
 /**
  * Mocks MSW du service `/services` (v6) consommé par `useServiceDetailsQueryOption`/
@@ -16,6 +23,9 @@ export const setupMswMock = (mockParams: MockParams = {}) => {
     ...toMswHandlers([
       ...getAuthenticationMocks({ isAuthMocked: true }),
       ...getServicesMocks(mockParams),
+      ...getTenantMocks(mockParams),
+      ...getVaultMocks(mockParams),
+      ...getIamMocks(mockParams),
     ]),
   );
 };

--- a/packages/manager/modules/backup-licenses/src/test-utils/watchApiCalls.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/watchApiCalls.ts
@@ -1,0 +1,17 @@
+import { SetupServer } from 'msw/node';
+
+const mswServer = () => (global as unknown as { server: SetupServer }).server;
+
+export const watchApiCalls = (pathFragment: string): string[] => {
+  const calls: string[] = [];
+
+  mswServer().events.on('request:start', ({ request }) => {
+    if (request.url.includes(pathFragment)) {
+      calls.push(request.url);
+    }
+  });
+
+  return calls;
+};
+
+export const stopWatchingApiCalls = () => mswServer().events.removeAllListeners();

--- a/packages/manager/modules/backup-licenses/src/types/BackupLicense.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/BackupLicense.type.ts
@@ -1,5 +1,5 @@
-import { Resource } from './Resource.type';
 import { LicenseApiValue } from './Order.type';
+import { Resource } from './Resource.type';
 
 /**
  * Le champ de jointure vers le vault n'est pas confirmé côté API (§14 de la spec

--- a/packages/manager/modules/backup-licenses/src/types/Resource.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Resource.type.ts
@@ -1,4 +1,4 @@
-/** Les 7 membres de `common.ResourceStatusEnum` (schéma v2, 2026-06-16). */
+/** Les 8 membres de `common.ResourceStatusEnum` du contrat v2 `backupServices`. */
 export type ResourceStatus =
   | 'CREATING'
   | 'DELETING'
@@ -6,6 +6,7 @@ export type ResourceStatus =
   | 'OUT_OF_SYNC'
   | 'READY'
   | 'SUSPENDED'
+  | 'UNKNOWN'
   | 'UPDATING';
 
 export type TaskStatus = 'ERROR' | 'PENDING' | 'RUNNING' | 'SCHEDULED' | 'WAITING_USER_INPUT';

--- a/packages/manager/modules/backup-licenses/src/types/Resource.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Resource.type.ts
@@ -1,4 +1,12 @@
-export type ResourceStatus = 'CREATING' | 'DELETING' | 'ERROR' | 'READY' | 'SUSPENDED' | 'UPDATING';
+/** Les 7 membres de `common.ResourceStatusEnum` (schéma v2, 2026-06-16). */
+export type ResourceStatus =
+  | 'CREATING'
+  | 'DELETING'
+  | 'ERROR'
+  | 'OUT_OF_SYNC'
+  | 'READY'
+  | 'SUSPENDED'
+  | 'UPDATING';
 
 export type TaskStatus = 'ERROR' | 'PENDING' | 'RUNNING' | 'SCHEDULED' | 'WAITING_USER_INPUT';
 

--- a/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
@@ -3,9 +3,24 @@
  * Copie réduite du type de `@ovh-ux/backup-agent` : ce module ne peut pas l'importer
  * (dépendance fantôme, cf. §5 de la spec BKP-1225).
  */
-import { Resource } from './Resource.type';
+import { Resource, ResourceStatus } from './Resource.type';
 
 export type VaultBillingType = 'BUNDLE' | 'PAYGO';
+
+export type BucketRole = 'PRIMARY' | 'REPLICA';
+
+export type BucketPerformance = 'HIGH_PERF' | 'STANDARD';
+
+export type VaultBucket = {
+  id: string;
+  name: string;
+  performance: BucketPerformance;
+  region: string;
+  role: BucketRole;
+  status: ResourceStatus;
+  /** Champ supposé, absent du schéma v2 publié (2026-06-16). */
+  endPoint?: string;
+};
 
 export type Vault = {
   id: string;
@@ -15,6 +30,17 @@ export type Vault = {
   type: VaultBillingType;
   /** Champ attendu par le ticket, absent de tout contrat connu — cf. §14 de la spec. */
   vaultProductLine?: string;
+  /** Ajoutés pour les vaults (BKP-1221/1222) : la facturation n'en a pas besoin. */
+  status?: ResourceStatus;
+  buckets?: VaultBucket[];
+  vspcTenants?: string[];
 };
 
-export type VaultResource = Resource<Vault>;
+export type VaultResource = Resource<Vault> & {
+  iam?: { id: string; urn: string; displayName?: string; tags?: Record<string, string> };
+};
+
+export type VaultBucketAccess = {
+  accessKey: string;
+  secretKey: string;
+};

--- a/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
@@ -1,11 +1,13 @@
 /**
- * Domaine des vaults Backup Licenses, côté facturation (BKP-1225).
- * Copie réduite du type de `@ovh-ux/backup-agent` : ce module ne peut pas l'importer
+ * Projection de `backup.tenant.vault.CurrentState` et de ses membres (contrat v2 `backupServices`).
+ * Les types ne sont pas importés de `@ovh-ux/backup-agent` : ce module ne peut pas en dépendre
  * (dépendance fantôme, cf. §5 de la spec BKP-1225).
  */
 import { Resource, ResourceStatus } from './Resource.type';
 
 export type VaultBillingType = 'BUNDLE' | 'PAYGO';
+
+export type VaultProductLine = 'BACKUP_AGENT' | 'BACKUP_LICENSES';
 
 export type BucketRole = 'PRIMARY' | 'REPLICA';
 
@@ -18,8 +20,6 @@ export type VaultBucket = {
   region: string;
   role: BucketRole;
   status: ResourceStatus;
-  /** Champ supposé, absent du schéma v2 publié (2026-06-16). */
-  endPoint?: string;
 };
 
 export type Vault = {
@@ -28,8 +28,10 @@ export type Vault = {
   resourceName: string;
   region: string;
   type: VaultBillingType;
-  /** Champ attendu par le ticket, absent de tout contrat connu — cf. §14 de la spec. */
-  vaultProductLine?: string;
+  /** Quota inclus d'un vault BUNDLE ; null pour PAYGO, BACKUP_AGENT ou hors sujet. */
+  includedSoftQuotaGb?: number | null;
+  /** Nullable au contrat, tant que les vaults existants ne sont pas rétro-remplis. */
+  vaultProductLine?: VaultProductLine | null;
   /** Ajoutés pour les vaults (BKP-1221/1222) : la facturation n'en a pas besoin. */
   status?: ResourceStatus;
   buckets?: VaultBucket[];
@@ -40,7 +42,14 @@ export type VaultResource = Resource<Vault> & {
   iam?: { id: string; urn: string; displayName?: string; tags?: Record<string, string> };
 };
 
+/**
+ * `backup.tenant.vault.bucket.Credentials` : la réponse porte elle-même l'endpoint S3 et le code
+ * de région court (`backup.RegionCodeEnum`), qui n'est pas le `common.RegionEnum` du bucket.
+ */
 export type VaultBucketAccess = {
   accessKey: string;
+  bucketName: string;
+  endpoint: string;
+  regionCode: string;
   secretKey: string;
 };

--- a/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.spec.ts
@@ -8,6 +8,7 @@ import {
   getBackupServicesBaseRoute,
   getLicenseConsumptionRoute,
   getServiceConsumptionRoute,
+  getVaultBucketCredentialsRoute,
   getVaultsRoute,
   getVspcTenantsRoute,
 } from './apiRoutes';
@@ -41,6 +42,12 @@ describe('apiRoutes', () => {
 
   it('builds the vaults route for a given tenant id', () => {
     expect(getVaultsRoute('tenant-1')).toBe(`${BACKUP_SERVICES_ROUTE}/tenant-1/vault`);
+  });
+
+  it('builds the bucket credentials route for a given vault and bucket id', () => {
+    expect(getVaultBucketCredentialsRoute('tenant-1', 'vault-1', 'bucket-1')).toBe(
+      `${BACKUP_SERVICES_ROUTE}/tenant-1/vault/vault-1/bucket/bucket-1/credentials`,
+    );
   });
 
   it('builds the storage consumption route (/element) for a given service id', () => {

--- a/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.ts
@@ -26,12 +26,11 @@ export const getVaultsRoute = (backupServicesId: string) =>
 export const getVaultRoute = (backupServicesId: string, vaultId: string) =>
   `${getVaultsRoute(backupServicesId)}/${vaultId}`;
 
-// Route supposée : le schéma v2 publié (2026-06-16) s'arrête à vault/{vaultId}, en GET et PUT.
-export const getVaultBucketAccessRoute = (
+export const getVaultBucketCredentialsRoute = (
   backupServicesId: string,
   vaultId: string,
   bucketId: string,
-) => `${getVaultRoute(backupServicesId, vaultId)}/bucket/${bucketId}/access`;
+) => `${getVaultRoute(backupServicesId, vaultId)}/bucket/${bucketId}/credentials`;
 
 /** Stockage d'un vault : `quantity` et `price` en un seul appel (§3.1 de la spec BKP-1225). */
 export const getServiceConsumptionRoute = (serviceId: string) =>

--- a/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/apiRoutes/apiRoutes.ts
@@ -23,6 +23,16 @@ export const getBackupServerRoute = (
 export const getVaultsRoute = (backupServicesId: string) =>
   `${getBackupServicesBaseRoute(backupServicesId)}/vault`;
 
+export const getVaultRoute = (backupServicesId: string, vaultId: string) =>
+  `${getVaultsRoute(backupServicesId)}/${vaultId}`;
+
+// Route supposée : le schéma v2 publié (2026-06-16) s'arrête à vault/{vaultId}, en GET et PUT.
+export const getVaultBucketAccessRoute = (
+  backupServicesId: string,
+  vaultId: string,
+  bucketId: string,
+) => `${getVaultRoute(backupServicesId, vaultId)}/bucket/${bucketId}/access`;
+
 /** Stockage d'un vault : `quantity` et `price` en un seul appel (§3.1 de la spec BKP-1225). */
 export const getServiceConsumptionRoute = (serviceId: string) =>
   `/services/${serviceId}/consumption/element`;

--- a/packages/manager/modules/backup-licenses/src/utils/iam.constants.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/iam.constants.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { IAM_ACTIONS, getTerminateIamActions } from './iam.constants';
+
+describe('getTerminateIamActions', () => {
+  it('gates the US subsidiary on the action guarding the DELETE form it is served', () => {
+    expect(getTerminateIamActions('US')).toEqual([
+      IAM_ACTIONS.servicesGet,
+      IAM_ACTIONS.servicesTerminateWithoutConfirmation,
+    ]);
+  });
+
+  it.each(['FR', 'CA', 'GB', undefined])(
+    'gates %s on the action guarding the POST termination form',
+    (ovhSubsidiary) => {
+      expect(getTerminateIamActions(ovhSubsidiary)).toEqual([
+        IAM_ACTIONS.servicesGet,
+        IAM_ACTIONS.servicesTerminate,
+      ]);
+    },
+  );
+});

--- a/packages/manager/modules/backup-licenses/src/utils/iam.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/iam.constants.ts
@@ -2,6 +2,7 @@ export const IAM_ACTIONS = {
   backupServicesGet: 'backupServices:apiovh:get',
   vaultGet: 'backupServices:apiovh:vault/get',
   vaultEdit: 'backupServices:apiovh:vault/edit',
+  vaultCredentialsGet: 'backupServices:apiovh:vault/credentials/get',
   servicesGet: 'account:apiovh:services/get',
   servicesTerminate: 'account:apiovh:services/terminate',
   servicesTerminateWithoutConfirmation: 'account:apiovh:services/terminateWithoutConfirmation',

--- a/packages/manager/modules/backup-licenses/src/utils/iam.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/iam.constants.ts
@@ -1,0 +1,24 @@
+export const IAM_ACTIONS = {
+  backupServicesGet: 'backupServices:apiovh:get',
+  vaultGet: 'backupServices:apiovh:vault/get',
+  vaultEdit: 'backupServices:apiovh:vault/edit',
+  servicesGet: 'account:apiovh:services/get',
+  servicesTerminate: 'account:apiovh:services/terminate',
+  servicesTerminateWithoutConfirmation: 'account:apiovh:services/terminateWithoutConfirmation',
+} as const;
+
+export const TERMINATION_DELETE_SUBSIDIARY = 'US';
+
+/**
+ * The two termination forms are guarded by two different actions, so the gate has to follow the call
+ * `useDeleteService` (manager-module-common-api) actually sends: `DELETE /services/{id}`
+ * (`services/terminateWithoutConfirmation`) for the US subsidiary, `POST /services/{id}/terminate`
+ * (`services/terminate`) everywhere else. Both branches first resolve the `serviceId` through
+ * `GET /services?resourceName=`, hence `services/get`.
+ */
+export const getTerminateIamActions = (ovhSubsidiary?: string): string[] => [
+  IAM_ACTIONS.servicesGet,
+  ovhSubsidiary === TERMINATION_DELETE_SUBSIDIARY
+    ? IAM_ACTIONS.servicesTerminateWithoutConfirmation
+    : IAM_ACTIONS.servicesTerminate,
+];

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultName.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultName.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateVaultName } from './vaultName';
+
+describe('validateVaultName', () => {
+  it.each(['a', 'vault-prod-paris', 'Vault01', 'a'.repeat(50)])('accepts %s', (name) => {
+    expect(validateVaultName(name)).toBeUndefined();
+  });
+
+  it('rejects an empty name', () => {
+    expect(validateVaultName('')).toBe('required');
+    expect(validateVaultName('   ')).toBe('required');
+  });
+
+  it('rejects a name over 50 characters', () => {
+    expect(validateVaultName('a'.repeat(51))).toBe('length');
+  });
+
+  it.each(['vault_01', 'vault.01', "vault'01", 'vault 01', 'vault@01'])(
+    'rejects %s on pattern',
+    (name) => {
+      expect(validateVaultName(name)).toBe('pattern');
+    },
+  );
+
+  it('rejects the dot the S3 bucket rule would allow, since the ticket lists hyphens only', () => {
+    expect(validateVaultName('my.vault')).toBe('pattern');
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultName.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultName.ts
@@ -1,0 +1,21 @@
+export const VAULT_NAME_MIN_LENGTH = 1;
+export const VAULT_NAME_MAX_LENGTH = 50;
+
+/**
+ * Ticket BKP-1223: "Min 1 char, max 50 chars. Alphanumeric and hyphens only." The create-vault
+ * mockup shows a different rule (3-63 characters, lowercase boundaries, apostrophe) — the ticket is
+ * the reference.
+ */
+export const VAULT_NAME_PATTERN = /^[a-zA-Z0-9-]+$/;
+
+export type VaultNameError = 'required' | 'length' | 'pattern';
+
+export const validateVaultName = (name: string): VaultNameError | undefined => {
+  const value = name?.trim() ?? '';
+
+  if (!value) return 'required';
+  if (value.length > VAULT_NAME_MAX_LENGTH) return 'length';
+  if (!VAULT_NAME_PATTERN.test(value)) return 'pattern';
+
+  return undefined;
+};

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatVaultRegions, getVaultRegionI18nKey } from './vaultRegion';
+
+describe('getVaultRegionI18nKey', () => {
+  it('resolves a region this offer can provision', () => {
+    expect(getVaultRegionI18nKey('eu-west-rbx')).toBe('rbx');
+  });
+
+  it('returns nothing for an unmapped region, leaving the raw code to be displayed', () => {
+    expect(getVaultRegionI18nKey('ap-southeast-syd')).toBeUndefined();
+  });
+});
+
+describe('formatVaultRegions', () => {
+  it('joins the translated regions', () => {
+    expect(
+      formatVaultRegions(['eu-west-rbx', 'eu-west-gra'], (region) => region.toUpperCase()),
+    ).toBe('EU-WEST-RBX, EU-WEST-GRA');
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.ts
@@ -1,0 +1,20 @@
+/**
+ * Aucun champ ne porte de libellé de région et `common.RegionEnum` compte 48 membres : seul le
+ * sous-ensemble que cette offre provisionne est mappé, le reste retombe sur le code brut, qui reste
+ * lisible. Les clés alimentent les libellés de ville du namespace partagé `region`.
+ */
+export const VAULT_REGION_I18N_KEYS: Record<string, string> = Object.freeze({
+  'eu-west-gra': 'gra',
+  'eu-west-par': 'par',
+  'eu-west-rbx': 'rbx',
+  'eu-west-sbg': 'sbg',
+});
+
+/** La casse varie selon la source : le contrat publie `eu-west-par`, les fixtures `EU-WEST-PAR`. */
+export const getVaultRegionI18nKey = (region: string): string | undefined =>
+  VAULT_REGION_I18N_KEYS[region?.toLowerCase()];
+
+export const formatVaultRegions = (
+  regions: string[],
+  translateRegion: (region: string) => string,
+): string => regions.map(translateRegion).join(', ');

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultRegion.ts
@@ -1,5 +1,5 @@
 /**
- * Aucun champ ne porte de libellé de région et `common.RegionEnum` compte 48 membres : seul le
+ * Aucun champ ne porte de libellé de région et `common.RegionEnum` compte 50 membres : seul le
  * sous-ensemble que cette offre provisionne est mappé, le reste retombe sur le code brut, qui reste
  * lisible. Les clés alimentent les libellés de ville du namespace partagé `region`.
  */

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ODS_BADGE_COLOR } from '@ovhcloud/ods-components';
+
+import { ResourceStatus } from '@/types/Resource.type';
+
+import {
+  VAULT_STATUS_LABEL,
+  getVaultStatusBadgeColor,
+  getVaultStatusLabel,
+  getVaultStatusTranslationKey,
+} from './vaultStatus';
+
+vi.mock('@ovhcloud/ods-components', () => ({
+  ODS_BADGE_COLOR: {
+    information: 'information',
+    critical: 'critical',
+    success: 'success',
+    warning: 'warning',
+  },
+}));
+
+const ALL_STATUSES: ResourceStatus[] = [
+  'CREATING',
+  'DELETING',
+  'ERROR',
+  'OUT_OF_SYNC',
+  'READY',
+  'SUSPENDED',
+  'UPDATING',
+];
+
+describe('getVaultStatusLabel', () => {
+  it('covers every status of the API enum', () => {
+    expect(Object.keys(VAULT_STATUS_LABEL).sort()).toEqual([...ALL_STATUSES].sort());
+  });
+
+  it.each([
+    ['READY', 'active'],
+    ['CREATING', 'creating'],
+  ])('maps %s to %s', (status, label) => {
+    expect(getVaultStatusLabel(status)).toBe(label);
+  });
+
+  it.each(['DELETING', 'ERROR', 'OUT_OF_SYNC', 'SUSPENDED', 'UPDATING'])(
+    'maps %s to error, as the ticket collapses everything but READY and CREATING',
+    (status) => {
+      expect(getVaultStatusLabel(status)).toBe('error');
+    },
+  );
+
+  it('degrades to error on an unknown status', () => {
+    expect(getVaultStatusLabel('HIBERNATING')).toBe('error');
+  });
+});
+
+describe('getVaultStatusBadgeColor', () => {
+  it.each([
+    ['READY', ODS_BADGE_COLOR.success],
+    ['CREATING', ODS_BADGE_COLOR.information],
+    ['SUSPENDED', ODS_BADGE_COLOR.critical],
+  ])('renders %s as %s', (status, color) => {
+    expect(getVaultStatusBadgeColor(status)).toBe(color);
+  });
+});
+
+describe('getVaultStatusTranslationKey', () => {
+  it.each([
+    ['READY', 'ready'],
+    ['CREATING', 'creating'],
+    ['OUT_OF_SYNC', 'error'],
+    ['HIBERNATING', 'error'],
+  ])('resolves %s to the shared status key "%s"', (status, key) => {
+    expect(getVaultStatusTranslationKey(status)).toBe(key);
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.spec.ts
@@ -27,6 +27,7 @@ const ALL_STATUSES: ResourceStatus[] = [
   'OUT_OF_SYNC',
   'READY',
   'SUSPENDED',
+  'UNKNOWN',
   'UPDATING',
 ];
 
@@ -42,7 +43,7 @@ describe('getVaultStatusLabel', () => {
     expect(getVaultStatusLabel(status)).toBe(label);
   });
 
-  it.each(['DELETING', 'ERROR', 'OUT_OF_SYNC', 'SUSPENDED', 'UPDATING'])(
+  it.each(['DELETING', 'ERROR', 'OUT_OF_SYNC', 'SUSPENDED', 'UNKNOWN', 'UPDATING'])(
     'maps %s to error, as the ticket collapses everything but READY and CREATING',
     (status) => {
       expect(getVaultStatusLabel(status)).toBe('error');

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.ts
@@ -1,0 +1,42 @@
+import { ODS_BADGE_COLOR } from '@ovhcloud/ods-components';
+
+import { ResourceStatus } from '@/types/Resource.type';
+
+export type VaultStatusLabel = 'active' | 'creating' | 'error';
+
+/**
+ * Ticket BKP-1221 maps the badge in three branches: READY → Active, PROVISIONING → Creating,
+ * anything else → Error. `PROVISIONING` is not a member of `common.ResourceStatusEnum`; the real
+ * value is `CREATING`, which is what the API sends and what is mapped here.
+ */
+export const VAULT_STATUS_LABEL: Record<ResourceStatus, VaultStatusLabel> = Object.freeze({
+  READY: 'active',
+  CREATING: 'creating',
+  DELETING: 'error',
+  ERROR: 'error',
+  OUT_OF_SYNC: 'error',
+  SUSPENDED: 'error',
+  UPDATING: 'error',
+});
+
+const BADGE_COLOR: Record<VaultStatusLabel, ODS_BADGE_COLOR> = Object.freeze({
+  active: ODS_BADGE_COLOR.success,
+  creating: ODS_BADGE_COLOR.information,
+  error: ODS_BADGE_COLOR.critical,
+});
+
+/** Keys of the shared `status` namespace whose values already read "Active"/"Creating"/"Error". */
+const SHARED_STATUS_KEY: Record<VaultStatusLabel, string> = Object.freeze({
+  active: 'ready',
+  creating: 'creating',
+  error: 'error',
+});
+
+export const getVaultStatusLabel = (resourceStatus: string): VaultStatusLabel =>
+  VAULT_STATUS_LABEL[resourceStatus?.toUpperCase() as ResourceStatus] ?? 'error';
+
+export const getVaultStatusBadgeColor = (resourceStatus: string): ODS_BADGE_COLOR =>
+  BADGE_COLOR[getVaultStatusLabel(resourceStatus)];
+
+export const getVaultStatusTranslationKey = (resourceStatus: string): string =>
+  SHARED_STATUS_KEY[getVaultStatusLabel(resourceStatus)];

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultStatus.ts
@@ -16,6 +16,7 @@ export const VAULT_STATUS_LABEL: Record<ResourceStatus, VaultStatusLabel> = Obje
   ERROR: 'error',
   OUT_OF_SYNC: 'error',
   SUSPENDED: 'error',
+  UNKNOWN: 'error',
   UPDATING: 'error',
 });
 


### PR DESCRIPTION
## Description

Activates the **Vaults** tab and renders the listing BKP-1221 specifies: the five columns (Name, Region, Immutability, Encryption, Status), its four states, and the row action menu.

The tab entry was already declared in `SERVICE_NAV_TABS` with `isDisabled` and the comment *« Retirer ce flag et ajouter la route correspondante dans `routes.tsx` suffit à l'activer »* — that is exactly what this does, mounting the route at the `TODO(1.2)` placeholder under `ServiceLayout`.

The vault data layer written for the billing tab is **completed rather than duplicated**:

- `Resource.type` gains `OUT_OF_SYNC`, the 7th member of `common.ResourceStatusEnum` that was missing;
- `Vault.type` gains `status`, `buckets`, `vspcTenants` and the IAM envelope as **optional** fields, so the billing fixtures keep working unchanged;
- `queryKeys`, `apiRoutes` and `vaults.requests` gain their vault entries.

### Two deliberate divergences from the ticket

Both because the module already decided otherwise and its reason holds:

- **The product-line filter keeps vaults that carry no `vaultProductLine`.** The ticket asks for an exact match, but the field is published by no contract — a strict filter would empty the tab for every customer until the backend ships it. This is the existing `selectBackupLicensesVaults` behaviour and its comment.
- **The region cell** resolves `currentState.region` through the offer's subset onto the shared `region` namespace, **case-insensitively**: the contract publishes lowercase codes (`eu-west-par`), the existing fixtures uppercase ones (`EU-WEST-PAR`).

### Test harness

Registers the shared translation namespaces in `i18ntest.utils`. They were imported for assertions but never added to i18next, so any component resolving `t('region:…')` rendered the raw key — which is why two `linked-servers` assertions matched untranslated keys and now match the labels.

Ticket Reference: BKP-1221

## Additional Information

**First PR of a stack of four** (BKP-1221 → BKP-1222 → BKP-1224 → BKP-1223). Each branch is autonomous: `routes.tsx` only declares the routes whose pages that branch brings, so no intermediate PR points at a missing component.

- 409 tests pass, `tsc --noEmit` and `lint:modern` clean.
- Opened as a draft: the standalone app could not be run locally (the `turbo build` postinstall fails in this environment), and two PO decisions are pending — see the divergences above.