### PR TITLE
fix(databases): warn about version upgrade downtime

### DIFF
--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
@@ -19,6 +19,7 @@
   "updateVersionInputLabel": "Choisissez une nouvelle version",
   "updateVersionCancelButton": "Annuler",
   "updateVersionSubmitButton": "Modifier",
+  "updateVersionDowntimeWarning": "Une interruption de service est à prévoir. Nous vous recommandons de planifier cette opération pendant une fenêtre de maintenance.",
   "updateVersionErrorSimilar": "Veuillez choisir une version différente de celle actuelle",
   "updateVersionToastErrorTitle": "Une erreur est survenue lors de la modification de la version de votre service",
   "updateVersionToastSuccessTitle": "Succès",

--- a/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
+++ b/packages/manager/apps/pci-databases-analytics/public/translations/pci-databases-analytics/services/service/settings/update/Messages_fr_FR.json
@@ -20,6 +20,7 @@
   "updateVersionCancelButton": "Annuler",
   "updateVersionSubmitButton": "Modifier",
   "updateVersionDowntimeWarning": "Une interruption de service est à prévoir. Nous vous recommandons de planifier cette opération pendant une fenêtre de maintenance.",
+  "updateVersionDowntimeWarningLink": "En savoir plus sur la mise à jour de version",
   "updateVersionErrorSimilar": "Veuillez choisir une version différente de celle actuelle",
   "updateVersionToastErrorTitle": "Une erreur est survenue lors de la modification de la version de votre service",
   "updateVersionToastSuccessTitle": "Succès",

--- a/packages/manager/apps/pci-databases-analytics/src/configuration/documentation.ts
+++ b/packages/manager/apps/pci-databases-analytics/src/configuration/documentation.ts
@@ -10,6 +10,14 @@ export const LINKS = {
     default:
       'https://docs.ovh.com/gb/en/publiccloud/databases/order-terraform/',
   },
+  DB_VERSION_UPGRADE: {
+    fr_FR:
+      'https://docs.ovhcloud.com/fr/guides/public-cloud/databases/faq#puis-je-mettre-%C3%A0-jour-manuellement-la-version-de-mon-sgbd-',
+    fr_CA:
+      'https://docs.ovhcloud.com/fr/guides/public-cloud/databases/faq#puis-je-mettre-%C3%A0-jour-manuellement-la-version-de-mon-sgbd-',
+    default:
+      'https://docs.ovhcloud.com/en/guides/public-cloud/databases/faq#can-i-manually-update-my-dbms-version',
+  },
   PG_OFFICIAL_DOCUMENTATION: 'https://www.postgresql.org/docs/',
   MySQL_OFFICIAL_DOCUMENTATION: 'https://dev.mysql.com/doc/',
 };

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
@@ -27,12 +27,16 @@ import { useServiceData } from '@/pages/services/[serviceId]/Service.context';
 import { useEditService } from '@/hooks/api/database/service/useEditService.hook';
 import { getCdbApiErrorMessage } from '@/lib/apiHelper';
 import { useGetAvailabilities } from '@/hooks/api/database/availability/useGetAvailabilities.hook';
+import { useLocale } from '@/hooks/useLocale';
+import { LINKS, getDocumentationUrl } from '@/configuration/documentation';
 import { useUpdateTree } from '../_components/useUpdateTree';
 import RouteModal from '@/components/route-modal/RouteModal';
 import VersionSelect from '@/components/order/version/VersionSelect.component';
+import A from '@/components/links/A.component';
 
 const UpdateVersion = () => {
   const { service, projectId } = useServiceData();
+  const locale = useLocale();
   const navigate = useNavigate();
   const toast = useToast();
   const { t } = useTranslation(
@@ -110,7 +114,15 @@ const UpdateVersion = () => {
             className="rounded-md"
           >
             <AlertDescription>
-              {t('updateVersionDowntimeWarning')}
+              {t('updateVersionDowntimeWarning')}{' '}
+              <A
+                data-testid="update-version-documentation-link"
+                href={getDocumentationUrl(LINKS.DB_VERSION_UPGRADE, locale)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('updateVersionDowntimeWarningLink')}
+              </A>
             </AlertDescription>
           </Alert>
           <Form {...form}>

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.modal.tsx
@@ -4,6 +4,8 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 import {
+  Alert,
+  AlertDescription,
   Button,
   DialogBody,
   DialogClose,
@@ -102,6 +104,15 @@ const UpdateVersion = () => {
           </DialogTitle>
         </DialogHeader>
         <DialogBody>
+          <Alert
+            data-testid="update-version-downtime-warning"
+            variant="warning"
+            className="rounded-md"
+          >
+            <AlertDescription>
+              {t('updateVersionDowntimeWarning')}
+            </AlertDescription>
+          </Alert>
           <Form {...form}>
             <form onSubmit={onSubmit} id="updateVersionForm">
               <FormField

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
@@ -101,6 +101,9 @@ describe('Update Version modal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('update-version-modal')).toBeInTheDocument();
     });
+    expect(
+      screen.getByTestId('update-version-downtime-warning'),
+    ).toBeInTheDocument();
     act(() => {
       fireEvent.click(screen.getByTestId('update-version-cancel-button'));
     });

--- a/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
+++ b/packages/manager/apps/pci-databases-analytics/src/pages/services/[serviceId]/settings/update/updateVersion/UpdateVersion.spec.tsx
@@ -23,6 +23,7 @@ import {
   mockedSuggestionsUpdate,
 } from '@/__tests__/helpers/mocks/updateMock';
 import { setMockedUseParams } from '@/__tests__/helpers/mockRouterDomHelper';
+import * as LocaleHook from '@/hooks/useLocale';
 import UpdateVersion from './UpdateVersion.modal';
 
 export const mockedCapabilitiesUpdate: database.Capabilities = {
@@ -84,9 +85,18 @@ vi.mock('@/hooks/api/catalog/useGetCatalog.hook', () => ({
   })),
 }));
 
+vi.mock('@/hooks/useLocale', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useLocale')>();
+  return {
+    ...actual,
+    useLocale: vi.fn(() => actual.Locale.fr_FR),
+  };
+});
+
 describe('Update Version modal', () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
+    vi.mocked(LocaleHook.useLocale).mockReturnValue(LocaleHook.Locale.fr_FR);
     setMockedUseParams({
       projectId: 'projectId',
       serviceId: 'serviceId',
@@ -104,6 +114,12 @@ describe('Update Version modal', () => {
     expect(
       screen.getByTestId('update-version-downtime-warning'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-version-documentation-link'),
+    ).toHaveAttribute(
+      'href',
+      'https://docs.ovhcloud.com/fr/guides/public-cloud/databases/faq#puis-je-mettre-%C3%A0-jour-manuellement-la-version-de-mon-sgbd-',
+    );
     act(() => {
       fireEvent.click(screen.getByTestId('update-version-cancel-button'));
     });
@@ -112,6 +128,20 @@ describe('Update Version modal', () => {
         screen.queryByTestId('update-version-modal'),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('uses the documentation matching the current locale', async () => {
+    vi.mocked(LocaleHook.useLocale).mockReturnValue(LocaleHook.Locale.en_GB);
+    render(<UpdateVersion />, { wrapper: RouterWithQueryClientWrapper });
+    await waitFor(() => {
+      expect(screen.getByTestId('update-version-modal')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId('update-version-documentation-link'),
+    ).toHaveAttribute(
+      'href',
+      'https://docs.ovhcloud.com/en/guides/public-cloud/databases/faq#can-i-manually-update-my-dbms-version',
+    );
   });
 
   // it('display error on update error', async () => {


### PR DESCRIPTION
## Description

Add a warning to the Managed Databases version-upgrade dialog explaining that a service interruption should be expected and recommending that the operation be planned during a maintenance window.

The repository contribution policy permits external contributors to add French translations only, so the new user-facing string is added to Messages_fr_FR.json.

## Commit structure

The documentation link is intentionally isolated in the second commit because I am not certain whether the linked documentation is still current or required. If the documentation link is not desired, that commit can simply be dropped and the first commit containing only the downtime warning can be merged on its own.

## Testing

- Targeted UpdateVersion Vitest test
- git diff --check
