### PR TITLE
feat(dedicated.dbaas): retire legacy access management behind a flag

### DIFF
--- a/packages/manager/modules/dbaas-logs/src/components/dual-list/component.js
+++ b/packages/manager/modules/dbaas-logs/src/components/dual-list/component.js
@@ -19,5 +19,8 @@ export default {
     onAdd: '&',
     onRemove: '&',
     bulkActionEnabled: '<',
+    // Renders the attached (target) pane alone, with its per-item remove
+    // affordance: the source pane and every add control disappear.
+    revokeOnly: '<?',
   },
 };

--- a/packages/manager/modules/dbaas-logs/src/components/dual-list/index.less
+++ b/packages/manager/modules/dbaas-logs/src/components/dual-list/index.less
@@ -309,4 +309,17 @@
       color: @oui-dual-list-empty-label-color;
     }
   }
+
+  /* Revoke-only: the attached pane is the whole widget. It keeps its
+     flex-basis of 100%, so it fills the row on its own; but it must also stop
+     behaving like the collapsed half of an accordion on narrow screens. */
+  &_revoke-only {
+    .oui-dual-list__target > .oui-dual-list__content {
+      .flexbox();
+    }
+
+    .oui-dual-list__header_toggle {
+      display: none;
+    }
+  }
 }

--- a/packages/manager/modules/dbaas-logs/src/components/dual-list/template.html
+++ b/packages/manager/modules/dbaas-logs/src/components/dual-list/template.html
@@ -1,5 +1,8 @@
-<div class="oui-dual-list">
-    <div class="oui-dual-list__source">
+<div
+    class="oui-dual-list"
+    data-ng-class="{ 'oui-dual-list_revoke-only': $ctrl.revokeOnly }"
+>
+    <div class="oui-dual-list__source" data-ng-if="!$ctrl.revokeOnly">
         <div class="oui-dual-list__header">
             <span>{{$ctrl.sourceListLabel}}</span>
             <span data-ng-if="!$ctrl.sourceListLoading"

--- a/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/component.js
+++ b/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/component.js
@@ -1,0 +1,19 @@
+import controller from './controller';
+import template from './template.html';
+
+export default {
+  template,
+  controller,
+  bindings: {
+    // The { answered, isDecommissioned } object resolved once on the root
+    // dbaas-logs state.
+    legacyAccess: '<',
+    trackClick: '<',
+    // Optional: when a surface owns an enable-IAM action, the notice link
+    // triggers it instead of navigating to the roles listing.
+    onEnableIam: '&?',
+    // Optional: suppress the enable-IAM link on a surface where the roles
+    // listing is not a valid destination (a service awaiting configuration).
+    hideEnableIam: '<?',
+  },
+};

--- a/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/constants.js
+++ b/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/constants.js
@@ -1,0 +1,25 @@
+export const TRACKING_HITS = {
+  ENABLE_IAM: 'legacy-access-notice::switch-to-ovhcloud-iam',
+  GUIDE: 'legacy-access-notice::go-to-logs-data-platform-guide',
+};
+
+// The canonical Logs Data Platform guide hub. Deliberately *not* the module's
+// own LOG_DATA_PLATFORM_GUIDES map (detail/detail.constants.js), which the
+// sidebar uses: that one is keyed by subsidiary and points at help.ovhcloud.com
+// knowledge-base categories, whereas this notice must send customers to the
+// docs.ovhcloud.com landing page.
+// Sliced by language, not by country: `en` serves en_GB, `fr` serves fr_FR and
+// fr_CA. These seven cover every locale the manager offers.
+export const GUIDE_URL_TEMPLATE =
+  'https://docs.ovhcloud.com/{{lang}}/guides/manage-and-operate/observability/logs-data-platform/landing-page-logs-data-platform';
+
+export const GUIDE_LANGUAGES = ['de', 'en', 'es', 'fr', 'it', 'pl', 'pt'];
+
+export const DEFAULT_GUIDE_LANGUAGE = 'en';
+
+export default {
+  TRACKING_HITS,
+  GUIDE_URL_TEMPLATE,
+  GUIDE_LANGUAGES,
+  DEFAULT_GUIDE_LANGUAGE,
+};

--- a/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/controller.js
+++ b/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/controller.js
@@ -1,0 +1,47 @@
+import {
+  DEFAULT_GUIDE_LANGUAGE,
+  GUIDE_LANGUAGES,
+  GUIDE_URL_TEMPLATE,
+  TRACKING_HITS,
+} from './constants';
+
+export default class LegacyAccessNoticeCtrl {
+  /* @ngInject */
+  constructor($translate) {
+    this.$translate = $translate;
+  }
+
+  $onInit() {
+    // The guide hub is published per language, so the displayed locale is what
+    // selects it — its primary subtag, degrading to English for anything the
+    // hub does not publish, so the link always has a destination.
+    const [language] = (this.$translate.use() || '')
+      .toLowerCase()
+      .split(/[-_]/);
+    this.guideUrl = GUIDE_URL_TEMPLATE.replace(
+      '{{lang}}',
+      GUIDE_LANGUAGES.includes(language) ? language : DEFAULT_GUIDE_LANGUAGE,
+    );
+    // '&?' leaves the binding undefined when the attribute is absent, which is
+    // how a surface says it has no enable-IAM action of its own to offer.
+    this.hasEnableIamAction = !!this.onEnableIam;
+    // One signal, two messages: the notice can never outlive the controls it
+    // announces.
+    const state = this.legacyAccess?.isDecommissioned ? 'after' : 'before';
+    this.titleKey = `logs_legacy_access_${state}_title`;
+    this.descriptionKey = `logs_legacy_access_${state}_description`;
+  }
+
+  enableIam() {
+    this.trackClick(TRACKING_HITS.ENABLE_IAM);
+    return this.onEnableIam();
+  }
+
+  goToRoles() {
+    this.trackClick(TRACKING_HITS.ENABLE_IAM);
+  }
+
+  goToGuide() {
+    this.trackClick(TRACKING_HITS.GUIDE);
+  }
+}

--- a/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/index.js
+++ b/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/index.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import component from './component';
+
+const moduleName = 'dbaasLogsLegacyAccessNotice';
+
+angular
+  .module(moduleName, [])
+  .component('dbaasLogsLegacyAccessNotice', component);
+
+export default moduleName;

--- a/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/template.html
+++ b/packages/manager/modules/dbaas-logs/src/components/legacy-access-notice/template.html
@@ -1,0 +1,32 @@
+<oui-message
+    data-type="info"
+    class="mb-3"
+    data-ng-if="$ctrl.legacyAccess.answered"
+>
+    <p class="font-weight-bold" data-translate="{{:: $ctrl.titleKey }}"></p>
+    <p data-translate="{{:: $ctrl.descriptionKey }}"></p>
+    <a
+        data-ng-if="!$ctrl.hideEnableIam && $ctrl.hasEnableIamAction"
+        class="d-block"
+        href=""
+        data-ng-click="$ctrl.enableIam()"
+        data-translate="logs_legacy_access_enable_iam"
+    ></a>
+    <a
+        data-ng-if="!$ctrl.hideEnableIam && !$ctrl.hasEnableIamAction"
+        class="d-block"
+        data-ui-sref="dbaas-logs.detail.roles"
+        data-ng-click="$ctrl.goToRoles()"
+        data-translate="logs_legacy_access_enable_iam"
+    ></a>
+    <a
+        class="d-block"
+        data-ng-href="{{:: $ctrl.guideUrl }}"
+        target="_blank"
+        rel="noopener"
+        data-ng-click="$ctrl.goToGuide()"
+    >
+        <span data-translate="logs_legacy_access_guide"></span>
+        <i class="oui-icon oui-icon-external-link" aria-hidden="true"></i>
+    </a>
+</oui-message>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/home/home.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/home/home.component.js
@@ -14,6 +14,8 @@ export default {
     aliasIds: '<',
     encryptionKeysIds: '<',
     goToResiliate: '<',
+    legacyAccess: '<',
+    trackClick: '<',
   },
   controller,
   controllerAs: 'ctrl',

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/home/logs-home.html
@@ -17,6 +17,12 @@
             data-translate-values="{ disabledDate: ctrl.lastUpdatedDate }"
         ></span>
     </div>
+    <dbaas-logs-legacy-access-notice
+        class="d-block m-3"
+        data-ng-if="!ctrl.service.isIamEnabled"
+        data-legacy-access="ctrl.legacyAccess"
+        data-track-click="ctrl.trackClick"
+    ></dbaas-logs-legacy-access-notice>
     <div class="row d-lg-flex mb-3">
         <div class="col-xm-12 col-md-4" data-ng-if="!ctrl.isAccountDisabled">
             <oui-tile
@@ -258,7 +264,11 @@
                     data-term="{{::'logs_home_password'|translate}}"
                     data-description="******"
                 >
-                    <oui-action-menu data-compact data-placement="end">
+                    <oui-action-menu
+                        data-compact
+                        data-placement="end"
+                        data-ng-if="!ctrl.legacyAccess.isDecommissioned"
+                    >
                         <oui-action-menu-item
                             aria-label="{{::'logs_edit'|translate}}"
                             data-on-click="ctrl.editPassword()"

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.component.js
@@ -2,6 +2,11 @@ import controller from './edit-permissions.controller';
 import template from './edit-permissions.html';
 
 export default {
+  bindings: {
+    service: '<',
+    legacyAccess: '<',
+    trackClick: '<',
+  },
   controller,
   controllerAs: 'ctrl',
   template,

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/edit-permissions/edit-permissions.html
@@ -7,6 +7,12 @@
         data-translate="logs_roles_permissions_subtitle"
         data-translate-values="{role:ctrl.roleDetails.data.name}"
     ></p>
+
+    <dbaas-logs-legacy-access-notice
+        data-ng-if="!ctrl.service.isIamEnabled"
+        data-legacy-access="ctrl.legacyAccess"
+        data-track-click="ctrl.trackClick"
+    ></dbaas-logs-legacy-access-notice>
     <oui-tabs>
         <oui-tabs-item
             data-heading="{{ ::'logs_roles_permissions_read_only' | translate }}"
@@ -29,6 +35,7 @@
                         on-remove="ctrl.removePermission(items, 'streamId')"
                         bulk-action-enabled="false"
                         height="300px"
+                        revoke-only="ctrl.legacyAccess.isDecommissioned"
                     >
                     </cui-dual-list>
                 </div>
@@ -50,6 +57,7 @@
                         on-remove="ctrl.removePermission(items, 'dashboardId')"
                         bulk-action-enabled="false"
                         height="300px"
+                        revoke-only="ctrl.legacyAccess.isDecommissioned"
                     >
                     </cui-dual-list>
                 </div>
@@ -71,6 +79,7 @@
                         on-remove="ctrl.removePermission(items, 'indexId')"
                         bulk-action-enabled="false"
                         height="300px"
+                        revoke-only="ctrl.legacyAccess.isDecommissioned"
                     >
                     </cui-dual-list>
                 </div>
@@ -92,6 +101,7 @@
                         on-remove="ctrl.removePermission(items, 'aliasId')"
                         bulk-action-enabled="false"
                         height="300px"
+                        revoke-only="ctrl.legacyAccess.isDecommissioned"
                     >
                     </cui-dual-list>
                 </div>
@@ -113,6 +123,7 @@
                         on-remove="ctrl.removePermission(items, 'osdId')"
                         bulk-action-enabled="false"
                         height="300px"
+                        revoke-only="ctrl.legacyAccess.isDecommissioned"
                     >
                     </cui-dual-list>
                 </div>
@@ -138,6 +149,7 @@
                     on-remove="ctrl.removePermission(items, 'dashboardId')"
                     bulk-action-enabled="false"
                     height="300px"
+                    revoke-only="ctrl.legacyAccess.isDecommissioned"
                 >
                 </cui-dual-list>
             </div>
@@ -158,6 +170,7 @@
                     on-remove="ctrl.removePermission(items, 'indexId')"
                     bulk-action-enabled="false"
                     height="300px"
+                    revoke-only="ctrl.legacyAccess.isDecommissioned"
                 >
                 </cui-dual-list>
             </div>
@@ -178,6 +191,7 @@
                     on-remove="ctrl.removePermission(items, 'osdId')"
                     bulk-action-enabled="false"
                     height="300px"
+                    revoke-only="ctrl.legacyAccess.isDecommissioned"
                 >
                 </cui-dual-list>
             </div>

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/logs-roles.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/logs-roles.html
@@ -1,6 +1,19 @@
 <section>
     <h3 data-translate="logs_roles_title"></h3>
-    <p data-translate="logs_roles_description"></p>
+    <p
+        data-ng-if="!ctrl.legacyAccess.isDecommissioned"
+        data-translate="logs_roles_description"
+    ></p>
+    <p
+        data-ng-if="ctrl.legacyAccess.isDecommissioned"
+        data-translate="logs_roles_description_decommissioned"
+    ></p>
+    <dbaas-logs-legacy-access-notice
+        data-ng-if="!ctrl.service.isIamEnabled"
+        data-legacy-access="ctrl.legacyAccess"
+        data-track-click="ctrl.trackClick"
+        data-on-enable-iam="ctrl.showEnableIam()"
+    ></dbaas-logs-legacy-access-notice>
     <oui-datagrid
         id="roles-datagrid"
         data-rows-loader="ctrl.loadRoles($config)"
@@ -18,6 +31,7 @@
                 type="button"
                 class="oui-button oui-button_secondary"
                 data-ng-click="ctrl.add()"
+                data-ng-if="!ctrl.legacyAccess.isDecommissioned"
             >
                 <span
                     class="oui-icon oui-icon-add pr-1"
@@ -72,7 +86,9 @@
             <oui-action-menu-item data-on-click="ctrl.summary($row)"
                 ><span data-translate="logs_show_summary"></span
             ></oui-action-menu-item>
-            <oui-action-menu-item data-on-click="ctrl.add($row)"
+            <oui-action-menu-item
+                data-on-click="ctrl.add($row)"
+                data-ng-if="!ctrl.legacyAccess.isDecommissioned"
                 ><span data-translate="logs_edit"></span
             ></oui-action-menu-item>
             <oui-action-menu-item data-on-click="ctrl.editPermissions($row)"

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/members/logs-roles-members.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/members/logs-roles-members.html
@@ -9,13 +9,22 @@
     ></p>
     <p data-translate="logs_roles_members_description"></p>
 
+    <dbaas-logs-legacy-access-notice
+        data-ng-if="!ctrl.service.isIamEnabled"
+        data-legacy-access="ctrl.legacyAccess"
+        data-track-click="ctrl.trackClick"
+    ></dbaas-logs-legacy-access-notice>
+
     <oui-datagrid rows="ctrl.availableMembers.data">
         <oui-datagrid-topbar>
             <button
                 type="button"
                 class="oui-button oui-button_secondary"
                 data-ng-click="ctrl.add()"
-                data-ng-if="!ctrl.delete.loading"
+                data-ng-if="
+                    !ctrl.delete.loading &&
+                    !ctrl.legacyAccess.isDecommissioned
+                "
             >
                 <i class="oui-icon oui-icon-add pr-1" aria-hidden="true"></i> {{
                 ::'logs_roles_members_add' | translate }}

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/members/members.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/members/members.component.js
@@ -2,6 +2,11 @@ import controller from './logs-roles-members.controller';
 import template from './logs-roles-members.html';
 
 export default {
+  bindings: {
+    service: '<',
+    legacyAccess: '<',
+    trackClick: '<',
+  },
   controller,
   controllerAs: 'ctrl',
   template,

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/roles/roles.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/roles/roles.component.js
@@ -4,6 +4,8 @@ import template from './logs-roles.html';
 export default {
   bindings: {
     service: '<',
+    legacyAccess: '<',
+    trackClick: '<',
   },
   controller,
   controllerAs: 'ctrl',

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/add/add.routing.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/add/add.routing.js
@@ -1,6 +1,17 @@
+// Hiding a button never stops a typed address, and this is the only
+// bookmarkable legacy write address in the module.
+const redirectTo = (transition) =>
+  transition
+    .injector()
+    .getAsync('legacyAccess')
+    .then(({ isDecommissioned }) =>
+      isDecommissioned ? 'dbaas-logs.detail.tokens' : false,
+    );
+
 export default /* @ngInject */ ($stateProvider) => {
   $stateProvider.state('dbaas-logs.detail.tokens.add', {
     url: '/add',
+    redirectTo,
     views: {
       logsTokensAdd: 'dbaasLogsDetailTokensAdd',
     },

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/logs-tokens.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/logs-tokens.html
@@ -3,7 +3,20 @@
         ><span data-translate="logs_tokens_title"></span
     ></oui-back-button>
 
-    <p data-translate="logs_tokens_description"></p>
+    <p
+        data-ng-if="!ctrl.legacyAccess.isDecommissioned"
+        data-translate="logs_tokens_description"
+    ></p>
+    <p
+        data-ng-if="ctrl.legacyAccess.isDecommissioned"
+        data-translate="logs_tokens_description_decommissioned"
+    ></p>
+
+    <dbaas-logs-legacy-access-notice
+        data-ng-if="!ctrl.service.isIamEnabled"
+        data-legacy-access="ctrl.legacyAccess"
+        data-track-click="ctrl.trackClick"
+    ></dbaas-logs-legacy-access-notice>
 
     <oui-datagrid
         id="tokens-datagrid"
@@ -15,6 +28,7 @@
                 class="oui-button oui-button_secondary"
                 data-ui-sref="dbaas-logs.detail.tokens.add"
                 data-ng-disabled="ctrl.delete.loading"
+                data-ng-if="!ctrl.legacyAccess.isDecommissioned"
             >
                 <span
                     class="oui-icon oui-icon-add pr-1"

--- a/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/tokens.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/detail/tokens/tokens.component.js
@@ -2,6 +2,11 @@ import controller from './logs-tokens.controller';
 import template from './logs-tokens.html';
 
 export default {
+  bindings: {
+    service: '<',
+    legacyAccess: '<',
+    trackClick: '<',
+  },
   controller,
   controllerAs: 'ctrl',
   template,

--- a/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.component.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.component.js
@@ -8,6 +8,8 @@ export default {
     service: '<',
     goBack: '<',
     goToDetail: '<',
+    legacyAccess: '<',
+    trackClick: '<',
   },
   template,
 };

--- a/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.controller.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.controller.js
@@ -44,6 +44,13 @@ export default class LogsAccountSetupCtrl {
         value: ACCOUNT_MODES.PASSWORD,
       },
     ];
+    if (this.legacyAccess?.isDecommissioned) {
+      // Password setup is retired: OVHcloud IAM is the only setup path left,
+      // so the choice is not offered and setupAccount() can only enable IAM.
+      this.accountModes = this.accountModes.filter(
+        ({ value }) => value === ACCOUNT_MODES.IAM,
+      );
+    }
     [this.accountMode] = this.accountModes;
   }
 

--- a/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.html
+++ b/packages/manager/modules/dbaas-logs/src/logs/list/account-setup/account-setup.html
@@ -9,7 +9,15 @@
     data-loading="$ctrl.loading"
 >
     <form novalidate name="$ctrl.form">
+        <dbaas-logs-legacy-access-notice
+            class="d-block mb-3"
+            data-ng-if="$ctrl.legacyAccess.isDecommissioned"
+            data-legacy-access="$ctrl.legacyAccess"
+            data-track-click="$ctrl.trackClick"
+            data-hide-enable-iam="true"
+        ></dbaas-logs-legacy-access-notice>
         <oui-field
+            data-ng-if="!$ctrl.legacyAccess.isDecommissioned"
             data-label="{{:: 'dbaas_logs_account_setup_auth_mode' | translate }}"
         >
             <oui-select

--- a/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/logs-constants.js
@@ -1,6 +1,10 @@
 export default {
   SERVICE_TYPE: 'DBAAS_LOGS',
   TRACKING_PREFIX: 'DedicatedServers::dbaas::ldp',
+  FEATURE: {
+    LEGACY_ACCESS_DECOMMISSIONED:
+      'logs-data-platform:legacy-access-decommissioned',
+  },
   LDP_PLAN_CODE: 'logs-account',
   LDP_PLAN_CODE_ENTERPRISE: 'logs-enterprise',
   COLDSTORAGE: 'COLDSTORAGE',

--- a/packages/manager/modules/dbaas-logs/src/logs/logs.module.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/logs.module.js
@@ -5,6 +5,7 @@ import '@uirouter/angularjs';
 import '@ovh-ux/manager-at-internet-configuration';
 import '@ovh-ux/manager-core';
 import '@ovh-ux/ng-ovh-cloud-universe-components';
+import ngOvhFeatureFlipping from '@ovh-ux/ng-ovh-feature-flipping';
 import 'ovh-api-services';
 import '@ovh-ux/ui-kit';
 import 'angular-ui-bootstrap';
@@ -23,6 +24,7 @@ import logsOnboarding from './onboarding';
 import logsOrder from './order/order.module';
 import routing from './logs.routing';
 import cuiDualList from '../components/dual-list';
+import legacyAccessNotice from '../components/legacy-access-notice';
 
 const moduleName = 'ovhManagerDbaasLogsDashboard';
 
@@ -38,6 +40,8 @@ angular
     'ovhManagerAtInternetConfiguration',
     cuiDualList,
     empty,
+    legacyAccessNotice,
+    ngOvhFeatureFlipping,
     logsOrder,
     logsDetail,
     logsList,

--- a/packages/manager/modules/dbaas-logs/src/logs/logs.routing.js
+++ b/packages/manager/modules/dbaas-logs/src/logs/logs.routing.js
@@ -15,6 +15,26 @@ export default /* @ngInject */ ($stateProvider) => {
           type: 'action',
         });
       },
+      // The single place the decommission flag is read and its polarity
+      // inverted. `answered` records that the request actually succeeded, so
+      // the notice never asserts a date state the application does not know.
+      legacyAccess: /* @ngInject */ (ovhFeatureFlipping) =>
+        ovhFeatureFlipping
+          .checkFeatureAvailability([
+            LogConstants.FEATURE.LEGACY_ACCESS_DECOMMISSIONED,
+          ])
+          .then((result) => ({
+            answered: true,
+            // isFeatureAvailable returns the raw value, undefined for an
+            // absent key: only an explicit true means decommissioned.
+            isDecommissioned:
+              result.isFeatureAvailable(
+                LogConstants.FEATURE.LEGACY_ACCESS_DECOMMISSIONED,
+              ) === true,
+          }))
+          // Fail closed: a failed request, an unpublished key and the loading
+          // window all keep the legacy write controls available.
+          .catch(() => ({ answered: false, isDecommissioned: false })),
       logs: /* @ngInject */ (OvhApiDbaas) =>
         OvhApiDbaas.Logs()
           .v6()

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_de_DE.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "OVHcloud Audit-Logs",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
   "logs_roles_enable_iam": "OVHcloud IAM aktivieren",
-  "logs_iam_policies_get_error": "Beim Laden der IAM-Richtlinien ist ein Fehler aufgetreten."
+  "logs_iam_policies_get_error": "Beim Laden der IAM-Richtlinien ist ein Fehler aufgetreten.",
+  "logs_legacy_access_before_title": "Die historische Zugriffsverwaltung wird durch OVHcloud IAM ersetzt.",
+  "logs_legacy_access_before_description": "Die Rollen, Token und die Passwort-Authentifizierung für diesen Dienst werden entfernt. Aktivieren Sie OVHcloud IAM für diesen Dienst, um dessen Zugriffe weiterhin zu verwalten.",
+  "logs_legacy_access_after_title": "Die Zugriffsverwaltung erfolgt nun über OVHcloud IAM.",
+  "logs_legacy_access_after_description": "Sie können für diesen Dienst keine Rollen, Token oder Passwörter mehr erstellen oder bearbeiten. Bestehende Elemente bleiben sichtbar und können weiterhin widerrufen werden. Aktivieren Sie OVHcloud IAM für diesen Dienst, um dessen Zugriffe zu verwalten.",
+  "logs_legacy_access_enable_iam": "Zu OVHcloud IAM wechseln",
+  "logs_legacy_access_guide": "Dokumentation zu Logs Data Platform aufrufen",
+  "logs_roles_description_decommissioned": "Die Rollenverwaltung wird durch OVHcloud IAM ersetzt. Bestehende Rollen bleiben sichtbar und können weiterhin gelöscht werden, sie können jedoch nicht mehr erstellt oder bearbeitet werden.",
+  "logs_tokens_description_decommissioned": "Die Token-Verwaltung wird durch OVHcloud IAM ersetzt. Bestehende Token bleiben sichtbar und können weiterhin widerrufen werden, es ist jedoch nicht mehr möglich, neue zu erstellen."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_en_GB.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "OVHcloud Logs Audit",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
   "logs_roles_enable_iam": "Enable OVHcloud IAM",
-  "logs_iam_policies_get_error": "An error occurred while loading IAM policies."
+  "logs_iam_policies_get_error": "An error occurred while loading IAM policies.",
+  "logs_legacy_access_before_title": "Legacy access management is being replaced by OVHcloud IAM",
+  "logs_legacy_access_before_description": "The roles, tokens and password authentication for this service will be removed. Enable OVHcloud IAM on this service to continue managing its access.",
+  "logs_legacy_access_after_title": "Access management is now provided by OVHcloud IAM",
+  "logs_legacy_access_after_description": "You can no longer create or modify a role, token or password for this service. Existing items remain visible and can still be revoked. Enable OVHcloud IAM on this service to manage its access.",
+  "logs_legacy_access_enable_iam": "Switch to OVHcloud IAM",
+  "logs_legacy_access_guide": "Consult the Logs Data Platform documentation",
+  "logs_roles_description_decommissioned": "Role management is being replaced by OVHcloud IAM. Existing roles remain visible and can still be deleted, but they can no longer be created or modified.",
+  "logs_tokens_description_decommissioned": "Token management is being replaced by OVHcloud IAM. Existing tokens remain visible and can still be revoked, but it is no longer possible to create new ones."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_es_ES.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
   "logs_roles_enable_iam": "Activar IAM OVHcloud",
-  "logs_iam_policies_get_error": "Se ha producido un error al cargar las directivas IAM."
+  "logs_iam_policies_get_error": "Se ha producido un error al cargar las directivas IAM.",
+  "logs_legacy_access_before_title": "La gestión de accesos histórica es sustituida por IAM OVHcloud",
+  "logs_legacy_access_before_description": "Los roles, los tokens y la autenticación por contraseña de este servicio van a ser retirados. Activad IAM OVHcloud en este servicio para seguir gestionando sus accesos.",
+  "logs_legacy_access_after_title": "La gestión de accesos está ahora garantizada por IAM OVHcloud",
+  "logs_legacy_access_after_description": "Ya no podéis crear ni modificar ningún rol, token o contraseña para este servicio. Los elementos existentes siguen siendo visibles y todavía pueden revocarse. Activad IAM OVHcloud en este servicio para gestionar sus accesos.",
+  "logs_legacy_access_enable_iam": "Pasar a IAM OVHcloud",
+  "logs_legacy_access_guide": "Consultar la documentación de Logs Data Platform",
+  "logs_roles_description_decommissioned": "La gestión de roles es sustituida por IAM OVHcloud. Los roles existentes siguen siendo visibles y todavía pueden eliminarse, pero ya no pueden crearse ni modificarse.",
+  "logs_tokens_description_decommissioned": "La gestión de tokens es sustituida por IAM OVHcloud. Los tokens existentes siguen siendo visibles y todavía pueden revocarse, pero ya no es posible crear otros nuevos."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_CA.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
   "streams_subscriptions_resource_products_account-api": "Espace client OVHcloud & OVHcloud API",
   "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "logs_legacy_access_before_title": "La gestion des accès historique est remplacée par l'IAM OVHcloud",
+  "logs_legacy_access_before_description": "Les rôles, les jetons et l'authentification par mot de passe de ce service vont être retirés. Activez l'IAM OVHcloud sur ce service pour continuer à gérer ses accès.",
+  "logs_legacy_access_after_title": "La gestion des accès est désormais assurée par l'IAM OVHcloud",
+  "logs_legacy_access_after_description": "Vous ne pouvez plus créer ni modifier de rôle, de jeton ou de mot de passe pour ce service. Les éléments existants restent visibles et peuvent toujours être révoqués. Activez l'IAM OVHcloud sur ce service pour gérer ses accès.",
+  "logs_legacy_access_enable_iam": "Passer à l'IAM OVHcloud",
+  "logs_legacy_access_guide": "Consulter la documentation Logs Data Platform",
+  "logs_roles_description_decommissioned": "La gestion des rôles est remplacée par l'IAM OVHcloud. Les rôles existants restent visibles et peuvent toujours être supprimés, mais ils ne peuvent plus être créés ni modifiés.",
+  "logs_tokens_description_decommissioned": "La gestion des jetons est remplacée par l'IAM OVHcloud. Les jetons existants restent visibles et peuvent toujours être révoqués, mais il n'est plus possible d'en créer de nouveaux."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_fr_FR.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_webhosting": "Web Hosting",
   "streams_subscriptions_resource_products_account-api": "Espace client OVHcloud & OVHcloud API",
   "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
-  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service"
+  "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
+  "logs_legacy_access_before_title": "La gestion des accès historique est remplacée par l'IAM OVHcloud",
+  "logs_legacy_access_before_description": "Les rôles, les jetons et l'authentification par mot de passe de ce service vont être retirés. Activez l'IAM OVHcloud sur ce service pour continuer à gérer ses accès.",
+  "logs_legacy_access_after_title": "La gestion des accès est désormais assurée par l'IAM OVHcloud",
+  "logs_legacy_access_after_description": "Vous ne pouvez plus créer ni modifier de rôle, de jeton ou de mot de passe pour ce service. Les éléments existants restent visibles et peuvent toujours être révoqués. Activez l'IAM OVHcloud sur ce service pour gérer ses accès.",
+  "logs_legacy_access_enable_iam": "Passer à l'IAM OVHcloud",
+  "logs_legacy_access_guide": "Consulter la documentation Logs Data Platform",
+  "logs_roles_description_decommissioned": "La gestion des rôles est remplacée par l'IAM OVHcloud. Les rôles existants restent visibles et peuvent toujours être supprimés, mais ils ne peuvent plus être créés ni modifiés.",
+  "logs_tokens_description_decommissioned": "La gestion des jetons est remplacée par l'IAM OVHcloud. Les jetons existants restent visibles et peuvent toujours être révoqués, mais il n'est plus possible d'en créer de nouveaux."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_it_IT.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "Audit Logs OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
   "logs_roles_enable_iam": "Attivare IAM OVHcloud",
-  "logs_iam_policies_get_error": "Si è verificato un errore durante il caricamento delle politiche IAM."
+  "logs_iam_policies_get_error": "Si è verificato un errore durante il caricamento delle politiche IAM.",
+  "logs_legacy_access_before_title": "La gestione degli accessi storica è sostituita dall'IAM OVHcloud",
+  "logs_legacy_access_before_description": "I ruoli, i token e l'autenticazione tramite password di questo servizio verranno rimossi. Attiva l'IAM OVHcloud su questo servizio per continuare a gestirne gli accessi.",
+  "logs_legacy_access_after_title": "La gestione degli accessi è ora garantita dall'IAM OVHcloud",
+  "logs_legacy_access_after_description": "Non puoi più creare né modificare ruoli, token o password per questo servizio. Gli elementi esistenti rimangono visibili e possono sempre essere revocati. Attiva l'IAM OVHcloud su questo servizio per gestire i suoi accessi.",
+  "logs_legacy_access_enable_iam": "Passa all'IAM OVHcloud",
+  "logs_legacy_access_guide": "Consulta la documentazione di Logs Data Platform",
+  "logs_roles_description_decommissioned": "La gestione dei ruoli è sostituita dall'IAM OVHcloud. I ruoli esistenti rimangono visibili e possono sempre essere eliminati, ma non possono più essere creati né modificati.",
+  "logs_tokens_description_decommissioned": "La gestione dei token è sostituita dall'IAM OVHcloud. I token esistenti rimangono visibili e possono sempre essere revocati, ma non è più possibile crearne di nuovi."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pl_PL.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "Audyt logów OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes Service",
   "logs_roles_enable_iam": "Włącz IAM OVHcloud",
-  "logs_iam_policies_get_error": "Wystąpił błąd podczas ładowania polityk IAM."
+  "logs_iam_policies_get_error": "Wystąpił błąd podczas ładowania polityk IAM.",
+  "logs_legacy_access_before_title": "Dotychczasowe zarządzanie dostępem zostało zastąpione przez IAM OVHcloud",
+  "logs_legacy_access_before_description": "Role, tokeny oraz uwierzytelnianie hasłem w tej usłudze zostaną wycofane. Aktywuj IAM OVHcloud w tej usłudze, aby kontynuować zarządzanie dostępem do niej.",
+  "logs_legacy_access_after_title": "Zarządzanie dostępem jest od teraz zapewniane przez IAM OVHcloud",
+  "logs_legacy_access_after_description": "Nie możesz już tworzyć ani modyfikować roli, tokenu ani hasła dla tej usługi. Istniejące elementy pozostają widoczne i nadal można je unieważnić. Aktywuj IAM OVHcloud w tej usłudze, aby zarządzać dostępem do niej.",
+  "logs_legacy_access_enable_iam": "Przejdź na IAM OVHcloud",
+  "logs_legacy_access_guide": "Zapoznaj się z dokumentacją Logs Data Platform",
+  "logs_roles_description_decommissioned": "Zarządzanie rolami zostało zastąpione przez IAM OVHcloud. Istniejące role pozostają widoczne i nadal można je usuwać, jednak nie można ich już tworzyć ani modyfikować.",
+  "logs_tokens_description_decommissioned": "Zarządzanie tokenami zostało zastąpione przez IAM OVHcloud. Istniejące tokeny pozostają widoczne i nadal można je unieważniać, jednak nie ma już możliwości tworzenia nowych."
 }

--- a/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/dbaas-logs/src/logs/translations/Messages_pt_PT.json
@@ -803,5 +803,13 @@
   "streams_subscriptions_resource_products_account-audit": "Auditoria Logs OVHcloud",
   "streams_subscriptions_resource_products_cloud-project-kube": "Managed Kubernetes",
   "logs_roles_enable_iam": "Ativar o IAM OVHcloud",
-  "logs_iam_policies_get_error": "Ocorreu um erro aquando do carregamento das políticas IAM."
+  "logs_iam_policies_get_error": "Ocorreu um erro aquando do carregamento das políticas IAM.",
+  "logs_legacy_access_before_title": "A gestão de acessos histórica é substituída pelo IAM OVHcloud",
+  "logs_legacy_access_before_description": "As funções, os tokens e a autenticação por palavra-passe deste serviço vão ser retirados. Ative o IAM OVHcloud neste serviço para continuar a gerir os seus acessos.",
+  "logs_legacy_access_after_title": "A gestão de acessos é agora assegurada pelo IAM OVHcloud",
+  "logs_legacy_access_after_description": "Já não pode criar nem modificar funções, tokens ou palavras-passe para este serviço. Os elementos existentes permanecem visíveis e podem sempre ser revogados. Ative o IAM OVHcloud neste serviço para gerir os seus acessos.",
+  "logs_legacy_access_enable_iam": "Passar para o IAM OVHcloud",
+  "logs_legacy_access_guide": "Consultar a documentação Logs Data Platform",
+  "logs_roles_description_decommissioned": "A gestão de funções é substituída pelo IAM OVHcloud. As funções existentes permanecem visíveis e podem sempre ser eliminadas, mas já não podem ser criadas nem modificadas.",
+  "logs_tokens_description_decommissioned": "A gestão de tokens é substituída pelo IAM OVHcloud. Os tokens existentes permanecem visíveis e podem sempre ser revogados, mas já não é possível criar novos."
 }


### PR DESCRIPTION
Every legacy write control on a non-IAM Logs Data Platform service is now gated on the logs-data-platform:legacy-access-decommissioned availability flag: the password tile action, the account-setup password mode, Add a token (button and route), Add a role, the row Edit entry, Add a member, and the attach panes of the role permissions widget. Reads, deletes, revokes and detaches are untouched, and nothing is removed: before the date the interface is unchanged apart from an informational notice.

The flag is read once, on the root state, and fails closed. A failed request, an unpublished key and the loading window all resolve to "not decommissioned", which keeps the legacy controls available.

resolves: #MAOBS-629

<!--
Hello 👋 Thank you for submitting a Pull Request.

Have any questions? Check out the contributing docs at https://github.com/ovh/manager/blob/master/CONTRIBUTING.md

Please read the following before submitting:

- Keep your PR as small as possible to make easy reviews.
- Commits are signed-off.
- Update only Messages_fr_FR.json locales for any content changes.
- Lint has passed locally.
- Standalone app was ran and tested locally.
- Ticket reference is mentioned in linked commits (internal only).
- Breaking change is mentioned in relevant commits.
- Limit your PR to one type (build, ci, docs, feat, fix, perf, refactor, revert, style, test or release)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->


<!-- Provide Jira ticket or Github issue -->
Ticket Reference: #...    <!-- prefix each issue number with "#", if any  -->

## Additional Information

<!-- 
Mention any other information relevant to the PRs. It can be,

- link dependencies of PR
- Translations ticket reference
- Screenshots to better explain the change
 -->
