### PR TITLE
feat(hub): change support widget for Digital Agent API (FR only) + links for fr

### DIFF
--- a/packages/manager/apps/container/src/container/common/digital-agent.spec.ts
+++ b/packages/manager/apps/container/src/container/common/digital-agent.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { DIGITAL_AGENT_URL, isDigitalAgentEnabled } from './digital-agent';
+
+describe('digital-agent', () => {
+  it('targets the Manager V7 digital agent', () => {
+    expect(DIGITAL_AGENT_URL).toBe('/beta/#/support/digital-agent');
+  });
+
+  it('is enabled for FR customers on the EU manager', () => {
+    expect(isDigitalAgentEnabled('EU', 'FR')).toBe(true);
+  });
+
+  it('is disabled for the other subsidiaries of the EU manager', () => {
+    ['GB', 'DE', 'ES', 'IT', 'PL', 'PT', 'MA', 'SN', 'TN', 'NL', 'IE'].forEach(
+      (subsidiary) => {
+        expect(isDigitalAgentEnabled('EU', subsidiary)).toBe(false);
+      },
+    );
+  });
+
+  it('is disabled on the other managers', () => {
+    expect(isDigitalAgentEnabled('CA', 'FR')).toBe(false);
+    expect(isDigitalAgentEnabled('US', 'FR')).toBe(false);
+  });
+});

--- a/packages/manager/apps/container/src/container/common/digital-agent.ts
+++ b/packages/manager/apps/container/src/container/common/digital-agent.ts
@@ -1,0 +1,24 @@
+import { Region } from '@ovh-ux/manager-config';
+
+/**
+ * The Digital Agent is served by the Manager V7, mounted under /beta/ on the
+ * same origin as the V6 manager (same convention as BETA_MANAGER_URL).
+ */
+export const DIGITAL_AGENT_URL = '/beta/#/support/digital-agent';
+
+/** Regions on which the Digital Agent replaces the Help Center entry points. */
+export const DIGITAL_AGENT_REGIONS: string[] = [Region.EU];
+
+/** Subsidiaries for which the Digital Agent replaces the Help Center entry points. */
+export const DIGITAL_AGENT_SUBSIDIARIES: string[] = ['FR'];
+
+/**
+ * The Digital Agent is opened in primary for FR customers on the EU manager
+ * only. Every other region / subsidiary keeps the Help Center links.
+ */
+export const isDigitalAgentEnabled = (
+  region: Region | string,
+  ovhSubsidiary: string,
+): boolean =>
+  DIGITAL_AGENT_REGIONS.includes(region) &&
+  DIGITAL_AGENT_SUBSIDIARIES.includes(ovhSubsidiary);

--- a/packages/manager/apps/container/src/container/legacy/account-sidebar/UsefulLinks/useUsefulLinks.spec.ts
+++ b/packages/manager/apps/container/src/container/legacy/account-sidebar/UsefulLinks/useUsefulLinks.spec.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DIGITAL_AGENT_URL } from '@/container/common/digital-agent';
+
+import useUsefulLinks from './useUsefulLinks';
+
+const mocks = vi.hoisted(() => ({
+  user: { ovhSubsidiary: 'FR' },
+  region: 'EU',
+  openLiveChat: vi.fn(),
+  isLivechatEnabled: true,
+}));
+
+vi.mock('@/context/useApplicationContext', () => ({
+  useShell: () => ({
+    getPlugin: (plugin: string) =>
+      ({
+        environment: {
+          getEnvironment: () => ({
+            getRegion: () => mocks.region,
+            getUser: () => mocks.user,
+          }),
+        },
+        navigation: { getURL: (app: string, hash: string) => `${app}${hash}` },
+        ux: { openLiveChat: mocks.openLiveChat },
+      }[plugin]),
+  }),
+}));
+
+vi.mock('@/core/container', () => ({
+  default: () => ({
+    isLivechatEnabled: mocks.isLivechatEnabled,
+    setChatbotReduced: vi.fn(),
+  }),
+}));
+
+const getLink = (id: string) =>
+  renderHook(() => useUsefulLinks())
+    .result.current.getUsefulLinks()
+    .find((link) => link.id === id);
+
+describe('useUsefulLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.region = 'EU';
+    mocks.user = { ovhSubsidiary: 'FR' };
+    mocks.isLivechatEnabled = true;
+  });
+
+  it('points the create ticket and live chat links to the digital agent for FR on EU', () => {
+    expect(getLink('createTicket')).toMatchObject({
+      href: DIGITAL_AGENT_URL,
+      external: false,
+    });
+    expect(getLink('chatbot')).toMatchObject({
+      href: DIGITAL_AGENT_URL,
+      external: false,
+    });
+    expect(getLink('chatbot').action).toBeUndefined();
+  });
+
+  it('keeps the help center links for the other subsidiaries', () => {
+    mocks.user = { ovhSubsidiary: 'GB' };
+
+    expect(getLink('createTicket')).toMatchObject({
+      href:
+        'https://help.ovhcloud.com/csm?id=csm_get_help&ovhSubsidiary=GB',
+      external: true,
+    });
+    expect(getLink('chatbot').href).toBeUndefined();
+
+    getLink('chatbot').action();
+    expect(mocks.openLiveChat).toHaveBeenCalled();
+  });
+
+  it('keeps the help center links for FR customers outside of the EU manager', () => {
+    mocks.region = 'CA';
+
+    expect(getLink('createTicket')).toMatchObject({
+      href:
+        'https://help.ovhcloud.com/csm?id=csm_get_help&ovhSubsidiary=FR',
+      external: true,
+    });
+    expect(getLink('chatbot').href).toBeUndefined();
+  });
+});

--- a/packages/manager/apps/container/src/container/legacy/account-sidebar/UsefulLinks/useUsefulLinks.ts
+++ b/packages/manager/apps/container/src/container/legacy/account-sidebar/UsefulLinks/useUsefulLinks.ts
@@ -5,6 +5,10 @@ import constants from './constants';
 import { UsefulLink } from './Link/usefulLink';
 
 import { useShell } from '@/context/useApplicationContext';
+import {
+  DIGITAL_AGENT_URL,
+  isDigitalAgentEnabled,
+} from '@/container/common/digital-agent';
 import useContainer from '@/core/container';
 
 import getOdsIcon from '../getOdsIcon';
@@ -25,6 +29,7 @@ const useUsefulLinks = (): UseUsefulLinks => {
   const { isLivechatEnabled, setChatbotReduced } = useContainer();
 
   const isEUOrCA = ['EU', 'CA'].includes(region);
+  const isDigitalAgent = isDigitalAgentEnabled(region, user.ovhSubsidiary);
 
   const getUsefulLinks = (): UsefulLink[] => {
     const trackingPrefix = 'hub::sidebar::useful-links';
@@ -45,14 +50,21 @@ const useUsefulLinks = (): UseUsefulLinks => {
       },
       ...(isLivechatEnabled
         ? [
-            {
-              id: 'chatbot',
-              action: () => {
-                shell.getPlugin('ux').openLiveChat();
-                setChatbotReduced(false);
-              },
-              icon: getOdsIcon(ODS_ICON_NAME.SPEECH_BUBBLE_CONCEPT),
-            },
+            isDigitalAgent
+              ? {
+                  id: 'chatbot',
+                  external: false,
+                  href: DIGITAL_AGENT_URL,
+                  icon: getOdsIcon(ODS_ICON_NAME.SPEECH_BUBBLE_CONCEPT),
+                }
+              : {
+                  id: 'chatbot',
+                  action: () => {
+                    shell.getPlugin('ux').openLiveChat();
+                    setChatbotReduced(false);
+                  },
+                  icon: getOdsIcon(ODS_ICON_NAME.SPEECH_BUBBLE_CONCEPT),
+                },
           ]
         : []),
       {
@@ -75,8 +87,10 @@ const useUsefulLinks = (): UseUsefulLinks => {
         ? [
             {
               id: 'createTicket',
-              external: true,
-              href: constants[region].support.createTicket(user.ovhSubsidiary),
+              external: !isDigitalAgent,
+              href: isDigitalAgent
+                ? DIGITAL_AGENT_URL
+                : constants[region].support.createTicket(user.ovhSubsidiary),
               tracking: `${trackingPrefix}::go-to-create-ticket`,
               icon: getOdsIcon(ODS_ICON_NAME.USER_SUPPORT_CONCEPT),
             },

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance/AssistanceSidebar.spec.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance/AssistanceSidebar.spec.tsx
@@ -1,7 +1,7 @@
 import { vi, it, describe, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import AssistanceSidebar, { AssistanceProps } from '.';
-import { mockShell } from '../mocks/sidebarMocks';
+import { mockPlugins, mockShell, mockUser } from '../mocks/sidebarMocks';
 import { assistanceTree } from '../navigation-tree/assistance';
 
 vi.mock('@/context', () => ({
@@ -65,6 +65,7 @@ const id = 'assistance-sidebar';
 describe('AssistanceSidebar.component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUser.ovhSubsidiary = 'FR';
   });
 
   it('should render', () => {
@@ -89,6 +90,29 @@ describe('AssistanceSidebar.component', () => {
     expect(
       screen.queryAllByTestId('short-assistance-link-popover-anchor'),
     ).not.toBeNull();
+  });
+
+  describe('Digital Agent in primary', () => {
+    const clickLivechat = () => {
+      renderAssistanceSidebar({ ...props, isShort: false });
+      assistanceTree.children.find((node) => node.id === 'livechat')?.onClick();
+    };
+
+    it('should not open the V6 live chat for FR customers on the EU manager', () => {
+      mockUser.ovhSubsidiary = 'FR';
+      clickLivechat();
+      expect(mockPlugins.ux.openLiveChat).not.toHaveBeenCalled();
+      expect(mockPlugins.tracking.trackClick).toHaveBeenCalledWith({
+        name: 'navbar_v3_entry_home::assistance_live_chat',
+        type: 'navigation',
+      });
+    });
+
+    it('should still open the V6 live chat for the other subsidiaries', () => {
+      mockUser.ovhSubsidiary = 'GB';
+      clickLivechat();
+      expect(mockPlugins.ux.openLiveChat).toHaveBeenCalled();
+    });
   });
 
   describe('AI Chatbot Integration', () => {

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/Assistance/index.tsx
@@ -5,6 +5,7 @@ import useProductNavReshuffle from '@/core/product-nav-reshuffle';
 import useContainer from '@/core/container';
 import { Node } from '../navigation-tree/node';
 import { AssistanceLinkItem } from './AssistanceLinkItem';
+import { isDigitalAgentEnabled } from '@/container/common/digital-agent';
 
 export interface AssistanceProps {
   nodeTree?: Node;
@@ -26,6 +27,10 @@ const AssistanceSidebar: React.FC<ComponentProps<AssistanceProps>> = ({
   const urls = useURL(environment);
   const trackingPlugin = shell.getPlugin('tracking');
   const region = environment.getRegion();
+  const isDigitalAgent = isDigitalAgentEnabled(
+    region,
+    environment.getUser()?.ovhSubsidiary,
+  );
 
   const {
     closeNavigationSidebar,
@@ -45,7 +50,8 @@ const AssistanceSidebar: React.FC<ComponentProps<AssistanceProps>> = ({
       if (
         node.url &&
         typeof node.url === 'string' &&
-        !node.url.startsWith('http')
+        !node.url.startsWith('http') &&
+        !node.url.startsWith('/')
       ) {
         node.url = urls.get(node.url as keyof ContentURLS);
       }
@@ -71,8 +77,12 @@ const AssistanceSidebar: React.FC<ComponentProps<AssistanceProps>> = ({
           break;
         case 'livechat':
           node.onClick = () => {
-            shell.getPlugin('ux').openLiveChat();
-            setChatbotReduced(false);
+            // When the Digital Agent is in primary the entry is a plain link
+            // to the Manager V7, the V6 live chat widget is not opened anymore.
+            if (!isDigitalAgent) {
+              shell.getPlugin('ux').openLiveChat();
+              setChatbotReduced(false);
+            }
             trackNode('assistance_live_chat');
             closeNavigationSidebar();
           };
@@ -122,7 +132,7 @@ const AssistanceSidebar: React.FC<ComponentProps<AssistanceProps>> = ({
       <>
         <div
           ref={popoverAnchorRef}
-          className="flex justify-center my-2 h-[3.5rem]"
+          className="my-2 flex h-14 justify-center"
           tabIndex={0}
           onFocus={() =>
             document.getElementById('useful-links-button')?.focus()
@@ -134,7 +144,7 @@ const AssistanceSidebar: React.FC<ComponentProps<AssistanceProps>> = ({
 
   return (
     <ul
-      className="mt-auto pb-3 flex-none"
+      className="mt-auto flex-none pb-3"
       id="useful-links"
       role="menu"
       data-testid="assistance-sidebar"

--- a/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
+++ b/packages/manager/apps/container/src/container/nav-reshuffle/sidebar/index.tsx
@@ -39,6 +39,10 @@ import { Node } from './navigation-tree/node';
 import useProductNavReshuffle from '@/core/product-nav-reshuffle';
 import { ExcludedNodeIdsList } from './navigation-tree/excluded';
 import { ShortAssistanceLinkItem } from './Assistance/ShortAssistanceLinkItem';
+import {
+  DIGITAL_AGENT_URL,
+  isDigitalAgentEnabled,
+} from '@/container/common/digital-agent';
 
 interface ServicesCountError {
   url: string;
@@ -143,11 +147,24 @@ const Sidebar = (): JSX.Element => {
       const results = await fetchFeatureAvailabilityData(features);
 
       const region = environmentPlugin.getEnvironment().getRegion();
+      const { ovhSubsidiary } = environmentPlugin.getEnvironment().getUser();
       const [tree] = initTree([navigationTree], results, region);
 
       const mxPlanNode = findNodeById(tree, 'mxplan');
       if (mxPlanNode && region === 'CA') {
         mxPlanNode.routing.hash = '#/email_mxplan';
+      }
+
+      // Digital Agent in primary: the assistance entry points no longer target
+      // the Help Center but the Manager V7 Digital Agent.
+      if (isDigitalAgentEnabled(region, ovhSubsidiary)) {
+        ['createTicket', 'livechat'].forEach((nodeId) => {
+          const node = findNodeById(tree, nodeId);
+          if (!node) return;
+          node.url = DIGITAL_AGENT_URL;
+          node.isExternal = false;
+          delete node.routing;
+        });
       }
 
       if (results['web-hosting:managed-cms-ga']) {

--- a/packages/manager/apps/hub/src/components/hub-support/HubSupport.component.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/HubSupport.component.tsx
@@ -15,17 +15,31 @@ import { OsdsChip, OsdsIcon, OsdsLink, OsdsText, OsdsTile } from '@ovhcloud/ods-
 import { ShellContext } from '@ovh-ux/manager-react-shell-client';
 
 import { Skeletons } from '@/components/skeletons/Skeletons.component';
-import { useFetchHubSupport } from '@/data/hooks/apiHubSupport/useHubSupport';
+import { useHubSupportTickets } from '@/data/hooks/hubSupportTickets/useHubSupportTickets';
 
 import TileError from '../tile-error/TileError.component';
-import { SUPPORT_URLS } from './HubSupport.constants';
+import {
+  DIGITAL_AGENT_URLS,
+  MAX_DIGITAL_AGENT_TICKETS_TO_DISPLAY,
+  MAX_TICKETS_TO_DISPLAY,
+  SUPPORT_URLS,
+} from './HubSupport.constants';
 import { HubSupportHelp } from './hub-support-help/HubSupportHelp.component';
 import { HubSupportTable } from './hub-support-table/HubSupportTable.component';
+
+/**
+ * The Digital Agent lives in the Manager V7, outside of the hub iframe, hence
+ * `_top`. Help Center links stay external, V6 tickets stay in the iframe.
+ */
+const getSeeAllTarget = (isDigitalAgent: boolean, isEUOrCA: boolean) => {
+  if (isDigitalAgent) return OdsHTMLAnchorElementTarget._top;
+  return isEUOrCA ? OdsHTMLAnchorElementTarget._blank : OdsHTMLAnchorElementTarget._self;
+};
 
 export default function HubSupport() {
   const { t } = useTranslation('hub/support');
   const { t: tCommon } = useTranslation('hub');
-  const { data, refetch, isLoading, error } = useFetchHubSupport();
+  const { isDigitalAgent, tickets, count, refetch, isLoading, error } = useHubSupportTickets();
   const context = useContext(ShellContext);
   const { navigation } = context.shell;
   const { environment } = context;
@@ -37,6 +51,10 @@ export default function HubSupport() {
 
   useEffect(() => {
     void (async () => {
+      if (isDigitalAgent) {
+        setUrlSeeAll(DIGITAL_AGENT_URLS.allTickets);
+        return;
+      }
       const url = isEUOrCA
         ? SUPPORT_URLS.allTickets + ovhSubsidiary
         : ((await navigation.getURL('dedicated', '#/ticket', {})) as string);
@@ -57,8 +75,8 @@ export default function HubSupport() {
               refetch={void refetch}
             />
           )}
-          {!error && !data.count && <HubSupportHelp />}
-          {!error && !!data.count && (
+          {!error && !count && <HubSupportHelp />}
+          {!error && !!count && (
             <>
               <div className="mb-2 flex items-center gap-4">
                 <OsdsText
@@ -70,7 +88,7 @@ export default function HubSupport() {
                   {t('hub_support_title')}
                 </OsdsText>
                 <OsdsChip color={ODS_THEME_COLOR_INTENT.primary} size={ODS_CHIP_SIZE.sm}>
-                  {data.count}
+                  {count}
                 </OsdsChip>
                 <div className="ml-auto flex items-center gap-4">
                   <OsdsIcon
@@ -84,29 +102,34 @@ export default function HubSupport() {
                   />
                   <OsdsLink
                     href={urlSeeAll}
-                    target={
-                      isEUOrCA
-                        ? OdsHTMLAnchorElementTarget._blank
-                        : OdsHTMLAnchorElementTarget._self
+                    target={getSeeAllTarget(isDigitalAgent, isEUOrCA)}
+                    rel={
+                      isEUOrCA && !isDigitalAgent ? OdsHTMLAnchorElementRel.noreferrer : undefined
                     }
-                    rel={isEUOrCA ? OdsHTMLAnchorElementRel.noreferrer : undefined}
                     color={ODS_THEME_COLOR_INTENT.primary}
                     className="text-right font-bold"
                   >
                     {tCommon('hub_support_see_more')}
-                    <span slot="end">
-                      <OsdsIcon
-                        hoverable
-                        name={ODS_ICON_NAME.EXTERNAL_LINK}
-                        size={ODS_ICON_SIZE.xs}
-                        color={ODS_THEME_COLOR_INTENT.primary}
-                      />
-                    </span>
+                    {!isDigitalAgent && (
+                      <span slot="end">
+                        <OsdsIcon
+                          hoverable
+                          name={ODS_ICON_NAME.EXTERNAL_LINK}
+                          size={ODS_ICON_SIZE.xs}
+                          color={ODS_THEME_COLOR_INTENT.primary}
+                        />
+                      </span>
+                    )}
                   </OsdsLink>
                 </div>
               </div>
               <div className="w-full">
-                <HubSupportTable tickets={data.data} />
+                <HubSupportTable
+                  tickets={tickets}
+                  maxTickets={
+                    isDigitalAgent ? MAX_DIGITAL_AGENT_TICKETS_TO_DISPLAY : MAX_TICKETS_TO_DISPLAY
+                  }
+                />
               </div>
             </>
           )}

--- a/packages/manager/apps/hub/src/components/hub-support/HubSupport.constants.ts
+++ b/packages/manager/apps/hub/src/components/hub-support/HubSupport.constants.ts
@@ -1,8 +1,21 @@
+/** Rows displayed when the tile is fed by 2api `/hub/support`. */
 export const MAX_TICKETS_TO_DISPLAY = 2;
+
+/** Rows displayed when it is fed by the Digital Agent: matches X-Pagination-Size. */
+export const MAX_DIGITAL_AGENT_TICKETS_TO_DISPLAY = 4;
 
 export const SUPPORT_URLS = {
   allTickets:
     'https://help.ovhcloud.com/csm?id=csm_cases_requests&spa=1&table=sn_customerservice_case&filter=active%3Dtrue&p=1&o=sys_updated_on&d=desc&ovhSubsidiary=',
   viewTicket:
     'https://help.ovhcloud.com/csm?id=csm_ticket&table=sn_customerservice_case&number=CS{ticketId}&view=csp&ovhSubsidiary=',
+};
+
+/**
+ * Digital Agent (Manager V7, served under /beta/ on the same origin).
+ * `{conversationId}` is the `/support/conversation` id, not the CSxxxxx number.
+ */
+export const DIGITAL_AGENT_URLS = {
+  allTickets: '/beta/#/support/tickets?type=ticket',
+  viewTicket: '/beta/#/support/digital-agent/{conversationId}',
 };

--- a/packages/manager/apps/hub/src/components/hub-support/HubSupport.spec.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/HubSupport.spec.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import HubSupport from '@/components/hub-support/HubSupport.component';
-import { SupportDataResponse, Ticket } from '@/types/support.type';
+import { SupportTicketRow } from '@/types/support.type';
 
 const { refetch } = vi.hoisted(() => {
   return { refetch: vi.fn() };
@@ -16,7 +16,9 @@ vi.mock('../skeletons/Skeletons.component', () => ({
 }));
 
 vi.mock('./hub-support-table/HubSupportTable.component', () => ({
-  HubSupportTable: ({}: { tickets: Ticket[] }) => <div data-testid="hub-support-table"></div>,
+  HubSupportTable: ({ maxTickets }: { tickets: SupportTicketRow[]; maxTickets: number }) => (
+    <div data-testid="hub-support-table" data-max-tickets={maxTickets}></div>
+  ),
 }));
 
 vi.mock('../tile-error/TileError.component', () => ({
@@ -28,21 +30,22 @@ vi.mock('./hub-support-help/HubSupportHelp.component', () => ({
 }));
 
 const useFetchMockValue = {
-  data: { count: 3, data: [] } as SupportDataResponse,
-  isFetched: true,
+  isDigitalAgent: false,
+  tickets: [] as SupportTicketRow[],
+  count: 3,
   isLoading: false,
-  error: false,
+  error: false as unknown,
   refetch,
 };
 
-vi.mock('@/data/hooks/apiHubSupport/useHubSupport', () => ({
-  useFetchHubSupport: vi.fn(() => useFetchMockValue),
+vi.mock('@/data/hooks/hubSupportTickets/useHubSupportTickets', () => ({
+  useHubSupportTickets: vi.fn(() => useFetchMockValue),
 }));
 
 const mocks = vi.hoisted(() => ({
   environment: {
     getRegion: vi.fn(),
-    getUser: vi.fn(() => ({ ovhSubsidiary: 'FR' })),
+    getUser: vi.fn(() => ({ ovhSubsidiary: 'GB' })),
   },
   shell: {
     navigation: {
@@ -65,6 +68,14 @@ vi.mock('@ovh-ux/manager-react-shell-client', () => ({
 }));
 
 describe('HubSupport Component', () => {
+  beforeEach(() => {
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'GB' });
+    useFetchMockValue.isDigitalAgent = false;
+    useFetchMockValue.count = 3;
+    useFetchMockValue.isLoading = false;
+    useFetchMockValue.error = false;
+  });
+
   it('renders correctly with data for EU', () => {
     mocks.environment.getRegion.mockReturnValue('EU');
 
@@ -77,12 +88,29 @@ describe('HubSupport Component', () => {
     expect(osdsLinkElement).not.toBeNull();
     expect(osdsLinkElement).toHaveAttribute(
       'href',
-      'https://help.ovhcloud.com/csm?id=csm_cases_requests&spa=1&table=sn_customerservice_case&filter=active%3Dtrue&p=1&o=sys_updated_on&d=desc&ovhSubsidiary=FR',
+      'https://help.ovhcloud.com/csm?id=csm_cases_requests&spa=1&table=sn_customerservice_case&filter=active%3Dtrue&p=1&o=sys_updated_on&d=desc&ovhSubsidiary=GB',
     );
     expect(osdsLinkElement).toHaveAttribute('target', '_blank');
     expect(osdsLinkElement).toHaveAttribute('rel', 'noreferrer');
     const hubSupportTable = screen.getByTestId('hub-support-table');
     expect(hubSupportTable).toBeInTheDocument();
+    expect(hubSupportTable).toHaveAttribute('data-max-tickets', '2');
+  });
+
+  it('points "see all" to the Digital Agent tickets for FR customers on EU', async () => {
+    mocks.environment.getRegion.mockReturnValue('EU');
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'FR' });
+    useFetchMockValue.isDigitalAgent = true;
+
+    render(<HubSupport />);
+
+    await waitFor(() => {
+      const osdsLinkElement = screen.getByText('hub_support_see_more').closest('osds-link');
+      expect(osdsLinkElement).toHaveAttribute('href', '/beta/#/support/tickets?type=ticket');
+      expect(osdsLinkElement).toHaveAttribute('target', '_top');
+      expect(osdsLinkElement).not.toHaveAttribute('rel');
+      expect(screen.getByTestId('hub-support-table')).toHaveAttribute('data-max-tickets', '4');
+    });
   });
 
   it('renders correctly with data for US', async () => {
@@ -115,7 +143,6 @@ describe('HubSupport Component', () => {
 
   it('displays loading skeleton when isLoading is true', () => {
     useFetchMockValue.isLoading = true;
-    useFetchMockValue.data = undefined;
 
     render(<HubSupport />);
 
@@ -125,7 +152,7 @@ describe('HubSupport Component', () => {
 
   it('displays HubSupportHelp when there are no tickets and loading is false', () => {
     useFetchMockValue.isLoading = false;
-    useFetchMockValue.data = { count: 0, data: [] };
+    useFetchMockValue.count = 0;
 
     render(<HubSupport />);
 

--- a/packages/manager/apps/hub/src/components/hub-support/hub-support-table/HubSupportTable.component.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/hub-support-table/HubSupportTable.component.tsx
@@ -2,24 +2,24 @@ import React, { FunctionComponent } from 'react';
 
 import { OsdsTable } from '@ovhcloud/ods-components/react';
 
-import { Ticket } from '@/types/support.type';
+import { SupportTicketRow } from '@/types/support.type';
 
-import { MAX_TICKETS_TO_DISPLAY } from '../HubSupport.constants';
 import { HubSupportTableItem } from './hub-support-table-item/HubSupportTableItem.component';
 
 type Props = {
-  tickets: Ticket[];
+  tickets: SupportTicketRow[];
+  /** Source dependent, see the MAX_*_TO_DISPLAY constants. */
+  maxTickets: number;
 };
 
-export const HubSupportTable: FunctionComponent<Props> = ({ tickets }) => {
-  // This code below is superfluous because the API always returns only 2 tickets.
-  const limitedTickets = tickets.slice(0, MAX_TICKETS_TO_DISPLAY);
+export const HubSupportTable: FunctionComponent<Props> = ({ tickets, maxTickets }) => {
+  const limitedTickets = tickets.slice(0, maxTickets);
   return (
     <OsdsTable className="block">
       <table className="table-auto">
         <tbody>
           {limitedTickets.map((ticketItem) => (
-            <HubSupportTableItem key={ticketItem.ticketId} ticket={ticketItem} />
+            <HubSupportTableItem key={ticketItem.key} ticket={ticketItem} />
           ))}
         </tbody>
       </table>

--- a/packages/manager/apps/hub/src/components/hub-support/hub-support-table/HubSupportTable.spec.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/hub-support-table/HubSupportTable.spec.tsx
@@ -4,49 +4,40 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Ticket } from '@/types/support.type';
+import { SupportTicketRow } from '@/types/support.type';
 
 import { HubSupportTable } from './HubSupportTable.component';
 
 vi.mock('./hub-support-table-item/HubSupportTableItem.component', () => ({
-  HubSupportTableItem: ({ ticket }: { ticket: Ticket }) => (
-    <tr data-testid={`support-item-${ticket.ticketId}`}>
-      <td>{ticket.ticketId}</td>
+  HubSupportTableItem: ({ ticket }: { ticket: SupportTicketRow }) => (
+    <tr data-testid={`support-item-${ticket.key}`}>
+      <td>{ticket.label}</td>
     </tr>
   ),
 }));
 
+const tickets: SupportTicketRow[] = [1, 2, 3, 4, 5].map((n) => ({
+  key: `${n}`,
+  label: `service ${n}`,
+  state: `state ${n}`,
+  subject: `subject ${n}`,
+  ticketId: `${n}`,
+}));
+
 describe('HubSupportTable Component', () => {
-  it('renders a table with a maximum of 2 support items', () => {
-    const tickets: Ticket[] = [
-      {
-        ticketId: '1',
-        serviceName: 'service 1',
-        state: 'state 1',
-        subject: 'subject 1',
-      },
-      {
-        ticketId: '2',
-        serviceName: 'service 2',
-        state: 'state 2',
-        subject: 'subject 2',
-      },
-      {
-        ticketId: '3',
-        serviceName: 'service 3',
-        state: 'state 3',
-        subject: 'subject 3',
-      },
-    ];
+  it.each([
+    ['/hub/support', 2],
+    ['the Digital Agent', 4],
+  ])('caps the rows at the %s limit', (_source, maxTickets) => {
+    render(<HubSupportTable tickets={tickets} maxTickets={maxTickets} />);
 
-    render(<HubSupportTable tickets={tickets} />);
-
-    expect(screen.getByTestId('support-item-1')).toBeInTheDocument();
-    expect(screen.getByTestId('support-item-2')).toBeInTheDocument();
-    expect(screen.queryByTestId('support-item-3')).not.toBeInTheDocument();
+    for (let n = 1; n <= maxTickets; n += 1) {
+      expect(screen.getByTestId(`support-item-${n}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByTestId(`support-item-${maxTickets + 1}`)).not.toBeInTheDocument();
 
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
-    expect(table.querySelectorAll('tr')).toHaveLength(2);
+    expect(table.querySelectorAll('tr')).toHaveLength(maxTickets);
   });
 });

--- a/packages/manager/apps/hub/src/components/hub-support/hub-support-table/hub-support-table-item/HubSupportTableItem.component.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/hub-support-table/hub-support-table-item/HubSupportTableItem.component.tsx
@@ -14,12 +14,22 @@ import {
   useOvhTracking,
 } from '@ovh-ux/manager-react-shell-client';
 
-import { Ticket } from '@/types/support.type';
+import { SupportTicketRow } from '@/types/support.type';
+import { isDigitalAgentEnabled } from '@/utils/digitalAgent';
 
-import { SUPPORT_URLS } from '../../HubSupport.constants';
+import { DIGITAL_AGENT_URLS, SUPPORT_URLS } from '../../HubSupport.constants';
 
 type Props = {
-  ticket: Ticket;
+  ticket: SupportTicketRow;
+};
+
+/**
+ * The Digital Agent lives in the Manager V7, outside of the hub iframe, hence
+ * `_top`. Help Center links stay external, V6 tickets stay in the iframe.
+ */
+const getTicketLinkTarget = (isDigitalAgent: boolean, isEUOrCA: boolean) => {
+  if (isDigitalAgent) return OdsHTMLAnchorElementTarget._top;
+  return isEUOrCA ? OdsHTMLAnchorElementTarget._blank : OdsHTMLAnchorElementTarget._self;
 };
 
 export const HubSupportTableItem: FunctionComponent<Props> = ({ ticket }) => {
@@ -52,9 +62,27 @@ export const HubSupportTableItem: FunctionComponent<Props> = ({ ticket }) => {
   const [url, setUrl] = useState<string>('');
 
   const isEUOrCA = ['EU', 'CA'].includes(region);
+  const isDigitalAgent = isDigitalAgentEnabled(region, ovhSubsidiary);
+
+  const { conversationId } = ticket;
 
   useEffect(() => {
     void (async () => {
+      if (isDigitalAgent) {
+        // Never send a FR customer back to the Help Center: when the
+        // conversation id is not resolved (yet), open the Digital Agent ticket
+        // list rather than the CSM page.
+        setUrl(
+          conversationId
+            ? DIGITAL_AGENT_URLS.viewTicket.replace(
+                '{conversationId}',
+                encodeURIComponent(conversationId),
+              )
+            : DIGITAL_AGENT_URLS.allTickets,
+        );
+        return;
+      }
+
       const linkResult: string = isEUOrCA
         ? SUPPORT_URLS.viewTicket.replace('{ticketId}', ticket.ticketId) + ovhSubsidiary
         : ((await navigation.getURL(
@@ -65,7 +93,7 @@ export const HubSupportTableItem: FunctionComponent<Props> = ({ ticket }) => {
 
       setUrl(linkResult);
     })();
-  }, [ticket.ticketId]);
+  }, [ticket.ticketId, isDigitalAgent, conversationId]);
 
   const handleClick = () => {
     trackClick({
@@ -77,9 +105,9 @@ export const HubSupportTableItem: FunctionComponent<Props> = ({ ticket }) => {
   };
 
   return (
-    <tr key={ticket.ticketId}>
+    <tr key={ticket.key}>
       <th scope="row" className="break-all !font-bold">
-        {ticket.serviceName}
+        {ticket.label}
       </th>
       <th scope="row">{ticket.subject}</th>
       <th scope="row" className="!min-w-min">
@@ -91,8 +119,8 @@ export const HubSupportTableItem: FunctionComponent<Props> = ({ ticket }) => {
         <OsdsLink
           href={url}
           onClick={handleClick}
-          target={isEUOrCA ? OdsHTMLAnchorElementTarget._blank : OdsHTMLAnchorElementTarget._self}
-          rel={isEUOrCA ? OdsHTMLAnchorElementRel.noreferrer : undefined}
+          target={getTicketLinkTarget(isDigitalAgent, isEUOrCA)}
+          rel={isEUOrCA && !isDigitalAgent ? OdsHTMLAnchorElementRel.noreferrer : undefined}
           color={ODS_THEME_COLOR_INTENT.primary}
           className="text-right font-bold"
         >

--- a/packages/manager/apps/hub/src/components/hub-support/hub-support-table/hub-support-table-item/HubSupportTableItem.spec.tsx
+++ b/packages/manager/apps/hub/src/components/hub-support/hub-support-table/hub-support-table-item/HubSupportTableItem.spec.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 
-import { Ticket } from '@/types/support.type';
+import { SupportTicketRow } from '@/types/support.type';
 
 import { HubSupportTableItem } from './HubSupportTableItem.component';
 
@@ -15,7 +15,7 @@ const trackClickMock = vi.fn();
 const mocks = vi.hoisted(() => ({
   environment: {
     getRegion: vi.fn(),
-    getUser: () => ({ ovhSubsidiary: 'FR' }),
+    getUser: vi.fn(() => ({ ovhSubsidiary: 'GB' })),
   },
   shell: {
     navigation: {
@@ -38,36 +38,85 @@ vi.mock('@ovh-ux/manager-react-shell-client', () => ({
   },
 }));
 
-const mockTicket: Ticket = {
-  ticketId: '123',
-  serviceName: 'Service A',
+/** Row as built from 2api `/hub/support`. */
+const hubSupportRow: SupportTicketRow = {
+  key: '123',
+  label: 'Service A',
   subject: 'Subject A',
   state: 'open',
+  ticketId: '123',
+};
+
+/** Row as built from apiv6 `/support/conversation`. */
+const conversationRow: SupportTicketRow = {
+  key: 'a1b2c3d4-e5f6-4711-8899-aabbccddeeff',
+  label: '#CS123',
+  subject: 'Subject A',
+  state: 'open',
+  ticketId: 'CS123',
+  conversationId: 'a1b2c3d4-e5f6-4711-8899-aabbccddeeff',
 };
 
 describe('HubSupportTableItem Component', () => {
+  beforeEach(() => {
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'GB' });
+  });
+
   it('renders support information correctly for EU region', async () => {
     mocks.environment.getRegion.mockReturnValue('EU');
 
-    render(<HubSupportTableItem ticket={mockTicket} />);
+    render(<HubSupportTableItem ticket={hubSupportRow} />);
 
-    expect(screen.getByText(mockTicket.serviceName)).toBeInTheDocument();
-    expect(screen.getByText(mockTicket.subject)).toBeInTheDocument();
+    expect(screen.getByText(hubSupportRow.label)).toBeInTheDocument();
+    expect(screen.getByText(hubSupportRow.subject)).toBeInTheDocument();
     expect(screen.getByText('hub_support_state_open')).toBeInTheDocument();
     await screen.findByText('hub_support_read');
     const osdsLinkElement = screen.getByText('hub_support_read').closest('osds-link');
     expect(osdsLinkElement).toHaveAttribute(
       'href',
-      'https://help.ovhcloud.com/csm?id=csm_ticket&table=sn_customerservice_case&number=CS123&view=csp&ovhSubsidiary=FR',
+      'https://help.ovhcloud.com/csm?id=csm_ticket&table=sn_customerservice_case&number=CS123&view=csp&ovhSubsidiary=GB',
     );
     expect(osdsLinkElement).toHaveAttribute('target', '_blank');
     expect(osdsLinkElement).toHaveAttribute('rel', 'noreferrer');
   });
 
+  it('links to the Digital Agent conversation for FR customers on EU', async () => {
+    mocks.environment.getRegion.mockReturnValue('EU');
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'FR' });
+
+    render(<HubSupportTableItem ticket={conversationRow} />);
+
+    expect(screen.getByText('#CS123')).toBeInTheDocument();
+
+    await waitFor(() => {
+      const osdsLinkElement = screen.getByText('hub_support_read').closest('osds-link');
+      expect(osdsLinkElement).toHaveAttribute(
+        'href',
+        `/beta/#/support/digital-agent/${conversationRow.conversationId}`,
+      );
+      expect(osdsLinkElement).toHaveAttribute('target', '_top');
+      expect(osdsLinkElement).not.toHaveAttribute('rel');
+    });
+  });
+
+  it('falls back to the Digital Agent ticket list, never to the help center', async () => {
+    mocks.environment.getRegion.mockReturnValue('EU');
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'FR' });
+
+    render(<HubSupportTableItem ticket={{ ...conversationRow, conversationId: undefined }} />);
+
+    await waitFor(() => {
+      const osdsLinkElement = screen.getByText('hub_support_read').closest('osds-link');
+      expect(osdsLinkElement).toHaveAttribute('href', '/beta/#/support/tickets?type=ticket');
+      expect(osdsLinkElement).toHaveAttribute('target', '_top');
+      expect(osdsLinkElement.getAttribute('href')).not.toContain('help.ovhcloud.com');
+    });
+  });
+
   it('renders support information correctly for US region', async () => {
     mocks.environment.getRegion.mockReturnValue('US');
 
-    render(<HubSupportTableItem ticket={mockTicket} />);
+    render(<HubSupportTableItem ticket={hubSupportRow} />);
 
     await screen.findByText('hub_support_read');
     await waitFor(() => {
@@ -75,8 +124,8 @@ describe('HubSupportTableItem Component', () => {
       expect(osdsLinkElement).toHaveAttribute('href', 'mocked-url');
       expect(osdsLinkElement).toHaveAttribute('target', '_self');
       expect(osdsLinkElement).not.toHaveAttribute('rel');
-      expect(screen.getByText(mockTicket.serviceName)).toBeInTheDocument();
-      expect(screen.getByText(mockTicket.subject)).toBeInTheDocument();
+      expect(screen.getByText(hubSupportRow.label)).toBeInTheDocument();
+      expect(screen.getByText(hubSupportRow.subject)).toBeInTheDocument();
       expect(screen.getByText('hub_support_state_open')).toBeInTheDocument();
     });
   });
@@ -84,7 +133,7 @@ describe('HubSupportTableItem Component', () => {
   it('calls trackClick on link click', async () => {
     mocks.environment.getRegion.mockReturnValue('EU');
 
-    render(<HubSupportTableItem ticket={mockTicket} />);
+    render(<HubSupportTableItem ticket={hubSupportRow} />);
 
     const linkElement = screen.getByText('hub_support_read');
     expect(linkElement).toBeInTheDocument();
@@ -102,7 +151,7 @@ describe('HubSupportTableItem Component', () => {
   it('applies correct color based on support state', () => {
     mocks.environment.getRegion.mockReturnValue('EU');
 
-    render(<HubSupportTableItem ticket={{ ...mockTicket, state: 'closed' }} />);
+    render(<HubSupportTableItem ticket={{ ...hubSupportRow, state: 'closed' }} />);
 
     const chip = screen.getByText('hub_support_state_closed');
     expect(chip).toHaveAttribute('color', ODS_THEME_COLOR_INTENT.info);

--- a/packages/manager/apps/hub/src/data/api/apiSupportConversation.spec.ts
+++ b/packages/manager/apps/hub/src/data/api/apiSupportConversation.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getSupportConversations } from './apiSupportConversation';
+
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+
+vi.mock('@ovh-ux/manager-core-api', () => ({ v6: { get: getMock } }));
+
+describe('getSupportConversations', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    getMock.mockResolvedValue({ data: [] });
+  });
+
+  it('calls apiv6 with the same query as the V7 dashboard', async () => {
+    await getSupportConversations();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    const [url, config] = getMock.mock.calls[0] as [
+      string,
+      { params: URLSearchParams; headers: Record<string, string> },
+    ];
+
+    expect(url).toBe('/support/conversation');
+    // repeated `state` params, no `state[]` brackets
+    expect(config.params.toString()).toBe(
+      'ticketCreated=true&type=standard&state=new&state=open&state=awaiting-info&sort=modified-on-desc',
+    );
+    expect(config.headers).toEqual({
+      'X-Pagination-Size': '4',
+      'X-Pagination-Cursor': '1',
+    });
+  });
+
+  it('returns the conversation list as-is', async () => {
+    const conversations = [{ id: 'uuid-1' }];
+    getMock.mockResolvedValue({ data: conversations });
+
+    await expect(getSupportConversations()).resolves.toBe(conversations);
+  });
+});

--- a/packages/manager/apps/hub/src/data/api/apiSupportConversation.ts
+++ b/packages/manager/apps/hub/src/data/api/apiSupportConversation.ts
@@ -1,0 +1,44 @@
+import { v6 } from '@ovh-ux/manager-core-api';
+
+import { SupportConversation, SupportConversationState } from '@/types/support.type';
+
+/**
+ * `/hub/support` only exposes the ServiceNow case number (CSxxxxx) while the
+ * Digital Agent is addressed by conversation id, so the conversations have to
+ * be resolved separately. Same call as the V7 dashboard.
+ */
+
+/** Open states only — mirrors the tickets `/hub/support` returns. */
+export const SUPPORT_CONVERSATION_OPEN_STATES: SupportConversationState[] = [
+  'new',
+  'open',
+  'awaiting-info',
+];
+
+export const SUPPORT_CONVERSATION_PAGE_SIZE = 4;
+
+/**
+ * Repeated `state` params (`state=new&state=open&…`), so URLSearchParams is
+ * built by hand: axios would serialize an array as `state[]=new`.
+ */
+const buildSupportConversationParams = (): URLSearchParams => {
+  const params = new URLSearchParams();
+  // exclude drafts / conversations without a ticket
+  params.set('ticketCreated', 'true');
+  // exclude alerts
+  params.set('type', 'standard');
+  SUPPORT_CONVERSATION_OPEN_STATES.forEach((state) => params.append('state', state));
+  params.set('sort', 'modified-on-desc');
+  return params;
+};
+
+export const getSupportConversations = async (): Promise<SupportConversation[]> => {
+  const { data } = await v6.get<SupportConversation[]>('/support/conversation', {
+    params: buildSupportConversationParams(),
+    headers: {
+      'X-Pagination-Size': `${SUPPORT_CONVERSATION_PAGE_SIZE}`,
+      'X-Pagination-Cursor': '1',
+    },
+  });
+  return data;
+};

--- a/packages/manager/apps/hub/src/data/hooks/apiSupportConversation/useSupportConversations.tsx
+++ b/packages/manager/apps/hub/src/data/hooks/apiSupportConversation/useSupportConversations.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getSupportConversations } from '@/data/api/apiSupportConversation';
+import { SupportConversation } from '@/types/support.type';
+
+export const supportConversationsQueryKey = ['get-support-conversations'];
+
+export const useSupportConversations = ({ enabled }: { enabled: boolean }) =>
+  useQuery<SupportConversation[]>({
+    queryKey: supportConversationsQueryKey,
+    queryFn: getSupportConversations,
+    enabled,
+  });

--- a/packages/manager/apps/hub/src/data/hooks/hubSupportTickets/useHubSupportTickets.spec.tsx
+++ b/packages/manager/apps/hub/src/data/hooks/hubSupportTickets/useHubSupportTickets.spec.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SupportConversation } from '@/types/support.type';
+
+import { useHubSupportTickets } from './useHubSupportTickets';
+
+const mocks = vi.hoisted(() => ({
+  environment: {
+    getRegion: vi.fn(() => 'EU'),
+    getUser: vi.fn(() => ({ ovhSubsidiary: 'FR' })),
+  },
+  hubSupport: { data: undefined, isLoading: false, error: null, refetch: vi.fn() } as Record<
+    string,
+    unknown
+  >,
+  conversations: { data: undefined, isLoading: false, error: null, refetch: vi.fn() } as Record<
+    string,
+    unknown
+  >,
+  useFetchHubSupport: vi.fn(),
+  useSupportConversations: vi.fn(),
+}));
+
+vi.mock('@ovh-ux/manager-react-shell-client', () => ({
+  ShellContext: React.createContext({ environment: mocks.environment }),
+}));
+
+vi.mock('@/data/hooks/apiHubSupport/useHubSupport', () => ({
+  useFetchHubSupport: (options: { enabled: boolean }) => {
+    mocks.useFetchHubSupport(options);
+    return mocks.hubSupport;
+  },
+}));
+
+vi.mock('@/data/hooks/apiSupportConversation/useSupportConversations', () => ({
+  useSupportConversations: (options: { enabled: boolean }) => {
+    mocks.useSupportConversations(options);
+    return mocks.conversations;
+  },
+}));
+
+const conversation = (id: string, number: string): SupportConversation => ({
+  id,
+  name: `subject ${number}`,
+  createdOn: '2026-08-01T10:00:00+02:00',
+  modifiedOn: '2026-08-02T10:00:00+02:00',
+  state: 'awaiting-info',
+  type: 'standard',
+  ticket: { number },
+});
+
+describe('useHubSupportTickets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.environment.getRegion.mockReturnValue('EU');
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'FR' });
+    mocks.hubSupport.data = undefined;
+    mocks.conversations.data = undefined;
+  });
+
+  it('sources FR customers on EU from /support/conversation only', () => {
+    mocks.conversations.data = [conversation('uuid-1', 'CS123')];
+
+    const { result } = renderHook(() => useHubSupportTickets());
+
+    expect(mocks.useFetchHubSupport).toHaveBeenCalledWith({ enabled: false });
+    expect(mocks.useSupportConversations).toHaveBeenCalledWith({ enabled: true });
+    expect(result.current.isDigitalAgent).toBe(true);
+    expect(result.current.tickets).toEqual([
+      {
+        key: 'uuid-1',
+        label: '#CS123',
+        subject: 'subject CS123',
+        // awaiting-info has no V6 translation: the query only asks for open states
+        state: 'open',
+        ticketId: 'CS123',
+        conversationId: 'uuid-1',
+      },
+    ]);
+    expect(result.current.count).toBe(1);
+  });
+
+  it('drops conversations without a ticket', () => {
+    mocks.conversations.data = [
+      { ...conversation('uuid-1', 'CS123'), ticket: null },
+      conversation('uuid-2', 'CS456'),
+    ];
+
+    const { result } = renderHook(() => useHubSupportTickets());
+
+    expect(result.current.tickets.map((t) => t.key)).toEqual(['uuid-2']);
+  });
+
+  it('keeps /hub/support for the other subsidiaries', () => {
+    mocks.environment.getUser.mockReturnValue({ ovhSubsidiary: 'GB' });
+    mocks.hubSupport.data = {
+      count: 7,
+      data: [{ ticketId: 123, serviceName: 'Service A', subject: 'Subject A', state: 'open' }],
+    };
+
+    const { result } = renderHook(() => useHubSupportTickets());
+
+    expect(mocks.useFetchHubSupport).toHaveBeenCalledWith({ enabled: true });
+    expect(mocks.useSupportConversations).toHaveBeenCalledWith({ enabled: false });
+    expect(result.current.isDigitalAgent).toBe(false);
+    expect(result.current.tickets).toEqual([
+      {
+        key: '123',
+        label: 'Service A',
+        subject: 'Subject A',
+        state: 'open',
+        ticketId: '123',
+      },
+    ]);
+    // the 2api count is the grand total, not the page size
+    expect(result.current.count).toBe(7);
+  });
+
+  it('keeps /hub/support for FR customers outside of the EU manager', () => {
+    mocks.environment.getRegion.mockReturnValue('CA');
+
+    renderHook(() => useHubSupportTickets());
+
+    expect(mocks.useFetchHubSupport).toHaveBeenCalledWith({ enabled: true });
+    expect(mocks.useSupportConversations).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it('reports the state of the active query only', () => {
+    mocks.conversations.isLoading = true;
+    mocks.hubSupport.isLoading = false;
+
+    const { result } = renderHook(() => useHubSupportTickets());
+
+    expect(result.current.isLoading).toBe(true);
+    mocks.conversations.isLoading = false;
+  });
+});

--- a/packages/manager/apps/hub/src/data/hooks/hubSupportTickets/useHubSupportTickets.ts
+++ b/packages/manager/apps/hub/src/data/hooks/hubSupportTickets/useHubSupportTickets.ts
@@ -1,0 +1,66 @@
+import { useContext, useMemo } from 'react';
+
+import { ShellContext } from '@ovh-ux/manager-react-shell-client';
+
+import { useFetchHubSupport } from '@/data/hooks/apiHubSupport/useHubSupport';
+import { useSupportConversations } from '@/data/hooks/apiSupportConversation/useSupportConversations';
+import { SupportConversation, SupportTicketRow, Ticket } from '@/types/support.type';
+import { isDigitalAgentEnabled } from '@/utils/digitalAgent';
+
+const toDigitalAgentRow = (conversation: SupportConversation): SupportTicketRow => ({
+  key: conversation.id,
+  label: `#${conversation.ticket.number}`,
+  subject: conversation.name,
+  // The query only asks for new / open / awaiting-info, all "open" in the V6
+  // vocabulary, which has no translation for the finer conversation states.
+  state: 'open',
+  ticketId: conversation.ticket.number,
+  conversationId: conversation.id,
+});
+
+const toHubSupportRow = (ticket: Ticket): SupportTicketRow => ({
+  key: String(ticket.ticketId),
+  label: ticket.serviceName,
+  subject: ticket.subject,
+  state: ticket.state,
+  ticketId: String(ticket.ticketId),
+});
+
+/**
+ * Feeds the support tile. FR customers on the EU manager are served by apiv6
+ * `/support/conversation`, the same source as the V7 dashboard, so that every
+ * row carries the conversation id the Digital Agent addresses tickets by.
+ * Everyone else keeps 2api `/hub/support`.
+ */
+export const useHubSupportTickets = () => {
+  const { environment } = useContext(ShellContext);
+  const region = environment.getRegion();
+  const { ovhSubsidiary } = environment.getUser();
+  const isDigitalAgent = isDigitalAgentEnabled(region, ovhSubsidiary);
+
+  const hubSupport = useFetchHubSupport({ enabled: !isDigitalAgent });
+  const conversations = useSupportConversations({ enabled: isDigitalAgent });
+
+  const tickets = useMemo<SupportTicketRow[]>(() => {
+    if (isDigitalAgent) {
+      // Defensive: ticketCreated=true should already exclude ticketless conversations.
+      return (conversations.data ?? []).filter((c) => c.ticket).map(toDigitalAgentRow);
+    }
+    return (hubSupport.data?.data ?? []).map(toHubSupportRow);
+  }, [isDigitalAgent, conversations.data, hubSupport.data]);
+
+  const query = isDigitalAgent ? conversations : hubSupport;
+
+  return {
+    isDigitalAgent,
+    tickets,
+    // The conversation route is a plain array capped by X-Pagination-Size,
+    // so the Digital Agent count is the page size, not the grand total.
+    count: isDigitalAgent ? tickets.length : (hubSupport.data?.count ?? 0),
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};
+
+export default useHubSupportTickets;

--- a/packages/manager/apps/hub/src/types/support.type.ts
+++ b/packages/manager/apps/hub/src/types/support.type.ts
@@ -15,3 +15,45 @@ export type SupportDataResponse = {
 export type SupportResponse = {
   support: ApiEnvelope<SupportDataResponse>;
 };
+
+export type SupportConversationState =
+  | 'awaiting-info'
+  | 'cancelled'
+  | 'closed'
+  | 'new'
+  | 'open'
+  | 'resolved';
+
+export type SupportConversationTicket = {
+  number: string;
+  priority?: number;
+};
+
+/** Item returned by apiv6 `GET /support/conversation` (narrowed to what we use). */
+export type SupportConversation = {
+  id: string;
+  name: string;
+  createdOn: string;
+  modifiedOn: string;
+  state: SupportConversationState;
+  type: string;
+  ticket: SupportConversationTicket | null;
+};
+
+/**
+ * Normalized row rendered by the support tile, whatever the source: 2api
+ * `/hub/support` or apiv6 `/support/conversation` for the Digital Agent.
+ */
+export type SupportTicketRow = {
+  /** React key: conversation id or case number depending on the source. */
+  key: string;
+  /** First column: service name (`/hub/support`) or #case number (conversations). */
+  label: string;
+  subject: string;
+  /** One of the `hub_support_state_*` translation suffixes. */
+  state: string;
+  /** Case number, for the Help Center and V6 links. Always set by both sources. */
+  ticketId: string;
+  /** Conversation id, for the Digital Agent link. */
+  conversationId?: string;
+};

--- a/packages/manager/apps/hub/src/utils/digitalAgent.spec.ts
+++ b/packages/manager/apps/hub/src/utils/digitalAgent.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDigitalAgentEnabled } from './digitalAgent';
+
+describe('isDigitalAgentEnabled', () => {
+  it('is enabled for FR customers on the EU manager', () => {
+    expect(isDigitalAgentEnabled('EU', 'FR')).toBe(true);
+  });
+
+  it('is disabled for the other subsidiaries of the EU manager', () => {
+    ['GB', 'DE', 'ES', 'IT', 'PL', 'PT', 'MA', 'SN', 'TN', 'NL', 'IE'].forEach((subsidiary) => {
+      expect(isDigitalAgentEnabled('EU', subsidiary)).toBe(false);
+    });
+  });
+
+  it('is disabled on the other managers', () => {
+    expect(isDigitalAgentEnabled('CA', 'FR')).toBe(false);
+    expect(isDigitalAgentEnabled('US', 'FR')).toBe(false);
+  });
+});

--- a/packages/manager/apps/hub/src/utils/digitalAgent.ts
+++ b/packages/manager/apps/hub/src/utils/digitalAgent.ts
@@ -1,0 +1,17 @@
+/**
+ * The Digital Agent is served by the Manager V7, mounted under /beta/ on the
+ * same origin as the V6 manager.
+ */
+
+/** Regions on which the Digital Agent replaces the Help Center entry points. */
+export const DIGITAL_AGENT_REGIONS = ['EU'];
+
+/** Subsidiaries for which the Digital Agent replaces the Help Center entry points. */
+export const DIGITAL_AGENT_SUBSIDIARIES = ['FR'];
+
+/**
+ * The Digital Agent is opened in primary for FR customers on the EU manager
+ * only. Every other region / subsidiary keeps the Help Center links.
+ */
+export const isDigitalAgentEnabled = (region: string, ovhSubsidiary: string): boolean =>
+  DIGITAL_AGENT_REGIONS.includes(region) && DIGITAL_AGENT_SUBSIDIARIES.includes(ovhSubsidiary);


### PR DESCRIPTION
## Description

Change for FR customer only widget and link from support to Digital Agent directly on manager v7 

Ticket Reference:  #MANAGER-22282

## Additional Information
