### PR TITLE
feat(backup-licenses): order an additional vault (BKP-1223)

### DIFF
--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "Der Vorgang dauert länger als erwartet. Bitte aktualisieren Sie die Seite."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "The operation is taking longer than expected. Please refresh the page."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",
@@ -46,6 +47,26 @@
       "hide_secret": "Hide the secret key",
       "copy_field": "Copy the {{field}} field",
       "value_hidden": "Value hidden"
+    }
+  },
+  "order": {
+    "title": "Order an additional vault",
+    "field": {
+      "name": {
+        "label": "Vault name",
+        "hint": "Min 1 char, max 50 chars. Alphanumeric and hyphens only."
+      },
+      "region": {
+        "label": "Storage region"
+      }
+    },
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of €0.007/GB/month from the first byte consumed.",
+    "success": "Vault order is being processed.",
+    "error": {
+      "submit_failed": "The vault order could not be sent. Please try again in a few moments.",
+      "name_required": "We just need a name for your vault.",
+      "name_format": "Use 1 to 50 characters, letters, digits and hyphens only.",
+      "region_required": "Choose the region where your vault will be stored."
     }
   }
 }

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "La operación está tardando más de lo esperado. Actualiza la página."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "La liste des vaults n'a pas pu être chargée.",
       "retry": "Réessayer"
-    }
+    },
+    "polling_timeout": "L'opération prend plus de temps que prévu. Veuillez actualiser la page."
   },
   "terminate": {
     "message": "Êtes-vous sûr de vouloir résilier le vault {{name}} (région : {{region}}) ? Toutes les données qu'il contient seront définitivement perdues. Cette action est irréversible.",
@@ -46,6 +47,26 @@
       "hide_secret": "Masquer la clé secrète",
       "copy_field": "Copier le champ {{field}}",
       "value_hidden": "Valeur masquée"
+    }
+  },
+  "order": {
+    "title": "Commander un vault supplémentaire",
+    "field": {
+      "name": {
+        "label": "Nom du vault",
+        "hint": "1 à 50 caractères. Caractères alphanumériques et tirets uniquement."
+      },
+      "region": {
+        "label": "Région de stockage"
+      }
+    },
+    "pricing_message": "Ce vault sera facturé au tarif à la consommation de 0,007 €/Gio/mois dès le premier octet consommé.",
+    "success": "Votre commande de vault est en cours de traitement.",
+    "error": {
+      "submit_failed": "La commande du vault n'a pas pu être envoyée. Veuillez réessayer dans quelques instants.",
+      "name_required": "Il nous manque juste un nom pour votre vault.",
+      "name_format": "Utilisez de 1 à 50 caractères : lettres, chiffres et tirets uniquement.",
+      "region_required": "Choisissez la région dans laquelle votre vault sera stocké."
     }
   }
 }

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "La liste des vaults n'a pas pu être chargée.",
       "retry": "Réessayer"
-    }
+    },
+    "polling_timeout": "L'opération prend plus de temps que prévu. Veuillez actualiser la page."
   },
   "terminate": {
     "message": "Êtes-vous sûr de vouloir résilier le vault {{name}} (région : {{region}}) ? Toutes les données qu'il contient seront définitivement perdues. Cette action est irréversible.",
@@ -46,6 +47,26 @@
       "hide_secret": "Masquer la clé secrète",
       "copy_field": "Copier le champ {{field}}",
       "value_hidden": "Valeur masquée"
+    }
+  },
+  "order": {
+    "title": "Commander un vault supplémentaire",
+    "field": {
+      "name": {
+        "label": "Nom du vault",
+        "hint": "1 à 50 caractères. Caractères alphanumériques et tirets uniquement."
+      },
+      "region": {
+        "label": "Région de stockage"
+      }
+    },
+    "pricing_message": "Ce vault sera facturé au tarif à la consommation de 0,007 €/Gio/mois dès le premier octet consommé.",
+    "success": "Votre commande de vault est en cours de traitement.",
+    "error": {
+      "submit_failed": "La commande du vault n'a pas pu être envoyée. Veuillez réessayer dans quelques instants.",
+      "name_required": "Il nous manque juste un nom pour votre vault.",
+      "name_format": "Utilisez de 1 à 50 caractères : lettres, chiffres et tirets uniquement.",
+      "region_required": "Choisissez la région dans laquelle votre vault sera stocké."
     }
   }
 }

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "L'operazione sta richiedendo più tempo del previsto. Aggiorna la pagina."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
@@ -26,7 +26,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "Operacja trwa dłużej niż oczekiwano. Odśwież stronę."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
@@ -24,7 +24,8 @@
     "error": {
       "message": "The vault list could not be loaded.",
       "retry": "Retry"
-    }
+    },
+    "polling_timeout": "A operação está a demorar mais do que o esperado. Atualize a página."
   },
   "terminate": {
     "message": "Are you sure you want to terminate the vault {{name}} (region: {{region}})? All data stored in this vault will be permanently lost. This action is irreversible.",

--- a/packages/manager/modules/backup-licenses/src/components/FieldError/FieldError.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/FieldError/FieldError.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
+import { OdsText } from '@ovhcloud/ods-components/react';
+
+export const fieldErrorId = (fieldId: string) => `${fieldId}-error`;
+
+/**
+ * Message d'erreur d'un champ, rendu dans le light DOM plutôt que via la prop `error` d'ODS : ODS 18
+ * l'affiche dans son shadow root, où aucune région live ne l'annonce et où aucun `aria-describedby`
+ * ne peut l'atteindre. Le conteneur est monté dès le premier rendu — une région live qui naît avec son
+ * texte reste muette — et vide tant que le champ est valide.
+ */
+export const FieldError = ({ fieldId, message }: { fieldId: string; message?: string | null }) => (
+  <div id={fieldErrorId(fieldId)} aria-live="polite" className="mt-1">
+    {message && (
+      <OdsText
+        preset={ODS_TEXT_PRESET.caption}
+        className="font-semibold text-[var(--ods-color-critical-500)]"
+      >
+        {message}
+      </OdsText>
+    )}
+  </div>
+);

--- a/packages/manager/modules/backup-licenses/src/components/order/OrderTextField/OrderTextField.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/components/order/OrderTextField/OrderTextField.component.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
 import { OdsFormField, OdsInput, OdsText } from '@ovhcloud/ods-components/react';
+
+import { FieldError } from '@/components/FieldError/FieldError.component';
 
 interface OrderTextFieldProps {
   id: string;
@@ -12,27 +14,38 @@ interface OrderTextFieldProps {
   /** Message d'erreur déjà traduit, ou null si le champ est valide / non touché. */
   error?: string | null;
   required?: boolean;
+  isDisabled?: boolean;
   onChange: (value: string) => void;
   onBlur?: () => void;
 }
 
 /** Champ texte du tunnel : label + astérisque requis + hint + erreur inline (ODS FormField/Input). */
-export default function OrderTextField({
-  id,
-  label,
-  value,
-  placeholder,
-  hint,
-  error,
-  required = false,
-  onChange,
-  onBlur,
-}: OrderTextFieldProps) {
+const OrderTextField = forwardRef<HTMLOdsInputElement, OrderTextFieldProps>(function OrderTextField(
+  {
+    id,
+    label,
+    value,
+    placeholder,
+    hint,
+    error,
+    required = false,
+    isDisabled = false,
+    onChange,
+    onBlur,
+  },
+  ref,
+) {
   return (
-    <OdsFormField className="block" error={error ?? undefined}>
+    <OdsFormField className="block">
       <label htmlFor={id} slot="label">
         {label}
-        {required && <span className="ml-1 text-[var(--ods-color-critical-500)]">*</span>}
+        {/* Masqué : le caractère obligatoire est porté par `isRequired`, qu'un lecteur d'écran
+            annonce — un astérisque lu à la fin du libellé ne veut rien dire. */}
+        {required && (
+          <span aria-hidden="true" className="ml-1 text-[var(--ods-color-critical-500)]">
+            *
+          </span>
+        )}
       </label>
       {hint && (
         <OdsText slot="helper" preset={ODS_TEXT_PRESET.caption}>
@@ -40,14 +53,24 @@ export default function OrderTextField({
         </OdsText>
       )}
       <OdsInput
+        ref={ref}
         id={id}
         name={id}
         value={value}
         placeholder={placeholder}
+        // Le `<label for>` du light DOM nomme l'hôte, pas l'`<input>` du shadow root qui reçoit
+        // réellement le focus ; et aucun IDREF ne franchit la frontière, donc l'erreur ne peut être
+        // rattachée au contrôle que par son nom accessible.
+        ariaLabel={error ? `${label}, ${error}` : label}
         hasError={!!error}
+        isDisabled={isDisabled}
+        isRequired={required}
         onOdsChange={(event) => onChange(String(event.detail.value ?? ''))}
         onOdsBlur={onBlur}
       />
+      <FieldError fieldId={id} message={error} />
     </OdsFormField>
   );
-}
+});
+
+export default OrderTextField;

--- a/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
@@ -1,8 +1,8 @@
 import { v2 } from '@ovh-ux/manager-core-api';
 
 import { USE_API_MOCKS } from '@/mocks/mocks.config';
-import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
-import { VaultBucketAccess, VaultOrder, VaultResource } from '@/types/Vault.type';
+import { mockVaultBucketCredentials, mockVaults } from '@/mocks/vaults/vaults.mock';
+import { VaultBucketCredentials, VaultOrder, VaultResource } from '@/types/Vault.type';
 import { getVaultBucketCredentialsRoute, getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
 
 export const getVaults = async (backupServicesId: string): Promise<VaultResource[]> => {
@@ -17,10 +17,10 @@ export const getVaultBucketCredentials = async (
   backupServicesId: string,
   vaultId: string,
   bucketId: string,
-): Promise<VaultBucketAccess> => {
-  if (USE_API_MOCKS) return mockVaultBucketAccess;
+): Promise<VaultBucketCredentials> => {
+  if (USE_API_MOCKS) return mockVaultBucketCredentials;
 
-  const { data } = await v2.get<VaultBucketAccess>(
+  const { data } = await v2.get<VaultBucketCredentials>(
     getVaultBucketCredentialsRoute(backupServicesId, vaultId, bucketId),
     { headers: { Pragma: 'no-cache' } },
   );

--- a/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
+++ b/packages/manager/modules/backup-licenses/src/data/api/vaults/vaults.requests.ts
@@ -2,7 +2,7 @@ import { v2 } from '@ovh-ux/manager-core-api';
 
 import { USE_API_MOCKS } from '@/mocks/mocks.config';
 import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
-import { VaultBucketAccess, VaultResource } from '@/types/Vault.type';
+import { VaultBucketAccess, VaultOrder, VaultResource } from '@/types/Vault.type';
 import { getVaultBucketCredentialsRoute, getVaultsRoute } from '@/utils/apiRoutes/apiRoutes';
 
 export const getVaults = async (backupServicesId: string): Promise<VaultResource[]> => {
@@ -26,3 +26,33 @@ export const getVaultBucketCredentials = async (
   );
   return data;
 };
+
+export const VAULT_ORDER_CHANNEL_UNAVAILABLE = 'vault ordering channel is not delivered';
+
+export type VaultOrderChannel = (order: VaultOrder) => Promise<void>;
+
+/**
+ * How an order is placed, and today the answer is "it cannot be". Three published facts, not an
+ * omission: `.../vault` exposes GET only, the `POST /publicCloud/.../storage/object/bucket` BKP-1223
+ * names is absent from the v2 schema (that section is Rancher-only), and the express order link its
+ * 2026-07-10 comment replaced the route with was never documented. Sending anything would mean
+ * inventing a route, so this rejects and the modal shows its failure state.
+ */
+const undeliveredChannel: VaultOrderChannel = () =>
+  Promise.reject(new Error(VAULT_ORDER_CHANNEL_UNAVAILABLE));
+
+let vaultOrderChannel: VaultOrderChannel = undeliveredChannel;
+
+/**
+ * The single swap point of the slice: when the channel lands — the express link, or the Agora cart
+ * slice 0.2 already uses through `createCart` — it is installed here and nothing else changes.
+ *
+ * It is also what makes the submit path walkable while the channel is missing: no route means no MSW
+ * handler, so `src/mocks/vaults/vaults.orderChannel.ts` installs the outcome instead of serving it,
+ * off the same `setupMswMock` params as the list fixtures. Passing nothing restores the stub.
+ */
+export const setVaultOrderChannel = (channel?: VaultOrderChannel): void => {
+  vaultOrderChannel = channel ?? undeliveredChannel;
+};
+
+export const orderVault = (order: VaultOrder): Promise<void> => vaultOrderChannel(order);

--- a/packages/manager/modules/backup-licenses/src/data/hooks/useOrderVault/useOrderVault.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/data/hooks/useOrderVault/useOrderVault.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VAULT_ORDER_CHANNEL_UNAVAILABLE, orderVault } from '@/data/api/vaults/vaults.requests';
+import { queryKeys } from '@/data/queries/queryKeys';
+
+import { useOrderVault } from './useOrderVault';
+
+vi.mock('@/data/api/vaults/vaults.requests', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/data/api/vaults/vaults.requests')>()),
+  orderVault: vi.fn(),
+}));
+
+const mockedOrderVault = vi.mocked(orderVault);
+
+const order = { name: 'vault-paygo-01', region: 'eu-west-par' };
+
+const renderOrderVault = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  // A sequence rather than two call counts: what matters is that the refresh completes *before* the
+  // caller is told, which only the order shows.
+  const sequence: string[] = [];
+  const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(() => {
+    sequence.push('refreshed');
+    return Promise.resolve();
+  });
+  const onSuccess = vi.fn(() => {
+    sequence.push('confirmed');
+  });
+  const { result } = renderHook(() => useOrderVault({ onSuccess }), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+
+  return { result, invalidateQueries, onSuccess, sequence };
+};
+
+describe('useOrderVault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends the name and the region the customer supplied, and nothing else', async () => {
+    mockedOrderVault.mockResolvedValue(undefined);
+    const { result } = renderOrderVault();
+
+    result.current.mutate(order);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedOrderVault).toHaveBeenCalledWith(order);
+  });
+
+  it('refreshes the vault list before handing back, so the new row is already there', async () => {
+    mockedOrderVault.mockResolvedValue(undefined);
+    const { result, invalidateQueries, onSuccess, sequence } = renderOrderVault();
+
+    result.current.mutate(order);
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.vaults.all() });
+    expect(sequence).toEqual(['refreshed', 'confirmed']);
+  });
+
+  it('neither refreshes nor confirms when the order is refused', async () => {
+    mockedOrderVault.mockRejectedValue(new Error('nope'));
+    const { result, invalidateQueries, onSuccess } = renderOrderVault();
+
+    result.current.mutate(order);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateQueries).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('fails today, because no ordering channel is published to send an order to', async () => {
+    const { orderVault: realOrderVault } = await vi.importActual<
+      typeof import('@/data/api/vaults/vaults.requests')
+    >('@/data/api/vaults/vaults.requests');
+
+    await expect(realOrderVault(order)).rejects.toThrow(VAULT_ORDER_CHANNEL_UNAVAILABLE);
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/data/hooks/useOrderVault/useOrderVault.ts
+++ b/packages/manager/modules/backup-licenses/src/data/hooks/useOrderVault/useOrderVault.ts
@@ -1,0 +1,28 @@
+import { UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { TApiCustomError } from '@ovh-ux/manager-core-api';
+
+import { orderVault } from '@/data/api/vaults/vaults.requests';
+import { queryKeys } from '@/data/queries/queryKeys';
+import { VaultOrder } from '@/types/Vault.type';
+
+export const useOrderVault = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: () => void;
+  onError?: (error: TApiCustomError) => void;
+}): UseMutationResult<void, TApiCustomError, VaultOrder> => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (order: VaultOrder) => orderVault(order),
+    onError,
+    onSuccess: async () => {
+      // Awaited, so the confirmation the caller raises lands on a list that already holds the new
+      // row in its "Creating" state rather than on the one the customer saw before ordering.
+      await queryClient.invalidateQueries({ queryKey: queryKeys.vaults.all() });
+      onSuccess();
+    },
+  });
+};

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.spec.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
 
-import { mockEdgeCaseVaults, mockVaultBucketAccess } from '@/mocks/vaults/vaults.mock';
+import { mockEdgeCaseVaults, mockVaultBucketCredentials } from '@/mocks/vaults/vaults.mock';
 import { setupMswMock } from '@/test-utils/setupMsw';
 import { VaultResource } from '@/types/Vault.type';
 
@@ -68,7 +68,7 @@ describe('vaultsQueries.bucketCredentials', () => {
       vaultsQueries.withClient(queryClient).bucketCredentials('0001', '0001-b1'),
     );
 
-    expect(credentials).toEqual(mockVaultBucketAccess);
+    expect(credentials).toEqual(mockVaultBucketCredentials);
   });
 
   it('rejects when the credentials call fails', async () => {

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.handler.ts
@@ -2,7 +2,7 @@ import { PathParams } from 'msw';
 
 import { Handler } from '@ovh-ux/manager-core-test-utils';
 
-import { mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
+import { mockVaultBucketCredentials, mockVaults } from '@/mocks/vaults/vaults.mock';
 import { VaultResource } from '@/types/Vault.type';
 
 export type TVaultMockParams = {
@@ -71,7 +71,7 @@ export const getVaultMocks = ({
     {
       url: '/backupServices/tenant/:backupServicesId/vault/:vaultId/bucket/:bucketId/credentials',
       response: () =>
-        isVaultCredentialsError ? { message: 'Internal server error' } : mockVaultBucketAccess,
+        isVaultCredentialsError ? { message: 'Internal server error' } : mockVaultBucketCredentials,
       api: 'v2',
       method: 'get',
       status: isVaultCredentialsError ? 500 : 200,

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.mock.ts
@@ -8,7 +8,7 @@
  */
 import { getVaultIamUrn } from '@/mocks/iam/iam.mock';
 import { ResourceStatus } from '@/types/Resource.type';
-import { VaultBucket, VaultBucketAccess, VaultResource } from '@/types/Vault.type';
+import { VaultBucket, VaultBucketCredentials, VaultResource } from '@/types/Vault.type';
 
 /**
  * L'API sert chaque vault avec son enveloppe IAM : sans elle, les entrées du menu d'action restent
@@ -222,7 +222,7 @@ export const mockEdgeCaseVaults: VaultResource[] = withIam([
   },
 ]).concat(vaultWithoutIamEnvelope);
 
-export const mockVaultBucketAccess: VaultBucketAccess = {
+export const mockVaultBucketCredentials: VaultBucketCredentials = {
   accessKey: 'AKIAMOCKACCESSKEY',
   bucketName: 'bucket-vault-2-b1',
   endpoint: 's3.eu-west-par.io.cloud.ovh.net',

--- a/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.orderChannel.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/vaults/vaults.orderChannel.ts
@@ -1,0 +1,29 @@
+import { TApiCustomError } from '@ovh-ux/manager-core-api';
+
+import { VaultOrderChannel, setVaultOrderChannel } from '@/data/api/vaults/vaults.requests';
+
+/**
+ * What the ordering channel answers, chosen rather than served: BKP-1223's route is undelivered, so
+ * there is nothing for MSW to intercept and the outcome is installed on the channel itself. It sits
+ * beside the MSW handlers and is driven by the same `setupMswMock` params, so `accepted` chains into
+ * `vaultCreatingCallsBeforeReady` — a mocked order lands on a list that is still provisioning.
+ *
+ * The day the channel is published this file mocks the route instead, and the params keep their names.
+ */
+export type VaultOrderOutcome = 'accepted' | 'name-rejected' | 'error';
+
+export type TVaultOrderMockParams = {
+  vaultOrderOutcome?: VaultOrderOutcome;
+};
+
+const apiFailure = (status: number, message: string): TApiCustomError =>
+  ({ response: { status, data: { class: 'Client::BadRequest', message } } }) as TApiCustomError;
+
+const CHANNELS: Record<VaultOrderOutcome, VaultOrderChannel> = {
+  accepted: () => Promise.resolve(),
+  'name-rejected': () => Promise.reject(apiFailure(409, 'This vault name is already taken')),
+  error: () => Promise.reject(apiFailure(500, 'Internal server error')),
+};
+
+export const installVaultOrderChannel = ({ vaultOrderOutcome }: TVaultOrderMockParams): void =>
+  setVaultOrderChannel(vaultOrderOutcome && CHANNELS[vaultOrderOutcome]);

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/Vaults.page.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { ODS_BUTTON_SIZE } from '@ovhcloud/ods-components';
 import { OdsButton } from '@ovhcloud/ods-components/react';
 
-import { Datagrid, Notifications } from '@ovh-ux/manager-react-components';
+import { Datagrid } from '@ovh-ux/manager-react-components';
 
 import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
 import { routeUrls } from '@/routes/routes.constants';
@@ -16,6 +16,10 @@ import { VaultsEmptyState } from './_components/VaultsEmptyState.component';
 import { VaultsErrorState } from './_components/VaultsErrorState.component';
 import { useVaultColumns } from './_hooks/useVaultColumns.hook';
 import { useVaultsList } from './_hooks/useVaultsList.hook';
+
+export const VAULTS_TEST_IDS = {
+  page: 'vaults-page',
+} as const;
 
 export default function VaultsPage() {
   const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.VAULTS);
@@ -44,12 +48,7 @@ export default function VaultsPage() {
   };
 
   return (
-    <section className="flex flex-col gap-6">
-      {/* DEFERRED: BKP-1215 owns the tab shell that renders <Notifications /> once for every tab, and
-          is not delivered — the module's MainLayout is still a two-placeholder-tab stub this route
-          must not mount under. Until then the tab hosts its own, or the termination toast
-          (ux.md § Notifications) is added to a store nothing reads. Drop it when the shell lands. */}
-      <Notifications />
+    <section className="flex flex-col gap-6" data-testid={VAULTS_TEST_IDS.page}>
       <div className="flex">
         <OdsButton
           data-testid="order-vault"

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.a11y.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.a11y.spec.tsx
@@ -1,7 +1,7 @@
 import { screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockVaultBucketAccess, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { mockVaultBucketCredentials, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
 import { VAULT_SECRET_MASK } from '@/module.constants';
 import { labels } from '@/test-utils/i18ntest.utils';
 
@@ -41,7 +41,7 @@ describe('VaultCredentialsPage — what the modal says out loud', () => {
     // A skeleton is an empty shadow root, and a live region announces text changes, not names: the
     // wording has to be a text node the region holds, not an `aria-label` on it.
     expect(await within(status).findByText(labels.vaults.credentials.loading)).toBeInTheDocument();
-    expect(screen.queryByText(mockVaultBucketAccess.accessKey)).not.toBeInTheDocument();
+    expect(screen.queryByText(mockVaultBucketCredentials.accessKey)).not.toBeInTheDocument();
 
     await waitForCredentials();
 

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.network.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.network.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockVaultBucketAccess } from '@/mocks/vaults/vaults.mock';
+import { mockVaultBucketCredentials } from '@/mocks/vaults/vaults.mock';
 import { stopWatchingApiCalls, watchApiCalls } from '@/test-utils/watchApiCalls';
 
 import {
@@ -56,10 +56,10 @@ describe('VaultCredentialsPage — requêtes émises', () => {
     // Un client S3 signe avec la région qu'on lui donne et refuse celle que l'endpoint contredit :
     // les deux champs sortent donc de la même réponse, ici sur un bucket en `eu-west-gra`.
     const region = screen.getByTestId('vault-credentials-region');
-    expect(region).toHaveTextContent(mockVaultBucketAccess.regionCode);
+    expect(region).toHaveTextContent(mockVaultBucketCredentials.regionCode);
     expect(region).not.toHaveTextContent('eu-west-gra');
     expect(screen.getByTestId('vault-credentials-endpoint')).toHaveTextContent(
-      mockVaultBucketAccess.endpoint,
+      mockVaultBucketCredentials.endpoint,
     );
   });
 });

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.page.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mockVaultBucketAccess, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { mockVaultBucketCredentials, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
 import { VAULT_SECRET_MASK } from '@/module.constants';
 import { labels } from '@/test-utils/i18ntest.utils';
 
@@ -50,10 +50,10 @@ describe('VaultCredentialsPage', () => {
 
     await waitForCredentials();
     expect(screen.getByTestId('vault-credentials-region')).toHaveTextContent(
-      mockVaultBucketAccess.regionCode,
+      mockVaultBucketCredentials.regionCode,
     );
     expect(screen.getByTestId('vault-credentials-endpoint')).toHaveTextContent(
-      mockVaultBucketAccess.endpoint,
+      mockVaultBucketCredentials.endpoint,
     );
   });
 
@@ -62,7 +62,7 @@ describe('VaultCredentialsPage', () => {
 
     await waitForCredentials();
     expect(secretField()).toHaveTextContent(VAULT_SECRET_MASK);
-    expect(container.textContent).not.toContain(mockVaultBucketAccess.secretKey);
+    expect(container.textContent).not.toContain(mockVaultBucketCredentials.secretKey);
   });
 
   it('shows the access key in clear, with no reveal control of its own', async () => {
@@ -70,7 +70,7 @@ describe('VaultCredentialsPage', () => {
 
     await waitForCredentials();
     expect(screen.getByTestId('vault-credentials-access-key')).toHaveTextContent(
-      mockVaultBucketAccess.accessKey,
+      mockVaultBucketCredentials.accessKey,
     );
     // Counted, never queried by id: wrapping the access key in the secret field — the mockup
     // regression this guards (ux.md divergence #12) — renames its toggle, so an id query would stay
@@ -89,7 +89,7 @@ describe('VaultCredentialsPage', () => {
 
     await revealSecret();
 
-    expect(secretField()).toHaveTextContent(mockVaultBucketAccess.secretKey);
+    expect(secretField()).toHaveTextContent(mockVaultBucketCredentials.secretKey);
     expect(byName(labels.vaults.credentials.hide)).toHaveAccessibleDescription(a11y.hide_secret);
 
     await maskSecret();
@@ -102,7 +102,7 @@ describe('VaultCredentialsPage', () => {
 
     await waitForCredentials();
     await revealSecret();
-    expect(secretField()).toHaveTextContent(mockVaultBucketAccess.secretKey);
+    expect(secretField()).toHaveTextContent(mockVaultBucketCredentials.secretKey);
 
     unmount();
     await renderCredentials(paygoVault.id);
@@ -112,14 +112,22 @@ describe('VaultCredentialsPage', () => {
   });
 
   it.each([
-    ['vault-credentials-region', mockVaultBucketAccess.regionCode, labels.region.region],
+    ['vault-credentials-region', mockVaultBucketCredentials.regionCode, labels.region.region],
     [
       'vault-credentials-endpoint',
-      mockVaultBucketAccess.endpoint,
+      mockVaultBucketCredentials.endpoint,
       labels.vaults.credentials.field.endpoint,
     ],
-    ['vault-credentials-access-key', mockVaultBucketAccess.accessKey, labels.system.key_access],
-    ['vault-credentials-secret-key', mockVaultBucketAccess.secretKey, labels.system.key_secret],
+    [
+      'vault-credentials-access-key',
+      mockVaultBucketCredentials.accessKey,
+      labels.system.key_access,
+    ],
+    [
+      'vault-credentials-secret-key',
+      mockVaultBucketCredentials.secretKey,
+      labels.system.key_secret,
+    ],
   ])('copies %s and confirms it inside the dialog', async (_, expected, fieldLabel) => {
     await renderCredentials(paygoVault.id);
 
@@ -152,7 +160,7 @@ describe('VaultCredentialsPage', () => {
     await waitForCredentials();
     await userEvent.click(copyButton(labels.system.key_secret));
 
-    expect(writeText).toHaveBeenCalledWith(mockVaultBucketAccess.secretKey);
+    expect(writeText).toHaveBeenCalledWith(mockVaultBucketCredentials.secretKey);
     expect(secretField()).toHaveTextContent(VAULT_SECRET_MASK);
   });
 
@@ -172,8 +180,8 @@ describe('VaultCredentialsPage', () => {
     const { container } = await renderCredentials(paygoVault.id, failingCredentialsParams);
 
     expect(await screen.findByText(labels.vaults.credentials.error)).toBeVisible();
-    expect(container.textContent).not.toContain(mockVaultBucketAccess.secretKey);
-    expect(container.textContent).not.toContain(mockVaultBucketAccess.accessKey);
+    expect(container.textContent).not.toContain(mockVaultBucketCredentials.secretKey);
+    expect(container.textContent).not.toContain(mockVaultBucketCredentials.accessKey);
     expect(screen.queryByTestId('vault-credentials-loading')).not.toBeInTheDocument();
   });
 

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.route.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/VaultCredentials.route.spec.ts
@@ -1,7 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { mockVaultBucketAccess, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { mockVaultBucketCredentials, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
 import { getVaultCredentialsUrl, routeUrls } from '@/routes/routes.constants';
 import { renderTest } from '@/test-utils/Test.utils';
 import { stopWatchingApiCalls, watchApiCalls } from '@/test-utils/watchApiCalls';
@@ -36,7 +36,7 @@ describe('[INTEGRATION] Vault credentials route', () => {
     });
 
     expect(
-      await screen.findByText(mockVaultBucketAccess.accessKey, undefined, { timeout: 20_000 }),
+      await screen.findByText(mockVaultBucketCredentials.accessKey, undefined, { timeout: 20_000 }),
     ).toBeVisible();
   });
 });

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/_test/credentials.harness.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/credentials/_test/credentials.harness.tsx
@@ -6,7 +6,11 @@ import { RenderResult, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
-import { mockEdgeCaseVaults, mockVaultBucketAccess, mockVaults } from '@/mocks/vaults/vaults.mock';
+import {
+  mockEdgeCaseVaults,
+  mockVaultBucketCredentials,
+  mockVaults,
+} from '@/mocks/vaults/vaults.mock';
 import { getVaultActionsTriggerId } from '@/pages/vaults/vaults.constants';
 import { getVaultCredentialsUrl, routeUrls, subRoutes } from '@/routes/routes.constants';
 import { labels } from '@/test-utils/i18ntest.utils';
@@ -92,4 +96,4 @@ export const copiedMessage = () =>
   within(copyConfirmation()).getByText(labels.vaults.credentials.copied_toast);
 
 export const waitForCredentials = () =>
-  screen.findByText(mockVaultBucketAccess.accessKey, undefined, { timeout: 5000 });
+  screen.findByText(mockVaultBucketCredentials.accessKey, undefined, { timeout: 5000 });

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.spec.tsx
@@ -1,0 +1,317 @@
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { labels } from '@/test-utils/i18ntest.utils';
+
+import { VAULT_ORDER_TEST_IDS } from './OrderVault.page';
+import {
+  LOCATIONS,
+  addSuccessMock,
+  cancelButton,
+  chooseRegion,
+  clickCancel,
+  clickSubmit,
+  fillValidOrder,
+  isDisabled,
+  isEnabled,
+  mockedGetLocations,
+  mockedOrderVault,
+  nameAccessibleName,
+  nameErrorLiveRegion,
+  nameFieldError,
+  nameInput,
+  navigateMock,
+  regionControlSection,
+  regionFieldError,
+  regionOptionLabels,
+  regionSelect,
+  renderOrderModal,
+  submitButton,
+  submitFromKeyboard,
+  typeName,
+} from './_test/order.harness';
+
+vi.mock('@/data/api/locations/locations.requests');
+vi.mock('@/data/api/vaults/vaults.requests', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/data/api/vaults/vaults.requests')>()),
+  orderVault: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@ovh-ux/manager-react-components', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@ovh-ux/manager-react-components')>()),
+  useNotifications: () => ({ addSuccess: addSuccessMock, addError: vi.fn() }),
+}));
+
+const order = labels.vaults.order;
+
+describe('OrderVaultPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetLocations.mockResolvedValue(LOCATIONS);
+    mockedOrderVault.mockResolvedValue(undefined);
+  });
+
+  it('collects a vault name and a storage region, and asks for nothing else', async () => {
+    await renderOrderModal();
+
+    expect(await screen.findByText(order.field.name.label)).toBeVisible();
+    expect(screen.getByText(order.field.region.label)).toBeVisible();
+    expect(nameInput()).toBeTruthy();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+  });
+
+  it('offers no vault type to choose, because ordering is pay-as-you-go only', async () => {
+    await renderOrderModal();
+
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+    expect(screen.queryByText(labels.order.step.license_type.label)).not.toBeInTheDocument();
+    expect(document.querySelectorAll('ods-radio')).toHaveLength(0);
+    // Two form controls in the modal, so no third input slipped in from the mockup.
+    expect(document.querySelectorAll('ods-input, ods-select')).toHaveLength(2);
+  });
+
+  it('states how the vault will be billed, which the mockup omits and the ticket requires', async () => {
+    await renderOrderModal();
+
+    expect(await screen.findByTestId(VAULT_ORDER_TEST_IDS.pricing)).toHaveTextContent(
+      order.pricing_message,
+    );
+  });
+
+  it('starts with both fields empty and the order control locked', async () => {
+    await renderOrderModal();
+
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+    expect(nameInput().getAttribute('value')).toBe('');
+    expect(regionSelect().getAttribute('value')).toBe('');
+    expect(isDisabled(submitButton())).toBe(true);
+  });
+
+  it('names each region from the referential, exactly as the order funnel names it', async () => {
+    await renderOrderModal();
+
+    await waitFor(() => expect(regionOptionLabels()).toHaveLength(LOCATIONS.length));
+    // The label the funnel's region cards render, built from the very Location[] this field receives —
+    // so no machine code can surface here for a region a shared namespace happens not to carry.
+    expect(regionOptionLabels()).toEqual(['France – Paris', 'France – Gravelines']);
+  });
+
+  it('waits for the referential rather than offering an empty region list', async () => {
+    mockedGetLocations.mockReturnValue(new Promise(() => undefined));
+
+    await renderOrderModal();
+
+    expect(await screen.findByText(order.field.region.label)).toBeVisible();
+    expect(document.querySelector('ods-skeleton')).toBeTruthy();
+    expect(regionSelect()).toBeFalsy();
+  });
+
+  it('says so when the referential cannot be read, and stays unsubmittable', async () => {
+    mockedGetLocations.mockRejectedValue(new Error('referential down'));
+
+    await renderOrderModal();
+
+    expect(await screen.findByText(labels.error.error_loading_page)).toBeVisible();
+    expect(regionSelect()).toBeFalsy();
+    expect(isDisabled(submitButton())).toBe(true);
+  });
+
+  it('announces the referential landing instead of swapping the control silently', async () => {
+    let resolveLocations: (locations: typeof LOCATIONS) => void = () => undefined;
+    mockedGetLocations.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLocations = resolve;
+      }),
+    );
+
+    await renderOrderModal();
+
+    // One container across skeleton, select and failure message: replaced content is announced, a
+    // replaced container is not (WCAG 2.1 SC 4.1.3).
+    const section = regionControlSection();
+    expect(section.getAttribute('aria-busy')).toBe('true');
+    expect(section.querySelector('ods-skeleton')).toBeTruthy();
+
+    resolveLocations(LOCATIONS);
+
+    await waitFor(() => expect(section.getAttribute('aria-busy')).toBe('false'));
+    expect(section.contains(regionSelect())).toBe(true);
+    expect(regionControlSection()).toBe(section);
+  });
+
+  it('keeps the order control locked until a region is chosen', async () => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName('vault-paygo-01');
+
+    await waitFor(() => expect(nameFieldError()).toBeNull());
+    expect(isDisabled(submitButton())).toBe(true);
+    expect(regionFieldError()).toBeNull();
+  });
+
+  it('orders the vault the customer described, confirms it, and closes', async () => {
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+
+    await clickSubmit();
+
+    await waitFor(() =>
+      expect(mockedOrderVault).toHaveBeenCalledWith({
+        name: 'vault-paygo-01',
+        region: LOCATIONS[0].name,
+      }),
+    );
+    expect(addSuccessMock).toHaveBeenCalledWith(order.success);
+    expect(navigateMock).toHaveBeenCalledWith('/vaults');
+  });
+
+  it('reports a refused order inside the modal, and gives up none of the input', async () => {
+    mockedOrderVault.mockRejectedValue(new Error('channel down'));
+
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+    await clickSubmit();
+
+    expect(await screen.findByTestId(VAULT_ORDER_TEST_IDS.error)).toHaveTextContent(
+      order.error.submit_failed,
+    );
+    expect(nameInput().getAttribute('value')).toBe('vault-paygo-01');
+    expect(regionSelect().getAttribute('value')).toBe(LOCATIONS[0].name);
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(addSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it('announces that failure, instead of only drawing it', async () => {
+    mockedOrderVault.mockRejectedValue(new Error('channel down'));
+
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+    // The region has to pre-exist the failure: assistive tech ignores one that appears with its text.
+    const liveRegion = screen.getByRole('alert');
+    expect(liveRegion).toBeEmptyDOMElement();
+
+    await clickSubmit();
+
+    await waitFor(() => expect(liveRegion).toHaveTextContent(order.error.submit_failed));
+  });
+
+  it('prefers the reason the API gives over its own wording', async () => {
+    mockedOrderVault.mockRejectedValue({
+      response: { status: 503, data: { message: 'Ordering is temporarily unavailable' } },
+    });
+
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+    await clickSubmit();
+
+    expect(await screen.findByTestId(VAULT_ORDER_TEST_IDS.error)).toHaveTextContent(
+      'Ordering is temporarily unavailable',
+    );
+  });
+
+  describe('a name the backend refuses', () => {
+    const refused = {
+      response: { status: 409, data: { message: 'This vault name is already taken' } },
+    };
+
+    it('lands on the field the customer has to change, not in a modal-level banner', async () => {
+      mockedOrderVault.mockRejectedValue(refused);
+
+      await renderOrderModal();
+      await fillValidOrder('vault-paygo-01');
+      await clickSubmit();
+
+      await waitFor(() => expect(nameFieldError()).toBe('This vault name is already taken'));
+      expect(screen.queryByTestId(VAULT_ORDER_TEST_IDS.error)).not.toBeInTheDocument();
+    });
+
+    it('is announced and carried by the accessible name of the field it belongs to', async () => {
+      mockedOrderVault.mockRejectedValue(refused);
+
+      await renderOrderModal();
+      await fillValidOrder('vault-paygo-01');
+      // Live region present before the failure: assistive tech ignores one that appears with its text.
+      expect(nameErrorLiveRegion()).toBeEmptyDOMElement();
+      await clickSubmit();
+
+      await waitFor(() =>
+        expect(nameAccessibleName()).toBe(
+          `${order.field.name.label}, This vault name is already taken`,
+        ),
+      );
+    });
+
+    it('keeps the modal open on the entered values, and takes a new name straight away', async () => {
+      mockedOrderVault.mockRejectedValue(refused);
+
+      await renderOrderModal();
+      await fillValidOrder('vault-paygo-01');
+      await clickSubmit();
+
+      await waitFor(() => expect(nameFieldError()).toBe('This vault name is already taken'));
+      expect(nameInput().getAttribute('value')).toBe('vault-paygo-01');
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      typeName('vault-paygo-02');
+
+      await waitFor(() => expect(nameFieldError()).toBeNull());
+      expect(isEnabled(submitButton())).toBe(true);
+    });
+
+    it('moves the focus to the name, so the customer is not left where they were', async () => {
+      mockedOrderVault.mockRejectedValue(refused);
+
+      await renderOrderModal();
+      await fillValidOrder('vault-paygo-01');
+      const focus = vi.spyOn(nameInput() as HTMLElement, 'focus');
+      await clickSubmit();
+
+      await waitFor(() => expect(focus).toHaveBeenCalled());
+    });
+  });
+
+  it('focuses the field in error when an invalid form is submitted from the keyboard', async () => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName('my_vault');
+    chooseRegion();
+    // ODS 18 submits the form on Enter inside an input, so the disabled primary button is not the only
+    // way in; the ODS host delegates the focus it receives to the control inside its shadow root.
+    const focus = vi.spyOn(nameInput() as HTMLElement, 'focus');
+    submitFromKeyboard();
+
+    await waitFor(() => expect(nameFieldError()).toBe(order.error.name_format));
+    expect(focus).toHaveBeenCalled();
+    expect(mockedOrderVault).not.toHaveBeenCalled();
+  });
+
+  it('freezes the form while the order is in flight, but never the way out', async () => {
+    mockedOrderVault.mockReturnValue(new Promise(() => undefined));
+
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+    await clickSubmit();
+
+    await waitFor(() => expect(isDisabled(nameInput())).toBe(true));
+    expect(isDisabled(regionSelect())).toBe(true);
+    expect(submitButton().getAttribute('is-loading')).toBe('true');
+    expect(isDisabled(cancelButton())).toBe(false);
+  });
+
+  it('leaves without ordering anything when the customer cancels', async () => {
+    await renderOrderModal();
+    await fillValidOrder('vault-paygo-01');
+
+    clickCancel();
+
+    expect(mockedOrderVault).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/vaults');
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { useTranslation } from 'react-i18next';
+
+import { ODS_MESSAGE_COLOR } from '@ovhcloud/ods-components';
+import { OdsMessage } from '@ovhcloud/ods-components/react';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+import { Modal, useNotifications } from '@ovh-ux/manager-react-components';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { useLocations } from '@/data/hooks/useLocations/useLocations';
+import { useOrderVault } from '@/data/hooks/useOrderVault/useOrderVault';
+import { routeUrls } from '@/routes/routes.constants';
+import {
+  VAULT_ORDER_SERVER_ERROR_TYPE,
+  getVaultOrderErrorMessage,
+  isVaultNameRejection,
+} from '@/utils/vault/vaultOrderError';
+
+import { VaultNameField } from './_components/VaultNameField.component';
+import { VaultRegionField } from './_components/VaultRegionField.component';
+import { useVaultOrderForm } from './_hooks/useVaultOrderForm.hook';
+
+export const VAULT_ORDER_TEST_IDS = {
+  submit: 'vault-order-submit',
+  cancel: 'vault-order-cancel',
+  error: 'vault-order-error',
+  pricing: 'vault-order-pricing',
+} as const;
+
+export default function OrderVaultPage() {
+  const { t } = useTranslation([BACKUP_LICENSES_NAMESPACES.VAULTS, NAMESPACES.ACTIONS]);
+  const navigate = useNavigate();
+  const { addSuccess } = useNotifications();
+  const {
+    data: locations,
+    isPending: areLocationsPending,
+    isError: isLocationsError,
+  } = useLocations();
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { isValid },
+  } = useVaultOrderForm();
+
+  const closeModal = () => navigate(routeUrls.vaults);
+
+  const { mutate, isPending, error } = useOrderVault({
+    onSuccess: () => {
+      addSuccess(t('order.success'));
+      closeModal();
+    },
+    // A refused name belongs on the field the customer has to change, not in a banner that only says
+    // the order failed. Which rejections are name-scoped is decided from the status alone, because the
+    // error shape R4 needs is still unpublished — see `isVaultNameRejection`.
+    onError: (failure) => {
+      if (isVaultNameRejection(failure)) {
+        setError(
+          'name',
+          { type: VAULT_ORDER_SERVER_ERROR_TYPE, message: getVaultOrderErrorMessage(failure) },
+          { shouldFocus: true },
+        );
+      }
+    },
+  });
+
+  const submit = handleSubmit((values) => mutate(values));
+
+  const channelFailure =
+    error && !isVaultNameRejection(error)
+      ? getVaultOrderErrorMessage(error) || t('order.error.submit_failed')
+      : null;
+
+  return (
+    <Modal
+      isOpen
+      heading={t('order.title')}
+      onDismiss={closeModal}
+      primaryLabel={t(`${NAMESPACES.ACTIONS}:order`)}
+      isPrimaryButtonDisabled={!isValid || isPending}
+      isPrimaryButtonLoading={isPending}
+      onPrimaryButtonClick={() => void submit()}
+      primaryButtonTestId={VAULT_ORDER_TEST_IDS.submit}
+      secondaryLabel={t(`${NAMESPACES.ACTIONS}:cancel`)}
+      onSecondaryButtonClick={closeModal}
+      secondaryButtonTestId={VAULT_ORDER_TEST_IDS.cancel}
+    >
+      <form
+        className="flex flex-col gap-6"
+        noValidate
+        aria-busy={isPending}
+        onSubmit={(event) => void submit(event)}
+      >
+        {/* Mounted from the first render and never unmounted: a live region born with its content is
+            silent, so a failure appearing in a fresh node would never be announced. Out of flow while
+            empty, since a zero-height flex item still claims the column's gap. */}
+        <div role="alert" className={channelFailure ? undefined : 'absolute'}>
+          {channelFailure && (
+            <OdsMessage
+              color={ODS_MESSAGE_COLOR.critical}
+              isDismissible={false}
+              data-testid={VAULT_ORDER_TEST_IDS.error}
+            >
+              {channelFailure}
+            </OdsMessage>
+          )}
+        </div>
+        <VaultNameField control={control} isDisabled={isPending} />
+        <VaultRegionField
+          control={control}
+          isDisabled={isPending}
+          locations={locations}
+          isPending={areLocationsPending}
+          isError={isLocationsError}
+        />
+        {/* The one price literal of the feature, and a knowing exception: BKP-1223 AC 4 pins this
+            sentence verbatim, rate included, while the conventions want every price read from the
+            catalog. `GET /order/catalog/public/backupServices` is the exit, and this offering's PAYGO
+            planCode is unpublished (technical.md § WRITE — ordering), so the exception is raised as a
+            kickback rather than worked around here — masking the figure only breaks the AC. */}
+        <OdsMessage
+          color={ODS_MESSAGE_COLOR.information}
+          isDismissible={false}
+          data-testid={VAULT_ORDER_TEST_IDS.pricing}
+        >
+          {t('order.pricing_message')}
+        </OdsMessage>
+      </form>
+    </Modal>
+  );
+}

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.route.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.route.spec.tsx
@@ -1,0 +1,88 @@
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getLocations } from '@/data/api/locations/locations.requests';
+import { VAULTS_TEST_IDS } from '@/pages/vaults/Vaults.page';
+import { routeUrls } from '@/routes/routes.constants';
+import { renderTest } from '@/test-utils/Test.utils';
+import { labels } from '@/test-utils/i18ntest.utils';
+import { MockParams } from '@/test-utils/setupMsw';
+import { resetVaultPollingDeadlines } from '@/utils/vault/vaultPolling';
+
+import { VAULT_ORDER_TEST_IDS } from './OrderVault.page';
+import { LOCATIONS, clickSubmit, fillValidOrder, nameFieldError } from './_test/order.harness';
+
+vi.mock('@/data/api/locations/locations.requests');
+
+const order = labels.vaults.order;
+
+const orderModalHeading = () => screen.queryByText(order.title);
+const channelFailure = () => screen.queryByTestId(VAULT_ORDER_TEST_IDS.error);
+
+const submitAnOrder = async (mockParams: MockParams = {}) => {
+  await renderTest({ initialRoute: routeUrls.orderVault, ...mockParams });
+  await fillValidOrder('vault-paygo-01');
+  await clickSubmit();
+};
+
+/**
+ * The submit path walked through the real request module: the outcome comes from the mocked ordering
+ * channel (`vaultOrderOutcome`), not from a `vi.mock` of the module under test, so what these cover is
+ * the wiring — the confirmation, the tab it lands on, and both error branches.
+ */
+describe('[INTEGRATION] Order-a-vault route', () => {
+  beforeEach(() => {
+    vi.mocked(getLocations).mockResolvedValue(LOCATIONS);
+    resetVaultPollingDeadlines();
+  });
+
+  it('opens the modal at /vaults/order, so the tab CTA and a pasted URL both reach it', async () => {
+    await renderTest({ initialRoute: routeUrls.orderVault });
+
+    expect(
+      await screen.findByText(order.field.name.label, undefined, { timeout: 20_000 }),
+    ).toBeVisible();
+    expect(orderModalHeading()).toBeVisible();
+  });
+
+  it('renders the vaults tab at /vaults, with no modal over it', async () => {
+    await renderTest({ initialRoute: routeUrls.vaults });
+
+    expect(await screen.findByTestId(VAULTS_TEST_IDS.page)).toBeVisible();
+    await waitFor(() => expect(orderModalHeading()).not.toBeInTheDocument());
+  });
+
+  it('confirms an accepted order on the tab it returns to, and closes the modal', async () => {
+    await submitAnOrder({ vaultOrderOutcome: 'accepted' });
+
+    expect(await screen.findByText(order.success)).toBeVisible();
+    expect(screen.getByTestId(VAULTS_TEST_IDS.page)).toBeVisible();
+    await waitFor(() => expect(orderModalHeading()).not.toBeInTheDocument());
+  });
+
+  it('lands a name the backend refuses on the field, and keeps the modal open', async () => {
+    await submitAnOrder({ vaultOrderOutcome: 'name-rejected' });
+
+    await waitFor(() => expect(nameFieldError()).toBe('This vault name is already taken'));
+    expect(orderModalHeading()).toBeVisible();
+    expect(channelFailure()).not.toBeInTheDocument();
+  });
+
+  it('keeps a server-side refusal in the modal banner, and off every field', async () => {
+    await submitAnOrder({ vaultOrderOutcome: 'error' });
+
+    expect(await screen.findByTestId(VAULT_ORDER_TEST_IDS.error)).toHaveTextContent(
+      'Internal server error',
+    );
+    expect(nameFieldError()).toBeNull();
+  });
+
+  it('renders its failure state while no ordering channel is published at all', async () => {
+    await submitAnOrder();
+
+    expect(await screen.findByTestId(VAULT_ORDER_TEST_IDS.error)).toHaveTextContent(
+      order.error.submit_failed,
+    );
+    expect(orderModalHeading()).toBeVisible();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVaultName.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVaultName.spec.tsx
@@ -1,0 +1,125 @@
+import { waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { labels } from '@/test-utils/i18ntest.utils';
+
+import {
+  LOCATIONS,
+  blurName,
+  chooseRegion,
+  clickSubmit,
+  fillValidOrder,
+  isDisabled,
+  isEnabled,
+  mockedGetLocations,
+  mockedOrderVault,
+  nameFieldError,
+  regionSelect,
+  renderOrderModal,
+  submitButton,
+  typeName,
+} from './_test/order.harness';
+
+vi.mock('@/data/api/locations/locations.requests');
+vi.mock('@/data/api/vaults/vaults.requests', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/data/api/vaults/vaults.requests')>()),
+  orderVault: vi.fn(),
+}));
+
+const order = labels.vaults.order;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetLocations.mockResolvedValue(LOCATIONS);
+  mockedOrderVault.mockResolvedValue(undefined);
+});
+
+describe('vault name rule — min 1, max 50, alphanumeric and hyphens', () => {
+  const accepted = [
+    'a',
+    'vault-01',
+    'Vault-01',
+    '-vault',
+    'vault-',
+    'a'.repeat(50),
+    '  vault-01  ',
+  ];
+  const rejected = [
+    'a'.repeat(51),
+    'my_vault',
+    "my-vault's-01",
+    'vault.01',
+    'vault 01',
+    // Padding buys no room: the rule reads the trimmed name, so 51 characters stay 51.
+    `  ${'a'.repeat(51)}  `,
+  ];
+
+  it.each(accepted)('accepts %s', async (name) => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName(name);
+    chooseRegion();
+
+    await waitFor(() => expect(isEnabled(submitButton())).toBe(true));
+  });
+
+  it.each(rejected)('refuses %s', async (name) => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName(name);
+    chooseRegion();
+    blurName();
+
+    await waitFor(() => expect(nameFieldError()).toBe(order.error.name_format));
+    expect(isDisabled(submitButton())).toBe(true);
+  });
+
+  it('refuses an empty name and says what is missing, once the field has been visited', async () => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName('vault-01');
+    typeName('');
+    blurName();
+
+    await waitFor(() => expect(nameFieldError()).toBe(order.error.name_required));
+  });
+
+  it('treats a name made of spaces as no name at all', async () => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName('   ');
+    chooseRegion();
+    blurName();
+
+    await waitFor(() => expect(nameFieldError()).toBe(order.error.name_required));
+    expect(isDisabled(submitButton())).toBe(true);
+  });
+
+  it('orders the trimmed name, so no padding reaches a name nothing can rename', async () => {
+    await renderOrderModal();
+    await fillValidOrder('  vault-01  ');
+
+    await clickSubmit();
+
+    await waitFor(() =>
+      expect(mockedOrderVault).toHaveBeenCalledWith({
+        name: 'vault-01',
+        region: LOCATIONS[0].name,
+      }),
+    );
+  });
+
+  it('holds its judgement while the customer is still typing', async () => {
+    await renderOrderModal();
+    await waitFor(() => expect(regionSelect()).toBeTruthy());
+
+    typeName('vault_');
+
+    await waitFor(() => expect(isDisabled(submitButton())).toBe(true));
+    expect(nameFieldError()).toBeNull();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/_components/VaultNameField.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/_components/VaultNameField.component.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { Control, useController } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import OrderTextField from '@/components/order/OrderTextField/OrderTextField.component';
+import { VAULT_ORDER_SERVER_ERROR_TYPE } from '@/utils/vault/vaultOrderError';
+
+import { VaultOrderFormValues } from '../_hooks/useVaultOrderForm.hook';
+
+export const VAULT_ORDER_NAME_FIELD_ID = 'vault-order-name';
+
+export const VaultNameField = ({
+  control,
+  isDisabled,
+}: {
+  control: Control<VaultOrderFormValues>;
+  isDisabled?: boolean;
+}) => {
+  const { t } = useTranslation(BACKUP_LICENSES_NAMESPACES.VAULTS);
+  const {
+    field: { ref: registerControl, ...field },
+    fieldState: { error },
+  } = useController({ control, name: 'name' });
+
+  // The schema yields i18n keys; a rejection from the API yields a sentence, which must not go through
+  // `t()` — its own punctuation would be read as i18next's namespace and key separators.
+  const errorText =
+    error?.type === VAULT_ORDER_SERVER_ERROR_TYPE
+      ? error.message
+      : error?.message && t(error.message);
+
+  return (
+    <OrderTextField
+      // La ref permet à RHF de donner le focus au champ en erreur après un submit invalide.
+      ref={registerControl}
+      id={VAULT_ORDER_NAME_FIELD_ID}
+      label={t('order.field.name.label')}
+      hint={t('order.field.name.hint')}
+      value={field.value}
+      required
+      isDisabled={isDisabled}
+      error={errorText ?? null}
+      onChange={(value) => field.onChange(value)}
+      onBlur={field.onBlur}
+    />
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/_components/VaultRegionField.component.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/_components/VaultRegionField.component.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import { Control, useController } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { ODS_MESSAGE_COLOR } from '@ovhcloud/ods-components';
+import { OdsFormField, OdsMessage, OdsSelect, OdsSkeleton } from '@ovhcloud/ods-components/react';
+
+import { NAMESPACES } from '@ovh-ux/manager-common-translations';
+
+import { BACKUP_LICENSES_NAMESPACES } from '@/BackupLicenses.translations';
+import { FieldError } from '@/components/FieldError/FieldError.component';
+import { Location } from '@/types/Location.type';
+import { formatLocationTitle } from '@/utils/locationLabel/locationLabel';
+
+import { VaultOrderFormValues } from '../_hooks/useVaultOrderForm.hook';
+
+export const VAULT_ORDER_REGION_FIELD_ID = 'vault-order-region';
+export const VAULT_ORDER_REGION_CONTROL_ID = `${VAULT_ORDER_REGION_FIELD_ID}-control`;
+
+/**
+ * No hint under this field, deliberately: the region cannot be changed afterwards, but R5 has that as
+ * a consequence of what the contract can express, not as a promise any ticket makes to the customer —
+ * so the funnel's "This choice is final" is not carried over here.
+ */
+export const VaultRegionField = ({
+  control,
+  isDisabled,
+  locations,
+  isPending,
+  isError,
+}: {
+  control: Control<VaultOrderFormValues>;
+  isDisabled: boolean;
+  locations?: Location[];
+  isPending: boolean;
+  isError: boolean;
+}) => {
+  const { t } = useTranslation([
+    BACKUP_LICENSES_NAMESPACES.VAULTS,
+    NAMESPACES.ACTIONS,
+    NAMESPACES.ERROR,
+  ]);
+  // The region label belongs to the referential this list already carries, and `formatLocationTitle`
+  // is where the funnel reads it from — one source, so the modal, the funnel and the Region column
+  // name a region identically and no machine code can reach the customer.
+  const { t: tOrder } = useTranslation(BACKUP_LICENSES_NAMESPACES.ORDER);
+  const {
+    field: { ref: registerControl, ...field },
+    fieldState: { error },
+  } = useController({ control, name: 'region' });
+
+  const label = t('order.field.region.label');
+
+  const renderControl = () => {
+    if (isPending) {
+      return <OdsSkeleton />;
+    }
+
+    if (isError) {
+      return (
+        <OdsMessage color={ODS_MESSAGE_COLOR.critical} isDismissible={false}>
+          {t(`${NAMESPACES.ERROR}:error_loading_page`)}
+        </OdsMessage>
+      );
+    }
+
+    return (
+      <OdsSelect
+        ref={registerControl}
+        id={VAULT_ORDER_REGION_FIELD_ID}
+        name={field.name}
+        value={field.value}
+        placeholder={t(`${NAMESPACES.ACTIONS}:select_imperative`)}
+        ariaLabel={error?.message ? `${label}, ${t(error.message)}` : label}
+        hasError={!!error}
+        isDisabled={isDisabled}
+        isRequired
+        onOdsChange={(event) => field.onChange(String(event.detail.value ?? ''))}
+        onOdsBlur={field.onBlur}
+      >
+        {(locations ?? []).map((location) => (
+          <option key={location.name} value={location.name}>
+            {formatLocationTitle(tOrder, location)}
+          </option>
+        ))}
+      </OdsSelect>
+    );
+  };
+
+  return (
+    <OdsFormField className="block">
+      <label htmlFor={VAULT_ORDER_REGION_FIELD_ID} slot="label">
+        {label}
+        <span aria-hidden="true" className="ml-1 text-[var(--ods-color-critical-500)]">
+          *
+        </span>
+      </label>
+      {/* One container across the three branches: a skeleton silently replaced by a select, or by the
+          "referential unreadable" message, tells a screen-reader user nothing (WCAG 2.1 SC 4.1.3). */}
+      <div id={VAULT_ORDER_REGION_CONTROL_ID} aria-live="polite" aria-busy={isPending}>
+        {renderControl()}
+      </div>
+      <FieldError
+        fieldId={VAULT_ORDER_REGION_FIELD_ID}
+        message={error?.message && t(error.message)}
+      />
+    </OdsFormField>
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/_hooks/useVaultOrderForm.hook.ts
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/_hooks/useVaultOrderForm.hook.ts
@@ -1,0 +1,34 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { UseFormReturn, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { validateVaultName } from '@/utils/vault/vaultName';
+
+/**
+ * The name rule is not restated here: `validateVaultName` already owns BKP-1223's bounds and pattern
+ * and is unit-tested against them, so a schema copy would be a second rule free to drift.
+ *
+ * `.trim()` comes first because the resolver hands its parsed output to `handleSubmit`: trimming there
+ * is what keeps the rule and the ordered payload judging the same string.
+ */
+export const VAULT_ORDER_SCHEMA = z.object({
+  name: z
+    .string()
+    .trim()
+    .refine((value) => value !== '', { message: 'order.error.name_required' })
+    .refine((value) => value === '' || validateVaultName(value) === undefined, {
+      message: 'order.error.name_format',
+    }),
+  region: z.string().min(1, { message: 'order.error.region_required' }),
+});
+
+export type VaultOrderFormValues = z.infer<typeof VAULT_ORDER_SCHEMA>;
+
+export const useVaultOrderForm = (): UseFormReturn<VaultOrderFormValues> =>
+  useForm<VaultOrderFormValues>({
+    resolver: zodResolver(VAULT_ORDER_SCHEMA),
+    // Errors appear on blur and on submit, never on every keystroke: a half-typed name is not wrong
+    // yet. `isValid` still tracks the whole schema live, which is what gates the submit control.
+    mode: 'onTouched',
+    defaultValues: { name: '', region: '' },
+  });

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/_test/order.harness.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/_test/order.harness.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+import { RenderResult, fireEvent, screen, waitFor } from '@testing-library/react';
+import { expect, vi } from 'vitest';
+
+import { fieldErrorId } from '@/components/FieldError/FieldError.component';
+import { getLocations } from '@/data/api/locations/locations.requests';
+import { orderVault } from '@/data/api/vaults/vaults.requests';
+import { Location, LocationSpecificType, LocationType } from '@/types/Location.type';
+
+import { renderWithProviders } from '../../../../test-utils/renderWithProviders';
+import OrderVaultPage, { VAULT_ORDER_TEST_IDS } from '../OrderVault.page';
+import { VAULT_ORDER_NAME_FIELD_ID } from '../_components/VaultNameField.component';
+import {
+  VAULT_ORDER_REGION_CONTROL_ID,
+  VAULT_ORDER_REGION_FIELD_ID,
+} from '../_components/VaultRegionField.component';
+
+export const navigateMock = vi.fn();
+export const addSuccessMock = vi.fn();
+
+export const buildLocation = (name: string, cityName: string): Location => ({
+  name,
+  code: name.slice(-3).toUpperCase(),
+  cityName,
+  cityCode: name.slice(-3).toUpperCase(),
+  countryCode: 'FR',
+  countryName: 'France',
+  geographyName: 'Europe',
+  geographyCode: 'EU',
+  availabilityZones: [],
+  type: LocationType.REGION_3_AZ,
+  specificType: LocationSpecificType.STANDARD,
+});
+
+export const LOCATIONS: [Location, Location] = [
+  buildLocation('eu-west-par', 'Paris'),
+  buildLocation('eu-west-gra', 'Gravelines'),
+];
+
+export const mockedGetLocations = vi.mocked(getLocations);
+export const mockedOrderVault = vi.mocked(orderVault);
+
+export const renderOrderModal = (): Promise<RenderResult> =>
+  renderWithProviders(<OrderVaultPage />);
+
+const host = (id: string) => document.getElementById(id) as Element;
+
+export const nameInput = () => host(VAULT_ORDER_NAME_FIELD_ID);
+export const regionSelect = () => host(VAULT_ORDER_REGION_FIELD_ID);
+export const submitButton = () => screen.getByTestId(VAULT_ORDER_TEST_IDS.submit);
+export const cancelButton = () => screen.getByTestId(VAULT_ORDER_TEST_IDS.cancel);
+
+/**
+ * Both are strict on purpose: the ODS React wrapper applies props after the commit, so a missing
+ * `is-disabled` means "not settled yet", not "enabled" — reading it as enabled asserts on a control
+ * whose state has not landed.
+ */
+export const isDisabled = (element: Element) => element.getAttribute('is-disabled') === 'true';
+export const isEnabled = (element: Element) => element.getAttribute('is-disabled') === 'false';
+
+/**
+ * Activated with `fireEvent`, not user-event: the ODS button keeps the `disabled` of its own earlier
+ * render on the host for a tick after React has enabled it, and user-event declines to dispatch on a
+ * disabled element without reporting anything — the click is simply lost. Waiting for that attribute
+ * to clear deadlocks, since ODS drops it on the render the click itself causes. The gate that matters
+ * is still asserted: React only binds the handler once the form is valid.
+ */
+const activate = async (element: Element) => {
+  await waitFor(() => expect(isEnabled(element)).toBe(true));
+  fireEvent.click(element);
+};
+
+export const clickSubmit = () => activate(submitButton());
+export const clickCancel = () => fireEvent.click(cancelButton());
+
+/** The path the disabled primary button does not close: ODS 18 submits the form on Enter in an input. */
+export const submitFromKeyboard = () =>
+  fireEvent.submit(document.querySelector('form') as HTMLFormElement);
+
+/**
+ * ODS 18 controls emit their value through a custom event, and their inner control is a Tom Select
+ * instance in a shadow root that a native change never reaches — so the event is what a test fires.
+ */
+const emitChange = (element: Element, value: string) =>
+  fireEvent(element, new CustomEvent('odsChange', { detail: { value } }));
+
+export const typeName = (value: string) => emitChange(nameInput(), value);
+export const blurName = () => fireEvent(nameInput(), new CustomEvent('odsBlur'));
+export const chooseRegion = (region = LOCATIONS[0].name) => emitChange(regionSelect(), region);
+
+export const fillValidOrder = async (name = 'vault-paygo-01') => {
+  await waitFor(() => expect(regionSelect()).toBeTruthy());
+  typeName(name);
+  chooseRegion();
+  await waitFor(() => expect(isEnabled(submitButton())).toBe(true));
+};
+
+/** The options Tom Select took over: it moves them into the shadow root and empties the light DOM. */
+export const regionOptionLabels = () =>
+  [...(regionSelect().shadowRoot?.querySelectorAll('option') ?? [])]
+    .map((option) => option.textContent)
+    .filter(Boolean);
+
+/** Read where assistive tech reads it: the light-DOM live region, not ODS's shadow-root message. */
+export const fieldErrorOf = (fieldId: string) =>
+  document.getElementById(fieldErrorId(fieldId))?.textContent || null;
+
+export const nameFieldError = () => fieldErrorOf(VAULT_ORDER_NAME_FIELD_ID);
+export const regionFieldError = () => fieldErrorOf(VAULT_ORDER_REGION_FIELD_ID);
+
+export const nameErrorLiveRegion = () =>
+  document.getElementById(fieldErrorId(VAULT_ORDER_NAME_FIELD_ID)) as Element;
+
+export const nameAccessibleName = () => nameInput().getAttribute('aria-label');
+
+export const regionControlSection = () => host(VAULT_ORDER_REGION_CONTROL_ID);

--- a/packages/manager/modules/backup-licenses/src/routes/routes.tsx
+++ b/packages/manager/modules/backup-licenses/src/routes/routes.tsx
@@ -5,6 +5,7 @@ import { Route } from 'react-router-dom';
 import { PageType } from '@ovh-ux/manager-react-shell-client';
 
 import {
+  orderVaultRoutePath,
   subRoutes,
   terminateVaultRoutePath,
   urlParams,
@@ -34,6 +35,7 @@ const VaultCredentialsPage = React.lazy(
   () => import('@/pages/vaults/credentials/VaultCredentials.page'),
 );
 const TerminateVaultPage = React.lazy(() => import('@/pages/vaults/terminate/TerminateVault.page'));
+const OrderVaultPage = React.lazy(() => import('@/pages/vaults/order/OrderVault.page'));
 
 export default (
   <>
@@ -124,6 +126,13 @@ export default (
           Component={TerminateVaultPage}
           handle={{
             tracking: { pageName: 'terminate-vault', pageType: PageType.popup },
+          }}
+        />
+        <Route
+          path={orderVaultRoutePath}
+          Component={OrderVaultPage}
+          handle={{
+            tracking: { pageName: 'order-vault', pageType: PageType.popup },
           }}
         />
       </Route>

--- a/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/i18ntest.utils.ts
@@ -4,6 +4,7 @@ import { NAMESPACES } from '@ovh-ux/manager-common-translations';
 import actions from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/actions/Messages_fr_FR.json';
 import billing from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/billing/Messages_fr_FR.json';
 import commonDashboard from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/dashboard/Messages_fr_FR.json';
+import error from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/error/Messages_fr_FR.json';
 import region from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/region/Messages_fr_FR.json';
 import status from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/status/Messages_fr_FR.json';
 import system from '@ovh-ux/manager-common-translations/dist/@ovh-ux/manager-common-translations/system/Messages_fr_FR.json';
@@ -63,6 +64,7 @@ export const sharedResources: Record<string, unknown> = {
   [NAMESPACES.ACTIONS]: actions,
   [NAMESPACES.BILLING]: billing,
   [NAMESPACES.DASHBOARD]: commonDashboard,
+  [NAMESPACES.ERROR]: error,
   [NAMESPACES.REGION]: region,
   [NAMESPACES.STATUS]: status,
   [NAMESPACES.SYSTEM]: system,
@@ -119,4 +121,5 @@ export const labels = {
   generalInformation,
   billingTab,
   vaults,
+  error,
 };

--- a/packages/manager/modules/backup-licenses/src/test-utils/setupMsw.ts
+++ b/packages/manager/modules/backup-licenses/src/test-utils/setupMsw.ts
@@ -6,11 +6,16 @@ import { GetServicesMocksParams, getServicesMocks } from '@ovh-ux/manager-module
 import { TIamMockParams, getIamMocks } from '@/mocks/iam/iam.handler';
 import { TTenantMockParams, getTenantMocks } from '@/mocks/tenants/tenants.handler';
 import { TVaultMockParams, getVaultMocks } from '@/mocks/vaults/vaults.handler';
+import {
+  TVaultOrderMockParams,
+  installVaultOrderChannel,
+} from '@/mocks/vaults/vaults.orderChannel';
 
 export type MockParams = GetServicesMocksParams &
   TTenantMockParams &
   TVaultMockParams &
-  TIamMockParams;
+  TIamMockParams &
+  TVaultOrderMockParams;
 
 /**
  * Mocks MSW du service `/services` (v6) consommé par `useServiceDetailsQueryOption`/
@@ -19,6 +24,8 @@ export type MockParams = GetServicesMocksParams &
  * comme le reste des tests de pages de ce module.
  */
 export const setupMswMock = (mockParams: MockParams = {}) => {
+  // La commande d'un vault n'a pas de route : son issue est installée, pas servie par MSW.
+  installVaultOrderChannel(mockParams);
   (global as unknown as { server: SetupServer }).server?.resetHandlers(
     ...toMswHandlers([
       ...getAuthenticationMocks({ isAuthMocked: true }),

--- a/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
@@ -53,3 +53,9 @@ export type VaultBucketAccess = {
   regionCode: string;
   secretKey: string;
 };
+
+export type VaultOrder = {
+  name: string;
+  /** Code machine de la région, tel que `GET /location` le nomme (`eu-west-par`). */
+  region: string;
+};

--- a/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Vault.type.ts
@@ -46,7 +46,7 @@ export type VaultResource = Resource<Vault> & {
  * `backup.tenant.vault.bucket.Credentials` : la réponse porte elle-même l'endpoint S3 et le code
  * de région court (`backup.RegionCodeEnum`), qui n'est pas le `common.RegionEnum` du bucket.
  */
-export type VaultBucketAccess = {
+export type VaultBucketCredentials = {
   accessKey: string;
   bucketName: string;
   endpoint: string;

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultOrderError.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultOrderError.spec.ts
@@ -1,0 +1,61 @@
+import { AxiosResponse } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { TApiCustomError } from '@ovh-ux/manager-core-api';
+
+import { getVaultOrderErrorMessage, isVaultNameRejection } from './vaultOrderError';
+
+const failure = (status?: number, message?: string): TApiCustomError =>
+  ({
+    response: status
+      ? ({
+          status,
+          data: message === undefined ? {} : { class: 'Client::BadRequest', message },
+        } as AxiosResponse)
+      : undefined,
+  }) as TApiCustomError;
+
+describe('isVaultNameRejection', () => {
+  it('reads a 400 or a 409 that names a reason as a verdict on the name', () => {
+    expect(isVaultNameRejection(failure(400, 'Invalid vault name'))).toBe(true);
+    expect(isVaultNameRejection(failure(409, 'This vault name is already taken'))).toBe(true);
+  });
+
+  it('leaves a server-side failure with the channel, whatever it says', () => {
+    expect(isVaultNameRejection(failure(500, 'Internal server error'))).toBe(false);
+    expect(isVaultNameRejection(failure(503, 'Service unavailable'))).toBe(false);
+  });
+
+  it('leaves the other 4xx with the channel: none of them is a verdict on a field', () => {
+    // A missing order permission (R10) answers 403 with a message. Read as a name rejection, the modal
+    // would blame a name that is perfectly valid and hide the only reason the customer can act on.
+    expect(
+      isVaultNameRejection(failure(403, 'You are not authorized to perform this action')),
+    ).toBe(false);
+    expect(isVaultNameRejection(failure(401, 'This session has expired'))).toBe(false);
+    expect(isVaultNameRejection(failure(404, 'This service does not exist'))).toBe(false);
+    expect(isVaultNameRejection(failure(429, 'Too many requests'))).toBe(false);
+  });
+
+  it('leaves a transport failure with the channel: no answer means no verdict on any field', () => {
+    expect(isVaultNameRejection(failure())).toBe(false);
+    expect(isVaultNameRejection(undefined)).toBe(false);
+  });
+
+  it('needs the reason itself, since an empty 400 gives the customer nothing to change', () => {
+    expect(isVaultNameRejection(failure(400))).toBe(false);
+    expect(isVaultNameRejection(failure(400, ''))).toBe(false);
+  });
+});
+
+describe('getVaultOrderErrorMessage', () => {
+  it('hands back the reason the API gave', () => {
+    expect(getVaultOrderErrorMessage(failure(409, 'Already taken'))).toBe('Already taken');
+  });
+
+  it('is undefined when there is none, so the caller falls back to its own wording', () => {
+    expect(getVaultOrderErrorMessage(failure(500, ''))).toBeUndefined();
+    expect(getVaultOrderErrorMessage(failure())).toBeUndefined();
+    expect(getVaultOrderErrorMessage(null)).toBeUndefined();
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultOrderError.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultOrderError.ts
@@ -1,0 +1,29 @@
+import { TApiCustomError } from '@ovh-ux/manager-core-api';
+
+/** Marks a message that comes from the API and must be rendered as-is, never looked up in i18n. */
+export const VAULT_ORDER_SERVER_ERROR_TYPE = 'server';
+
+export const getVaultOrderErrorMessage = (error?: TApiCustomError | null): string | undefined =>
+  error?.response?.data?.message || undefined;
+
+/**
+ * The two statuses that can mean "the name is wrong": a refused format and a name already taken. The
+ * exact shape is an open [NEEDS CLARIFICATION] on R4 (owner: BE), so the status is the only signal
+ * available — which is why it stays this narrow. Every other 4xx is about the customer's rights or the
+ * route (401, 403, 404, 429), not about a field, and telling someone their vault name is the problem
+ * when they simply lack the order permission moves their focus into a value that is perfectly valid.
+ */
+const VAULT_NAME_REJECTION_STATUSES: readonly number[] = [400, 409];
+
+/**
+ * A rejection the customer can answer by changing the name, as opposed to one about the channel.
+ * Everything else — transport, 5xx, another 4xx, an answer with no message — is a channel failure the
+ * customer cannot fix by editing a field, and belongs in the modal-level banner.
+ */
+export const isVaultNameRejection = (error?: TApiCustomError | null): boolean => {
+  const status = error?.response?.status;
+
+  return (
+    !!getVaultOrderErrorMessage(error) && !!status && VAULT_NAME_REJECTION_STATUSES.includes(status)
+  );
+};

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultPolling.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultPolling.spec.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { mockEdgeCaseVaults, mockVaults, mockVaultsFromDesign } from '@/mocks/vaults/vaults.mock';
+import { VaultResource } from '@/types/Vault.type';
+
+import {
+  VAULT_POLLING_INTERVAL_MS,
+  VAULT_POLLING_TIMEOUT_MS,
+  getVaultsPollingState,
+  getVaultsRefetchInterval,
+  isVaultProvisioning,
+  resetVaultPollingDeadlines,
+} from './vaultPolling';
+
+const vaultNamed = (name: string): VaultResource =>
+  [...mockVaults, ...mockEdgeCaseVaults].find(
+    ({ currentState }) => currentState.name === name,
+  ) as VaultResource;
+
+const [, readyVault] = mockVaultsFromDesign as [VaultResource, VaultResource];
+
+// Les trois lignes de la maquette sont toutes READY : le vault en création vient des cas limites.
+const creatingVault = mockEdgeCaseVaults.find(
+  ({ id }) => id === 'vault-status-creating',
+) as VaultResource;
+
+const settled = (vault: VaultResource): VaultResource => ({
+  ...vault,
+  resourceStatus: 'READY',
+  currentTasks: [],
+});
+
+const provisioningVault = (id: string): VaultResource => ({
+  ...creatingVault,
+  id,
+  currentState: { ...creatingVault.currentState, id, name: `vault-paygo-${id}` },
+});
+
+describe('isVaultProvisioning', () => {
+  it('follows a vault the API reports as creating', () => {
+    expect(isVaultProvisioning(creatingVault)).toBe(true);
+  });
+
+  it('stops following it once it is ready with no task left', () => {
+    expect(isVaultProvisioning(settled(creatingVault))).toBe(false);
+    expect(isVaultProvisioning(readyVault)).toBe(false);
+  });
+
+  it('follows a vault whose task is still running, whatever its status reads', () => {
+    expect(
+      isVaultProvisioning({
+        ...readyVault,
+        currentTasks: [{ id: 'task-1', link: '', status: 'RUNNING', type: 'vault/update' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('leaves a failed or suspended vault alone, because it will never turn ready', () => {
+    expect(isVaultProvisioning(vaultNamed('vault-status-error'))).toBe(false);
+    expect(isVaultProvisioning(vaultNamed('vault-status-suspended'))).toBe(false);
+  });
+
+  it('treats a missing task list as no task, since the field is optional on the envelope', () => {
+    expect(isVaultProvisioning({ ...readyVault, currentTasks: undefined })).toBe(false);
+  });
+});
+
+describe('getVaultsRefetchInterval', () => {
+  const START = 1_700_000_000_000;
+
+  const provisioning = { state: { data: [...mockVaultsFromDesign, creatingVault] } };
+  const settledList = { state: { data: mockVaultsFromDesign.map(settled) } };
+
+  beforeEach(resetVaultPollingDeadlines);
+
+  it('polls every ten seconds while a vault is being created', () => {
+    expect(getVaultsRefetchInterval(provisioning, START)).toBe(VAULT_POLLING_INTERVAL_MS);
+  });
+
+  it('stops as soon as the vault has settled', () => {
+    expect(getVaultsRefetchInterval(settledList, START)).toBe(false);
+  });
+
+  it('does not poll a list that has not loaded yet', () => {
+    expect(getVaultsRefetchInterval({ state: {} }, START)).toBe(false);
+  });
+
+  it('does not end a running episode because a consumer mounted before the list resolved', () => {
+    getVaultsRefetchInterval(provisioning, START);
+    getVaultsRefetchInterval({ state: {} }, START + 60_000);
+
+    expect(getVaultsRefetchInterval(provisioning, START + VAULT_POLLING_TIMEOUT_MS)).toBe(false);
+  });
+
+  it('gives up on a vault stuck in creation once the five minutes are spent', () => {
+    getVaultsRefetchInterval(provisioning, START);
+
+    expect(getVaultsRefetchInterval(provisioning, START + VAULT_POLLING_TIMEOUT_MS - 1)).toBe(
+      VAULT_POLLING_INTERVAL_MS,
+    );
+    expect(getVaultsRefetchInterval(provisioning, START + VAULT_POLLING_TIMEOUT_MS)).toBe(false);
+  });
+
+  it('measures the five minutes from the moment provisioning appeared, not from the first read', () => {
+    // Forty reads a long session takes for other reasons — mounts, window-focus refetches, the
+    // invalidation an order fires — none of which may be charged to the episode that follows.
+    for (let read = 0; read < 40; read += 1) {
+      getVaultsRefetchInterval(settledList, START + read * 60_000);
+    }
+    const orderedAt = START + 40 * 60_000;
+
+    expect(getVaultsRefetchInterval(provisioning, orderedAt)).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(getVaultsRefetchInterval(provisioning, orderedAt + VAULT_POLLING_TIMEOUT_MS - 1)).toBe(
+      VAULT_POLLING_INTERVAL_MS,
+    );
+  });
+
+  it('gives the next order its own five minutes, once the previous one has settled', () => {
+    const firstOrder = getVaultsRefetchInterval(provisioning, START);
+    getVaultsRefetchInterval(provisioning, START + 2 * 60_000);
+    getVaultsRefetchInterval(settledList, START + 3 * 60_000);
+    const secondOrderAt = START + 4 * 60_000;
+
+    expect(firstOrder).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(getVaultsRefetchInterval(provisioning, secondOrderAt)).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(
+      getVaultsRefetchInterval(provisioning, secondOrderAt + VAULT_POLLING_TIMEOUT_MS - 1),
+    ).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(getVaultsRefetchInterval(provisioning, secondOrderAt + VAULT_POLLING_TIMEOUT_MS)).toBe(
+      false,
+    );
+  });
+
+  it('follows a vault by its id, so the same one read through two queries shares one episode', () => {
+    const sameVaultsAnotherQuery = { state: { data: [...mockVaultsFromDesign] } };
+
+    getVaultsRefetchInterval(provisioning, START);
+
+    expect(getVaultsRefetchInterval(sameVaultsAnotherQuery, START + VAULT_POLLING_TIMEOUT_MS)).toBe(
+      false,
+    );
+  });
+
+  it('gives a vault ordered while an earlier one is stuck in creation its own five minutes', () => {
+    const stuck = { state: { data: [creatingVault] } };
+    const stuckAndNewOrder = { state: { data: [creatingVault, provisioningVault('0004')] } };
+    const secondOrderAt = START + 10 * 60_000;
+
+    getVaultsRefetchInterval(stuck, START);
+    expect(getVaultsRefetchInterval(stuck, START + VAULT_POLLING_TIMEOUT_MS)).toBe(false);
+
+    expect(getVaultsRefetchInterval(stuckAndNewOrder, secondOrderAt)).toBe(
+      VAULT_POLLING_INTERVAL_MS,
+    );
+    expect(
+      getVaultsRefetchInterval(stuckAndNewOrder, secondOrderAt + VAULT_POLLING_TIMEOUT_MS - 1),
+    ).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(
+      getVaultsRefetchInterval(stuckAndNewOrder, secondOrderAt + VAULT_POLLING_TIMEOUT_MS),
+    ).toBe(false);
+  });
+
+  it('reads the clock itself when no caller supplies one', () => {
+    expect(getVaultsRefetchInterval(provisioning)).toBe(VAULT_POLLING_INTERVAL_MS);
+  });
+});
+
+describe('getVaultsPollingState', () => {
+  const START = 1_700_000_000_000;
+  const creatingList = [creatingVault];
+
+  beforeEach(resetVaultPollingDeadlines);
+
+  it('is settled on a list where nothing is provisioning, and on one that has not loaded', () => {
+    expect(getVaultsPollingState(mockVaultsFromDesign.map(settled), START)).toBe('settled');
+    expect(getVaultsPollingState([], START)).toBe('settled');
+    expect(getVaultsPollingState(undefined, START)).toBe('settled');
+  });
+
+  it('is settled on the status edge cases, none of which is a vault being provisioned', () => {
+    // CREATING est exclu : c'est le seul statut que le polling doit justement suivre.
+    const stuckStatuses = mockEdgeCaseVaults.filter(
+      ({ resourceStatus, currentState }) =>
+        currentState.name.startsWith('vault-status-') && resourceStatus !== 'CREATING',
+    );
+
+    expect(stuckStatuses.length).toBeGreaterThan(0);
+    expect(getVaultsPollingState(stuckStatuses, START)).toBe('settled');
+  });
+
+  it('is polling for a vault whose episode the refetch rule has not opened yet', () => {
+    expect(getVaultsPollingState(creatingList, START)).toBe('polling');
+  });
+
+  it('is polling until the last second of the episode', () => {
+    getVaultsRefetchInterval({ state: { data: creatingList } }, START);
+
+    expect(getVaultsPollingState(creatingList, START + VAULT_POLLING_TIMEOUT_MS - 1)).toBe(
+      'polling',
+    );
+  });
+
+  it('reports the ceiling R11 asks a message for, instead of reporting a settled list', () => {
+    getVaultsRefetchInterval({ state: { data: creatingList } }, START);
+
+    expect(getVaultsPollingState(creatingList, START + VAULT_POLLING_TIMEOUT_MS)).toBe('timed-out');
+  });
+
+  it('leaves the ceiling as soon as a newly ordered vault is being followed again', () => {
+    const stuckAndNewOrder = [creatingVault, provisioningVault('0004')];
+    const secondOrderAt = START + 10 * 60_000;
+
+    getVaultsRefetchInterval({ state: { data: creatingList } }, START);
+    getVaultsRefetchInterval({ state: { data: stuckAndNewOrder } }, secondOrderAt);
+
+    expect(getVaultsPollingState(stuckAndNewOrder, secondOrderAt)).toBe('polling');
+  });
+
+  it('opens no episode of its own, so rendering the state cannot start the clock', () => {
+    const query = { state: { data: creatingList } };
+
+    for (let render = 0; render < 40; render += 1) {
+      getVaultsPollingState(creatingList, START + render * 60_000);
+    }
+    const firstPoll = START + 40 * 60_000;
+
+    expect(getVaultsRefetchInterval(query, firstPoll)).toBe(VAULT_POLLING_INTERVAL_MS);
+    expect(getVaultsRefetchInterval(query, firstPoll + VAULT_POLLING_TIMEOUT_MS - 1)).toBe(
+      VAULT_POLLING_INTERVAL_MS,
+    );
+  });
+});

--- a/packages/manager/modules/backup-licenses/src/utils/vault/vaultPolling.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/vault/vaultPolling.ts
@@ -1,0 +1,97 @@
+import { VaultResource } from '@/types/Vault.type';
+
+/** Slice 2.5 (BKP-1220) owns these two figures; R11 reuses them rather than restating them. */
+export const VAULT_POLLING_INTERVAL_MS = 10_000;
+export const VAULT_POLLING_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Provisioning, not merely unsettled: an ERROR or SUSPENDED vault never becomes READY, so reading
+ * this off `selectIsVaultSettled` would poll a broken vault until the ceiling.
+ */
+export const isVaultProvisioning = (vault: VaultResource): boolean =>
+  vault.resourceStatus === 'CREATING' || !!vault.currentTasks?.length;
+
+/** Narrower than TanStack's `Query`, which satisfies it — the rule stays callable without a cache. */
+export type VaultsPollingQuery = {
+  state: { data?: VaultResource[] };
+};
+
+/**
+ * `'settled'` and `'timed-out'` both stop the polling and mean opposite things to the customer: the
+ * second is a vault still being created that nothing follows any more, which R11 answers with a message
+ * inviting a refresh. Reporting both as `false` left that ceiling unobservable.
+ */
+export type VaultsPollingState = 'settled' | 'polling' | 'timed-out';
+
+/**
+ * When each provisioning vault's episode must stop. Held outside the cache because no query state
+ * records when provisioning *started* — `dataUpdateCount` counts every read of the list for the whole
+ * life of the cache entry, so counting reads spends the second order's five minutes on the first.
+ *
+ * Keyed by vault, not by query, because an expired episode is deliberately kept: keyed by query, one
+ * vault stuck in creation would hold the whole list past its ceiling and nothing ordered afterwards
+ * would ever be polled.
+ */
+const vaultDeadlines = new Map<string, number>();
+
+/** The table outlives a query instance, so a test that opens an episode has to be able to drop it. */
+export const resetVaultPollingDeadlines = (): void => vaultDeadlines.clear();
+
+const provisioningVaults = (vaults: readonly VaultResource[] = []): VaultResource[] =>
+  vaults.filter(isVaultProvisioning);
+
+/**
+ * Reads the running episodes without opening one, so a render can ask "has the ceiling passed" without
+ * changing the answer. A vault no episode has been opened for yet counts as followed: its five minutes
+ * start on the next evaluation of the refetch rule, not here.
+ */
+export const getVaultsPollingState = (
+  vaults: readonly VaultResource[] | undefined,
+  now: number = Date.now(),
+): VaultsPollingState => {
+  const provisioning = provisioningVaults(vaults);
+
+  if (!provisioning.length) {
+    return 'settled';
+  }
+
+  const isFollowed = ({ id }: VaultResource) => {
+    const deadline = vaultDeadlines.get(id);
+    return deadline === undefined || now < deadline;
+  };
+
+  return provisioning.some(isFollowed) ? 'polling' : 'timed-out';
+};
+
+/**
+ * Opens an episode for every vault that has just started provisioning and closes the one of every
+ * vault that no longer is — so a vault ordered later is followed for a full five minutes even while an
+ * earlier one sits in creation past its own ceiling.
+ *
+ * The list keeps being re-read while at least one episode is live, so the refetch that crosses the
+ * last deadline is also what re-renders the consumers — which is how `getVaultsPollingState` gets the
+ * chance to report `'timed-out'` once polling has stopped.
+ */
+export const getVaultsRefetchInterval = (
+  { state }: VaultsPollingQuery,
+  now: number = Date.now(),
+): number | false => {
+  // A list that has not loaded is not a list where nothing is provisioning: reconciling on it would
+  // close the episodes of the vaults it is about to return.
+  if (!state.data) {
+    return false;
+  }
+
+  const provisioning = provisioningVaults(state.data);
+  const provisioningIds = new Set(provisioning.map(({ id }) => id));
+
+  [...vaultDeadlines.keys()]
+    .filter((vaultId) => !provisioningIds.has(vaultId))
+    .forEach((vaultId) => vaultDeadlines.delete(vaultId));
+
+  provisioning
+    .filter(({ id }) => !vaultDeadlines.has(id))
+    .forEach(({ id }) => vaultDeadlines.set(id, now + VAULT_POLLING_TIMEOUT_MS));
+
+  return getVaultsPollingState(provisioning, now) === 'polling' ? VAULT_POLLING_INTERVAL_MS : false;
+};


### PR DESCRIPTION
## Description

Adds the order modal as a child route of the listing: the two inputs the ticket specifies (vault name, storage region), its validation (min 1 / max 50, alphanumeric and hyphens), the pricing message, and the polling that follows the new vault until it settles.

### The submit cannot be delivered, and says so rather than pretending

Three published facts, not an omission:

- `.../vault` exposes **GET only**;
- the `POST /publicCloud/project/{projectId}/storage/object/bucket` the ticket names is **absent from the v2 schema** (that section is Rancher-only);
- the express order link its 2026-07-10 comment replaced the route with **was never documented**.

The channel is therefore a single swap point that rejects with an explicit error. When the real one lands — the express link, or the Agora cart slice 0.2 already uses — it is installed there and nothing else changes.

The region select is populated from the **`/location` referential the order funnel already consumes**, not from a hardcoded list.

### Extends the shared `OrderTextField` rather than duplicating it

- it now **forwards its ref**, so react-hook-form can focus the field in error after an invalid submit (`shouldFocusError`);
- it carries **`isRequired`** on the input instead of an asterisk a screen reader reads as punctuation (the asterisk becomes `aria-hidden`);
- it renders its error in a **light-DOM live region**, because no IDREF crosses the ODS shadow boundary — the error reaches assistive tech through the accessible name.

These are additive and optional, so the existing funnel is unaffected.

### Also drops a `<Notifications />` that had become a duplicate

The Vaults tab hosted its own, explicitly deferred until BKP-1215 delivered the shell. The shell now renders one for every tab, so keeping both showed the order confirmation **twice**.

Ticket Reference: BKP-1223

## Additional Information

**Fourth and last PR of the stack.** Depends on #23095 (BKP-1224) → #23094 (BKP-1222) → #23093 (BKP-1221).

- 553 tests pass, `tsc --noEmit` and `lint:modern` clean.
- Draft: the ordering channel is missing, so the submit path ends on its failure state by design.

### Two findings outside this stack's scope

- `src/mocks/mocks.config.ts` has **`USE_API_MOCKS = true`** committed, while its own comment prescribes `false`. Five billing tests depend on `true`, so this stack does not change it — but as it stands the module serves fixtures instead of calling the API.
- `Resource.type`'s `ResourceStatus` was missing `OUT_OF_SYNC`; completed in #23093.