### PR TITLE
fixup! refactor(backup-licenses): declare the product-line scope as a query select

### DIFF
--- a/packages/manager/modules/backup-licenses/src/data/queries/tenants.queries.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/tenants.queries.ts
@@ -10,11 +10,6 @@ import { queryKeys } from './queryKeys';
  * Cascade de résolution des identifiants (cf. §4 et §6 de la spec BKP-1216) :
  * `backupServicesId` puis `vspcTenantId` ne sont pas dans l'URL, ils sont résolus
  * par API et mis en cache.
- *
- * `/backupServices/tenant` et `.../vspc` servent aussi Backup Agent, et le tenant racine ne porte
- * aucune ligne produit : le périmètre ne se décide qu'au niveau VSPC (`vspcType`/`enabledAddons`).
- * Les deux identifiants sont donc résolus ensemble — prendre le premier de chaque liste
- * indépendamment retiendrait un service ou un tenant d'en face.
  */
 
 // ─── Base queries (no QueryClient needed) ───

--- a/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
+++ b/packages/manager/modules/backup-licenses/src/data/queries/vaults.queries.ts
@@ -6,14 +6,6 @@ import { selectBackupLicensesVaults } from '@/data/selectors/vaults.selectors';
 import { queryKeys } from './queryKeys';
 import { tenantsQueries } from './tenants.queries';
 
-/**
- * Le périmètre est un `select`, pas un filtre dans la `queryFn` : le cache garde la réponse de l'API
- * telle quelle, et chaque lecture reçoit la projection. Déclaré ici plutôt qu'à chaque `useQuery`,
- * un nouveau consommateur ne peut pas l'oublier.
- *
- * Attention : `select` n'est appliqué qu'à la lecture par `useQuery`. `ensureQueryData` et
- * `fetchQuery` renvoient la donnée brute du cache — un accès par ces voies doit filtrer lui-même.
- */
 const list = (queryClient: QueryClient) => () =>
   queryOptions({
     queryKey: queryKeys.vaults.all(),

--- a/packages/manager/modules/backup-licenses/src/data/selectors/tenants.selectors.ts
+++ b/packages/manager/modules/backup-licenses/src/data/selectors/tenants.selectors.ts
@@ -2,11 +2,6 @@ import { Resource } from '@/types/Resource.type';
 import { VspcTenant } from '@/types/VspcTenant.type';
 import { hasBackupLicensesAddon } from '@/utils/hasBackupLicensesAddon/hasBackupLicensesAddon';
 
-/**
- * `.../vspc` est partagée avec Backup Agent. Contrairement aux vaults, les deux discriminants ne
- * sont pas nullables au contrat : un tenant qui ne déclare rien n'est pas « à confirmer », il est
- * d'en face.
- */
 export const selectBackupLicensesVspcTenants = (
   tenants: Resource<VspcTenant>[],
 ): Resource<VspcTenant>[] => tenants.filter(hasBackupLicensesAddon);

--- a/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
+++ b/packages/manager/modules/backup-licenses/src/data/selectors/vaults.selectors.ts
@@ -1,11 +1,6 @@
 import { MODULE_PRODUCT_LINE } from '@/module.constants';
 import { VaultBucket, VaultResource } from '@/types/Vault.type';
 
-/**
- * Le contrat déclare `vaultProductLine` nullable « until existing vaults are backfilled » : un
- * vault sans product line est écarté quand même, quitte à vider l'écran, plutôt que d'exposer ici
- * un vault d'en face — un vault à tort inclus est indiscernable d'un vault légitime.
- */
 export const selectBackupLicensesVaults = (vaults: VaultResource[]): VaultResource[] =>
   vaults
     .filter(({ currentState: { vaultProductLine } }) => vaultProductLine === MODULE_PRODUCT_LINE)

--- a/packages/manager/modules/backup-licenses/src/mocks/tenants/tenants.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/tenants/tenants.mock.ts
@@ -16,10 +16,6 @@ export const mockBackupServicesTenants: Resource<BackupServicesTenant>[] = [
 
 export const VSPC_TENANT_ID = 'c2b8d4e5-0000-4000-8000-000000000001';
 
-/**
- * Tenant VSPC du périmètre Backup Licenses. `vspcType` et `enabledAddons` ne sont pas décoratifs :
- * la route `.../vspc` sert aussi Backup Agent, et sans eux la cascade écarte le tenant.
- */
 export const buildBackupLicensesVspcTenant = (
   id: string,
   currentState: Partial<VspcTenant> = {},

--- a/packages/manager/modules/backup-licenses/src/module.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/module.constants.ts
@@ -14,12 +14,6 @@ export const LABELS = {
   VSPC: 'VSPC',
 } as const;
 
-/**
- * Ligne produit servie par ce module. Les routes `/backupServices` sont partagées avec Backup
- * Agent, et c'est le seul endroit qui déclare laquelle des deux lignes nous concerne : les trois
- * filtres de périmètre (service, tenant VSPC, vaults) la lisent plutôt que de répéter le littéral.
- * Cf. spec `backup-licenses/product-line-scoping` R5.
- */
 export const MODULE_PRODUCT_LINE = 'BACKUP_LICENSES' as const;
 
 /** Affiché à la place d'une valeur absente dans une cellule du tableau. */


### PR DESCRIPTION
Drops the comments added by the product-line scoping work, as requested. **A single `fixup!` commit, meant to be squashed into `06b09f6156`** — `git rebase -i --autosquash` places it there on its own.

### What is removed

Six blocks, 33 comment lines, across the two scoping commits (`2b6b936f1a`, `06b09f6156`):

| File | Removed |
|---|---|
| `data/queries/vaults.queries.ts` | the `select` block on `list` |
| `data/queries/tenants.queries.ts` | the paragraph added to the cascade jsdoc |
| `data/selectors/tenants.selectors.ts` | the block on `selectBackupLicensesVspcTenants` |
| `data/selectors/vaults.selectors.ts` | the block on `selectBackupLicensesVaults` |
| `mocks/tenants/tenants.mock.ts` | the block on `buildBackupLicensesVspcTenant` |
| `module.constants.ts` | the block on `MODULE_PRODUCT_LINE` |

### Two things worth a look while reviewing

- **`tenants.queries.ts` is trimmed, not reverted.** Its jsdoc predates this work, so only the paragraph that was added is gone. Its closing sentence — *"Le client n'ayant en pratique qu'un service Backup Licenses, on prend le premier élément de chaque liste"* — was dropped too: that is precisely what the scoping change stopped doing, so restoring it would leave a false comment behind.
- **`vaults.selectors.ts` loses its comment outright.** The one it replaced described the opposite behaviour (the tolerant filter), so there is nothing to restore.

No comment is touched outside the two scoping commits. The one in `types/VspcTenant.type.ts` is left alone — it belongs to the `docs(backup-licenses)` commit, where the note *is* the deliverable alongside `API-STATUS.md`; say the word if it should go too.

### Checks

729 module tests green, `tsc` clean, lint 0 errors (2 pre-existing warnings, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)