### PR TITLE
fix(pci.object-storage): download correct object version

### DIFF
--- a/packages/manager/apps/pci-object-storage/src/pages/object-storage/storage/s3Id/objects/_hooks/useS3ObjectActions.hook.tsx
+++ b/packages/manager/apps/pci-object-storage/src/pages/object-storage/storage/s3Id/objects/_hooks/useS3ObjectActions.hook.tsx
@@ -72,7 +72,7 @@ export const useS3ObjectActions = ({
         method: storages.PresignedURLMethodEnum.GET,
         object: object.key,
         storageClass: object.storageClass,
-        versionId: '',
+        versionId: showVersion ? object.versionId : '',
       },
     });
   };


### PR DESCRIPTION
When the "see versions" toggle is on, the inline download action in the objects list always presigned with an empty versionId, so it downloaded the latest version regardless of the row clicked. Pass object.versionId when showVersion is enabled, mirroring the delete action.

ref: INC0261591

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
