### PR TITLE
fix(backup-licenses): read the vault paygo rate from the catalogue, not the cart

### DIFF
--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_de_DE.json
@@ -60,7 +60,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_en_GB.json
@@ -63,7 +63,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_es_ES.json
@@ -60,7 +60,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_CA.json
@@ -63,7 +63,7 @@
         "label": "Région de stockage"
       }
     },
-    "pricing_message": "Ce vault sera facturé au tarif à la consommation de {{price}} dès le premier octet consommé.",
+    "pricing_message": "Ce vault sera facturé au tarif à la consommation de {{price}} HT/Gio/mois dès le premier octet consommé.",
     "success": "Votre commande de vault est en cours de traitement.",
     "error": {
       "submit_failed": "La commande du vault n'a pas pu être envoyée. Veuillez réessayer dans quelques instants.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_fr_FR.json
@@ -63,7 +63,7 @@
         "label": "Région de stockage"
       }
     },
-    "pricing_message": "Ce vault sera facturé au tarif à la consommation de {{price}} dès le premier octet consommé.",
+    "pricing_message": "Ce vault sera facturé au tarif à la consommation de {{price}} HT/Gio/mois dès le premier octet consommé.",
     "success": "Votre commande de vault est en cours de traitement.",
     "error": {
       "submit_failed": "La commande du vault n'a pas pu être envoyée. Veuillez réessayer dans quelques instants.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_it_IT.json
@@ -60,7 +60,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pl_PL.json
@@ -62,7 +62,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
+++ b/packages/manager/modules/backup-licenses/public/translations/vaults/Messages_pt_PT.json
@@ -60,7 +60,7 @@
         "label": "Storage region"
       }
     },
-    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} from the first byte consumed.",
+    "pricing_message": "This vault will be billed at the pay-as-you-go rate of {{price}} ex. VAT/GB/month from the first byte consumed.",
     "success": "Vault order is being processed.",
     "error": {
       "submit_failed": "The vault order could not be sent. Please try again in a few moments.",

--- a/packages/manager/modules/backup-licenses/src/data/hooks/useVaultOrderPrice/useVaultOrderPrice.ts
+++ b/packages/manager/modules/backup-licenses/src/data/hooks/useVaultOrderPrice/useVaultOrderPrice.ts
@@ -1,34 +1,21 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 
-import { getBackupServicesOffers } from '@/data/api/order/order.requests';
-import { queryKeys } from '@/data/queries/queryKeys';
-import { tenantsQueries } from '@/data/queries/tenants.queries';
-import { BACKUP_LICENSES_ORDERABLE_VAULT_PLAN_CODE } from '@/module.constants';
-import { CartServiceOffer } from '@/types/OrderCart.type';
-import { findServiceOffer, getOfferInstallationPriceText } from '@/utils/serviceOffer/serviceOffer';
+import { useBackupServicesCatalog } from '@/data/hooks/useBackupServicesCatalog/useBackupServicesCatalog';
+import { BACKUP_LICENSES_VAULT_PAYGO_CONSUMPTION_PLAN_CODE } from '@/module.constants';
+import { formatCatalogPrice, getDefaultPricing } from '@/utils/planPricing/planPricing';
 
-const selectVaultOfferPriceText = (offers: CartServiceOffer[]): string | undefined =>
-  getOfferInstallationPriceText(
-    findServiceOffer(offers, BACKUP_LICENSES_ORDERABLE_VAULT_PLAN_CODE),
-  );
+export const useVaultOrderPrice = (): {
+  priceText?: string;
+  isPending: boolean;
+} => {
+  const { i18n } = useTranslation();
+  const { data: catalog, isPending } = useBackupServicesCatalog();
 
-export const useVaultOrderPrice = (): { priceText?: string; isPending: boolean } => {
-  const queryClient = useQueryClient();
+  const pricing = getDefaultPricing(catalog, BACKUP_LICENSES_VAULT_PAYGO_CONSUMPTION_PLAN_CODE);
+  const priceText =
+    catalog && pricing
+      ? formatCatalogPrice(pricing.price, catalog.locale.currencyCode, i18n.language)
+      : undefined;
 
-  const { data: serviceIds, isPending: isServiceNamePending } = useQuery({
-    ...tenantsQueries.withClient(queryClient).serviceIds(),
-    retry: false,
-  });
-  const serviceName = serviceIds?.backupServicesId;
-
-  const { data: priceText, isPending: arePricesPending } = useQuery({
-    queryKey: queryKeys.order.serviceOffers(serviceName ?? ''),
-    queryFn: () => getBackupServicesOffers(serviceName as string),
-    enabled: !!serviceName,
-    retry: false,
-    staleTime: Infinity,
-    select: selectVaultOfferPriceText,
-  });
-
-  return { priceText, isPending: isServiceNamePending || (!!serviceName && arePricesPending) };
+  return { priceText, isPending };
 };

--- a/packages/manager/modules/backup-licenses/src/mocks/catalog/catalog.mock.ts
+++ b/packages/manager/modules/backup-licenses/src/mocks/catalog/catalog.mock.ts
@@ -1,0 +1,64 @@
+import { OrderCatalog } from '@/types/Catalog.type';
+
+export const VAULT_STORAGE_PRICE_IN_UCENTS = 700_000;
+
+const consumptionPricing = {
+  capacities: ['consumption'],
+  mode: 'default',
+  commitment: 0,
+  intervalUnit: 'none',
+  interval: 0,
+  price: VAULT_STORAGE_PRICE_IN_UCENTS,
+  tax: 140_000,
+};
+
+const freeRentalPricings = [
+  {
+    capacities: ['installation'],
+    mode: 'default',
+    commitment: 0,
+    intervalUnit: 'none',
+    interval: 0,
+    price: 0,
+    tax: 0,
+  },
+  {
+    capacities: ['renew'],
+    mode: 'default',
+    commitment: 0,
+    intervalUnit: 'month',
+    interval: 1,
+    price: 0,
+    tax: 0,
+  },
+];
+
+export const mockBackupServicesCatalog: OrderCatalog = {
+  locale: { currencyCode: 'EUR', taxRate: 20 },
+  plans: [{ planCode: 'backup-tenant', pricings: freeRentalPricings }],
+  addons: [
+    {
+      planCode: 'backup-vault-backuplicenses-500G',
+      pricings: freeRentalPricings,
+    },
+    {
+      planCode: 'backup-vault-backuplicenses-paygo',
+      pricings: freeRentalPricings,
+    },
+    {
+      planCode: 'backup-vault-backuplicenses-500g-consumption',
+      pricings: [consumptionPricing],
+    },
+    {
+      planCode: 'backup-vault-backuplicenses-paygo-consumption',
+      pricings: [consumptionPricing],
+    },
+  ],
+};
+
+export const mockCatalogWithoutVaultStorage: OrderCatalog = {
+  ...mockBackupServicesCatalog,
+  addons: mockBackupServicesCatalog.addons.filter(
+    ({ planCode }) => !planCode.endsWith('-consumption'),
+  ),
+};

--- a/packages/manager/modules/backup-licenses/src/module.constants.ts
+++ b/packages/manager/modules/backup-licenses/src/module.constants.ts
@@ -71,6 +71,9 @@ export const BACKUP_LICENSES_VAULT_PLAN_CODES = [
  */
 export const BACKUP_LICENSES_VAULT_BUNDLE_PLAN_CODE = BACKUP_LICENSES_VAULT_PLAN_CODES[0];
 
+export const BACKUP_LICENSES_VAULT_PAYGO_CONSUMPTION_PLAN_CODE =
+  BACKUP_LICENSES_VAULT_PLAN_CODES[1];
+
 /** Volume de stockage inclus sur le vault en plan bundle (les 500 premiers Go). */
 export const INCLUDED_VAULT_STORAGE_GB = 500;
 

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.spec.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/OrderVault.page.spec.tsx
@@ -2,12 +2,10 @@ import { screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  TEST_VAULT_OFFER_PRICE_IN_UCENTS,
-  buildTestOfferPricing,
-  mockCartServiceOffers,
-  mockCartServiceOffersWithoutVault,
-  mockVaultServiceOffer,
-} from '@/mocks/order/order.mock';
+  VAULT_STORAGE_PRICE_IN_UCENTS,
+  mockCatalogWithoutVaultStorage,
+} from '@/mocks/catalog/catalog.mock';
+import { mockCartServiceOffers } from '@/mocks/order/order.mock';
 import { labels } from '@/test-utils/i18ntest.utils';
 
 import { VAULT_ORDER_TEST_IDS } from './OrderVault.page';
@@ -25,6 +23,7 @@ import {
   fillValidOrder,
   isDisabled,
   isEnabled,
+  mockedGetBackupServicesCatalog,
   mockedGetBackupServicesOffers,
   mockedOrderVault,
   nameAccessibleName,
@@ -38,12 +37,14 @@ import {
   regionOptionLabels,
   regionSelect,
   renderOrderModal,
+  resolveCatalog,
   resolveServiceName,
   submitButton,
   submitFromKeyboard,
   typeName,
 } from './_test/order.harness';
 
+vi.mock('@/data/api/catalog/catalog.requests');
 vi.mock('@/data/api/order/order.requests');
 vi.mock('@/data/api/tenants/tenants.requests');
 vi.mock('@/data/api/vaults/vaults.requests', async (importOriginal) => ({
@@ -63,16 +64,16 @@ vi.mock('@ovh-ux/manager-react-components', async (importOriginal) => ({
 
 const order = labels.vaults.order;
 
-/** The price Agora serves, deliberately fictional — see the warning on `order.mock.ts`. */
-const TEST_PRICE_TEXT = buildTestOfferPricing(TEST_VAULT_OFFER_PRICE_IN_UCENTS).price.text;
-
-const pricingSentence = (price: string) => order.pricing_message.replace('{{price}}', price);
+const VAULT_RATE_PATTERN = new RegExp(
+  String(VAULT_STORAGE_PRICE_IN_UCENTS / 100_000_000).replace('.', '[.,]'),
+);
 
 describe('OrderVaultPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedOrderVault.mockResolvedValue(undefined);
     mockedGetBackupServicesOffers.mockResolvedValue(mockCartServiceOffers);
+    resolveCatalog();
     resolveServiceName();
   });
 
@@ -97,11 +98,18 @@ describe('OrderVaultPage', () => {
   });
 
   describe('the pay-as-you-go rate, which the mockup omits and the ticket requires', () => {
-    it('states it at the rate the offer serves, interpolated into the sentence', async () => {
+    it('states the per-gibibyte rate the catalogue serves, interpolated into the sentence', async () => {
       await renderOrderModal();
 
       await waitFor(() => expect(pricingMessage()).toBeVisible());
-      expect(pricingMessage()).toHaveTextContent(pricingSentence(TEST_PRICE_TEXT));
+      expect(pricingMessage()).toHaveTextContent(VAULT_RATE_PATTERN);
+    });
+
+    it('never announces the free subscription rate of the orderable plan', async () => {
+      await renderOrderModal();
+
+      await waitFor(() => expect(pricingMessage()).toBeVisible());
+      expect(pricingMessage()).not.toHaveTextContent(/0[.,]00\s*€/);
     });
 
     it('ships no figure of its own: the sentence carries a placeholder, never an amount', () => {
@@ -109,8 +117,8 @@ describe('OrderVaultPage', () => {
       expect(order.pricing_message).not.toMatch(/\d/);
     });
 
-    it('skeletons the sentence while the offers are in flight, rather than half-stating it', async () => {
-      mockedGetBackupServicesOffers.mockReturnValue(new Promise(() => undefined));
+    it('skeletons the sentence while the catalogue is in flight, rather than half-stating it', async () => {
+      mockedGetBackupServicesCatalog.mockReturnValue(new Promise(() => undefined));
 
       await renderOrderModal();
 
@@ -118,8 +126,8 @@ describe('OrderVaultPage', () => {
       expect(pricingMessage()).not.toBeInTheDocument();
     });
 
-    it('drops the whole message when the catalogue serves no vault offer', async () => {
-      mockedGetBackupServicesOffers.mockResolvedValue(mockCartServiceOffersWithoutVault);
+    it('drops the whole message when the catalogue prices no vault storage', async () => {
+      mockedGetBackupServicesCatalog.mockResolvedValue(mockCatalogWithoutVaultStorage);
 
       await renderOrderModal();
 
@@ -129,23 +137,14 @@ describe('OrderVaultPage', () => {
       expect(screen.queryByText(/pay-as-you-go/)).not.toBeInTheDocument();
     });
 
-    it('drops it just as silently when the offers route itself is unreachable', async () => {
-      mockedGetBackupServicesOffers.mockRejectedValue(new Error('catalogue not declared'));
+    it('drops it just as silently when the catalogue route itself is unreachable', async () => {
+      mockedGetBackupServicesCatalog.mockRejectedValue(new Error('catalogue not declared'));
 
       await renderOrderModal();
 
       await waitFor(() => expect(pricingSkeleton()).not.toBeInTheDocument());
       expect(pricingMessage()).not.toBeInTheDocument();
       expect(screen.getByTestId(VAULT_ORDER_TEST_IDS.submit)).toBeVisible();
-    });
-
-    it('drops it when the vault offer carries no price at all', async () => {
-      mockedGetBackupServicesOffers.mockResolvedValue([{ ...mockVaultServiceOffer, prices: [] }]);
-
-      await renderOrderModal();
-
-      await waitFor(() => expect(pricingSkeleton()).not.toBeInTheDocument());
-      expect(pricingMessage()).not.toBeInTheDocument();
     });
   });
 
@@ -261,7 +260,10 @@ describe('OrderVaultPage', () => {
 
   it('prefers the reason the API gives over its own wording', async () => {
     mockedOrderVault.mockRejectedValue({
-      response: { status: 503, data: { message: 'Ordering is temporarily unavailable' } },
+      response: {
+        status: 503,
+        data: { message: 'Ordering is temporarily unavailable' },
+      },
     });
 
     await renderOrderModal();
@@ -275,7 +277,10 @@ describe('OrderVaultPage', () => {
 
   describe('a name the backend refuses', () => {
     const refused = {
-      response: { status: 409, data: { message: 'This vault name is already taken' } },
+      response: {
+        status: 409,
+        data: { message: 'This vault name is already taken' },
+      },
     };
 
     it('lands on the field the customer has to change, not in a modal-level banner', async () => {

--- a/packages/manager/modules/backup-licenses/src/pages/vaults/order/_test/order.harness.tsx
+++ b/packages/manager/modules/backup-licenses/src/pages/vaults/order/_test/order.harness.tsx
@@ -4,10 +4,12 @@ import { RenderResult, fireEvent, screen, waitFor } from '@testing-library/react
 import { expect, vi } from 'vitest';
 
 import { fieldErrorId } from '@/components/FieldError/FieldError.component';
+import { getBackupServicesCatalog } from '@/data/api/catalog/catalog.requests';
 import { getBackupServicesOffers } from '@/data/api/order/order.requests';
 import { getBackupServicesTenants, getVspcTenants } from '@/data/api/tenants/tenants.requests';
 import { orderVault } from '@/data/api/vaults/vaults.requests';
 import { LOCATION_DEFINITIONS } from '@/data/locations.data';
+import { mockBackupServicesCatalog } from '@/mocks/catalog/catalog.mock';
 import {
   BACKUP_SERVICES_TENANT_ID,
   mockBackupServicesTenants,
@@ -32,6 +34,10 @@ export const LOCATIONS = LOCATION_DEFINITIONS;
 export const mockedOrderVault = vi.mocked(orderVault);
 export const mockedGetBackupServicesOffers = vi.mocked(getBackupServicesOffers);
 export const mockedGetBackupServicesTenants = vi.mocked(getBackupServicesTenants);
+export const mockedGetBackupServicesCatalog = vi.mocked(getBackupServicesCatalog);
+
+export const resolveCatalog = () =>
+  mockedGetBackupServicesCatalog.mockResolvedValue(mockBackupServicesCatalog);
 
 export const resolveServiceName = () => {
   mockedGetBackupServicesTenants.mockResolvedValue(mockBackupServicesTenants);

--- a/packages/manager/modules/backup-licenses/src/types/Catalog.type.ts
+++ b/packages/manager/modules/backup-licenses/src/types/Catalog.type.ts
@@ -5,6 +5,7 @@
  * (produit Veeam sœur, même forme de catalogue).
  */
 export interface CatalogPricing {
+  capacities?: string[];
   /** `'default'` = prix catalogue sans engagement (cf. `pricingMode` du snippet `createCart` du ticket). */
   mode: string;
   /**

--- a/packages/manager/modules/backup-licenses/src/utils/planPricing/planPricing.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/planPricing/planPricing.spec.ts
@@ -12,6 +12,29 @@ const catalog: OrderCatalog = {
   plans: [{ planCode: 'backup-tenant', pricings: [] }],
   addons: [
     {
+      planCode: 'backup-vault-backuplicenses-500g-consumption',
+      pricings: [
+        {
+          capacities: ['installation'],
+          mode: 'default',
+          commitment: 0,
+          intervalUnit: 'none',
+          interval: 0,
+          price: 0,
+          tax: 0,
+        },
+        {
+          capacities: ['consumption'],
+          mode: 'default',
+          commitment: 0,
+          intervalUnit: 'none',
+          interval: 0,
+          price: 700_000,
+          tax: 140_000,
+        },
+      ],
+    },
+    {
       planCode: 'vspc-backuplicenses-foundation-vm',
       pricings: [
         {
@@ -46,6 +69,12 @@ describe('getDefaultPricing', () => {
       price: 1_500_000_000,
       tax: 300_000_000,
     });
+  });
+
+  it("écarte le frais de mise en service et rend le tarif à l'unité consommée", () => {
+    expect(
+      getDefaultPricing(catalog, 'backup-vault-backuplicenses-500g-consumption'),
+    ).toMatchObject({ capacities: ['consumption'], price: 700_000 });
   });
 
   it("renvoie undefined si le plan n'existe pas dans le catalogue", () => {

--- a/packages/manager/modules/backup-licenses/src/utils/planPricing/planPricing.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/planPricing/planPricing.ts
@@ -1,5 +1,9 @@
 import { CatalogPricing, OrderCatalog } from '@/types/Catalog.type';
 
+const isActivationFee = (pricing: CatalogPricing): boolean =>
+  pricing.capacities?.includes('installation') === true &&
+  !pricing.capacities.includes('consumption');
+
 /**
  * Prix catalogue par défaut d'un plan (sans engagement). Les plans `backupServices` sont en
  * `pricingType: 'consumption'` : `intervalUnit`/`interval` valent `'none'`/`0` dans la réponse
@@ -14,7 +18,10 @@ export const getDefaultPricing = (
   const plan = [...(catalog?.plans ?? []), ...(catalog?.addons ?? [])].find(
     (candidate) => candidate.planCode === planCode,
   );
-  return plan?.pricings.find((pricing) => pricing.mode === 'default' && pricing.commitment === 0);
+  return plan?.pricings.find(
+    (pricing) =>
+      pricing.mode === 'default' && pricing.commitment === 0 && !isActivationFee(pricing),
+  );
 };
 
 const UCENTS_PER_UNIT = 100_000_000;

--- a/packages/manager/modules/backup-licenses/src/utils/serviceOffer/serviceOffer.spec.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/serviceOffer/serviceOffer.spec.ts
@@ -6,14 +6,12 @@ import {
   buildTestOfferPricing,
   mockCartServiceOffers,
   mockUnorderableServiceOffer,
-  mockVaultOfferInstallationPricing,
   mockVaultServiceOffer,
 } from '@/mocks/order/order.mock';
 import { CartOfferPricing, CartServiceOffer } from '@/types/OrderCart.type';
 
 import {
   findServiceOffer,
-  getOfferInstallationPriceText,
   getOfferInstallationPricing,
   getOfferOrderParameters,
 } from './serviceOffer';
@@ -58,30 +56,6 @@ describe('getOfferInstallationPricing', () => {
   });
 });
 
-describe('getOfferInstallationPriceText', () => {
-  it("hands back Agora's own formatted string, so the front formats no amount", () => {
-    expect(getOfferInstallationPriceText(mockVaultServiceOffer)).toBe(
-      mockVaultOfferInstallationPricing.price.text,
-    );
-  });
-
-  it('returns undefined rather than an empty string when the offer serves no text', () => {
-    const offer = withPrices([
-      pricing({ price: { ...mockVaultOfferInstallationPricing.price, text: '' } }),
-    ]);
-
-    expect(getOfferInstallationPriceText(offer)).toBeUndefined();
-  });
-
-  it('returns undefined when nothing about the offer is installable', () => {
-    expect(getOfferInstallationPriceText(mockUnorderableServiceOffer)).toBeUndefined();
-  });
-
-  it('returns undefined when the offer is missing', () => {
-    expect(getOfferInstallationPriceText(undefined)).toBeUndefined();
-  });
-});
-
 describe('getOfferOrderParameters', () => {
   it('reads the four POST parameters off the installable pricing', () => {
     expect(getOfferOrderParameters(mockVaultServiceOffer)).toEqual({
@@ -94,7 +68,11 @@ describe('getOfferOrderParameters', () => {
 
   it('never assumes the monthly default pattern — mode and duration come from the offer', () => {
     const offer = withPrices([
-      pricing({ capacities: ['installation'], duration: 'P1Y', pricingMode: 'consumption-hourly' }),
+      pricing({
+        capacities: ['installation'],
+        duration: 'P1Y',
+        pricingMode: 'consumption-hourly',
+      }),
     ]);
 
     expect(getOfferOrderParameters(offer)).toMatchObject({

--- a/packages/manager/modules/backup-licenses/src/utils/serviceOffer/serviceOffer.ts
+++ b/packages/manager/modules/backup-licenses/src/utils/serviceOffer/serviceOffer.ts
@@ -19,15 +19,6 @@ export const getOfferInstallationPricing = (
   offer?.prices.find(({ capacities }) => capacities.includes('installation'));
 
 /**
- * Le tarif prêt à afficher servi par Agora, celui-là même auquel la commande partira. Le front ne
- * formate ni n'arrondit aucun montant (R1) : `Price.text` est déjà localisé par subsidiary, là où
- * un `Intl.NumberFormat` à deux décimales écraserait un tarif au Go sous le centime.
- */
-export const getOfferInstallationPriceText = (
-  offer: CartOfferDefinition | undefined,
-): string | undefined => getOfferInstallationPricing(offer)?.price.text || undefined;
-
-/**
  * Le tarif qui porte la période de facturation à commander. `installation` annonce une durée nulle
  * (`P0D`, c'est un frais ponctuel) : le panier l'accepte à l'ajout, puis le checkout le refuse avec
  * « Invalid duration 0 ». C'est donc `renew` qui fait foi, et `installation` seulement à défaut.


### PR DESCRIPTION
## Problem

The **order-an-additional-vault** modal announced `0.00 €` where the customer expects the pay-as-you-go rate.

Two hypotheses were on the table — either Agora had the vault mis-referenced, or we displayed the wrong price (a monthly rate rather than the per-gibibyte one). The live API says it is neither.

## Root cause: the wrong source, on the wrong plan code

`useVaultOrderPrice` read the price off `GET /order/cartServiceOption/backupServices/{id}`. That route only publishes the **orderable** plan, and it is free:

| planCode | pricingType | capacities | price |
|---|---|---|---|
| `backup-vault-backuplicenses-paygo` | `rental` | `installation`, `renew` | **0** |

Both of its pricings are zero — subscribing a vault costs nothing, the usage is what gets billed. The rate is absent from that response entirely; it lives on a **different plan code**, which only the public catalogue exposes:

| planCode | pricingType | capacities | price |
|---|---|---|---|
| `backup-vault-backuplicenses-paygo-consumption` | `consumption` | `consumption` | **700 000 µcents = €0.007 / GiB** |

So the plan codes in `module.constants.ts` were correct all along; the comment claiming their casing was unconfirmed is now replaced by the dated reading. Both endpoints were captured against the live API on **2026-08-18** (EU, subsidiary FR, real tenant).

## Fix

- **`useVaultOrderPrice`** now reads the public catalogue on `BACKUP_LICENSES_VAULT_PAYGO_CONSUMPTION_PLAN_CODE` — the same source and mechanism `CardPrice` already uses in the order funnel. The degradation contract is unchanged: skeleton while in flight, then the whole sentence dropped if no rate (never a naked sentence, never a hardcoded amount).
- **`getDefaultPricing`** skips an activation fee, which satisfies `mode: 'default'` / `commitment: 0` exactly like the usage pricing and would win the `find`. Latent trap for `CardPrice` and `OrderRecapPanel`: they work today only because the `-consumption` plans publish a single pricing.
- **`getOfferInstallationPriceText`** removed — no caller left.
- **`mocks/catalog/catalog.mock.ts`** (new) carries the shape as read from the API, with both plan families side by side, so reading the wrong one produces zero again.
- **Translations (8 locales)**: the message now states the billing unit, worded exactly like `order.card.vault_storage_note`, which already announces this same rate — `HT/Gio/mois` in French, `ex. VAT/GB/month` in English.

## Before / after

| | Displayed |
|---|---|
| Before | This vault will be billed at the pay-as-you-go rate of **€0.00** from the first byte consumed. |
| After | This vault will be billed at the pay-as-you-go rate of **€0.007 ex. VAT/GB/month** from the first byte consumed. |

Confirmed in the running app against the live API, not only in tests: the network call moved from `cartServiceOption` to `order/catalog/public`.

## Tests

- `OrderVault.page.spec` rewritten onto the catalogue source, plus a test asserting the modal never announces the orderable plan's free rate — the mocked catalogue holds both, so reading the wrong one fails.
- **Mutation-checked**: pointing the hook back at the orderable plan code turns 3 tests red. They catch the regression rather than merely passing.
- `planPricing.spec`: the activation fee is skipped in favour of the per-unit rate.
- Full module suite: **736 passed**. 13 failures remain in `Order.page.spec` (8), `useOrderCartPreparation` (4) and `OnboardingGuard.page.spec` (1) — **pre-existing**, measured on a `git stash` baseline before this work, unrelated to this change.
- `tsc --noEmit` clean. Lint clean on the touched files (3 pre-existing errors remain in `vaultOrder.spec.ts` and `LinkedServers.page.tsx`, deliberately untouched).

## Two points for the reviewer

1. **`Gio` vs `Go`** — the wording follows the module's existing convention (`vault_storage_note` says `Gio` in French, `GB` in English) so the same rate is not labelled two different ways. Say the word if the team prefers `Go`.
2. **Untranslated locales** — `es`, `de`, `pt`, `it`, `pl` still carry the English sentence for `pricing_message`; they get the English unit rather than a localised unit inside an English sentence. A proper translation pass is a separate matter.

ref: #bkp-1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
