### PR TITLE
fix(databases): warn about version upgrade downtime

### DIFF
--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
@@ -19,6 +19,7 @@
   "updateVersionInputLabel": "Choisissez une nouvelle version",
   "updateVersionCancelButton": "Annuler",
   "updateVersionSubmitButton": "Modifier",
+  "updateVersionDowntimeWarning": "Cette opération peut entraîner une indisponibilité de votre service pendant cinq minutes. Nous vous recommandons de la planifier pendant une fenêtre de maintenance.",
   "updateVersionErrorSimilar": "Veuillez choisir une version différente de celle actuelle",
   "updateVersionToastErrorTitle": "Une erreur est survenue lors de la modification de la version de votre service",
   "updateVersionToastSuccessTitle": "Succès",

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
@@ -4,6 +4,8 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 import {
+  Alert,
+  AlertDescription,
   Button,
   DialogBody,
   DialogClose,
@@ -102,6 +104,15 @@ const UpdateVersion = () => {
           </DialogTitle>
         </DialogHeader>
         <DialogBody>
+          <Alert
+            data-testid="update-version-downtime-warning"
+            variant="warning"
+            className="rounded-md"
+          >
+            <AlertDescription>
+              {t('updateVersionDowntimeWarning')}
+            </AlertDescription>
+          </Alert>
           <Form {...form}>
             <form onSubmit={onSubmit} id="updateVersionForm">
               <FormField

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
@@ -101,6 +101,9 @@ describe('Update Version modal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('update-version-modal')).toBeInTheDocument();
     });
+    expect(
+      screen.getByTestId('update-version-downtime-warning'),
+    ).toBeInTheDocument();
     act(() => {
       fireEvent.click(screen.getByTestId('update-version-cancel-button'));
     });


### PR DESCRIPTION
## Description

Add a warning to the Managed Databases version-upgrade dialog explaining that the service can be unavailable for up to five minutes and recommending a maintenance window.

The repository contribution policy permits contributors to add French translations only, so the new user-facing string is added to `Messages_fr_FR.json`.

## Testing

- `pnpm exec vitest run "src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx"`
- `git diff --check`