### PR TITLE
fix(backup-licenses): align the BMC appName on the app id (Unknown application)

### DIFF
--- a/packages/manager/apps/bmc-backup-licenses/README.md
+++ b/packages/manager/apps/bmc-backup-licenses/README.md
@@ -1,4 +1,4 @@
-# bmc-backup-licenses-baremetal — OVHcloud Manager Application
+# bmc-backup-licenses — OVHcloud Manager Application
 
 ## Overview
 
@@ -15,7 +15,7 @@ The same codebase supports multiple product universes (PCI, Hub, Web, Zimbra) by
 Single source of truth for app identity, API strategy, feature flags, and tracking. Tokens like `app-gen-test` and `Hub` are filled by the generator.
 
 ```ts
-export const appName = 'bmc-backup-licenses-baremetal';
+export const appName = 'bmc-backup-licenses';
 
 export const APP_FEATURES = {
   // API strategies

--- a/packages/manager/apps/bmc-backup-licenses/src/App.constants.ts
+++ b/packages/manager/apps/bmc-backup-licenses/src/App.constants.ts
@@ -2,7 +2,7 @@ import { OnboardingConfigType } from '@/types/Onboarding.type';
 
 import backupLicensesImage from './assets/backup-licenses.png';
 
-export const appName = 'bmc-backup-licenses-baremetal';
+export const appName = 'bmc-backup-licenses';
 export const productName = 'OVHcloud Backup Licenses';
 
 export const AppConfig = {

--- a/packages/manager/apps/hpc-backup-licenses/README.md
+++ b/packages/manager/apps/hpc-backup-licenses/README.md
@@ -1,4 +1,4 @@
-# hpc-backup-licenses-iaas — OVHcloud Manager Application
+# hpc-backup-licenses — OVHcloud Manager Application
 
 > Universe: **HostedPrivatedCloud / HostedPrivatedCloud**
 
@@ -17,7 +17,7 @@ The same codebase supports multiple product universes (PCI, Hub, Web, Zimbra) by
 Single source of truth for app identity, API strategy, feature flags, and tracking. Tokens like `app-gen-test` and `Hub` are filled by the generator.
 
 ```ts
-export const appName = 'hpc-backup-licenses-iaas';
+export const appName = 'hpc-backup-licenses';
 
 export const APP_FEATURES = {
   // API strategies


### PR DESCRIPTION
## Problem

`Uncaught (in promise) Error: Unknown application 'bmc-backup-licenses-baremetal'`

The BMC app kept the `appName` it inherited from `bmc-backup-agent-baremetal`, while the
directory and the package were renamed to `bmc-backup-licenses`
(`@ovh-ux/manager-bmc-backup-licenses-app`). As soon as the µapp runs top-level — outside the
container iframe, on a host other than `localhost` — `initStandaloneClientApi` looks the id up in
the 2API `/applications` payload and throws:

https://github.com/ovh/manager/blob/develop/packages/components/ovh-shell/src/client/index.ts#L79

In the container iframe and on `localhost` the shell fabricates a default config, which is why the
mismatch went unnoticed.

## Fix

| file | before | after |
| --- | --- | --- |
| `apps/bmc-backup-licenses/src/App.constants.ts:5` | `bmc-backup-licenses-baremetal` | `bmc-backup-licenses` |
| `apps/bmc-backup-licenses/README.md:1,18` | `bmc-backup-licenses-baremetal` | `bmc-backup-licenses` |
| `apps/hpc-backup-licenses/README.md:1,20` | `hpc-backup-licenses-iaas` | `hpc-backup-licenses` |

HPC's `App.constants.ts` was already correct — only its README carried the generator's `-iaas`
suffix, contradicting the code next to it.

No occurrence of `backup-licenses-{baremetal,iaas}` is left in the repo outside the CHANGELOGs,
whose entries are lerna-generated history of the former package name and are left as-is.

## Scope

`appName` also feeds the i18n `defaultNS`, the tracking `chapter3` and `redirectionApp`. The
translations are namespaced by folder (`public/translations/onboarding/`), not by app name, so the
shell lookup is the only behaviour that changes.

`BackupLicensesScope = 'Baremetal'` in `Main.layout.tsx` is untouched — it is the module's product
discriminant (`'Unknown' | 'Enterprise' | 'Baremetal'`), not an app id. Likewise
`bmc-backup-agent-baremetal` is a distinct product whose suffix is legitimate.

## Commit shape

Single `fixup!` commit targeting `878ced02a4 feat(hpc-backup-licences): init hpc backup licences apps`
— the commit that performed the `licences` → `licenses` rename and left the `appName` behind
(`git blame` puts all five lines on its own fixup, `41b8c0f630`). It autosquashes onto the existing
history of the project branch.

## Follow-up, out of scope here

Worth confirming that `bmc-backup-licenses` is registered in 2API. Two hints it may not be yet:

- `container/src/core/dev/index.ts:54` still carries `// TODO: retirer une fois hpc-backup-licenses
  enregistrée côté 2API avec universe: 'hpc'`, so the registration of this app family is still in
  flight.
- there is no `bmc-backup-licenses` entry in the container navigation tree —
  `nav-reshuffle/.../bareMetalCloud.ts` only knows `bmc-backup-agent-baremetal`.

If the id is still unknown to 2API, the standalone error will simply change its label.

ref: #BKP-1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
