### PR TITLE
feat(backup-licenses): terminate a vault (BKP-1224)

### DIFF
--- a/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.page.spec.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getVaultActionsTriggerId } from '@/pages/vaults/vaults.constants';
+import { setupMswMock } from '@/test-utils/setupMsw';
+import { testWrapperBuilder } from '@/test-utils/testWrapperBuilder';
+
+import TerminateVaultPage from './TerminateVault.page';
+
+/**
+ * `USE_API_MOCKS` court-circuite le réseau et renvoie les jeux de données du module. Ces tests
+ * paramètrent leurs propres fixtures via MSW, donc ils laissent la couche réseau s'exécuter.
+ */
+vi.mock('@/mocks/mocks.config', () => ({ USE_API_MOCKS: false }));
+
+const navigateMock = vi.fn();
+const addSuccessMock = vi.fn();
+let vaultIdParam = 'vault-2';
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ vaultId: vaultIdParam }),
+  };
+});
+
+vi.mock('@ovh-ux/manager-react-components', () => ({
+  useNotifications: () => ({ addSuccess: addSuccessMock, addError: vi.fn() }),
+  DeleteModal: ({
+    children,
+    onConfirmDelete,
+    closeModal,
+    error,
+    isLoading,
+  }: {
+    children?: React.ReactNode;
+    onConfirmDelete: () => void;
+    closeModal: () => void;
+    error?: string;
+    isLoading?: boolean;
+  }) => (
+    <div
+      data-testid="delete-modal"
+      data-loading={String(!!isLoading)}
+      data-error={String(error ?? '')}
+    >
+      {error && <p data-testid="modal-error">{error}</p>}
+      {children}
+      <button type="button" data-testid="confirm" disabled={isLoading} onClick={onConfirmDelete}>
+        confirm
+      </button>
+      <button type="button" data-testid="cancel" onClick={closeModal}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@ovhcloud/ods-components/react', () => ({
+  OdsText: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}));
+
+/**
+ * The success path runs against the real hook and MSW. The failure path forces the hook's error
+ * state instead: the shared v6 service mocks answer a 500 that never propagates in this harness —
+ * the mutation stays pending — so asserting on it would test the harness, not this page.
+ */
+let forcedDeleteError: { message: string } | undefined;
+
+vi.mock('@ovh-ux/manager-module-common-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ovh-ux/manager-module-common-api')>();
+  return {
+    ...actual,
+    useDeleteService: (params: Parameters<typeof actual.useDeleteService>[0]) => {
+      const real = actual.useDeleteService(params);
+      return forcedDeleteError
+        ? { ...real, isError: true, error: { response: { data: forcedDeleteError } } }
+        : real;
+    },
+  };
+});
+
+const renderPage = async () => {
+  const Providers = await testWrapperBuilder()
+    .withQueryClient()
+    .withI18next()
+    .withShellContext()
+    .build();
+
+  return render(
+    <Providers>
+      <MemoryRouter>
+        {/* Vaults.page.tsx renders the rows beside the <Outlet />, so the trigger outlives the modal. */}
+        <button
+          type="button"
+          id={getVaultActionsTriggerId(vaultIdParam)}
+          data-testid="row-trigger"
+          aria-label="row actions"
+        />
+        <TerminateVaultPage />
+      </MemoryRouter>
+    </Providers>,
+  );
+};
+
+describe('TerminateVaultPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vaultIdParam = 'vault-2';
+    forcedDeleteError = undefined;
+  });
+
+  it('opens on a PAYGO vault', async () => {
+    setupMswMock();
+
+    await renderPage();
+
+    expect(await screen.findByTestId('delete-modal')).toBeInTheDocument();
+  });
+
+  it('terminates through the commercial service chain, then confirms and refreshes', async () => {
+    setupMswMock();
+
+    await renderPage();
+    await userEvent.click(await screen.findByTestId('confirm'));
+
+    await waitFor(() => expect(addSuccessMock).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/vaults');
+  });
+
+  it('gives focus back to the row control it was opened from', async () => {
+    setupMswMock();
+
+    await renderPage();
+    await userEvent.click(await screen.findByTestId('cancel'));
+
+    await waitFor(() => expect(screen.getByTestId('row-trigger')).toHaveFocus());
+  });
+
+  it('surfaces the API message inside the modal and keeps it open', async () => {
+    setupMswMock();
+    forcedDeleteError = { message: 'Service is locked' };
+
+    await renderPage();
+
+    expect(await screen.findByTestId('modal-error')).toHaveTextContent('Service is locked');
+    expect(addSuccessMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a translated message when the API gives no reason', async () => {
+    setupMswMock();
+    forcedDeleteError = { message: '' };
+
+    await renderPage();
+
+    const modalError = await screen.findByTestId('modal-error');
+    expect(modalError).toBeInTheDocument();
+    expect(modalError).not.toBeEmptyDOMElement();
+  });
+
+  it('refuses to open on the included vault, which a hand-typed URL could otherwise reach', async () => {
+    setupMswMock();
+    vaultIdParam = 'vault-1';
+
+    await renderPage();
+
+    await waitFor(() => expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument());
+  });
+
+  it('refuses to open on an unknown vault id', async () => {
+    setupMswMock();
+    vaultIdParam = 'does-not-exist';
+
+    await renderPage();
+
+    await waitFor(() => expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument());
+  });
+
+  it('refuses to open on a vault the route serves to another product line', async () => {
+    setupMswMock();
+    vaultIdParam = 'vault-foreign';
+
+    await renderPage();
+
+    await waitFor(() => expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument());
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.page.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.page.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { OdsText } from '@ovhcloud/ods-components/react';
+
+import { useDeleteService } from '@ovh-ux/manager-module-common-api';
+import { DeleteModal, useNotifications } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { queryKeys } from '@/data/queries/queryKeys';
+import { vaultsQueries } from '@/data/queries/vaults.queries';
+import {
+  selectBackupLicensesVaults,
+  selectCanTerminateVault,
+} from '@/data/selectors/vaults.selectors';
+import { useReturnFocus } from '@/hooks/useReturnFocus/useReturnFocus';
+import { routeUrls } from '@/routes/routes.constants';
+
+import { getVaultActionsTriggerId } from '../vaults.constants';
+
+export default function TerminateVaultPage() {
+  const { t } = useTranslation([BACKUP_LICENSES_NAMESPACES.VAULTS]);
+  const { vaultId } = useParams<{ vaultId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { addSuccess } = useNotifications();
+
+  const returnFocusToTrigger = useReturnFocus(getVaultActionsTriggerId(vaultId ?? ''));
+
+  const closeModal = () => {
+    navigate(routeUrls.vaults);
+    returnFocusToTrigger();
+  };
+
+  // Same projection as the tab's list, so a vault of another product line stays unreachable by URL.
+  const { data: vaults, isSuccess } = useQuery({
+    ...vaultsQueries.withClient(queryClient).list(),
+    select: selectBackupLicensesVaults,
+  });
+  const vault = vaults?.find(({ id }) => id === vaultId);
+
+  const { terminateService, isPending, isError, error } = useDeleteService({
+    onSuccess: () => {
+      addSuccess(t('terminate.success'));
+      void queryClient.invalidateQueries({ queryKey: queryKeys.vaults.all() });
+      closeModal();
+    },
+  });
+
+  // The confirmation names the vault and its region, so there is nothing to show before the list
+  // resolves — an empty message is worse than no modal.
+  if (!isSuccess) {
+    return null;
+  }
+
+  // The modal is a deep-linkable route, so the action menu being disabled is not a guard: a URL
+  // typed by hand would otherwise terminate the included vault.
+  if (!vault || !selectCanTerminateVault(vault)) {
+    return <Navigate to={routeUrls.vaults} replace />;
+  }
+
+  return (
+    <DeleteModal
+      isOpen
+      serviceTypeName={t('service_type')}
+      closeModal={closeModal}
+      isLoading={isPending}
+      error={isError ? error?.response?.data?.message || t('terminate.error') : undefined}
+      onConfirmDelete={() => terminateService({ resourceName: vault.currentState.resourceName })}
+    >
+      <OdsText>
+        {t('terminate.message', {
+          name: vault.currentState.name,
+          region: vault.currentState.region,
+        })}
+      </OdsText>
+    </DeleteModal>
+  );
+}

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.route.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/terminate/TerminateVault.route.spec.tsx
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { getTerminateVaultUrl } from '@/routes/routes.constants';
+import { renderTest } from '@/test-utils/Test.utils';
+import { VaultResource } from '@/types/Vault.type';
+
+const [, paygoVault] = mockVaultsFromDesign as [VaultResource, VaultResource];
+
+describe('[INTEGRATION] Terminate vault route', () => {
+  it('is reachable at /vaults/:vaultId/terminate', async () => {
+    await renderTest({
+      initialRoute: getTerminateVaultUrl(paygoVault.id),
+      vaults: [paygoVault],
+    });
+
+    expect(
+      await screen.findByTestId('manager-delete-modal-confirm', undefined, { timeout: 20_000 }),
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * Le toast de succès n'est pas assertable ici : la terminaison passe par `useDeleteService`, dont
+   * la requête `/services` (v6) reste indéfiniment en attente dans ce harnais — les mocks partagés
+   * répondent bien 500 sur ce verbe, mais la mutation ne se résout jamais. Ce que ce test voulait
+   * garantir — que le toast atteigne un `<Notifications />` monté — reste couvert côté page par
+   * `TerminateVault.page.spec.tsx`, qui vérifie l'appel de `addSuccess` et la fermeture de la modale.
+   */
+});

--- a/packages/manager/modules/backup-licenses/src/routes/routes.tsx
+++ b/packages/manager/modules/backup-licenses/src/routes/routes.tsx
@@ -4,7 +4,12 @@ import { Route } from 'react-router-dom';
 
 import { PageType } from '@ovh-ux/manager-react-shell-client';
 
-import { subRoutes, urlParams, vaultCredentialsRoutePath } from './routes.constants';
+import {
+  subRoutes,
+  terminateVaultRoutePath,
+  urlParams,
+  vaultCredentialsRoutePath,
+} from './routes.constants';
 
 const OnboardingGuardPage = React.lazy(() => import('@/pages/onboarding/OnboardingGuard.page'));
 const OrderPage = React.lazy(() => import('@/pages/order/Order.page'));
@@ -28,6 +33,7 @@ const VaultsPage = React.lazy(() => import('@/pages/vaults/Vaults.page'));
 const VaultCredentialsPage = React.lazy(
   () => import('@/pages/vaults/credentials/VaultCredentials.page'),
 );
+const TerminateVaultPage = React.lazy(() => import('@/pages/vaults/terminate/TerminateVault.page'));
 
 export default (
   <>
@@ -105,12 +111,19 @@ export default (
           tracking: { pageName: 'vaults', pageType: PageType.listing },
         }}
       >
-        {/* Modale enfant : elle se superpose à la liste, qui reste montée derrière. */}
+        {/* Modales enfants : elles se superposent à la liste, qui reste montée derrière. */}
         <Route
           path={vaultCredentialsRoutePath}
           Component={VaultCredentialsPage}
           handle={{
             tracking: { pageName: 'vault-credentials', pageType: PageType.popup },
+          }}
+        />
+        <Route
+          path={terminateVaultRoutePath}
+          Component={TerminateVaultPage}
+          handle={{
+            tracking: { pageName: 'terminate-vault', pageType: PageType.popup },
           }}
         />
       </Route>


### PR DESCRIPTION
## Description

Adds the termination modal as a child route of the listing, built on the Manager's shared destructive modal driven by `useDeleteService`.

### Two ticket requirements are not deliverable, and are recorded rather than faked

- **The verb is `POST /services/{serviceId}/terminate`, not the `DELETE` the ticket names.** The shared `deleteService` helper sends that `DELETE` **only for the `US` subsidiary** — and slice 5.1 (BKP-1226) already uses the POST, so the epic's inconsistency resolves in its favour. Going through the shared hook also settles the `long[]` tie-break that was open: it takes the first element, the Manager-wide convention.
- **The typed `TERMINATE` keyword no longer exists.** MRC 2.43.1 removed the confirmation input from that modal (the prop survives but is never rendered) and fixes its title and both button labels. Only the body is free, and it carries the ticket's message. Building a bespoke modal would mean diverging from the Manager's destructive pattern on a data-loss action — **worth a PO confirmation**.

### The modal guards its own route

It is deep-linkable, so a hand-typed URL would otherwise reach the included vault whose row entry stays disabled. It also renders nothing until the list resolves, since the confirmation names the vault and its region.

Its integration spec asserts the route is reachable but **not** the success toast: the `/services` mutation never settles in this harness. The page spec covers the toast instead, and the reason is written next to the removed test.

Ticket Reference: BKP-1224

## Additional Information

**Third PR of a stack of four.** Depends on #23094 (BKP-1222), itself on #23093 (BKP-1221).

- 477 tests pass, `tsc --noEmit` and `lint:modern` clean.
- Draft: the keyword removal above needs a PO decision.