### PR TITLE
feat(pci-savings-plan): add svp auto renewal error handling

### DIFF
--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_de_DE.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_de_DE.json
@@ -26,6 +26,7 @@
   "months_plural": "{{count}} Monate",
   "banner_renew_activate": "Die automatische Verlängerung des Savings Plan {{planName}} wurde erfolgreich aktiviert. Ihr Savings Plan wird am {{endDate}} verlängert.",
   "banner_renew_deactivate": " Die automatische Verlängerung des Savings Plan {{planName}} wurde erfolgreich deaktiviert. Ihr Savings Plan endet am {{endDate}}. Das Ablaufen Ihres Savings Plan hat keine Auswirkungen auf Ihre aktiven Dienste.",
+  "banner_renew_error": "Beim Ändern der automatischen Verlängerung des Savings Plan {{planName}} ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut. ({{ error }})",
   "banner_edit_name": "Der Name des Savings Plan wurde erfolgreich geändert.",
   "banner_create_sp": "Ihr Savings Plan wurde erstellt. Er ist ab dem {{startDate}} aktiv.",
   "informationMessage": "Sie können Ihre Dienstleistungen weiterhin wie gewohnt verwalten. Die Plattform berechnet automatisch Ihre Nutzung basierend auf den Konfigurationen Ihrer Savings Pläne und dem Verbrauch Ihrer bestehenden oder zukünftigen Ressourcen.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_en_GB.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_en_GB.json
@@ -26,6 +26,7 @@
   "months_plural": "{{count}} months",
   "banner_renew_activate": "Auto-renewal has been enabled for the {{planName}} Savings Plan. Your Savings Plan will be renewed on {{endDate}}",
   "banner_renew_deactivate": " Auto-renewal has been disabled for the {{planName}} Savings Plan. Your Savings Plan ends on {{endDate}}. Your active services will not be impacted when your Savings Plan expires.",
+  "banner_renew_error": "An error occurred while changing the auto-renewal settings of the {{planName}} Savings Plan. Please try again later. ({{ error }})",
   "banner_edit_name": "The name of the Savings Plan has been updated.",
   "banner_create_sp": "Your Savings Plan has been created. This will be active from {{startDate}}",
   "informationMessage": "You continue to manage your services as usual. The platform automatically calculates your usage based on your Savings Plan configurations and consumption of your existing or future resources.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_es_ES.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_es_ES.json
@@ -26,6 +26,7 @@
   "months_plural": "{{count}} meses",
   "banner_renew_activate": "La renovación automática del Savings Plan {{planName}} se ha activado correctamente. Su Savings Plan se renovará el {{endDate}}",
   "banner_renew_deactivate": " La renovación automática del Savings Plan {{planName}} se ha desactivado correctamente. Su Savings Plan finalizará el {{endDate}}. La expiración de su Savings Plan no afectará a sus servicios activos.",
+  "banner_renew_error": "Se ha producido un error al modificar la renovación automática del Savings Plan {{planName}}. Por favor, vuelva a intentarlo más tarde. ({{ error }})",
   "banner_edit_name": "El nombre del Savings Plan se ha modificado correctamente.",
   "banner_create_sp": "Su Savings Plan se ha creado correctamente. Este estará activo a partir del {{startDate}}",
   "informationMessage": "Siga administrando sus servicios como de costumbre. La plataforma calcula automáticamente su uso en función de las configuraciones de sus Savings Planes y del consumo de sus recursos existentes o futuros.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_CA.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_CA.json
@@ -27,6 +27,7 @@
   "months_other": "{{count}} mois",
   "banner_renew_activate": "Le renouvellement automatique du Savings Plan {{planName}} a été activé avec succès. Votre Savings Plan sera renouvelé le {{endDate}}",
   "banner_renew_deactivate": " Le renouvellement automatique du Savings Plan {{planName}} a été désactivé avec succès. Votre Savings Plan prendra fin le {{endDate}}. L'expiration de votre Savings Plan n'aura aucun impact sur vos services actifs.",
+  "banner_renew_error": "Erreur lors de la modification du renouvellement automatique du Savings Plan {{planName}}. Veuillez réessayer ultérieurement. ({{ error }})",
   "banner_edit_name": "Le nom du Savings Plan a été modifié avec succès.",
   "banner_create_sp": "Votre Savings Plan a été créé avec succès. Celui-ci sera actif à compter du {{startDate}}"
 }

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_fr_FR.json
@@ -27,6 +27,7 @@
   "months_other": "{{count}} mois",
   "banner_renew_activate": "Le renouvellement automatique du Savings Plan {{planName}} a été activé avec succès. Votre Savings Plan sera renouvelé le {{endDate}}",
   "banner_renew_deactivate": " Le renouvellement automatique du Savings Plan {{planName}} a été désactivé avec succès. Votre Savings Plan prendra fin le {{endDate}}. L'expiration de votre Savings Plan n'aura aucun impact sur vos services actifs.",
+  "banner_renew_error": "Erreur lors de la modification du renouvellement automatique du Savings Plan {{planName}}. Veuillez réessayer ultérieurement. ({{ error }})",
   "banner_edit_name": "Le nom du Savings Plan a été modifié avec succès.",
   "banner_create_sp": "Votre Savings Plan a été créé avec succès. Celui-ci sera actif à compter du {{startDate}}"
 }

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_it_IT.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_it_IT.json
@@ -26,6 +26,7 @@
   "months_plural": "{{count}} mesi",
   "banner_renew_activate": "Il rinnovo automatico del Savings Plan {{planName}} è stato attivato correttamente. Il Savings Plan sarà rinnovato il {{endDate}}",
   "banner_renew_deactivate": " Il rinnovo automatico del Savings Plan {{planName}} è stato disattivato correttamente. Il Savings Plan terminerà il {{endDate}}. La scadenza del tuo Savings Plan non avrà alcun impatto sui servizi attivi.",
+  "banner_renew_error": "Errore durante la modifica del rinnovo automatico del Savings Plan {{planName}}. Riprova più tardi. ({{ error }})",
   "banner_edit_name": "Il nome del Savings Plan è stato modificato correttamente.",
   "banner_create_sp": "Il tuo Savings Plan è stato creato correttamente e sarà attivo a partire dal {{startDate}}.",
   "informationMessage": "Continui a gestire i tuoi servizi come al solito. La piattaforma calcola automaticamente l’utilizzo in base alle configurazioni dei Savings Plan e al consumo delle risorse esistenti o future.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_pl_PL.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_pl_PL.json
@@ -26,6 +26,7 @@
   "months_plural": "Liczba miesięcy: {{count}}",
   "banner_renew_activate": "Automatyczne odnowienie Savings Plan {{planName}} zostało włączone. Savings Plan zostanie odnowiony dnia {{endDate}}",
   "banner_renew_deactivate": " Automatyczne odnowienie Savings Plan {{planName}} zostało wyłączone. Savings Plan zakończy się dnia {{endDate}}. Wygaśnięcie Savings Plan nie będzie miało wpływu na Twoje aktywne usługi.",
+  "banner_renew_error": "Wystąpił błąd podczas zmiany automatycznego odnowienia Savings Plan {{planName}}. Spróbuj ponownie później. ({{error}})",
   "banner_edit_name": "Nazwa Savings Plan została zmieniona.",
   "banner_create_sp": "Savings Plan został utworzony. Będzie aktywny od {{startDate}}",
   "informationMessage": "W dalszym ciągu możesz zarządzać swoimi usługami w zwykły sposób. Platforma automatycznie oblicza wykorzystanie zasobów w zależności od konfiguracji planów Savings oraz w zależności od zużycia istniejących lub przyszłych zasobów.",

--- a/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_pt_PT.json
+++ b/packages/manager/apps/pci-savings-plan/public/translations/listing/Messages_pt_PT.json
@@ -26,6 +26,7 @@
   "months_plural": "{{count}} mês/meses",
   "banner_renew_activate": "A renovação automática do Savings Plan {{planName}} foi ativada com sucesso. O seu Savings Plan será renovado a {{endDate}}",
   "banner_renew_deactivate": " A renovação automática do Savings Plan {{planName}} foi desativada com sucesso. O seu Savings Plan terminará a {{endDate}}. A expiração do Savings Plan não terá qualquer impacto nos seus serviços ativos.",
+  "banner_renew_error": "Ocorreu um erro aquando da modificação da renovação automática do Savings Plan {{planName}}. Tente novamente mais tarde. ({{ error }})",
   "banner_edit_name": "O nome do Savings Plan foi modificado com sucesso.",
   "banner_create_sp": "O seu Savings Plan foi criado com sucesso e ficará ativo a partir de {{startDate}}.",
   "informationMessage": "Continua a gerir os seus serviços como de costume. A plataforma calcula automaticamente a sua utilização em função das configurações dos seus Savings Plans e do consumo dos seus recursos existentes ou futuros.",

--- a/packages/manager/apps/pci-savings-plan/src/components/Modal/RenewModal.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Modal/RenewModal.tsx
@@ -8,12 +8,14 @@ type TRenewModal = {
   periodEndAction: SavingsPlanPlanedChangeStatus;
   onClose: () => void;
   onConfirm: () => void;
+  isPending: boolean;
 };
 
 export default function RenewModal({
   periodEndAction,
   onClose,
   onConfirm,
+  isPending,
 }: Readonly<TRenewModal>) {
   const { t } = useTranslation('renew');
 
@@ -38,6 +40,7 @@ export default function RenewModal({
         <OdsButton
           label={t(isReactivate ? 'buttons_deactivate' : 'buttons_activate')}
           onClick={onConfirm}
+          isLoading={isPending}
           data-testid="renewModal-button_confirm"
         />
       </div>

--- a/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.spec.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.spec.tsx
@@ -5,6 +5,7 @@ import { usePciUrl } from '@ovh-ux/manager-pci-common';
 import { useHref, useSearchParams } from 'react-router-dom';
 import ActionsCell from './ActionsCell';
 import { SavingsPlanPlanedChangeStatus, SavingsPlanStatus } from '@/types';
+import { isRepricedCommitment } from '@/utils/savingsPlan';
 
 const pciUrl = 'pciUrl';
 const useSearchParamsMocked = vi
@@ -138,6 +139,77 @@ describe('Considering ActionsCell', () => {
       expect(button).not.toBeInTheDocument();
     },
   );
+
+  describe('Given the instances repricing feature is enabled', () => {
+    it.each([
+      { period: 'P1M', months: 1 },
+      { period: 'P6M', months: 6 },
+      { period: 'P2Y', months: 24 },
+    ])(
+      'should disable the enableAutoRenew action on a $months month commitment',
+      ({ period }) => {
+        render(
+          <ActionsCell
+            {...mockedActionsCellProps}
+            periodEndAction={SavingsPlanPlanedChangeStatus.TERMINATE}
+            isRenewalActivationDisabled={isRepricedCommitment(period)}
+          />,
+        );
+
+        expect(
+          screen.getByRole('button', { name: 'enableAutoRenew' }),
+        ).toHaveAttribute('is-disabled', 'true');
+      },
+    );
+
+    it.each([
+      { period: 'P1Y', months: 12 },
+      { period: 'P3Y', months: 36 },
+    ])(
+      'should keep the enableAutoRenew action available on a $months month commitment',
+      ({ period }) => {
+        render(
+          <ActionsCell
+            {...mockedActionsCellProps}
+            periodEndAction={SavingsPlanPlanedChangeStatus.TERMINATE}
+            isRenewalActivationDisabled={isRepricedCommitment(period)}
+          />,
+        );
+
+        expect(
+          screen.getByRole('button', { name: 'enableAutoRenew' }),
+        ).not.toHaveAttribute('is-disabled', 'true');
+      },
+    );
+
+    it('should keep the disableAutoRenew action available on a repriced commitment', () => {
+      render(
+        <ActionsCell
+          {...mockedActionsCellProps}
+          periodEndAction={SavingsPlanPlanedChangeStatus.REACTIVATE}
+          isRenewalActivationDisabled={isRepricedCommitment('P6M')}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'disableAutoRenew' }),
+      ).not.toHaveAttribute('is-disabled', 'true');
+    });
+  });
+
+  it('should keep the enableAutoRenew action available on a repriced commitment when the feature is disabled', () => {
+    render(
+      <ActionsCell
+        {...mockedActionsCellProps}
+        periodEndAction={SavingsPlanPlanedChangeStatus.TERMINATE}
+        isRenewalActivationDisabled={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'enableAutoRenew' }),
+    ).not.toHaveAttribute('is-disabled', 'true');
+  });
 
   it('should display cancelSavingsPlan action when savings plan is on PENDING', () => {
     render(

--- a/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Table/ActionsCell.tsx
@@ -28,6 +28,7 @@ interface SavingsPlanActionsCell {
   flavor: string;
   status: SavingsPlanStatus;
   periodEndAction: SavingsPlanPlanedChangeStatus;
+  isRenewalActivationDisabled?: boolean;
 }
 
 const MenuItems = ({
@@ -38,6 +39,7 @@ const MenuItems = ({
   onClickRenew,
   periodEndAction,
   pciUrl,
+  isRenewalActivationDisabled,
 }: {
   id: string;
   status: SavingsPlanStatus;
@@ -46,6 +48,7 @@ const MenuItems = ({
   onClickRenew: () => void;
   periodEndAction: SavingsPlanPlanedChangeStatus;
   pciUrl: string;
+  isRenewalActivationDisabled?: boolean;
 }) => {
   const { t } = useTranslation(['listing', 'actions']);
   const { trackClick } = useOvhTracking();
@@ -58,6 +61,8 @@ const MenuItems = ({
     : cancelSavingsPlanPath;
 
   const isInstance = useMemo(() => isInstanceFlavor(flavor), [flavor]);
+  const isRenewalActivation =
+    periodEndAction === SavingsPlanPlanedChangeStatus.TERMINATE;
 
   return (
     <OdsPopover triggerId={`popover-trigger-${id}`}>
@@ -74,19 +79,16 @@ const MenuItems = ({
         {status !== SavingsPlanStatus.TERMINATED && (
           <OdsButton
             label={
-              periodEndAction === SavingsPlanPlanedChangeStatus.TERMINATE
-                ? t('enableAutoRenew')
-                : t('disableAutoRenew')
+              isRenewalActivation ? t('enableAutoRenew') : t('disableAutoRenew')
             }
             size={ODS_BUTTON_SIZE.sm}
             variant={ODS_BUTTON_VARIANT.ghost}
             text-align="start"
             onClick={onClickRenew}
+            isDisabled={isRenewalActivation && isRenewalActivationDisabled}
             role="button"
             aria-label={
-              periodEndAction === SavingsPlanPlanedChangeStatus.TERMINATE
-                ? t('enableAutoRenew')
-                : t('disableAutoRenew')
+              isRenewalActivation ? t('enableAutoRenew') : t('disableAutoRenew')
             }
           />
         )}
@@ -128,6 +130,7 @@ export default function ActionsCell({
   flavor,
   onClickEditName,
   onClickRenew,
+  isRenewalActivationDisabled,
 }: Readonly<SavingsPlanActionsCell>) {
   const pciUrl = usePciUrl();
 
@@ -153,6 +156,7 @@ export default function ActionsCell({
         flavor={flavor}
         status={status}
         periodEndAction={periodEndAction}
+        isRenewalActivationDisabled={isRenewalActivationDisabled}
         onClickEdit={onClickEdit}
         onClickRenew={() => {
           onClickRenew();

--- a/packages/manager/apps/pci-savings-plan/src/components/Table/TableContainer.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/components/Table/TableContainer.tsx
@@ -15,8 +15,9 @@ import PlannedChangeStatusChip from '../PlannedChangeStatusChip/PlannedChangeSta
 import StatusChip from '../StatusChip/StatusChip';
 import ActionsCell from './ActionsCell';
 import { SavingsPlanDatagridWrapper } from './Table.type';
-import { getDeploymentLabel } from '@/utils/savingsPlan';
+import { getDeploymentLabel, isRepricedCommitment } from '@/utils/savingsPlan';
 import { OdsBadge } from '@ovhcloud/ods-components/react';
+import { useSavingsPlanCreationOptionsFeatureAvailability } from '@/hooks/useSavingsPlanCreationOptionsFeatureAvailability';
 
 type SortableKey = Pick<
   SavingsPlanService,
@@ -37,6 +38,9 @@ export default function TableContainer({
     setSorting,
   } = useDatagridSearchParams();
   const [searchParams] = useSearchParams();
+  const {
+    isInstancesRepricingAvailable,
+  } = useSavingsPlanCreationOptionsFeatureAvailability();
 
   const paginatedData = useMemo(() => {
     const start = pagination.pageIndex * pagination.pageSize;
@@ -153,6 +157,10 @@ export default function TableContainer({
             flavor={props.flavor}
             status={props.status}
             periodEndAction={props.periodEndAction}
+            isRenewalActivationDisabled={
+              isInstancesRepricingAvailable &&
+              isRepricedCommitment(props.period)
+            }
             onClickRenew={() =>
               navigate({
                 pathname: `./${props.id}/renew`,
@@ -169,7 +177,7 @@ export default function TableContainer({
         ),
       },
     ],
-    [data, searchParams],
+    [data, searchParams, isInstancesRepricingAvailable],
   );
 
   return (

--- a/packages/manager/apps/pci-savings-plan/src/hooks/useSavingsPlanCreationOptionsFeatureAvailability.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/hooks/useSavingsPlanCreationOptionsFeatureAvailability.tsx
@@ -4,12 +4,18 @@ const svpApp = 'pci-savings-plan';
 
 const deployment3AZ = `${svpApp}:deployment-region-3-az`;
 const rancherService = `${svpApp}:rancher-service`;
+export const INSTANCES_REPRICING = `${svpApp}:repricing-instances-pre-com`;
 
 export const useSavingsPlanCreationOptionsFeatureAvailability = () => {
-  const { data } = useFeatureAvailability([deployment3AZ, rancherService]);
+  const { data } = useFeatureAvailability([
+    deployment3AZ,
+    rancherService,
+    INSTANCES_REPRICING,
+  ]);
 
   return {
     isDeployment3AZAvailable: data?.[deployment3AZ],
     isRancherServiceAvailable: data?.[rancherService],
+    isInstancesRepricingAvailable: data?.[INSTANCES_REPRICING],
   };
 };

--- a/packages/manager/apps/pci-savings-plan/src/pages/listing/renew-modal/index.spec.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/pages/listing/renew-modal/index.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { v6 } from '@ovh-ux/manager-core-api';
+import {
+  useNavigate,
+  useRouteLoaderData,
+  useSearchParams,
+} from 'react-router-dom';
+import { useNotifications } from '@ovh-ux/manager-react-components';
+import { UseQueryResult } from '@tanstack/react-query';
+import RenewModalPage from './index';
+import { renderWithMockedWrappers } from '@/__tests__/wrapper';
+import { tMock } from '@/utils/test/setupTests';
+import { useSavingsPlan, useSavingsPlanId } from '@/hooks/useSavingsPlan';
+import { pciSavingsPlanMocked } from '@/__mocks__/savingsPlan';
+import { SavingsPlanService } from '@/types';
+
+const serviceId = 2025;
+const navigate = vi.fn();
+const listSubscribedSavingsPlans = vi.fn();
+const changePeriodEndAction = vi.fn();
+const addSuccess = vi.fn();
+const addError = vi.fn();
+const clearNotifications = vi.fn();
+const refetchSavingsPlan = vi.fn();
+
+vi.mock('react-router-dom');
+vi.mocked(useNavigate).mockReturnValue(navigate);
+vi.mocked(useRouteLoaderData).mockReturnValue({ serviceId });
+vi.mocked(useSearchParams).mockReturnValue([
+  new URLSearchParams('sorted=status'),
+  vi.fn(),
+]);
+
+vi.mock('@/hooks/useSavingsPlan', async (importOriginal) => {
+  const original: typeof import('@/hooks/useSavingsPlan') = await importOriginal();
+  return {
+    ...original,
+    useSavingsPlanId: vi.fn(),
+    useSavingsPlan: vi.fn(),
+  };
+});
+
+vi.mocked(useSavingsPlanId).mockReturnValue(pciSavingsPlanMocked.id);
+vi.mocked(useSavingsPlan).mockReturnValue(({
+  data: [pciSavingsPlanMocked],
+  refetch: refetchSavingsPlan,
+} as unknown) as UseQueryResult<SavingsPlanService[]>);
+
+vi.mock('@ovh-ux/manager-core-api');
+vi.mocked(v6.get).mockImplementation(listSubscribedSavingsPlans);
+vi.mocked(v6.post).mockImplementation(changePeriodEndAction);
+listSubscribedSavingsPlans.mockResolvedValue({
+  data: [pciSavingsPlanMocked],
+});
+
+vi.mock('@ovh-ux/manager-react-components');
+vi.mocked(useNotifications).mockImplementation(() => ({
+  addSuccess,
+  addError,
+  clearNotifications,
+}));
+
+const confirmRenewalChange = async () => {
+  renderWithMockedWrappers(<RenewModalPage />);
+
+  const button = screen.getByTestId('renewModal-button_confirm');
+  await act(() => userEvent.click(button));
+
+  return button;
+};
+
+describe('Considering RenewModal page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should notify the failure and close the modal when the renewal change fails', async () => {
+    changePeriodEndAction.mockRejectedValue(
+      new Error('changePeriodEndAction KO'),
+    );
+
+    await confirmRenewalChange();
+
+    await waitFor(() =>
+      expect(addError).toHaveBeenCalledWith('banner_renew_error'),
+    );
+    expect(tMock).toHaveBeenCalledWith('banner_renew_error', {
+      planName: pciSavingsPlanMocked.displayName,
+      error: 'changePeriodEndAction KO',
+    });
+    expect(addSuccess).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '..',
+      search: 'sorted=status',
+    });
+  });
+
+  it('should notify the success and close the modal when the renewal change succeeds', async () => {
+    changePeriodEndAction.mockResolvedValue({ data: {} });
+
+    await confirmRenewalChange();
+
+    await waitFor(() =>
+      expect(addSuccess).toHaveBeenCalledWith('banner_renew_deactivate'),
+    );
+    expect(addError).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '..',
+      search: 'sorted=status',
+    });
+  });
+
+  it('should clear previous notifications and disable the renewal on the subscribed plan', async () => {
+    changePeriodEndAction.mockResolvedValue({ data: {} });
+
+    await confirmRenewalChange();
+
+    expect(clearNotifications).toHaveBeenCalled();
+    expect(
+      changePeriodEndAction,
+    ).toHaveBeenCalledWith(
+      `/services/${serviceId}/savingsPlans/subscribed/${pciSavingsPlanMocked.id}/changePeriodEndAction`,
+      { periodEndAction: 'TERMINATE' },
+    );
+  });
+
+  it('should keep the confirm button loading while the renewal change is pending', async () => {
+    changePeriodEndAction.mockReturnValue(new Promise(() => {}));
+
+    const button = await confirmRenewalChange();
+
+    await waitFor(() => expect(button).toHaveAttribute('is-loading', 'true'));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/manager/apps/pci-savings-plan/src/pages/listing/renew-modal/index.tsx
+++ b/packages/manager/apps/pci-savings-plan/src/pages/listing/renew-modal/index.tsx
@@ -16,7 +16,7 @@ const RenewModalPage = () => {
   const savingsPlanId = useSavingsPlanId();
   const { data: savingsPlan, error, isError } = useSavingsPlan();
   const { t } = useTranslation('listing');
-  const { addSuccess } = useNotifications();
+  const { addSuccess, addError, clearNotifications } = useNotifications();
 
   const currentPlan = useMemo(
     () => savingsPlan?.find((p) => p.id === savingsPlanId),
@@ -34,7 +34,7 @@ const RenewModalPage = () => {
     );
   };
 
-  const { mutate: changePeriod } = useSavingsPlanChangePeriod({
+  const { mutate: changePeriod, isPending } = useSavingsPlanChangePeriod({
     savingsPlanId,
     onSuccess,
   });
@@ -49,12 +49,24 @@ const RenewModalPage = () => {
     navigate({ pathname: '..', search: searchParams.toString() });
 
   const onConfirm = () => {
-    changePeriod({
-      periodEndAction: periodEndAction
-        ? SavingsPlanPlanedChangeStatus.TERMINATE
-        : SavingsPlanPlanedChangeStatus.REACTIVATE,
-    });
-    goToPrevious();
+    clearNotifications();
+    changePeriod(
+      {
+        periodEndAction: periodEndAction
+          ? SavingsPlanPlanedChangeStatus.TERMINATE
+          : SavingsPlanPlanedChangeStatus.REACTIVATE,
+      },
+      {
+        onError: (mutationError) =>
+          addError(
+            t('banner_renew_error', {
+              planName: currentPlan?.displayName,
+              error: mutationError?.message,
+            }),
+          ),
+        onSettled: () => goToPrevious(),
+      },
+    );
   };
 
   return currentPlan ? (
@@ -62,6 +74,7 @@ const RenewModalPage = () => {
       periodEndAction={currentPlan.periodEndAction}
       onClose={() => goToPrevious()}
       onConfirm={onConfirm}
+      isPending={isPending}
     />
   ) : (
     <></>

--- a/packages/manager/apps/pci-savings-plan/src/utils/savingsPlan.test.ts
+++ b/packages/manager/apps/pci-savings-plan/src/utils/savingsPlan.test.ts
@@ -1,4 +1,8 @@
-import { isInstanceFlavor, isValidSavingsPlanName } from './savingsPlan';
+import {
+  isInstanceFlavor,
+  isRepricedCommitment,
+  isValidSavingsPlanName,
+} from './savingsPlan';
 
 describe('isValidSavingsPlanName', () => {
   it('should return true for valid names', () => {
@@ -45,5 +49,25 @@ describe('isInstanceFlavor', () => {
 
   it('should return false if the flavor is not an instance', () => {
     expect(isInstanceFlavor('Rancher')).toBe(false);
+  });
+});
+
+describe('isRepricedCommitment', () => {
+  it.each(['P1M', 'P6M', 'P2Y'])(
+    'should return true for the repriced %s commitment',
+    (period) => {
+      expect(isRepricedCommitment(period)).toBe(true);
+    },
+  );
+
+  it.each(['P3M', 'P1Y', 'P3Y'])(
+    'should return false for the still offered %s commitment',
+    (period) => {
+      expect(isRepricedCommitment(period)).toBe(false);
+    },
+  );
+
+  it('should return false when the period is missing', () => {
+    expect(isRepricedCommitment(undefined)).toBe(false);
   });
 });

--- a/packages/manager/apps/pci-savings-plan/src/utils/savingsPlan.ts
+++ b/packages/manager/apps/pci-savings-plan/src/utils/savingsPlan.ts
@@ -1,5 +1,6 @@
 import { TFunction } from 'i18next';
 import { formatDate } from './formatter/date';
+import { convertToDuration } from './commercial-catalog/utils';
 import {
   InstanceInfo,
   InstanceTechnicalName,
@@ -80,3 +81,10 @@ export const getInstancesInformation = (t: TFunction): InstanceInfo[] => [
 // We don't have a better way to check that, api return only a specific code and not an id related to scope (instance, rancher),
 // So if we have number in the flavor (b3-8, c3-16) it's an instance else it's a Rancher
 export const isInstanceFlavor = (flavor: string) => /\d/.test(flavor);
+
+// Commitments being repriced are no longer offered for resubscription,
+// so their renewal can be turned off but never back on.
+const REPRICED_COMMITMENT_DURATIONS_IN_MONTHS = [1, 6, 24];
+
+export const isRepricedCommitment = (period?: string) =>
+  REPRICED_COMMITMENT_DURATIONS_IN_MONTHS.includes(convertToDuration(period));


### PR DESCRIPTION
Adds error handling for svp auto renewal and a disable for renewal on 1,6 and 24 months controlled by feature flag "repricing-instances-pre-com". 
<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
