### PR TITLE
feat(account): show the company information modal on an invalid SIRET

### DIFF
--- a/packages/manager/apps/container/src/components/company-information-modal/CompanyInformationModal.component.tsx
+++ b/packages/manager/apps/container/src/components/company-information-modal/CompanyInformationModal.component.tsx
@@ -10,7 +10,7 @@ import { ODS_THEME_TYPOGRAPHY_SIZE, ODS_THEME_COLOR_INTENT } from "@ovhcloud/ods
 import { useApplication } from "@/context";
 import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT } from "@ovhcloud/ods-components";
 import { Trans, useTranslation } from "react-i18next";
-import { isConcernedByAccountToReview, isUserConcernedByBusinessVerification } from "./companyInformationModal.helpers";
+import { getContentKeyPrefix, isOnInvoicesApplication, isUserConcernedByBusinessVerification } from "./companyInformationModal.helpers";
 import { OdsHTMLAnchorElementRel, OdsHTMLAnchorElementTarget } from "@ovhcloud/ods-common-core";
 
 
@@ -21,25 +21,32 @@ const CompanyInformationModal: FC = () => {
   const tracking = shell.getPlugin('tracking');
   const { t } = useTranslation('company-information-modal');
 
-  // Content varies with the certificate: account-to-review gets the new "review"
-  // wording, warning/critical keep the legacy wording.
+  // Content varies with what brought the modal up: account-to-review gets the
+  // "review" wording, warning/critical keep the legacy one, and an account
+  // without any certificate is here for its SIRET only.
   const user = shell.getPlugin('environment').getEnvironment().getUser();
-  const contentKeyPrefix = isConcernedByAccountToReview(user)
-    ? 'company_information_modal_review'
-    : 'company_information_modal';
+  const contentKeyPrefix = getContentKeyPrefix(user);
 
   const preferenceKey = toScreamingSnakeCase(MODAL_NAME);
   const accountEditionLink = useSuggestionTargetUrl();
+  const applications = shell
+    .getPlugin('environment')
+    .getEnvironment()
+    .getApplications();
 
-  const shouldDisplayModal = useCheckModalDisplay(
-    undefined,
-    undefined,
-    undefined,
-    preferenceKey,
-    INTERVAL_BETWEEN_DISPLAY_IN_S,
-    isUserConcernedByBusinessVerification,
-    [accountEditionLink],
-  );
+  // Of the two modals a missing SIRET raises, the billing one is the more
+  // restrictive, so it owns its application: this one keeps quiet in there and
+  // comes back on the next page the customer visits.
+  const shouldDisplayModal =
+    useCheckModalDisplay(
+      undefined,
+      undefined,
+      undefined,
+      preferenceKey,
+      INTERVAL_BETWEEN_DISPLAY_IN_S,
+      isUserConcernedByBusinessVerification,
+      [accountEditionLink],
+    ) && !isOnInvoicesApplication(applications);
 
   const [showModal, setShowModal] = useState(shouldDisplayModal);
   const { data: time } = useTime({ enabled: Boolean(shouldDisplayModal) });

--- a/packages/manager/apps/container/src/components/company-information-modal/CompanyInformationModal.spec.tsx
+++ b/packages/manager/apps/container/src/components/company-information-modal/CompanyInformationModal.spec.tsx
@@ -5,11 +5,16 @@ import * as usePreferencesModule from '@/data/hooks/preferences/usePreferences';
 import * as useTimeModule from '@/data/hooks/time/useTime';
 import CompanyInformationModal from '@/components/company-information-modal/CompanyInformationModal.component';
 
+// 14 digits with a Luhn checksum that adds up, and one that does not
+const VALID_SIRET = '98471504500014';
+const LUHN_INVALID_SIRET = '12345678901234';
+
 const mocks = vi.hoisted(() => ({
   user: {
     legalform: 'corporation',
     country: 'FR',
     certificates: ['fr-e-invoicing-warning'],
+    companyNationalIdentificationNumber: '98471504500014',
   },
   businessVerificationRequired: true,
 }));
@@ -44,6 +49,9 @@ vi.mock('@/context', () => ({
                 getApplicationURL: vi.fn(
                   (app) => `https://fake-manager.com/manager/${app}`,
                 ),
+                getApplications: vi.fn(() => ({
+                  billing: { container: { path: 'billing' } },
+                })),
                 getUser: vi.fn(() => mocks.user),
               }),
             };
@@ -76,6 +84,7 @@ describe('CompanyInformationModal', () => {
     mocks.user.legalform = 'corporation';
     mocks.user.country = 'FR';
     mocks.user.certificates = ['fr-e-invoicing-warning'];
+    mocks.user.companyNationalIdentificationNumber = VALID_SIRET;
     mocks.businessVerificationRequired = true;
     Object.defineProperty(window, 'location', {
       value: {
@@ -190,6 +199,186 @@ describe('CompanyInformationModal', () => {
     await waitFor(() => {
       expect(queryByText('company_information_modal_review_action_modify')).not.toBeNull();
       expect(queryByText('company_information_modal_action_modify')).toBeNull();
+    });
+  });
+
+  it.each([
+    ['an empty SIRET', ''],
+    ['a SIRET shorter than 14 digits', '984715045'],
+    ['a non numeric SIRET', '9847150450001A'],
+    ['a SIRET failing the Luhn checksum', LUHN_INVALID_SIRET],
+  ])('should render for a B2B account holding no certificate but %s', async (_, siret) => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = siret;
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('company-information-modal')).not.toBeNull();
+    });
+  });
+
+  it.each([
+    'individual',
+    'personalcorporation',
+    'other',
+    'association',
+    'administration',
+  ])(
+    'should not render for the %s legal form even with an invalid SIRET',
+    async (legalform) => {
+      mocks.user.certificates = [];
+      mocks.user.legalform = legalform;
+      mocks.user.companyNationalIdentificationNumber = '';
+
+      const { queryByTestId } = renderComponent();
+
+      await waitFor(() => {
+        expect(queryByTestId('company-information-modal')).toBeNull();
+      });
+    },
+  );
+
+  it.each(['FR', 'GP', 'MQ', 'RE'])(
+    'should render for a %s account with an invalid SIRET',
+    async (country) => {
+      mocks.user.certificates = [];
+      mocks.user.country = country;
+      mocks.user.companyNationalIdentificationNumber = '';
+
+      const { queryByTestId } = renderComponent();
+
+      await waitFor(() => {
+        expect(queryByTestId('company-information-modal')).not.toBeNull();
+      });
+    },
+  );
+
+  it.each(['GF', 'YT', 'BL', 'PM'])(
+    'should render for a %s account on its certificate, not on its SIRET',
+    async (country) => {
+      mocks.user.country = country;
+      mocks.user.companyNationalIdentificationNumber = '';
+      mocks.user.certificates = ['fr-e-invoicing-critical'];
+
+      const { queryByTestId, queryByText } = renderComponent();
+
+      await waitFor(() => {
+        expect(queryByTestId('company-information-modal')).not.toBeNull();
+        expect(queryByText('company_information_modal_action_modify')).not.toBeNull();
+      });
+    },
+  );
+
+  it.each(['GF', 'YT', 'BL', 'PM'])(
+    'should not render for a %s account whose only problem is its SIRET',
+    async (country) => {
+      mocks.user.certificates = [];
+      mocks.user.country = country;
+      mocks.user.companyNationalIdentificationNumber = '';
+
+      const { queryByTestId } = renderComponent();
+
+      await waitFor(() => {
+        expect(queryByTestId('company-information-modal')).toBeNull();
+      });
+    },
+  );
+
+  it('should not render for a B2B account holding a valid SIRET and no certificate', async () => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = VALID_SIRET;
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('company-information-modal')).toBeNull();
+    });
+  });
+
+  it('should display the siret content for an account holding no certificate', async () => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = '';
+
+    const { queryByText } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByText('company_information_modal_siret_action_modify')).not.toBeNull();
+      expect(queryByText('company_information_modal_action_modify')).toBeNull();
+      expect(queryByText('company_information_modal_review_action_modify')).toBeNull();
+    });
+  });
+
+  it.each([
+    ['fr-e-invoicing-warning', 'company_information_modal_action_modify'],
+    ['fr-e-invoicing-critical', 'company_information_modal_action_modify'],
+    ['fr-e-invoicing-account-to-review', 'company_information_modal_review_action_modify'],
+  ])('should let the %s certificate content win over the siret one', async (certificate, expectedKey) => {
+    mocks.user.certificates = [certificate];
+    mocks.user.companyNationalIdentificationNumber = '';
+
+    const { queryByText } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByText(expectedKey)).not.toBeNull();
+      expect(queryByText('company_information_modal_siret_action_modify')).toBeNull();
+    });
+  });
+
+  it.each([
+    ['the invoices page', '/manager/billing/', '#/history'],
+    ['any other billing page', '/manager/billing', '#/autorenew'],
+  ])('should leave %s to the billing modal', async (_, pathname, hash) => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = '';
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: `https://fake-manager.com${pathname}${hash}`,
+        pathname,
+      },
+      writable: true,
+    });
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('company-information-modal')).toBeNull();
+    });
+  });
+
+  it('should still render outside the billing application', async () => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = '';
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://fake-manager.com/manager/hub/#/',
+        pathname: '/manager/hub/',
+      },
+      writable: true,
+    });
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('company-information-modal')).not.toBeNull();
+    });
+  });
+
+  it('should not mistake an application whose path merely contains billing', async () => {
+    mocks.user.certificates = [];
+    mocks.user.companyNationalIdentificationNumber = '';
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://fake-manager.com/manager/pci-billing/#/',
+        pathname: '/manager/pci-billing/',
+      },
+      writable: true,
+    });
+
+    const { queryByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryByTestId('company-information-modal')).not.toBeNull();
     });
   });
 });

--- a/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.constants.ts
+++ b/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.constants.ts
@@ -1,3 +1,5 @@
+import { Country } from '@ovh-ux/manager-config';
+
 export const INTERVAL_BETWEEN_DISPLAY_IN_S = 60 * 60;
 export const MODAL_NAME = 'CompanyInformationModal';
 export const ELECTRONIC_BILLING_REGULATION_LINK = 'https://www.economie.gouv.fr/tout-savoir-sur-la-facturation-electronique-pour-les-entreprises';
@@ -8,4 +10,46 @@ export const TRACKING_CONTEXT = {
   chapter3: 'user',
   level2: 'Manager-Account',
   page: 'user::pop-up::business_verification_required',
+};
+
+export const ACCOUNT_TO_REVIEW_CERTIFICATE = 'fr-e-invoicing-account-to-review';
+export const E_INVOICING_CERTIFICATES = [
+  'fr-e-invoicing-warning',
+  'fr-e-invoicing-critical',
+  ACCOUNT_TO_REVIEW_CERTIFICATE,
+];
+
+// Certificate variants: mainland France and the overseas territories the reform
+// reaches.
+export const CERTIFICATE_CHECK_COUNTRIES: Country[] = [
+  'FR',
+  'GP',
+  'MQ',
+  'RE',
+  'GF',
+  'YT',
+  'BL',
+  'PM',
+];
+// The SIRET check stops at the territories French VAT applies to, since that is
+// what an electronic invoice is issued against.
+export const SIRET_CHECK_COUNTRIES: Country[] = ['FR', 'GP', 'MQ', 'RE'];
+export const SIRET_REGEX = /^\d{14}$/;
+// A SIRET is a SIREN (9 digits) followed by a NIC (5).
+export const SIREN_LENGTH = 9;
+// La Poste: the one SIREN whose SIRETs carry no Luhn checksum.
+export const LA_POSTE_SIREN = '356000000';
+// Never attributed, and a favourite placeholder.
+export const UNASSIGNED_SIREN = '000000000';
+
+// The billing application carries its own, more restrictive modal on the
+// invoices page (the billing module's eInvoicingWarning): this one steps aside
+// while the customer is in there.
+export const INVOICES_APPLICATION_ID = 'billing';
+
+// The wording depends on why the modal shows up (see getContentKeyPrefix).
+export const CONTENT_KEY_PREFIX = {
+  legacy: 'company_information_modal',
+  review: 'company_information_modal_review',
+  siret: 'company_information_modal_siret',
 };

--- a/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.helpers.spec.tsx
+++ b/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.helpers.spec.tsx
@@ -1,0 +1,166 @@
+import { User } from '@ovh-ux/manager-config';
+import {
+  getContentKeyPrefix,
+  isConcernedByInvalidSiret,
+  isSiretValid,
+  isUserConcernedByBusinessVerification,
+} from './companyInformationModal.helpers';
+
+const buildUser = (user: Partial<User>) =>
+  ({
+    legalform: 'corporation',
+    country: 'FR',
+    certificates: [],
+    companyNationalIdentificationNumber: '98471504500014',
+    ...user,
+  } as User);
+
+describe('isSiretValid', () => {
+  it.each(['98471504500014', '44306184100047'])(
+    'should accept the 14 digits of %s adding up to a Luhn checksum',
+    (siret) => {
+      expect(isSiretValid(siret)).toBe(true);
+    },
+  );
+
+  it('should accept a La Poste SIRET, which carries no Luhn checksum', () => {
+    expect(isSiretValid('35600000009075')).toBe(true);
+  });
+
+  it('should reject a La Poste SIRET whose digits do not add up to a multiple of 5', () => {
+    expect(isSiretValid('35600000009076')).toBe(false);
+  });
+
+  it.each([
+    ['an empty value', ''],
+    ['a missing value', undefined],
+    ['fewer than 14 digits', '984715045'],
+    ['more than 14 digits', '984715045000141'],
+    ['a letter', '9847150450001A'],
+    ['a formatted SIRET', '984 715 045 00014'],
+    ['a broken Luhn checksum', '12345678901234'],
+    ['a valid 14-digit checksum over an invalid SIREN', '12345678000006'],
+    ['a zeroed SIREN, which passes Luhn trivially', '00000000000000'],
+  ])('should reject %s', (_, siret) => {
+    expect(isSiretValid(siret)).toBe(false);
+  });
+});
+
+describe('isConcernedByInvalidSiret', () => {
+  it('should catch a company without a valid SIRET', () => {
+    const user = buildUser({ companyNationalIdentificationNumber: '' });
+
+    expect(isConcernedByInvalidSiret(user)).toBe(true);
+  });
+
+  it.each([
+    'individual',
+    'personalcorporation',
+    'other',
+    'association',
+    'administration',
+  ])('should leave the %s legal form out', (legalform) => {
+    const user = buildUser({
+      legalform: legalform as User['legalform'],
+      companyNationalIdentificationNumber: '',
+    });
+
+    expect(isConcernedByInvalidSiret(user)).toBe(false);
+  });
+
+  it.each(['FR', 'GP', 'MQ', 'RE'])(
+    'should cover the %s customers',
+    (country) => {
+      const user = buildUser({
+        country: country as User['country'],
+        companyNationalIdentificationNumber: '',
+      });
+
+      expect(isConcernedByInvalidSiret(user)).toBe(true);
+    },
+  );
+
+  it.each(['GF', 'YT', 'PM', 'DE'])(
+    'should leave the %s customers out',
+    (country) => {
+      const user = buildUser({
+        country: country as User['country'],
+        companyNationalIdentificationNumber: '',
+      });
+
+      expect(isConcernedByInvalidSiret(user)).toBe(false);
+    },
+  );
+
+  it('should leave an account holding a valid SIRET out', () => {
+    expect(isConcernedByInvalidSiret(buildUser({}))).toBe(false);
+  });
+
+  it('should catch an account whose SIRET was zeroed out', () => {
+    const user = buildUser({
+      companyNationalIdentificationNumber: '00000000000000',
+    });
+
+    expect(isConcernedByInvalidSiret(user)).toBe(true);
+  });
+});
+
+describe('isUserConcernedByBusinessVerification', () => {
+  it('should keep the certificate holders in', () => {
+    const user = buildUser({ certificates: ['fr-e-invoicing-warning'] });
+
+    expect(isUserConcernedByBusinessVerification(user)).toBe(true);
+  });
+
+  it.each(['FR', 'GP', 'MQ', 'RE', 'GF', 'YT', 'BL', 'PM'])(
+    'should reach a %s certificate holder, beyond the SIRET countries',
+    (country) => {
+      const user = buildUser({
+        country: country as User['country'],
+        certificates: ['fr-e-invoicing-critical'],
+      });
+
+      expect(isUserConcernedByBusinessVerification(user)).toBe(true);
+    },
+  );
+
+  it('should leave a certificate holder outside France out', () => {
+    const user = buildUser({
+      country: 'DE',
+      certificates: ['fr-e-invoicing-critical'],
+    });
+
+    expect(isUserConcernedByBusinessVerification(user)).toBe(false);
+  });
+
+  it('should take in an account without any certificate but with an invalid SIRET', () => {
+    const user = buildUser({ companyNationalIdentificationNumber: '' });
+
+    expect(isUserConcernedByBusinessVerification(user)).toBe(true);
+  });
+
+  it('should leave out an account without certificate holding a valid SIRET', () => {
+    expect(isUserConcernedByBusinessVerification(buildUser({}))).toBe(false);
+  });
+});
+
+describe('getContentKeyPrefix', () => {
+  it.each([
+    ['fr-e-invoicing-account-to-review', 'company_information_modal_review'],
+    ['fr-e-invoicing-warning', 'company_information_modal'],
+    ['fr-e-invoicing-critical', 'company_information_modal'],
+  ])('should let the %s certificate wording win over the SIRET one', (certificate, expected) => {
+    const user = buildUser({
+      certificates: [certificate],
+      companyNationalIdentificationNumber: '',
+    });
+
+    expect(getContentKeyPrefix(user)).toBe(expected);
+  });
+
+  it('should fall back to the SIRET wording without any certificate', () => {
+    const user = buildUser({ companyNationalIdentificationNumber: '' });
+
+    expect(getContentKeyPrefix(user)).toBe('company_information_modal_siret');
+  });
+});

--- a/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.helpers.tsx
+++ b/packages/manager/apps/container/src/components/company-information-modal/companyInformationModal.helpers.tsx
@@ -1,6 +1,18 @@
 import { getMe } from "@/data/api/me";
 import { User } from "@ovh-ux/manager-config";
 import { useQuery } from "@tanstack/react-query";
+import {
+  ACCOUNT_TO_REVIEW_CERTIFICATE,
+  CERTIFICATE_CHECK_COUNTRIES,
+  CONTENT_KEY_PREFIX,
+  E_INVOICING_CERTIFICATES,
+  INVOICES_APPLICATION_ID,
+  LA_POSTE_SIREN,
+  SIREN_LENGTH,
+  SIRET_CHECK_COUNTRIES,
+  SIRET_REGEX,
+  UNASSIGNED_SIREN,
+} from "./companyInformationModal.constants";
 
 export const useBusinessVerificationRequired = (enabled: boolean) => useQuery({
   queryKey: ['me', 'business-verification-required'],
@@ -9,15 +21,92 @@ export const useBusinessVerificationRequired = (enabled: boolean) => useQuery({
   enabled,
 });
 
-export const isUserConcernedByBusinessVerification = (user: User) =>
-  user.legalform === 'corporation' &&
-  user.country === 'FR' &&
-  (user.certificates?.includes('fr-e-invoicing-warning') ||
-    user.certificates?.includes('fr-e-invoicing-critical') ||
-    user.certificates?.includes('fr-e-invoicing-account-to-review'));
+const isLuhnValid = (digits: string) =>
+  digits
+    .split('')
+    .reverse()
+    .reduce((total, digit, index) => {
+      const value = index % 2 ? Number(digit) * 2 : Number(digit);
+      return total + (value > 9 ? value - 9 : value);
+    }, 0) %
+    10 ===
+  0;
 
-// The modal content depends on the certificate the user holds:
-// - fr-e-invoicing-account-to-review => new "review" content
+const sumOfDigits = (digits: string) =>
+  digits.split('').reduce((total, digit) => total + Number(digit), 0);
+
+// A SIRET is 14 digits: a SIREN and its NIC. Both the SIREN alone and the 14
+// digits as a whole carry a Luhn checksum, and since the two double different
+// positions, passing one says nothing about the other: check both.
+export const isSiretValid = (siret?: string) => {
+  if (!siret || !SIRET_REGEX.test(siret)) {
+    return false;
+  }
+  const siren = siret.slice(0, SIREN_LENGTH);
+  // Luhn cannot catch a zeroed SIREN: its digits add up to 0, which is a
+  // multiple of 10. It is never attributed, so turn it away on its own.
+  if (siren === UNASSIGNED_SIREN) {
+    return false;
+  }
+  if (!isLuhnValid(siren)) {
+    return false;
+  }
+  // La Poste is the documented exception: no Luhn on its SIRETs, their digits
+  // add up to a multiple of 5 instead. Accept either rather than hold a real
+  // customer's invoices back on a checksum they were never meant to carry.
+  if (siret.startsWith(LA_POSTE_SIREN)) {
+    return sumOfDigits(siret) % 5 === 0 || isLuhnValid(siret);
+  }
+  return isLuhnValid(siret);
+};
+
+// The container gives each application the first path segment after its base
+// (see core/routing/iframe-app-router): '/manager/billing/#/history' in
+// production, '/billing/#/history' in development. Comparing that segment
+// beats comparing whole URLs, which differ between the two.
+export const isOnInvoicesApplication = (
+  applications: Record<string, { container?: { path?: string } }>,
+) => {
+  const path =
+    applications?.[INVOICES_APPLICATION_ID]?.container?.path ||
+    INVOICES_APPLICATION_ID;
+  const { pathname } = new URL(window.location.href);
+  return pathname.replace(/\/+$/, '').endsWith(`/${path}`);
+};
+
+const hasEInvoicingCertificate = (user: User) =>
+  E_INVOICING_CERTIFICATES.some((certificate) =>
+    user.certificates?.includes(certificate),
+  );
+
+// Companies the API flagged with an e-invoicing certificate.
+const isConcernedByCertificate = (user: User) =>
+  user.legalform === 'corporation' &&
+  CERTIFICATE_CHECK_COUNTRIES.includes(user.country) &&
+  hasEInvoicingCertificate(user);
+
+// Certificate-free audience: companies whose SIRET is missing or malformed —
+// nothing to bill electronically with, so they have to fill it in. Narrower
+// than the certificates on countries, same legal form.
+export const isConcernedByInvalidSiret = (user: User) =>
+  user.legalform === 'corporation' &&
+  SIRET_CHECK_COUNTRIES.includes(user.country) &&
+  !isSiretValid(user.companyNationalIdentificationNumber);
+
+export const isUserConcernedByBusinessVerification = (user: User) =>
+  isConcernedByCertificate(user) || isConcernedByInvalidSiret(user);
+
+// The modal content depends on why it shows up, a certificate always taking
+// precedence over the SIRET check:
+// - fr-e-invoicing-account-to-review => "review" content
 // - fr-e-invoicing-warning / fr-e-invoicing-critical => legacy content
-export const isConcernedByAccountToReview = (user: User) =>
-  Boolean(user.certificates?.includes('fr-e-invoicing-account-to-review'));
+// - no certificate at all (invalid SIRET only) => "siret" content
+export const getContentKeyPrefix = (user: User) => {
+  if (user.certificates?.includes(ACCOUNT_TO_REVIEW_CERTIFICATE)) {
+    return CONTENT_KEY_PREFIX.review;
+  }
+  if (hasEInvoicingCertificate(user)) {
+    return CONTENT_KEY_PREFIX.legacy;
+  }
+  return CONTENT_KEY_PREFIX.siret;
+};

--- a/packages/manager/apps/container/src/hooks/modal/useModal.spec.tsx
+++ b/packages/manager/apps/container/src/hooks/modal/useModal.spec.tsx
@@ -57,6 +57,20 @@ describe('useModal', () => {
       )).toEqual(false);
     });
 
+    it('should exclude a url carrying its own query params', () => {
+      const excludedUrl = 'https://fake-manager.com/manager/dedicated/#/billing/history';
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: `${excludedUrl}?page=1&sort=date`,
+        },
+        writable: true,
+      });
+      expect(useCheckModalDisplaySynchronous(
+        undefined,
+        [excludedUrl],
+      )).toEqual(false);
+    });
+
     it('should return false if included urls check is not validated', () => {
       Object.defineProperty(window, 'location', {
         value: {
@@ -91,7 +105,7 @@ describe('useModal', () => {
     it('should skip following tests if any previous fails', () => {
       const excludedUrls = ['https://fake-manager.com/manager/billing/#/autorenew/agreements'];
       const includedUrls = ['https://fake-manager.com/manager/account/#/useraccount/info'];
-      const excludedUrlsCheckSpy = vi.spyOn(excludedUrls, 'indexOf');
+      const excludedUrlsCheckSpy = vi.spyOn(excludedUrls, 'some');
       const includedUrlsCheckSpy = vi.spyOn(includedUrls, 'indexOf');
       useCheckModalDisplaySynchronous(
         (user: User) => user.kycValidated,

--- a/packages/manager/apps/container/src/hooks/modal/useModal.tsx
+++ b/packages/manager/apps/container/src/hooks/modal/useModal.tsx
@@ -21,7 +21,9 @@ export const useCheckModalDisplaySynchronous = (
     return false;
   }
 
-  if (excludedUrls?.length && excludedUrls.indexOf(window.location.href) !== -1) {
+  // The page being displayed carries its own query params (a filter, a field to
+  // focus): an excluded URL matches the current location as a prefix.
+  if (excludedUrls?.length && excludedUrls.some((url) => window.location.href.startsWith(url))) {
     return false;
   }
 

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_de_DE.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_de_DE.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "Ich bin eine Privatperson",
   "company_information_modal_info_individual": "Wenn Ihr Konto kein Unternehmen ist, gehen Sie zum Formular zur Bearbeitung Ihres Profils und ändern Sie den Kontotyp auf „Privatperson“.",
   "company_information_modal_review_title": "EIN KLICK ZUR BESTÄTIGUNG IHRER DATEN",
-  "company_information_modal_review_description": "Die elektronische Rechnungsstellung wird in Frankreich ab dem 1. September 2026 obligatorisch (<anchor>alles über die elektronische Rechnungsstellung erfahren</anchor>). Um die Konformität Ihrer zukünftigen Rechnungen zu gewährleisten, bestätigen Sie bitte Ihre Rechnungsdaten durch Eingabe Ihrer SIRET-Nummer. Wir kümmern uns um den Rest.",
-  "company_information_modal_review_action_modify": "Meine SIRET-Nummer überprüfen"
+  "company_information_modal_review_description": "Die elektronische Rechnungsstellung ist in Frankreich seit dem 1. September 2026 obligatorisch (<anchor>alles Wissenswerte zur elektronischen Rechnungsstellung</anchor>). Um die Konformität Ihrer nächsten Rechnungen zu gewährleisten, bestätigen Sie bitte Ihre Rechnungsdaten durch Angabe Ihrer SIRET-Nummer. Wir kümmern uns um den Rest.",
+  "company_information_modal_review_action_modify": "Meine SIRET-Nummer überprüfen",
+  "company_information_modal_siret_title": "OBLIGATORISCHE AKTION",
+  "company_information_modal_siret_description": "Die elektronische Rechnungsstellung ist in Frankreich seit dem 1. September 2026 obligatorisch (<anchor>alles Wissenswerte zur elektronischen Rechnungsstellung</anchor>). Um die Konformität Ihrer nächsten Rechnungen zu gewährleisten, bestätigen Sie bitte Ihre Rechnungsdaten durch Angabe Ihrer SIRET-Nummer. Wir kümmern uns um den Rest.",
+  "company_information_modal_siret_action_modify": "Meine Daten eingeben"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_en_GB.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_en_GB.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "I’m an individual",
   "company_information_modal_info_individual": "If your account is not a business, please go to the profile editing form and change the account type to 'Individual'.",
   "company_information_modal_review_title": "ONE CLICK TO CONFIRM YOUR DATA",
-  "company_information_modal_review_description": "Electronic invoicing becomes mandatory in France from 1 September 2026 (<anchor>find out all about electronic invoicing</anchor>). To ensure the compliance of your future invoices, please confirm your billing data by entering your SIRET number. We take care of the rest.",
-  "company_information_modal_review_action_modify": "Verify my SIRET"
+  "company_information_modal_review_description": "Electronic invoicing has been mandatory in France since 1 September 2026 (<anchor>find out everything about electronic invoicing</anchor>). To ensure the compliance of your future invoices, please confirm your billing details by entering your SIRET number. We take care of the rest.",
+  "company_information_modal_review_action_modify": "Verify my SIRET",
+  "company_information_modal_siret_title": "MANDATORY ACTION",
+  "company_information_modal_siret_description": "Electronic invoicing has been mandatory in France since 1 September 2026 (<anchor>find out everything about electronic invoicing</anchor>). To ensure the compliance of your future invoices, please confirm your billing details by entering your SIRET number. We take care of the rest.",
+  "company_information_modal_siret_action_modify": "Enter my details"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_es_ES.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_es_ES.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "Soy un particular",
   "company_information_modal_info_individual": "Si vuestra cuenta no es una empresa, id al formulario de edición de vuestro perfil y modificad el tipo de cuenta a « Particular ».",
   "company_information_modal_review_title": "UN CLIC PARA CONFIRMAR SUS DATOS",
-  "company_information_modal_review_description": "La facturación electrónica será obligatoria en Francia a partir del 1 de septiembre de 2026 (<anchor>todo sobre la facturación electrónica</anchor>). Para garantizar la conformidad de sus próximas facturas, confirme sus datos de facturación facilitando su número de SIRET. ¡nosotros nos encargamos del resto!",
-  "company_information_modal_review_action_modify": "Verificar mi SIRET"
+  "company_information_modal_review_description": "La facturación electrónica es obligatoria en Francia desde el 1 de septiembre de 2026 (<anchor>todo lo que debe saber sobre la facturación electrónica</anchor>). Para garantizar la conformidad de sus próximas facturas, le rogamos que confirme sus datos de facturación indicando su número de SIRET. ¡nosotros nos encargamos del resto!",
+  "company_information_modal_review_action_modify": "Verificar mi SIRET",
+  "company_information_modal_siret_title": "ACCIÓN OBLIGATORIA",
+  "company_information_modal_siret_description": "La facturación electrónica es obligatoria en Francia desde el 1 de septiembre de 2026 (<anchor>todo lo que debe saber sobre la facturación electrónica</anchor>). Para garantizar la conformidad de sus próximas facturas, le rogamos que confirme sus datos de facturación indicando su número de SIRET. ¡nosotros nos encargamos del resto!",
+  "company_information_modal_siret_action_modify": "Indicar mis datos"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_fr_CA.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_fr_CA.json
@@ -3,6 +3,9 @@
   "company_information_modal_description": "Des informations concernant votre organisation sont non conformes. La mise à jour de celles-ci est obligatoire dans le cadre de la réforme de la facturation électronique <anchor>tout savoir sur la facturation électronique</anchor>. Renseignez votre SIRET, nous nous chargeons du reste.",
   "company_information_modal_action_modify": "Mettre à jour mes données",
   "company_information_modal_review_title": "UN CLIC POUR CONFIRMER VOS DONNÉES",
-  "company_information_modal_review_description": "La facturation électronique devient obligatoire en France à partir du 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
-  "company_information_modal_review_action_modify": "Vérifier mon SIRET"
+  "company_information_modal_review_description": "La facturation électronique est obligatoire en France depuis le 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
+  "company_information_modal_review_action_modify": "Vérifier mon SIRET",
+  "company_information_modal_siret_title": "ACTION OBLIGATOIRE",
+  "company_information_modal_siret_description": "La facturation électronique est obligatoire en France depuis le 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
+  "company_information_modal_siret_action_modify": "Renseignez mes données"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_fr_FR.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_fr_FR.json
@@ -3,6 +3,9 @@
   "company_information_modal_description": "Des informations concernant votre organisation sont non conformes. La mise à jour de celles-ci est obligatoire dans le cadre de la réforme de la facturation électronique <anchor>tout savoir sur la facturation électronique</anchor>. Renseignez votre SIRET, nous nous chargeons du reste.",
   "company_information_modal_action_modify": "Mettre à jour mes données",
   "company_information_modal_review_title": "UN CLIC POUR CONFIRMER VOS DONNÉES",
-  "company_information_modal_review_description": "La facturation électronique devient obligatoire en France à partir du 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
-  "company_information_modal_review_action_modify": "Vérifier mon SIRET"
+  "company_information_modal_review_description": "La facturation électronique est obligatoire en France depuis le 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
+  "company_information_modal_review_action_modify": "Vérifier mon SIRET",
+  "company_information_modal_siret_title": "ACTION OBLIGATOIRE",
+  "company_information_modal_siret_description": "La facturation électronique est obligatoire en France depuis le 1er septembre 2026 (<anchor>tout savoir sur la facturation électronique</anchor>). Pour assurer la conformité de vos prochaines factures, veuillez confirmer vos données de facturation en renseignant votre numéro de SIRET. Nous nous chargeons du reste.",
+  "company_information_modal_siret_action_modify": "Renseignez mes données"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_it_IT.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_it_IT.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "Sono un privato",
   "company_information_modal_info_individual": "Se il vostro account non è un'azienda, recatevi sul modulo di modifica del vostro profilo e cambiate il tipo di account in « Privato ».",
   "company_information_modal_review_title": "UN CLIC PER CONFERMARE I SUOI DATI",
-  "company_information_modal_review_description": "La fatturazione elettronica diventa obbligatoria in Francia a partire dal 1° settembre 2026 (<anchor>tutto sulla fatturazione elettronica</anchor>). Per garantire la conformità delle Sue prossime fatture, La preghiamo di confermare i Suoi dati di fatturazione inserendo il Suo numero di SIRET. Al resto pensiamo noi.",
-  "company_information_modal_review_action_modify": "Verificare il mio SIRET"
+  "company_information_modal_review_description": "La fatturazione elettronica è obbligatoria in Francia dal 1° settembre 2026 (<anchor>tutto quello che c'è da sapere sulla fatturazione elettronica</anchor>). Per garantire la conformità delle vostre prossime fatture, siete pregati di confermare i vostri dati di fatturazione inserendo il vostro numero SIRET. Al resto pensiamo noi.",
+  "company_information_modal_review_action_modify": "Verificare il mio SIRET",
+  "company_information_modal_siret_title": "AZIONE OBBLIGATORIA",
+  "company_information_modal_siret_description": "La fatturazione elettronica è obbligatoria in Francia dal 1° settembre 2026 (<anchor>tutto quello che c'è da sapere sulla fatturazione elettronica</anchor>). Per garantire la conformità delle vostre prossime fatture, siete pregati di confermare i vostri dati di fatturazione inserendo il vostro numero SIRET. Al resto pensiamo noi.",
+  "company_information_modal_siret_action_modify": "Inserisci i miei dati"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_pl_PL.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_pl_PL.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "Jestem osobą prywatną",
   "company_information_modal_info_individual": "Jeśli Twoje konto nie jest kontem firmowym, przejdź do formularza edycji swojego profilu i zmień typ konta na „Osoba fizyczna”.",
   "company_information_modal_review_title": "JEDNO KLIKNIĘCIE, ABY POTWIERDZIĆ SWOJE DANE",
-  "company_information_modal_review_description": "Fakturowanie elektroniczne staje się obowiązkowe we Francji od 1 września 2026 r. (<anchor>dowiedz się więcej o fakturowaniu elektronicznym</anchor>). Aby zapewnić zgodność swoich przyszłych faktur, potwierdź swoje dane rozliczeniowe, podając swój numer SIRET. Kolejne zadania są już po naszej stronie.",
-  "company_information_modal_review_action_modify": "Zweryfikuj mój numer SIRET"
+  "company_information_modal_review_description": "Fakturowanie elektroniczne jest we Francji obowiązkowe od 1 września 2026 r. (<anchor>dowiedz się wszystkiego o fakturowaniu elektronicznym</anchor>). Aby zapewnić zgodność swoich przyszłych faktur, prosimy o potwierdzenie danych rozliczeniowych poprzez podanie numeru SIRET. Kolejne zadania są już po naszej stronie.",
+  "company_information_modal_review_action_modify": "Zweryfikuj mój numer SIRET",
+  "company_information_modal_siret_title": "DZIAŁANIE OBOWIĄZKOWE",
+  "company_information_modal_siret_description": "Fakturowanie elektroniczne jest we Francji obowiązkowe od 1 września 2026 r. (<anchor>dowiedz się wszystkiego o fakturowaniu elektronicznym</anchor>). Aby zapewnić zgodność swoich przyszłych faktur, prosimy o potwierdzenie danych rozliczeniowych poprzez podanie numeru SIRET. Kolejne zadania są już po naszej stronie.",
+  "company_information_modal_siret_action_modify": "Wypełnij moje dane"
 }

--- a/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_pt_PT.json
+++ b/packages/manager/apps/container/src/public/translations/company-information-modal/Messages_pt_PT.json
@@ -5,6 +5,9 @@
   "company_information_modal_action_individual": "Sou um particular",
   "company_information_modal_info_individual": "Se a sua conta não for uma empresa, dirija-se ao formulário de edição do seu perfil e altere o tipo de conta para «Particular». ",
   "company_information_modal_review_title": "UM CLIQUE PARA CONFIRMAR OS SEUS DADOS",
-  "company_information_modal_review_description": "A faturação eletrónica torna-se obrigatória em França a partir de 1 de setembro de 2026 (<anchor>saiba tudo sobre a faturação eletrónica</anchor>). Para garantir a conformidade das suas próximas faturas, confirme os seus dados de faturação indicando o seu número de SIRET. A OVHcloud trata do resto.",
-  "company_information_modal_review_action_modify": "Verificar o meu SIRET"
+  "company_information_modal_review_description": "A faturação eletrónica é obrigatória em França desde 1 de setembro de 2026 (<anchor>saiba tudo sobre a faturação eletrónica</anchor>). Para assegurar a conformidade das suas próximas faturas, confirme os seus dados de faturação indicando o seu número de SIRET. A OVHcloud trata do resto.",
+  "company_information_modal_review_action_modify": "Verificar o meu SIRET",
+  "company_information_modal_siret_title": "AÇÃO OBRIGATÓRIA",
+  "company_information_modal_siret_description": "A faturação eletrónica é obrigatória em França desde 1 de setembro de 2026 (<anchor>saiba tudo sobre a faturação eletrónica</anchor>). Para assegurar a conformidade das suas próximas faturas, confirme os seus dados de faturação indicando o seu número de SIRET. A OVHcloud trata do resto.",
+  "company_information_modal_siret_action_modify": "Preencher os meus dados"
 }

--- a/packages/manager/modules/billing/package.json
+++ b/packages/manager/modules/billing/package.json
@@ -13,7 +13,9 @@
   "main": "./src/index.js",
   "scripts": {
     "lint": "manager-legacy-lint --kinds tsx,js,css,html,md --continue",
-    "lint:fix": "manager-legacy-lint --kinds tsx,js,css,html,md --fix --continue"
+    "lint:fix": "manager-legacy-lint --kinds tsx,js,css,html,md --fix --continue",
+    "test": "manager-test run",
+    "test:coverage": "manager-test run --coverage"
   },
   "dependencies": {
     "@module-federation/runtime": "0.8.12",
@@ -26,7 +28,8 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@ovh-ux/manager-static-analysis-legacy-kit": "^0.1.0"
+    "@ovh-ux/manager-static-analysis-legacy-kit": "^0.1.0",
+    "@ovh-ux/manager-tests-setup": "^0.8.0"
   },
   "peerDependencies": {
     "@ovh-ux/manager-billing-components": "^2.0.0 || ^3.0.0",

--- a/packages/manager/modules/billing/src/main/history/billing-main-history.controller.js
+++ b/packages/manager/modules/billing/src/main/history/billing-main-history.controller.js
@@ -117,6 +117,10 @@ export default class BillingMainHistoryCtrl extends ListLayoutHelper.ListLayoutC
   $onInit() {
     this.selectedBills = [];
     this.defaultFilterColumn = 'billId';
+    // A B2B/B2G account without a valid SIRET gets no invoice through an
+    // approved platform: say so on arrival, not only once a download is
+    // attempted.
+    this.showEInvoicingWarningModal = !this.canDownloadInvoices;
 
     super.$onInit();
 

--- a/packages/manager/modules/billing/src/main/history/billing-main-history.helpers.js
+++ b/packages/manager/modules/billing/src/main/history/billing-main-history.helpers.js
@@ -1,0 +1,59 @@
+// Mainland France, Guadeloupe, Martinique and Réunion: the audience the
+// container's company information modal covers for the same check.
+const SIRET_COUNTRIES = ['FR', 'GP', 'MQ', 'RE'];
+const SIRET_REGEX = /^\d{14}$/;
+// A SIRET is a SIREN (9 digits) followed by a NIC (5).
+const SIREN_LENGTH = 9;
+// La Poste: the one SIREN whose SIRETs carry no Luhn checksum.
+const LA_POSTE_SIREN = '356000000';
+// Never attributed, and a favourite placeholder.
+const UNASSIGNED_SIREN = '000000000';
+
+const isLuhnValid = (digits) =>
+  digits
+    .split('')
+    .reverse()
+    .reduce((total, digit, index) => {
+      const value = index % 2 ? Number(digit) * 2 : Number(digit);
+      return total + (value > 9 ? value - 9 : value);
+    }, 0) %
+    10 ===
+  0;
+
+const sumOfDigits = (digits) =>
+  digits.split('').reduce((total, digit) => total + Number(digit), 0);
+
+// A SIRET is 14 digits: a SIREN and its NIC. Both the SIREN alone and the 14
+// digits as a whole carry a Luhn checksum, and since the two double different
+// positions, passing one says nothing about the other: check both.
+export const isSiretValid = (siret) => {
+  if (!siret || !SIRET_REGEX.test(siret)) {
+    return false;
+  }
+  const siren = siret.slice(0, SIREN_LENGTH);
+  // Luhn cannot catch a zeroed SIREN: its digits add up to 0, which is a
+  // multiple of 10. It is never attributed, so turn it away on its own.
+  if (siren === UNASSIGNED_SIREN) {
+    return false;
+  }
+  if (!isLuhnValid(siren)) {
+    return false;
+  }
+  // La Poste is the documented exception: no Luhn on its SIRETs, their digits
+  // add up to a multiple of 5 instead. Accept either rather than hold a real
+  // customer's invoices back on a checksum they were never meant to carry.
+  if (siret.startsWith(LA_POSTE_SIREN)) {
+    return sumOfDigits(siret) % 5 === 0 || isLuhnValid(siret);
+  }
+  return isLuhnValid(siret);
+};
+
+// These companies owe a SIRET: without a valid one their invoices cannot be
+// issued through an approved platform, so the PDF stays out of reach until they
+// fill it in. Kept in sync with the container's company information modal
+// (apps/container/src/components/company-information-modal), which decides on
+// the same audience.
+export const isSiretMissingOrInvalid = (user) =>
+  user.legalform === 'corporation' &&
+  SIRET_COUNTRIES.includes(user.country) &&
+  !isSiretValid(user.companyNationalIdentificationNumber);

--- a/packages/manager/modules/billing/src/main/history/billing-main-history.helpers.spec.js
+++ b/packages/manager/modules/billing/src/main/history/billing-main-history.helpers.spec.js
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSiretMissingOrInvalid,
+  isSiretValid,
+} from './billing-main-history.helpers';
+
+// 14 digits whose Luhn checksum adds up, and one that does not
+const VALID_SIRET = '98471504500014';
+const LUHN_INVALID_SIRET = '12345678901234';
+// passes the Luhn of its 14 digits, but its SIREN 123456780 does not
+const BAD_SIREN_SIRET = '12345678000006';
+// La Poste, no Luhn: its digits add up to a multiple of 5
+const LA_POSTE_SIRET = '35600000009075';
+
+const buildUser = (user) => ({
+  legalform: 'corporation',
+  country: 'FR',
+  companyNationalIdentificationNumber: VALID_SIRET,
+  ...user,
+});
+
+describe('isSiretValid', () => {
+  it.each([VALID_SIRET, '44306184100047'])(
+    'accepts the 14 digits of %s adding up to a Luhn checksum',
+    (siret) => {
+      expect(isSiretValid(siret)).toBe(true);
+    },
+  );
+
+  it.each([
+    ['an empty value', ''],
+    ['a missing value', undefined],
+    ['fewer than 14 digits', '984715045'],
+    ['more than 14 digits', '984715045000141'],
+    ['a letter', '9847150450001A'],
+    ['a formatted SIRET', '984 715 045 00014'],
+    ['a broken Luhn checksum', LUHN_INVALID_SIRET],
+    ['a valid 14-digit checksum over an invalid SIREN', BAD_SIREN_SIRET],
+    ['a zeroed SIREN, which passes Luhn trivially', '00000000000000'],
+  ])('rejects %s', (_, siret) => {
+    expect(isSiretValid(siret)).toBe(false);
+  });
+
+  it('accepts a La Poste SIRET, which carries no Luhn checksum', () => {
+    expect(isSiretValid(LA_POSTE_SIRET)).toBe(true);
+  });
+
+  it('rejects a La Poste SIRET whose digits do not add up to a multiple of 5', () => {
+    expect(isSiretValid('35600000009076')).toBe(false);
+  });
+});
+
+describe('isSiretMissingOrInvalid', () => {
+  it('holds the invoices of a company without a SIRET back', () => {
+    const user = buildUser({ companyNationalIdentificationNumber: '' });
+
+    expect(isSiretMissingOrInvalid(user)).toBe(true);
+  });
+
+  it.each([
+    ['failing its checksum', LUHN_INVALID_SIRET],
+    ['built on an invalid SIREN', BAD_SIREN_SIRET],
+    ['zeroed out', '00000000000000'],
+  ])('holds the invoices back on a SIRET %s', (_, siret) => {
+    const user = buildUser({ companyNationalIdentificationNumber: siret });
+
+    expect(isSiretMissingOrInvalid(user)).toBe(true);
+  });
+
+  it('lets a La Poste establishment through', () => {
+    const user = buildUser({
+      companyNationalIdentificationNumber: LA_POSTE_SIRET,
+    });
+
+    expect(isSiretMissingOrInvalid(user)).toBe(false);
+  });
+
+  it.each([
+    'individual',
+    'personalcorporation',
+    'other',
+    'association',
+    'administration',
+  ])('leaves the %s legal form alone', (legalform) => {
+    const user = buildUser({
+      legalform,
+      companyNationalIdentificationNumber: '',
+    });
+
+    expect(isSiretMissingOrInvalid(user)).toBe(false);
+  });
+
+  it.each(['FR', 'GP', 'MQ', 'RE'])('covers the %s customers', (country) => {
+    const user = buildUser({
+      country,
+      companyNationalIdentificationNumber: '',
+    });
+
+    expect(isSiretMissingOrInvalid(user)).toBe(true);
+  });
+
+  it.each(['GF', 'YT', 'PM', 'DE'])(
+    'leaves the %s customers alone, SIRET or not',
+    (country) => {
+      const user = buildUser({
+        country,
+        companyNationalIdentificationNumber: '',
+      });
+
+      expect(isSiretMissingOrInvalid(user)).toBe(false);
+    },
+  );
+
+  it('lets a valid SIRET through', () => {
+    expect(isSiretMissingOrInvalid(buildUser({}))).toBe(false);
+  });
+});

--- a/packages/manager/modules/billing/src/main/history/billing-main-history.routes.js
+++ b/packages/manager/modules/billing/src/main/history/billing-main-history.routes.js
@@ -4,6 +4,8 @@ import get from 'lodash/get';
 import omit from 'lodash/omit';
 import partition from 'lodash/partition';
 
+import { isSiretMissingOrInvalid } from './billing-main-history.helpers';
+
 const mapDateFilter = (comparator, value) => {
   switch (comparator) {
     case 'isAfter':
@@ -182,9 +184,7 @@ export default /* @ngInject */ ($stateProvider, coreConfigProvider) => {
             .then((feature) => !feature.isFeatureAvailable(featureName));
         },
         canDownloadInvoices: /* @ngInject */ (currentUser) =>
-          currentUser.country !== 'FR' ||
-          currentUser.legalform !== 'corporation' ||
-          currentUser.companyNationalIdentificationNumber,
+          !isSiretMissingOrInvalid(currentUser),
         breadcrumb: () => null,
         hideBreadcrumb: () => true,
       },

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.controller.js
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.controller.js
@@ -1,13 +1,20 @@
 export default class {
   /* @ngInject */
-  constructor(coreURLBuilder) {
+  constructor($window, coreURLBuilder) {
+    this.$window = $window;
     this.coreURLBuilder = coreURLBuilder;
   }
 
   $onInit() {
     this.siretEditionLink = this.coreURLBuilder.buildURL(
       'account',
-      '#/useraccount/infos?fieldToFocus=ovh_form_content_activity',
+      '#/useraccount/infos?fieldToFocus=siretForm',
     );
+  }
+
+  // The account form lives in another application: leave the manager behind
+  // rather than routing inside billing.
+  goToSiretEdition() {
+    this.$window.top.location.href = this.siretEditionLink;
   }
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.module.js
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.module.js
@@ -6,7 +6,7 @@ import uiRouter from '@uirouter/angularjs';
 
 import component from './e-invoicing-warning.component';
 
-const moduleName = 'ovhManagerBillingMainHistoryPostalMailOptions';
+const moduleName = 'ovhManagerBillingMainHistoryEInvoicingWarning';
 
 angular
   .module(moduleName, [

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.template.html
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/e-invoicing-warning.template.html
@@ -3,12 +3,14 @@
         <div class="modal-content">
             <div class="oui-modal-backdrop"></div>
         </div>
-        <oui-modal data-on-dismiss="$ctrl.close()">
-            <p data-translate="e_invoicing_warning_introduction"></p>
-            <p
-                data-translate="e_invoicing_warning_action"
-                data-translate-values="{ 'href': $ctrl.siretEditionLink }"
-            ></p>
+        <oui-modal
+            data-heading="{{:: 'e_invoicing_warning_title' | translate }}"
+            data-primary-label="{{:: 'e_invoicing_warning_cta' | translate }}"
+            data-primary-action="$ctrl.goToSiretEdition()"
+            data-on-dismiss="$ctrl.close()"
+        >
+            <p data-translate="e_invoicing_warning_description"></p>
+            <p data-translate="e_invoicing_warning_compliance"></p>
         </oui-modal>
     </div>
 </div>

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_de_DE.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_de_DE.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "Sie können Ihre Rechnung derzeit nicht herunterladen. Wir benötigen eine gültige SIRET-Nummer, die mit Ihrem Account verbunden ist, um Rechnungen zu generieren und herunterzuladen. Sobald Ihre SIRET-Nummer aktualisiert ist, können Sie Ihre Rechnungen herunterladen.",
-  "e_invoicing_warning_action": "Sie können Ihre SIRET-Nummer <a href={{href}}>hier</a> aktualisieren."
+  "e_invoicing_warning_action": "Sie können Ihre SIRET-Nummer <a href={{href}}>hier</a> aktualisieren.",
+  "e_invoicing_warning_title": "Rechnung nicht verfügbar: SIRET fehlt",
+  "e_invoicing_warning_description": "Sie haben in Ihrem Kundenbereich keine SIRET-Nummer angegeben. Wir sind daher nicht in der Lage, Ihnen Ihre Rechnungen über eine zugelassene Plattform zuzustellen, wie es die am 1. September 2026 in Kraft getretene Reform der elektronischen Rechnungsstellung vorschreibt.",
+  "e_invoicing_warning_compliance": "Um die Konformität herzustellen, geben Sie bitte Ihre SIRET-Nummer an, damit Sie Ihre PDF-Rechnung herunterladen können.",
+  "e_invoicing_warning_cta": "Meine SIRET-Nummer angeben"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_en_GB.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_en_GB.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "You cannot download your bill at this time. A valid SIRET/company registration number associated with your account is required to generate and download invoices. Once your SIRET/company registration number is updated, your bills will be available for download.",
-  "e_invoicing_warning_action": "Update your SIRET/company registration number <a href={{href}}>here.</a>"
+  "e_invoicing_warning_action": "Update your SIRET/company registration number <a href={{href}}>here.</a>",
+  "e_invoicing_warning_title": "Invoice unavailable: Missing SIRET",
+  "e_invoicing_warning_description": "You have not provided a SIRET in your customer area. We are therefore unable to send you your invoices via an approved platform as required by the electronic invoicing reform that came into force on 1 September 2026.",
+  "e_invoicing_warning_compliance": "In order to comply, please provide your SIRET number so that you can download your PDF invoice.",
+  "e_invoicing_warning_cta": "Provide my SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_es_ES.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_es_ES.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "En este momento no es posible descargar su factura. Necesitamos un número SIRET válido asociado a su cuenta para generar y descargar facturas. Una vez actualizado su número SIRET, podrá descargar sus facturas.",
-  "e_invoicing_warning_action": "Puede actualizar su número SIRET <a href={{href}}>aquí.</a>"
+  "e_invoicing_warning_action": "Puede actualizar su número SIRET <a href={{href}}>aquí.</a>",
+  "e_invoicing_warning_title": "Factura no disponible: Falta el SIRET",
+  "e_invoicing_warning_description": "No ha indicado ningún SIRET en su área de cliente. Por tanto, no podemos enviarle sus facturas a través de una plataforma autorizada, tal y como exige la reforma de la facturación electrónica que entró en vigor el 1 de septiembre de 2026.",
+  "e_invoicing_warning_compliance": "Para ponerse en conformidad, le rogamos que indique su número de SIRET para poder descargar su factura en PDF.",
+  "e_invoicing_warning_cta": "Indicar mi SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_fr_CA.json
@@ -1,4 +1,6 @@
 {
-  "e_invoicing_warning_introduction": "Vous ne pouvez actuellement pas télécharger votre facture. En effet, nous avons besoin d'un numéro SIRET valide associé à votre compte pour générer et télécharger des factures. Une fois votre numéro SIRET mis à jour, vous pourrez télécharger vos factures.",
-  "e_invoicing_warning_action": "Vous pouvez mettre à jour votre numéro SIRET <a href={{href}}>ici.</a>"
+  "e_invoicing_warning_title": "Facture indisponible : SIRET manquant",
+  "e_invoicing_warning_description": "Vous n'avez pas renseigné de SIRET dans votre espace client. Nous ne sommes donc pas en mesure de vous adresser vos factures via une plateforme agréée comme l'exige la réforme de la facturation électronique entrée en vigueur le 1er septembre 2026.",
+  "e_invoicing_warning_compliance": "Afin de vous mettre en conformité, veuillez renseigner votre numéro de SIRET afin de pouvoir télécharger votre facture PDF.",
+  "e_invoicing_warning_cta": "Renseigner mon SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_fr_FR.json
@@ -1,4 +1,6 @@
 {
-  "e_invoicing_warning_introduction": "Vous ne pouvez actuellement pas télécharger votre facture. En effet, nous avons besoin d'un numéro SIRET valide associé à votre compte pour générer et télécharger des factures. Une fois votre numéro SIRET mis à jour, vous pourrez télécharger vos factures.",
-  "e_invoicing_warning_action": "Vous pouvez mettre à jour votre numéro SIRET <a href={{href}}>ici.</a>"
+  "e_invoicing_warning_title": "Facture indisponible : SIRET manquant",
+  "e_invoicing_warning_description": "Vous n'avez pas renseigné de SIRET dans votre espace client. Nous ne sommes donc pas en mesure de vous adresser vos factures via une plateforme agréée comme l'exige la réforme de la facturation électronique entrée en vigueur le 1er septembre 2026.",
+  "e_invoicing_warning_compliance": "Afin de vous mettre en conformité, veuillez renseigner votre numéro de SIRET afin de pouvoir télécharger votre facture PDF.",
+  "e_invoicing_warning_cta": "Renseigner mon SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_it_IT.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_it_IT.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "Al momento non puoi scaricare la tua fattura. Per generare e scaricare fatture abbiamo infatti bisogno di un numero SIRET valido associato al tuo account. Una volta aggiornato il tuo numero SIRET, potrai scaricare le tue fatture.",
-  "e_invoicing_warning_action": "Puoi aggiornare il tuo numero SIRET <a href={{href}}>qui</a>."
+  "e_invoicing_warning_action": "Puoi aggiornare il tuo numero SIRET <a href={{href}}>qui</a>.",
+  "e_invoicing_warning_title": "Fattura non disponibile: SIRET mancante",
+  "e_invoicing_warning_description": "Non ha inserito un SIRET nel Suo spazio cliente. Non siamo pertanto in grado di inviarLe le fatture tramite una piattaforma accreditata come richiesto dalla riforma della fatturazione elettronica entrata in vigore il 1° settembre 2026.",
+  "e_invoicing_warning_compliance": "Per mettersi in regola, La invitiamo a inserire il Suo numero di SIRET per poter scaricare la Sua fattura PDF.",
+  "e_invoicing_warning_cta": "Inserire il mio SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_pl_PL.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "Nie możesz teraz pobrać faktury. Do generowania i pobierania faktur potrzebny jest prawidłowy numer SIRET przypisany do Twojego konta. Po zaktualizowaniu numeru SIRET będziesz mógł pobrać faktury.",
-  "e_invoicing_warning_action": "Numer SIRET zaktualizujesz<a href={{href}}>tutaj.</a>"
+  "e_invoicing_warning_action": "Numer SIRET zaktualizujesz<a href={{href}}>tutaj.</a>",
+  "e_invoicing_warning_title": "Faktura niedostępna: Brak numeru SIRET",
+  "e_invoicing_warning_description": "Nie podano numeru SIRET w Państwa panelu klienta. W związku z tym nie jesteśmy w stanie przesyłać Państwu faktur za pośrednictwem zatwierdzonej platformy, zgodnie z wymogami reformy fakturowania elektronicznego, która weszła w życie 1 września 2026 r.",
+  "e_invoicing_warning_compliance": "Aby zapewnić zgodność z przepisami, prosimy o podanie numeru SIRET w celu pobrania faktury w formacie PDF.",
+  "e_invoicing_warning_cta": "Podaj mój numer SIRET"
 }

--- a/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/billing/src/main/history/eInvoicingWarning/translations/Messages_pt_PT.json
@@ -1,4 +1,8 @@
 {
   "e_invoicing_warning_introduction": "Atualmente, não pode transferir a sua fatura. Necessitamos de um número SIRET válido associado à sua conta para gerar e transferir faturas. Assim que o número SIRET estiver atualizado, poderá descarregar as suas faturas.",
-  "e_invoicing_warning_action": "Pode atualizar o seu número SIRET <a href={{href}}>aqui.</a>"
+  "e_invoicing_warning_action": "Pode atualizar o seu número SIRET <a href={{href}}>aqui.</a>",
+  "e_invoicing_warning_title": "Fatura indisponível: SIRET em falta",
+  "e_invoicing_warning_description": "Não indicou um SIRET na sua área de cliente. Não estamos, portanto, em condições de lhe enviar as suas faturas através de uma plataforma certificada, conforme exigido pela reforma da faturação eletrónica que entrou em vigor a 1 de setembro de 2026.",
+  "e_invoicing_warning_compliance": "Para se colocar em conformidade, por favor indique o seu número de SIRET para poder descarregar a sua fatura em PDF.",
+  "e_invoicing_warning_cta": "Indicar o meu SIRET"
 }

--- a/packages/manager/modules/billing/vitest.config.js
+++ b/packages/manager/modules/billing/vitest.config.js
@@ -1,0 +1,16 @@
+import {
+  createConfig,
+  mergeConfig,
+  sharedConfig,
+} from '@ovh-ux/manager-tests-setup';
+
+export default mergeConfig(
+  sharedConfig,
+  createConfig({
+    test: {
+      coverage: {
+        include: ['src/main/history/**/*.js'],
+      },
+    },
+  }),
+);


### PR DESCRIPTION
## Description

The modal only reached FR corporations the API had already flagged with an e-invoicing certificate. FR B2B/B2G accounts — corporation, association or administration, in FR and the DROM — whose SIRET is missing or fails its Luhn checksum now get it too: there is nothing to bill them electronically with, so they have to fill it in.

getContentKeyPrefix replaces isConcernedByAccountToReview and picks between the three wordings, a certificate always taking precedence over the SIRET check. The new "siret" variant lands in the 8 locales.

Also carries a temporary debug change in new-account-form-controller.js that appends TEST to the e-invoicing address so PUT /me rejects it, to exercise the stale-address path against the real API. It is marked DO NOT COMMIT in place and has to go before review.


Ticket Reference:  #MANAGER-22233

## Additional Information

