### PR TITLE
feat(manager): add new commitment number form for B2G customer on order - O2CBIL-1342

### DIFF
--- a/packages/manager/modules/billing/src/billing.module.js
+++ b/packages/manager/modules/billing/src/billing.module.js
@@ -5,6 +5,7 @@ import ngPaginationFront from '@ovh-ux/ng-pagination-front';
 import set from 'lodash/set';
 import autorenew from './autoRenew/autorenew.module';
 import billingMain from './main/billing-main.module';
+import commitment from './commitment/billing-commitment-entry.module';
 import dateRangeSelectionService from './common/dateRangeSelection';
 import debtAccount from './dbtAccount/billing-debtAccount.service';
 import featureAvailability from './billing-feature-availability';
@@ -57,6 +58,7 @@ angular
     ngPaginationFront,
     autorenew,
     billingMain,
+    commitment,
     history,
     paymentCreditAdd,
     order,

--- a/packages/manager/modules/billing/src/commitment/billing-commitment-entry.controller.js
+++ b/packages/manager/modules/billing/src/commitment/billing-commitment-entry.controller.js
@@ -1,0 +1,40 @@
+export default class BillingCommitmentEntryCtrl {
+  /* @ngInject */
+  constructor($state, $http, $log, orderId, ordersFilter) {
+    this.$state = $state;
+    this.$http = $http;
+    this.$log = $log;
+    this.orderId = orderId;
+    this.ordersFilter = ordersFilter;
+    this.commitmentNumber = null;
+    this.loading = false;
+    this.error = null;
+    this.success = false;
+  }
+
+  goToOrders() {
+    this.$state.go('billing.orders.orders', {
+      filter: this.ordersFilter,
+    });
+  }
+
+  submit() {
+    this.loading = true;
+    this.error = null;
+
+    return this.$http
+      .put(`/me/order/${this.orderId}/engagementNumber`, {
+        engagementNumber: this.commitmentNumber.trim(),
+      })
+      .then(() => {
+        this.success = true;
+      })
+      .catch((err) => {
+        this.error = true;
+        this.$log.error(err);
+      })
+      .finally(() => {
+        this.loading = false;
+      });
+  }
+}

--- a/packages/manager/modules/billing/src/commitment/billing-commitment-entry.html
+++ b/packages/manager/modules/billing/src/commitment/billing-commitment-entry.html
@@ -1,0 +1,72 @@
+<div class="billing-commitment-entry">
+    <oui-header
+        data-heading="{{ :: 'commitment_entry_title' | translate }}"
+        data-description="{{ :: 'commitment_entry_description' | translate }}"
+    >
+    </oui-header>
+
+    <p
+        data-translate="commitment_entry_order_number"
+        data-translate-values="{ t0: $ctrl.orderId }"
+    ></p>
+
+    <div data-ng-if="$ctrl.success">
+        <oui-message type="success">
+            <span
+                data-translate="commitment_entry_success"
+                data-translate-values="{ t0: $ctrl.commitmentNumber, t1: $ctrl.orderId }"
+            ></span>
+        </oui-message>
+        <button
+            type="button"
+            class="oui-button oui-button_secondary"
+            ng-click="$ctrl.goToOrders()"
+        >
+            <span data-translate="orders_retract_return_to_orders"></span>
+        </button>
+    </div>
+
+    <div data-ng-if="!$ctrl.success">
+        <form
+            name="$ctrl.commitmentForm"
+            novalidate
+            data-ng-submit="$ctrl.commitmentForm.$valid && $ctrl.submit()"
+        >
+            <oui-spinner data-ng-if="$ctrl.loading"></oui-spinner>
+
+            <div data-ng-if="!$ctrl.loading">
+                <oui-field
+                    data-label="{{ :: 'commitment_entry_number_label' | translate }}"
+                    data-help-text="{{ :: 'commitment_entry_number_title' | translate }}"
+                    data-error-messages="{
+                        required: ('commitment_entry_number_required' | translate),
+                        pattern: ('commitment_entry_number_invalid' | translate)
+                    }"
+                >
+                    <input
+                        class="oui-input"
+                        type="text"
+                        id="commitmentNumber"
+                        name="commitmentNumber"
+                        data-ng-model="$ctrl.commitmentNumber"
+                        data-required
+                        data-ng-pattern="/^[A-Za-z0-9_+\/-]+$/"
+                        title="{{ 'commitment_entry_number_title' | translate }}"
+                    />
+                </oui-field>
+
+                <oui-form-actions
+                    data-submit-text="{{:: 'commitment_entry_submit' | translate }}"
+                    data-cancel-text="{{:: 'common_back' | translate }}"
+                    data-on-cancel="$ctrl.goToOrders()"
+                    data-disabled="$ctrl.commitmentForm.$invalid"
+                >
+                </oui-form-actions>
+            </div>
+        </form>
+
+        <oui-message data-ng-if="$ctrl.error" type="error">
+            <span data-translate="commitment_entry_error"></span>
+        </oui-message>
+    </div>
+</div>

--- a/packages/manager/modules/billing/src/commitment/billing-commitment-entry.module.js
+++ b/packages/manager/modules/billing/src/commitment/billing-commitment-entry.module.js
@@ -1,0 +1,11 @@
+import uiRouter from '@uirouter/angularjs';
+import routing from './billing-commitment-entry.routing';
+
+const moduleName = 'ovhManagerBillingCommitment';
+
+angular
+  .module(moduleName, [uiRouter])
+  .config(routing)
+  .run(/* @ngTranslationsInject:json ./translations */);
+
+export default moduleName;

--- a/packages/manager/modules/billing/src/commitment/billing-commitment-entry.routing.js
+++ b/packages/manager/modules/billing/src/commitment/billing-commitment-entry.routing.js
@@ -1,0 +1,19 @@
+import controller from './billing-commitment-entry.controller';
+import template from './billing-commitment-entry.html';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('billing.commitment', {
+    url: '/commitment/:orderId?ordersFilter',
+    template,
+    controller,
+    controllerAs: '$ctrl',
+    translations: { value: ['./translations'], format: 'json' },
+    resolve: {
+      breadcrumb: /* @ngInject */ ($translate) =>
+        $translate.instant('commitment_entry_title'),
+      orderId: /* @ngInject */ ($transition$) => $transition$.params().orderId,
+      ordersFilter: /* @ngInject */ ($transition$) =>
+        $transition$.params().ordersFilter,
+    },
+  });
+};

--- a/packages/manager/modules/billing/src/commitment/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/commitment/translations/Messages_fr_FR.json
@@ -1,0 +1,12 @@
+{
+  "commitment_entry_title": "Saisir un numéro d'engagement",
+  "commitment_entry_description": "Veuillez renseigner votre numéro d'engagement",
+  "commitment_entry_order_number": "Commande n° {{t0}}",
+  "commitment_entry_number_label": "Numéro d'engagement",
+  "commitment_entry_number_title": "Le numéro saisi doit respecter le format alphanumérique [0-9] [A-Z] et les caractères spéciaux suivants : '-' ; '_' ; '+' ; '/'",
+  "commitment_entry_number_required": "Le numéro d'engagement est requis.",
+  "commitment_entry_number_invalid": "Le numéro d'engagement ne doit contenir que des lettres, des chiffres et les caractères - _ + /.",
+  "commitment_entry_submit": "Valider",
+  "commitment_entry_error": "Une erreur s'est produite lors de la vérification du numéro d'engagement.",
+  "commitment_entry_success": "Le numéro d'engagement {{t0}} a bien été enregistré pour la commande {{t1}}."
+}

--- a/packages/manager/modules/billing/src/orders/orders/billing-orders.constant.js
+++ b/packages/manager/modules/billing/src/orders/orders/billing-orders.constant.js
@@ -4,8 +4,14 @@ export const BILLING_ORDERS_STATUS = {
   NOT_PAID: 'notPaid',
   ORDER_EXPIRED: 'orderExpired',
   DOCUMENTS_REQUESTED: 'documentsRequested',
+  DELIVERING: 'delivering',
 };
+
+export const COMMITMENT_ENTRY_ALLOWED_LEGALFORM = 'administration';
+export const COMMITMENT_ENTRY_ALLOWED_BILLING_COUNTRY = 'FR';
 
 export default {
   BILLING_ORDERS_STATUS,
+  COMMITMENT_ENTRY_ALLOWED_LEGALFORM,
+  COMMITMENT_ENTRY_ALLOWED_BILLING_COUNTRY,
 };

--- a/packages/manager/modules/billing/src/orders/orders/billing-orders.controller.js
+++ b/packages/manager/modules/billing/src/orders/orders/billing-orders.controller.js
@@ -1,7 +1,11 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
 import omit from 'lodash/omit';
-import { BILLING_ORDERS_STATUS } from './billing-orders.constant';
+import {
+  BILLING_ORDERS_STATUS,
+  COMMITMENT_ENTRY_ALLOWED_LEGALFORM,
+  COMMITMENT_ENTRY_ALLOWED_BILLING_COUNTRY,
+} from './billing-orders.constant';
 
 export default class BillingOrdersCtrl {
   /* @ngInject */
@@ -19,10 +23,12 @@ export default class BillingOrdersCtrl {
     goToOrder,
     goToOrderRetractation,
     goToCorrespondingBill,
+    goToCommitmentEntry,
     updateFilterParam,
     billingFeatureAvailability,
     timeNow,
     kycValidated,
+    currentUser,
   ) {
     this.$q = $q;
     this.$log = $log;
@@ -37,10 +43,21 @@ export default class BillingOrdersCtrl {
     this.goToOrder = goToOrder;
     this.goToOrderRetractation = goToOrderRetractation;
     this.goToCorrespondingBill = goToCorrespondingBill;
+    this.goToCommitmentEntry = goToCommitmentEntry;
     this.updateFilterParam = updateFilterParam;
     this.allowOrderTracking = billingFeatureAvailability.allowOrderTracking();
     this.timeNow = timeNow;
     this.kycValidated = kycValidated;
+    this.currentUser = currentUser;
+  }
+
+  allowCommitmentEntry($row) {
+    return (
+      $row.status === BILLING_ORDERS_STATUS.DELIVERING &&
+      this.currentUser.legalform === COMMITMENT_ENTRY_ALLOWED_LEGALFORM &&
+      this.currentUser.billingCountry ===
+        COMMITMENT_ENTRY_ALLOWED_BILLING_COUNTRY
+    );
   }
 
   descriptionOfHeading() {

--- a/packages/manager/modules/billing/src/orders/orders/billing-orders.html
+++ b/packages/manager/modules/billing/src/orders/orders/billing-orders.html
@@ -133,6 +133,13 @@
             >
                 <span data-translate="orders_order_view_bill"></span>
             </oui-action-menu-item>
+            <oui-action-menu-item
+                data-ng-if="$ctrl.allowCommitmentEntry($row)"
+                data-on-click="$ctrl.goToCommitmentEntry($row, $ctrl.filter)"
+            >
+                <span data-translate="commitment_entry"></span>
+            </oui-action-menu-item>
         </oui-action-menu>
     </oui-datagrid>
 </div>
+

--- a/packages/manager/modules/billing/src/orders/orders/orders.routing.js
+++ b/packages/manager/modules/billing/src/orders/orders/orders.routing.js
@@ -99,6 +99,12 @@ export default /* @ngInject */ ($stateProvider) => {
           });
       },
 
+      goToCommitmentEntry: /* @ngInject */ ($state) => (order, filter) =>
+        $state.go('billing.commitment', {
+          orderId: order.orderId,
+          ordersFilter: filter,
+        }),
+
       updateFilterParam: /* @ngInject */ ($state) => (filter) =>
         $state.go(
           'billing.orders.orders',

--- a/packages/manager/modules/billing/src/orders/orders/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/billing/src/orders/orders/translations/Messages_fr_FR.json
@@ -30,5 +30,6 @@
   "orders_order_action_retract": "Annuler la commande",
   "orders_order_view_bill": "Voir ma facture",
   "orders_tracking": "Suivi de commande",
-  "orders_order_status_orderExpired": "Commande expirée"
+  "orders_order_status_orderExpired": "Commande expirée",
+  "commitment_entry": "Saisir un numéro d'engagement"
 }


### PR DESCRIPTION
## Description

Add commitment number entry form for B2G orders

Adds a new page allowing B2G (administration) customers to submit a commitment/engagement number for their order. A new action button appears on the billing orders list, visible only for orders that are in delivering status, belong to a customer with legal form administration, and whose billing country is FR. Clicking it opens a dedicated form (billing.commitment state) where the customer can enter and submit the engagement number, which is sent via PUT /me/order/{orderId}/engagementNumber. On success, the user can navigate back to the orders list.

Ticket Reference: O2CBIL-1342
