### PR TITLE
feat(account): add pixel tracking consent checkbox on account edition

### DIFF
--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.js
@@ -6,9 +6,11 @@ import map from 'lodash/map';
 import startsWith from 'lodash/startsWith';
 import { LANGUAGES } from '@ovh-ux/manager-config';
 import {
+  CONSENT_RESYNC_EVENT,
   PHONE_PREFIX,
   MODEL_DEBOUNCE_DELAY,
   FIELD_NAME_LIST,
+  PIXEL_TRACKING_RESET_EVENT,
   USER_TYPE_ENTERPRISE,
 } from '../new-account-form-component.constants';
 
@@ -114,6 +116,46 @@ export default class NewAccountFormFieldController {
     if (this.rule.fieldName === 'smsConsent') {
       this.$scope.$on('account.smsConsent.reset', () => {
         // switch value to false only if it is true
+        if (this.value) {
+          this.onChange();
+          this.value = false;
+        }
+      });
+    }
+
+    // The two marketing-consent checkboxes are the only fields whose displayed
+    // state the API can contradict after a submit. That state is this local
+    // copy — setInitialValue() runs once, at $onInit, behind a truthy-only
+    // guard, and the parent's ng-repeat tracks by fieldName — so re-injecting
+    // the rule cannot repaint a box. The parent hands the freshly fetched
+    // decision back through this event instead.
+    // No onChange() here on purpose: the parent has already set the model to
+    // the decision it re-read, so the model already matches both the server
+    // and the value assigned below — notifying it would only re-enter
+    // onFieldChange, emitting a consent trackClick and a rules refresh for a
+    // change the customer did not make.
+    if (
+      [
+        FIELD_NAME_LIST.commercialCommunicationsApproval,
+        FIELD_NAME_LIST.pixelTrackingConsent,
+      ].includes(this.rule.fieldName)
+    ) {
+      this.$scope.$on(CONSENT_RESYNC_EVENT, (event, decision = {}) => {
+        this.value = !!decision[this.rule.fieldName];
+      });
+    }
+
+    // Revoking marketing email consent revokes pixel tracking with it
+    // (business rule 9), so the box is cleared and disabled in the same UI
+    // update. Same shape as the smsConsent reset above — and THE ORDER OF THE
+    // TWO STATEMENTS IS LOAD-BEARING, for the same reason: onChange() re-reads
+    // this PRE-toggle local value and inverts it (see its checkbox branch), so
+    // it has to run while this.value is still true in order to push false into
+    // the model. Swapping the two lines would push TRUE — the exact opposite
+    // of a reset. Do not "tidy" this; there is a test that fails if you do.
+    if (this.rule.fieldName === FIELD_NAME_LIST.pixelTrackingConsent) {
+      this.$scope.$on(PIXEL_TRACKING_RESET_EVENT, () => {
+        // nothing to clear when it is already unchecked
         if (this.value) {
           this.onChange();
           this.value = false;

--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.spec.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.controller.spec.js
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import NewAccountFormFieldCtrl from './new-account-form-field-component.controller';
+
+// The app bundle provides angular as a global; the controller relies on it
+// rather than importing it. setInitialValue is the only reach from here.
+global.angular = {
+  copy: (value) => JSON.parse(JSON.stringify(value ?? null)),
+};
+
+const PIXEL_RESET = 'account.pixelTrackingConsent.reset';
+const RESYNC = 'account.consent.resync';
+const PIXEL = 'pixelTrackingConsent';
+const EMAIL_CONSENT = 'commercialCommunicationsApproval';
+
+const checkboxRule = (fieldName, initialValue = null) => ({
+  fieldName,
+  fieldType: 'checkbox',
+  mandatory: false,
+  defaultValue: null,
+  initialValue,
+});
+
+const build = (rule) => {
+  const listeners = {};
+  const $scope = {
+    $watch: () => {},
+    $emit: () => {},
+    $on: (name, fn) => {
+      listeners[name] = fn;
+    },
+  };
+  const onFieldChange = vi.fn();
+  const ctrl = new NewAccountFormFieldCtrl(
+    vi.fn(),
+    {},
+    $scope,
+    (fn) => fn(),
+    { instant: (key) => key },
+    { trackClick: vi.fn() },
+    { getUser: () => ({}) },
+  );
+  ctrl.rule = rule;
+  ctrl.fieldset = {};
+  ctrl.isIndianSubsidiary = false;
+  ctrl.newAccountForm = { onFieldChange, model: {}, rules: [] };
+  ctrl.$onInit();
+  return { ctrl, listeners, onFieldChange };
+};
+
+describe('the state a consent checkbox renders with', () => {
+  // business rule 1, and it keeps the Save button disabled on load
+  it('renders unchecked and writes nothing into the parent model', () => {
+    const { ctrl, onFieldChange } = build(checkboxRule(PIXEL, false));
+
+    expect(ctrl.value).toBeUndefined();
+    expect(onFieldChange).not.toHaveBeenCalled();
+  });
+
+  it('renders checked when the API granted it', () => {
+    const { ctrl } = build(checkboxRule(PIXEL, true));
+
+    expect(ctrl.value).toBe(true);
+  });
+});
+
+describe('revoking marketing email consent while pixel tracking is on', () => {
+  // THE regression this file exists for: onChange() re-reads the pre-toggle
+  // local value and inverts it, so it has to run BEFORE this.value = false.
+  // Swap the two statements and the model receives true instead.
+  it('pushes false into the model, not true', () => {
+    const rule = checkboxRule(PIXEL, true);
+    const { ctrl, listeners, onFieldChange } = build(rule);
+
+    listeners[PIXEL_RESET]();
+
+    expect(onFieldChange).toHaveBeenCalledWith(rule, false, ctrl.fieldset);
+    expect(ctrl.value).toBe(false);
+  });
+
+  it('does nothing when the box is already unchecked', () => {
+    const { ctrl, listeners, onFieldChange } = build(checkboxRule(PIXEL));
+
+    listeners[PIXEL_RESET]();
+
+    expect(onFieldChange).not.toHaveBeenCalled();
+    expect(ctrl.value).toBeUndefined();
+  });
+
+  it('is not listened for by any other checkbox', () => {
+    const { listeners } = build(checkboxRule(EMAIL_CONSENT, true));
+
+    expect(listeners[PIXEL_RESET]).toBeUndefined();
+  });
+
+  it('is not listened for by the sms consent checkbox either', () => {
+    const { listeners } = build(checkboxRule('smsConsent', true));
+
+    expect(listeners[PIXEL_RESET]).toBeUndefined();
+    expect(listeners['account.smsConsent.reset']).toBeTypeOf('function');
+  });
+
+  // The sms reset is byte-identical to the pixel one and carries the same
+  // invisible ordering contract, but nothing covered it: a first-match
+  // "tidy-up" of `this.onChange(); this.value = false;` lands on THAT block
+  // and pushes true into the model with the suite still green. It costs one
+  // assertion to close, and the harness is already built.
+  it('pins the same ordering contract on the sms consent reset', () => {
+    const rule = checkboxRule('smsConsent', true);
+    const { ctrl, listeners, onFieldChange } = build(rule);
+
+    listeners['account.smsConsent.reset']();
+
+    expect(onFieldChange).toHaveBeenCalledWith(rule, false, ctrl.fieldset);
+    expect(ctrl.value).toBe(false);
+  });
+});
+
+describe('a decision the API handed back after refusing a write', () => {
+  it('repaints the pixel checkbox from it', () => {
+    const { ctrl, listeners } = build(checkboxRule(PIXEL, true));
+
+    listeners[RESYNC](null, { [EMAIL_CONSENT]: true, [PIXEL]: false });
+
+    expect(ctrl.value).toBe(false);
+  });
+
+  it('repaints the marketing email checkbox from the same event', () => {
+    const { ctrl, listeners } = build(checkboxRule(EMAIL_CONSENT));
+
+    listeners[RESYNC](null, { [EMAIL_CONSENT]: true, [PIXEL]: false });
+
+    expect(ctrl.value).toBe(true);
+  });
+
+  // the parent already dropped the refused values, so the model matches the
+  // server: re-notifying would only dirty the form again
+  it('does not write back into the model', () => {
+    const { listeners, onFieldChange } = build(checkboxRule(PIXEL, true));
+
+    listeners[RESYNC](null, { [EMAIL_CONSENT]: true, [PIXEL]: false });
+
+    expect(onFieldChange).not.toHaveBeenCalled();
+  });
+
+  it('reads only its own field out of the payload', () => {
+    const { ctrl, listeners } = build(checkboxRule(PIXEL, true));
+
+    listeners[RESYNC](null, { [EMAIL_CONSENT]: true });
+
+    expect(ctrl.value).toBe(false);
+  });
+
+  it('survives an event carrying no decision', () => {
+    const { ctrl, listeners } = build(checkboxRule(PIXEL, true));
+
+    listeners[RESYNC](null);
+
+    expect(ctrl.value).toBe(false);
+  });
+
+  it('is not registered on an unrelated field', () => {
+    const { listeners } = build(checkboxRule('smsConsent', true));
+
+    expect(listeners[RESYNC]).toBeUndefined();
+  });
+});

--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.html
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.html
@@ -153,9 +153,10 @@
             data-ng-pattern="$ctrl.inputValidator"
             data-ng-required="$ctrl.rule.mandatory"
             data-disabled="$ctrl.rule.disabled()"
+            data-description="{{ $ctrl.rule.descriptionKey ? ($ctrl.rule.descriptionKey | translate) : '' }}"
         >
             <span
-                data-translate="{{ 'signup_field_' + $ctrl.rule.displayFieldName | translate }} {{ !$ctrl.rule.mandatory ? 'signup_not_mandatory_field' : '' | translate }}"
+                data-translate="{{ 'signup_field_' + $ctrl.rule.displayFieldName | translate:$ctrl.rule.translateValues }} {{ !$ctrl.rule.mandatory ? 'signup_not_mandatory_field' : '' | translate }}"
             ></span>
         </oui-checkbox>
 

--- a/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.scss
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/field/new-account-form-field-component.scss
@@ -1,0 +1,20 @@
+/**
+ * The ui-kit lays a checkbox label out as a flex row — the icon, then the text
+ * — and leaves the icon shrinkable. A label long enough to overflow the column
+ * therefore has the flex algorithm squeeze the icon's box, in proportion to how
+ * far it overflows: measured against oui.css, the pixel-tracking sentence takes
+ * it from 16px down to 4px, and even the one-line marketing-email label loses 3.
+ *
+ * The square the customer actually sees is an absolutely positioned ::before
+ * that keeps its 1rem whatever happens to its parent, so the text slides under
+ * the square and reads as glued to it — several pixels left of where a shorter
+ * label sits, which is what makes two stacked checkboxes look misaligned.
+ *
+ * Pinning the icon puts every checkbox of this form on the same 16px box plus
+ * the .5rem gap oui.css already gives `__text`, whatever the label length.
+ */
+new-account-form-field {
+  .oui-checkbox .oui-checkbox__icon {
+    flex-shrink: 0;
+  }
+}

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.constants.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.constants.js
@@ -10,6 +10,11 @@ export const READY_ONLY_RULES_PARAMS = [
   'smsConsent',
   // model-only field for the e-invoicing picker; /newAccount/rules rejects it
   'einvoicingBillingAddress',
+  // model-only field for the pixel-tracking checkbox: it is a decision on the
+  // marketing-email consent campaign, not a /me attribute, so both
+  // /newAccount/rules and PUT /me reject it. This single entry strips it from
+  // both (READY_ONLY_PARAMS is derived from this list just below).
+  'pixelTrackingConsent',
 ];
 
 export const READY_ONLY_PARAMS = [
@@ -68,6 +73,8 @@ export const SECTIONS = {
   contact: [
     'email',
     'commercialCommunicationsApproval',
+    // the pixel-tracking checkbox sits next to the marketing-email one
+    'pixelTrackingConsent',
     'spareEmail',
     'country',
     'address',
@@ -108,6 +115,10 @@ export const FIELD_NAME_LIST = {
   nationalIdentificationNumber: 'nationalIdentificationNumber',
   email: 'email',
   commercialCommunicationsApproval: 'commercialCommunicationsApproval',
+  // this position drives the display order (the rules are sorted by
+  // Object.keys(FIELD_NAME_LIST).indexOf), so the pixel checkbox renders right
+  // under the marketing-email one whatever the splice index was
+  pixelTrackingConsent: 'pixelTrackingConsent',
   spareEmail: 'spareEmail',
   password: 'password',
   timezone: 'timezone',
@@ -388,6 +399,18 @@ export const FIELD_WITHOUT_MARGIN_BOTTOM = ['email', 'phoneType', 'phone'];
 
 export const TRACKING_PREFIX = 'accountmodification';
 
+// Parent controller -> checkbox field components.
+// A checkbox's rendered state lives in the field component's own local value
+// (setInitialValue runs once, at $onInit, behind a truthy-only guard), and the
+// ng-repeat tracks by fieldName, so re-injecting a rule with a new
+// initialValue cannot repaint a box. These two events are the only way to push
+// state down.
+//
+// ...reset:  revoke pixel tracking because marketing email consent was revoked.
+// ...resync: repaint both consent checkboxes from a freshly fetched decision.
+export const PIXEL_TRACKING_RESET_EVENT = 'account.pixelTrackingConsent.reset';
+export const CONSENT_RESYNC_EVENT = 'account.consent.resync';
+
 export const FEATURES = {
   emailConsent: 'account:email-consent',
   smsConsent: 'account:sms-consent',
@@ -395,6 +418,12 @@ export const FEATURES = {
 };
 
 export const IN_SUBSIDIARY = 'IN';
+// French e-invoicing / SIRET / PPF-directory scope (DROM only), read by
+// isFrenchAssociation, siretFieldIsAvailable, isOtherCategoryControlActive,
+// isFieldHiddenForFr and the e-invoicing child's isEligible.
+// This is NOT the pixel-tracking consent scope: that one lives in
+// ./pixel-tracking-consent.js, covers every overseas collectivity plus Italy,
+// and is a different business rule. Do not merge the two lists.
 export const FR_COUNTRIES = ['FR', 'GP', 'MQ', 'GF', 'RE', 'YT'];
 export const USER_TYPE_ENTERPRISE = 'corporation';
 export const USER_TYPE_ASSOCIATION = 'association';
@@ -415,6 +444,8 @@ export default {
   FIELD_NAME_LIST,
   FIELD_WITHOUT_MARGIN_BOTTOM,
   TRACKING_PREFIX,
+  PIXEL_TRACKING_RESET_EVENT,
+  CONSENT_RESYNC_EVENT,
   FEATURES,
   IN_SUBSIDIARY,
   FR_COUNTRIES,

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.module.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-component.module.js
@@ -7,6 +7,8 @@ import '@uirouter/angularjs';
 
 import '@ovh-ux/sign-up';
 
+import './field/new-account-form-field-component.scss';
+
 import component from './new-account-form-component';
 import fieldComponent from './field/new-account-form-field-component';
 import einvoicingComponent from './einvoicing/new-account-form-einvoicing.component';

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.js
@@ -7,7 +7,9 @@ import { LANGUAGES } from '@ovh-ux/manager-config';
 
 import {
   CONSENT_MARKETING_EMAIL_NAME,
+  CONSENT_RESYNC_EVENT,
   FIELD_NAME_LIST,
+  PIXEL_TRACKING_RESET_EVENT,
   READY_ONLY_PARAMS,
   READY_ONLY_RULES_PARAMS,
   SECTIONS,
@@ -23,6 +25,11 @@ import {
   USER_TYPE_OTHER,
   SUBSIDIARIES_VAT_FIELD_OVERRIDE,
 } from './new-account-form-component.constants';
+import {
+  buildConsentDecisionPayload,
+  isPixelTrackingCountry,
+  readPixelConsent,
+} from './pixel-tracking-consent';
 import { KYC_STATUS } from '../../../identity-documents/user-identity-documents.constant';
 import { SUPPORT_URLS } from '../../user.constants';
 
@@ -90,6 +97,7 @@ export default class NewAccountFormController {
 
     this.consentDecision = null;
     this.smsConsentDecision = null;
+    this.pixelConsentDecision = null;
 
     // Validating a company in the SIRET lookup replaces the data the API
     // complained about, so its errors no longer describe the form.
@@ -180,6 +188,23 @@ export default class NewAccountFormController {
       })
       .then(({ email, sms }) => {
         this.consentDecision = !!email?.value;
+        // pixel.value drives the checkbox; pixel.history is the CNIL audit
+        // trail, not a UI need — never read it.
+        //
+        // Captured ONCE, on the first read. fetchRules re-runs on every field
+        // change, but a checkbox already on screen is never repainted by it:
+        // the rendered state is the field component's own local copy, set at
+        // its $onInit from rule.initialValue and never watched afterwards. So
+        // re-reading here would only desynchronise the two — a decision
+        // granted in another tab would become the submit-time fallback for a
+        // box the customer still sees unchecked, and saving any other field
+        // would write a consent the screen does not show. Keeping the loaded
+        // state means what is submitted is always what was displayed.
+        // resyncConsentDecisions is the one thing that moves it afterwards,
+        // and it repaints both boxes in the same breath.
+        if (this.pixelConsentDecision === null) {
+          this.pixelConsentDecision = readPixelConsent(email);
+        }
         this.smsConsentDecision =
           this.isSmsConsentAvailable &&
           !!Object.keys(sms?.sms || {}).some((key) => sms.sms[key]);
@@ -244,6 +269,88 @@ export default class NewAccountFormController {
             hasBottomMargin: true,
             disabled: () => this.model.phoneType !== 'mobile',
           });
+          // Pixel tracking, France + Italy only. Located by fieldName rather
+          // than by reusing emailFieldIndex, so the two splices above keep
+          // their arithmetic untouched. The splice position is cosmetic
+          // anyway: the display order is imposed by FIELD_NAME_LIST (the sort
+          // further down) and the fieldset by SECTIONS.contact.
+          //
+          // The gate is a LIVE read of the country the form currently shows
+          // (see the getter), never a value frozen at load: the country select
+          // is editable here, so the checkbox has to follow it. fetchRules
+          // re-runs on every field change, and this rule is rebuilt — or left
+          // out — against the country of that very moment.
+          //
+          // Leaving it out takes the unsaved pixel choice with it, through
+          // updateRules()' `delete this.model[fieldName]` loop, and that is the
+          // point rather than a side effect: a checkbox the customer can no
+          // longer see must not travel in the submit payload. Coming back into
+          // scope rebuilds the box from initialValue below — the decision the
+          // GET returned — never from the discarded click.
+          //
+          // This is where it differs from commercialCommunicationsApproval and
+          // smsConsent, which are injected unconditionally and so can never
+          // meet that delete loop.
+          if (this.isPixelTrackingAvailable) {
+            const emailConsentIndex = rules.findIndex(
+              (injected) =>
+                injected.fieldName ===
+                FIELD_NAME_LIST.commercialCommunicationsApproval,
+            );
+            rules.splice(emailConsentIndex + 1, 0, {
+              in: null,
+              mandatory: false,
+              // never a defaultValue: setDefaultValue() writes into the parent
+              // model at init and would dirty the form. Business rule 1 — no
+              // default consent, the box loads unchecked unless the API says
+              // otherwise.
+              defaultValue: null,
+              // reflects pixel.value from the GET: checked if true, unchecked
+              // if false (setInitialValue's guard is truthy-only, and an unset
+              // local value renders unchecked — the same thing on screen)
+              initialValue: this.pixelConsentDecision,
+              fieldName: FIELD_NAME_LIST.pixelTrackingConsent,
+              fieldType: 'checkbox',
+              regularExpression: null,
+              prefix: null,
+              examples: null,
+              hasBottomMargin: true,
+              // The label names the mailbox the pixels would measure, so the
+              // rule has to carry one — and it is the REGISTERED address, not
+              // the live this.model.email. An address typed into the email
+              // field above is not receiving anything yet: submit() routes it
+              // through changeEmail(), a procedure the customer still has to
+              // confirm from the CURRENT mailbox. Naming it here would state
+              // something untrue for as long as the change is pending, and
+              // would rewrite the sentence under the customer's eyes on every
+              // keystroke, since a field change refreshes the rules.
+              //
+              // The only rule that declares translateValues. Every other field
+              // leaves it undefined, which is what the label's
+              // `| translate:undefined` already resolves to today, so no other
+              // label changes.
+              translateValues: { email: this.originalModel?.email },
+              // Business rule 9: the API refuses pixel consent without email
+              // consent and fails the whole request, so the combination has to
+              // be unreachable in the UI — we never leave the box enabled and
+              // lean on the 400. The field template already binds this as
+              // data-disabled="$ctrl.rule.disabled()", and the one-way binding
+              // re-evaluates it on every digest pass, so it follows the other
+              // checkbox with no event and no watcher of its own. Keep it
+              // pure, cheap and allocation-free.
+              // Deliberately NO descriptionKey: the box renders exactly like
+              // the marketing-email checkbox above it, with nothing under the
+              // label. The field template interpolates '' when the key is
+              // absent, which leaves ouiCheckbox's hasDescription() false and
+              // renders no description element at all.
+              //
+              // The trade-off, should it ever need revisiting: disabled()
+              // greys the box out without saying why, and ouiCheckbox wired
+              // that reason to the input's aria-describedby, so a screen
+              // reader now announces the box unavailable with no explanation.
+              disabled: () => !this.isEmailConsentGranted(),
+            });
+          }
         }
         return rules;
       })
@@ -401,11 +508,14 @@ export default class NewAccountFormController {
           type: 'navigation',
         };
         if (this.isEmailConsentAvailable) {
-          const emailConsent =
-            typeof this.model.commercialCommunicationsApproval !== 'undefined'
-              ? this.model.commercialCommunicationsApproval
-              : this.consentDecision;
-          tracking.accountEmailConsent = emailConsent ? 'opt-in' : 'opt-out';
+          tracking.accountEmailConsent = this.isEmailConsentGranted()
+            ? 'opt-in'
+            : 'opt-out';
+          if (this.isPixelTrackingAvailable) {
+            tracking.accountPixelConsent = this.isPixelConsentGranted()
+              ? 'opt-in'
+              : 'opt-out';
+          }
         }
         if (this.isSmsConsentAvailable) {
           const smsConsent =
@@ -445,16 +555,42 @@ export default class NewAccountFormController {
     }
 
     const consentRequests = [];
+    // Both checkbox states go out in ONE request rather than two sequential
+    // calls: the campaign's PUT takes them together and applies the email
+    // decision first, so the pair can never be refused; it reads clearer and
+    // it saves a round trip. Which means the guard has to fire when EITHER
+    // value changed — keyed on the email value alone, as it was, a pixel-only
+    // change would send nothing at all.
+    //
+    // isEmailConsentAvailable gates the pair because it is literally the same
+    // request: the pixel decision is a field of the marketing-email campaign
+    // and cannot have a flag of its own without splitting that request.
+    const hasEmailConsentChange =
+      this.originalModel.commercialCommunicationsApproval !==
+      this.model.commercialCommunicationsApproval;
+    const hasPixelConsentChange =
+      this.isPixelTrackingAvailable &&
+      this.originalModel[FIELD_NAME_LIST.pixelTrackingConsent] !==
+        this.model[FIELD_NAME_LIST.pixelTrackingConsent];
     if (
       this.isEmailConsentAvailable &&
-      this.originalModel.commercialCommunicationsApproval !==
-        this.model.commercialCommunicationsApproval
+      (hasEmailConsentChange || hasPixelConsentChange)
     ) {
       consentRequests.push(
-        this.userAccountServiceInfos.updateConsentDecision(
-          CONSENT_MARKETING_EMAIL_NAME,
-          this.model.commercialCommunicationsApproval || false,
-        ),
+        this.userAccountServiceInfos
+          .updateConsentDecision(
+            CONSENT_MARKETING_EMAIL_NAME,
+            // isEmailConsentGranted(), not `this.model.x || false`: a
+            // pixel-only change leaves the email model key untouched, and
+            // sending false for it would revoke the customer's email consent
+            // as a side effect — and cascade the pixel decision back to denied
+            buildConsentDecisionPayload({
+              hasEmailConsent: this.isEmailConsentGranted(),
+              isPixelTrackingAvailable: this.isPixelTrackingAvailable,
+              hasPixelConsent: this.isPixelConsentGranted(),
+            }),
+          )
+          .catch((error) => this.resyncConsentDecisions(error)),
       );
     }
     if (
@@ -588,6 +724,72 @@ export default class NewAccountFormController {
   }
 
   /**
+   * The UI never builds { value: false, pixel: { value: true } } — the
+   * disabled rule makes it unreachable by clicking and
+   * buildConsentDecisionPayload clamps it away — but a page left open while
+   * email consent was revoked in another tab can still submit it, and the API
+   * answers 400 ("pixel tracking requires marketing email consent to be
+   * granted") having written NOTHING: email consent is not revoked either.
+   *
+   * Trusting the optimistic state after that would leave two checkboxes
+   * showing something the server refused, so re-fetch the decision with a GET
+   * and re-render both boxes from the fresh answer. Repainting needs the
+   * broadcast: the rendered value is the field component's own local copy,
+   * setInitialValue() runs only at $onInit behind a truthy-only guard, and the
+   * ng-repeat tracks by fieldName — so a rules refresh cannot move it.
+   *
+   * Attached to the consent request's OWN catch, not to submit()'s shared one:
+   * an unrelated 400 (a VAT the API refuses, typically) must not throw away
+   * the customer's consent choices.
+   *
+   * A failed re-read is swallowed with angular.noop, and the error is always
+   * re-rejected, so submit()'s catch still sets submitError and pushes the
+   * InfoErrors banner with the API's own message.
+   */
+  resyncConsentDecisions(error) {
+    // Scoped to the accounts the pixel checkbox exists for, and to the status
+    // the contract documents. Out of the country scope the payload carries no
+    // `pixel` key at all, so this route cannot answer the pixel/email 400 —
+    // any 400 it does answer there belongs to the worldwide marketing-email
+    // checkbox, which this epic does not touch. Recovering from it would
+    // silently throw that customer's click away and repaint their box, where
+    // today the error simply reaches submit()'s catch with the click intact
+    // for the retry the banner invites.
+    if (!this.isPixelTrackingAvailable || error?.status !== 400) {
+      return this.$q.reject(error);
+    }
+    return this.userAccountServiceInfos
+      .fetchConsentDecision(CONSENT_MARKETING_EMAIL_NAME)
+      .then((decision) => {
+        const hasEmailConsent = !!decision?.value;
+        const hasPixelConsent = readPixelConsent(decision);
+        this.consentDecision = hasEmailConsent;
+        this.pixelConsentDecision = hasPixelConsent;
+        // The refused choices must stop contradicting the server, so both keys
+        // are SET to what the GET just returned — not deleted. Deleting reads
+        // tidier (it also takes the form back to "unchanged" for the two
+        // consents) but it desynchronises the model from the checkboxes this
+        // very method is repainting, and it breaks the retry the error banner
+        // invites: with the keys gone the submit guards compare undefined to
+        // undefined and build no consent request at all, so pressing Save
+        // again reports success having written nothing — and for an account
+        // whose granted email consent DID reach originalModel, the guard fires
+        // while isEmailConsentGranted() falls back to the decision just
+        // re-read, re-granting the very consent the customer was revoking.
+        // Assigning instead keeps model, checkbox and server in agreement, so
+        // a retry is the redundant no-op write the contract calls safe.
+        this.model.commercialCommunicationsApproval = hasEmailConsent;
+        this.model[FIELD_NAME_LIST.pixelTrackingConsent] = hasPixelConsent;
+        this.$scope.$broadcast(CONSENT_RESYNC_EVENT, {
+          [FIELD_NAME_LIST.commercialCommunicationsApproval]: hasEmailConsent,
+          [FIELD_NAME_LIST.pixelTrackingConsent]: hasPixelConsent,
+        });
+      })
+      .catch(angular.noop)
+      .then(() => this.$q.reject(error));
+  }
+
+  /**
    * Drops the errors the API raised against data the customer has since
    * replaced: the banner it pushed to the alert container, and the inline
    * message the form renders from submitError.
@@ -677,6 +879,26 @@ export default class NewAccountFormController {
           chapter2: 'myaccount',
           chapter3: 'consent',
         });
+        // Cascade, mirroring the backend's own (business rule 9): revoking
+        // marketing email consent unchecks AND disables pixel tracking in the
+        // same UI update, so the form never shows a state the next GET would
+        // contradict. disabled() greys the box out by itself; only this reset
+        // clears the checkmark, because the rendered value is the field
+        // component's local copy.
+        //
+        // There is deliberately NO `else`. Re-checking email is not the mirror
+        // image (business rule 6): it only lifts disabled(), making the box
+        // checkable again while it stays UNCHECKED. Re-subscribing to email
+        // never restores pixel tracking — the customer opts back in
+        // explicitly, one click per checkbox, no bundled toggle and no
+        // "accept all" side effect.
+        //
+        // Gated on the country flag as well: out of scope no pixel rule was
+        // ever built, so there is no field component listening and nothing to
+        // ask for.
+        if (this.isPixelTrackingAvailable && !value) {
+          this.$scope.$broadcast(PIXEL_TRACKING_RESET_EVENT);
+        }
       }
 
       if (rule.fieldName === FIELD_NAME_LIST.phoneType) {
@@ -699,6 +921,32 @@ export default class NewAccountFormController {
         });
       }
 
+      // Reached by a real click on the pixel checkbox AND by the cascade
+      // above: the reset listener clears the box through the field's
+      // onChange(), which routes back into this very method, so revoking
+      // marketing email consent reports a `product-pixel-consent::disable`
+      // the customer never clicked, and the `return this.updateRules()` below
+      // fires a second, overlapping rules refresh for the one click.
+      //
+      // Left as is, deliberately: it is what the identical smsConsent cascade
+      // does today (a phoneType change reports an sms-consent hit the same
+      // way), the reported opt-out is a state change that genuinely happened,
+      // and suppressing it means either a payload threaded through onChange()
+      // or writing the model behind the field component's back — both worse
+      // than the duplicate hit. Do not read the broadcast as a way of keeping
+      // one click to one hit; it is not.
+      if (rule.fieldName === FIELD_NAME_LIST.pixelTrackingConsent) {
+        this.atInternet.trackClick({
+          name: `${TRACKING_PREFIX}::product-pixel-consent::${
+            value ? 'enable' : 'disable'
+          }`,
+          type: 'action',
+          chapter1: 'account',
+          chapter2: 'myaccount',
+          chapter3: 'consent',
+        });
+      }
+
       if (
         rule.fieldName === FIELD_NAME_LIST.legalform ||
         rule.fieldName === FIELD_NAME_LIST.country
@@ -715,6 +963,57 @@ export default class NewAccountFormController {
   // compare original model to edited model
   hasChanges() {
     return !angular.equals(this.originalModel, this.model);
+  }
+
+  /**
+   * Country scope of the pixel-tracking checkbox: France (all of its
+   * territory) and Italy, never anywhere else. Out of scope the rule is never
+   * built at all — no unchecked box, no disabled box, nothing.
+   *
+   * Re-read from the LIVE model on every access, so it tracks the country
+   * select as the customer edits it: an Italian account that switches to
+   * Germany loses the checkbox on that change, and switching back to Italy
+   * brings it in again. onFieldChange() already refreshes the rules on a
+   * country change (the FR_COUNTRIES gates further down work the same way),
+   * so nothing else has to be wired for this to repaint.
+   *
+   * A getter, not a method, so all six read sites — the rule injection, the
+   * two submit guards, the payload builder, the 400 recovery and the email
+   * cascade — read the current country with no call site left to go stale.
+   *
+   * Fails closed, in isPixelTrackingCountry: a model with no country, or with
+   * the 'UNKNOWN' placeholder, is not offered the checkbox.
+   *
+   * Permanent business scope, not a rollout: no feature flag guards it.
+   */
+  get isPixelTrackingAvailable() {
+    return isPixelTrackingCountry(this.model?.country);
+  }
+
+  /**
+   * A consent checkbox's loaded state lives in the field component's local
+   * value (from rule.initialValue), never in the model, so
+   * this.model.commercialCommunicationsApproval stays undefined until the
+   * customer actually clicks it: an account that already consented reads as
+   * undefined here while the box renders CHECKED. Falling back to the decision
+   * the GET returned is what keeps the pixel checkbox enabled on load for
+   * exactly the customers who are eligible for it.
+   *
+   * This is the fallback the submit-time tracking block used to carry inline;
+   * it now uses this method, so the expression exists once.
+   */
+  isEmailConsentGranted() {
+    return typeof this.model.commercialCommunicationsApproval !== 'undefined'
+      ? !!this.model.commercialCommunicationsApproval
+      : !!this.consentDecision;
+  }
+
+  // same undefined-until-clicked story as above
+  isPixelConsentGranted() {
+    return typeof this.model[FIELD_NAME_LIST.pixelTrackingConsent] !==
+      'undefined'
+      ? !!this.model[FIELD_NAME_LIST.pixelTrackingConsent]
+      : !!this.pixelConsentDecision;
   }
 
   // The SIRET search assistant detected a legal form from the selected company;

--- a/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.spec.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/new-account-form-controller.spec.js
@@ -211,3 +211,799 @@ describe('the API errors the form displays', () => {
     expect(alerter.resetMessage).toHaveBeenCalledWith('InfoErrors');
   });
 });
+
+// --- pixel-tracking consent -----------------------------------------------
+
+const CAMPAIGN = 'consent-marketing-email';
+const PIXEL = 'pixelTrackingConsent';
+const EMAIL_CONSENT = 'commercialCommunicationsApproval';
+// `spareEmail` is load-bearing, not padding: it is the real /newAccount/rules
+// field that sorts BETWEEN the two consent checkboxes if the pixel entry ever
+// leaves its FIELD_NAME_LIST slot. Without it the adjacency assertion below
+// holds wherever that entry sits, and the slot is pinned by nothing.
+const API_RULES = [
+  { fieldName: 'email' },
+  { fieldName: 'spareEmail' },
+  { fieldName: 'phone' },
+];
+
+// The consent path reaches collaborators build() deliberately leaves out: its
+// feature-flip promise never settles, so nothing past $onInit's first .then()
+// runs there. Widening build() would make fetchRules run for real in all 16
+// tests above.
+const buildWithConsent = (options = {}) => {
+  const {
+    decision = { value: true, pixel: { value: false } },
+    isRegionUs = false,
+    updateConsentDecision,
+    fetchConsentDecision,
+  } = options;
+  // deliberately NOT a destructuring default: `{ country: undefined }` is one
+  // of the cases under test (an account with no registered country, which must
+  // fail closed) and a default would silently turn it into 'FR'
+  const country = 'country' in options ? options.country : 'FR';
+  const broadcasts = [];
+  const $scope = {
+    $broadcast: (name, payload) => broadcasts.push({ name, payload }),
+    $on: () => {},
+  };
+  const $q = {
+    resolve: (value) => Promise.resolve(value),
+    reject: (value) => Promise.reject(value),
+    // fetchRules passes an object hash, submit() passes an array
+    all: (value) =>
+      Array.isArray(value)
+        ? Promise.all(value)
+        : Promise.all(Object.values(value)).then((settled) =>
+            Object.fromEntries(
+              Object.keys(value).map((key, index) => [key, settled[index]]),
+            ),
+          ),
+  };
+  const service = {
+    postRules: vi.fn(() =>
+      Promise.resolve(API_RULES.map((rule) => ({ ...rule }))),
+    ),
+    fetchConsentDecision:
+      fetchConsentDecision || vi.fn(() => Promise.resolve(decision)),
+    fetchMarketingConsentDecision: vi.fn(() => Promise.resolve({ sms: {} })),
+    updateConsentDecision:
+      updateConsentDecision || vi.fn(() => Promise.resolve(null)),
+    updateSmsMarketingConsentDecision: vi.fn(() => Promise.resolve(null)),
+    updateUseraccountInfos: vi.fn(() => Promise.resolve(null)),
+    changeEmail: vi.fn(() => Promise.resolve(null)),
+  };
+  const alerter = { alertFromSWS: vi.fn(), resetMessage: vi.fn() };
+  const atInternet = { trackClick: vi.fn(), trackPage: vi.fn() };
+  const ctrl = new NewAccountFormCtrl(
+    $q,
+    {},
+    (fn) => fn(),
+    {},
+    atInternet,
+    {
+      getUser: () => ({ country: 'fr', ovhSubsidiary: 'FR' }),
+      getUserLocale: () => 'fr_FR',
+      isRegion: (region) => isRegionUs && region === 'US',
+      updateUser: vi.fn(),
+      setUserLocale: vi.fn(),
+    },
+    alerter,
+    { instant: (key) => key },
+    vi.fn(),
+    $scope,
+    {
+      checkFeatureAvailability: () =>
+        Promise.resolve({
+          isFeatureAvailable: (feature) => feature === 'account:email-consent',
+        }),
+    },
+    { environment: { setUser: vi.fn() } },
+  );
+  ctrl.model = { country, email: 'me@ovhcloud.com' };
+  ctrl.readonly = [];
+  ctrl.action = 'update';
+  ctrl.userAccountServiceInfos = service;
+  ctrl.getKycStatus = vi.fn(() => Promise.resolve({}));
+  return { ctrl, broadcasts, service, atInternet, alerter };
+};
+
+const pixelRule = (ctrl) =>
+  (ctrl.rules || []).find((rule) => rule.fieldName === PIXEL);
+const broadcastNames = (broadcasts) => broadcasts.map(({ name }) => name);
+const consentPayload = (service) =>
+  service.updateConsentDecision.mock.calls[0][1];
+
+describe('where the pixel-tracking checkbox is offered', () => {
+  // France and Italy only, all French territory included
+  it.each([
+    ['FR', 'metropolitan France'],
+    ['GP', 'Guadeloupe'],
+    ['MQ', 'Martinique'],
+    ['GF', 'French Guiana'],
+    ['RE', 'Reunion'],
+    ['YT', 'Mayotte'],
+    ['BL', 'Saint-Barthelemy'],
+    ['MF', 'Saint-Martin'],
+    ['PM', 'Saint-Pierre-et-Miquelon'],
+    ['WF', 'Wallis-et-Futuna'],
+    ['PF', 'French Polynesia'],
+    ['NC', 'New Caledonia'],
+    ['TF', 'French Southern Territories'],
+    ['IT', 'Italy'],
+  ])('offers it to a %s account (%s)', async (country) => {
+    const { ctrl } = buildWithConsent({ country });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl)).toBeDefined();
+  });
+
+  // never for any other country: nothing renders at all
+  it.each([
+    ['DE', 'Germany'],
+    ['ES', 'Spain'],
+    ['GB', 'the United Kingdom'],
+    ['CH', 'Switzerland, which bills through the IT subsidiary'],
+    ['SM', 'San Marino, which bills through the IT subsidiary'],
+    ['VA', 'the Vatican, which bills through the IT subsidiary'],
+    [undefined, 'no country at all'],
+    ['UNKNOWN', 'the UNKNOWN placeholder'],
+  ])('builds no rule for %p (%s)', async (country) => {
+    const { ctrl } = buildWithConsent({ country });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl)).toBeUndefined();
+    expect(PIXEL in ctrl.model).toBe(false);
+  });
+
+  it('accepts a registered country written in lower case', async () => {
+    const { ctrl } = buildWithConsent({ country: 'it' });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl)).toBeDefined();
+  });
+
+  // the label names the mailbox, so it has to be handed the address
+  it('hands the label the registered account email', async () => {
+    const { ctrl } = buildWithConsent();
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).translateValues).toEqual({
+      email: 'me@ovhcloud.com',
+    });
+  });
+
+  // a pending changeEmail() is not the mailbox receiving anything yet
+  it('keeps naming the registered email while a new one is being typed', async () => {
+    const { ctrl } = buildWithConsent();
+    await ctrl.$onInit();
+
+    ctrl.model.email = 'nouvelle@ovhcloud.com';
+    await ctrl.updateRules();
+
+    expect(pixelRule(ctrl).translateValues).toEqual({
+      email: 'me@ovhcloud.com',
+    });
+  });
+
+  it('renders it right under the marketing email checkbox', async () => {
+    const { ctrl } = buildWithConsent();
+
+    await ctrl.$onInit();
+    const contact = ctrl
+      .getRulesBySection('contact')
+      .map((rule) => rule.fieldName);
+
+    expect(contact.indexOf(PIXEL)).toBe(contact.indexOf(EMAIL_CONSENT) + 1);
+  });
+
+  it('renders neither consent checkbox in the US region', async () => {
+    const { ctrl } = buildWithConsent({ isRegionUs: true });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl)).toBeUndefined();
+    expect(
+      ctrl.rules.find((rule) => rule.fieldName === EMAIL_CONSENT),
+    ).toBeUndefined();
+  });
+
+  // the country select is editable on this screen, so the scope is re-decided
+  // on every edit rather than frozen at load
+  it('takes the checkbox away when the customer edits the country out of scope', async () => {
+    const { ctrl } = buildWithConsent({ country: 'IT' });
+    await ctrl.$onInit();
+
+    ctrl.model.country = 'DE';
+    await ctrl.updateRules();
+
+    expect(pixelRule(ctrl)).toBeUndefined();
+    expect(ctrl.isPixelTrackingAvailable).toBe(false);
+  });
+
+  it('brings it in when the customer edits the country into scope', async () => {
+    const { ctrl } = buildWithConsent({ country: 'DE' });
+    await ctrl.$onInit();
+
+    ctrl.model.country = 'IT';
+    await ctrl.updateRules();
+
+    expect(pixelRule(ctrl)).toBeDefined();
+    expect(ctrl.isPixelTrackingAvailable).toBe(true);
+  });
+
+  // a box that left the screen must not leave its value behind in the payload
+  it('drops an unsaved pixel choice when the country leaves the scope', async () => {
+    const { ctrl } = buildWithConsent({ country: 'IT' });
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    ctrl.model.country = 'DE';
+    await ctrl.updateRules();
+
+    expect(PIXEL in ctrl.model).toBe(false);
+  });
+
+  it('sends no pixel key once the country has left the scope', async () => {
+    const { ctrl, service } = buildWithConsent({ country: 'IT' });
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+    ctrl.model[PIXEL] = true;
+
+    ctrl.model.country = 'DE';
+    await ctrl.updateRules();
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({ value: true });
+  });
+
+  // the click went with the box, so coming back shows the server state again
+  it('rebuilds the box from the loaded decision when the country comes back', async () => {
+    const { ctrl } = buildWithConsent({
+      country: 'IT',
+      decision: { value: true, pixel: { value: false } },
+    });
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    ctrl.model.country = 'DE';
+    await ctrl.updateRules();
+    ctrl.model.country = 'IT';
+    await ctrl.updateRules();
+
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+  });
+
+  // while the country stays in scope the rule is re-injected on every refresh,
+  // so updateRules' delete loop never sees it disappear
+  it('survives a rules refresh with the customer choice intact', async () => {
+    const { ctrl } = buildWithConsent();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.updateRules();
+
+    expect(pixelRule(ctrl)).toBeDefined();
+    expect(ctrl.model[PIXEL]).toBe(true);
+  });
+});
+
+describe('the state the pixel checkbox loads with', () => {
+  it('is checked when the API granted pixel tracking', async () => {
+    const { ctrl } = buildWithConsent({
+      decision: { value: true, pixel: { value: true } },
+    });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).initialValue).toBe(true);
+  });
+
+  it('is unchecked when the API denied it', async () => {
+    const { ctrl } = buildWithConsent({
+      decision: { value: true, pixel: { value: false } },
+    });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+  });
+
+  // business rule 1: no default consent
+  it('is unchecked by default, writing nothing into the model', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: true } });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+    expect(pixelRule(ctrl).defaultValue).toBe(null);
+    expect(pixelRule(ctrl).fieldType).toBe('checkbox');
+    expect(PIXEL in ctrl.model).toBe(false);
+    expect(ctrl.hasChanges()).toBe(false);
+  });
+
+  // A pixel consent the email gate would DISABLE is a consent the customer
+  // cannot withdraw from this screen (GDPR art. 7(3)), so an inconsistent pair
+  // renders unchecked rather than checked-and-greyed.
+  it('is unchecked when the API grants pixel tracking without email consent', async () => {
+    const { ctrl } = buildWithConsent({
+      decision: { value: false, pixel: { value: true } },
+    });
+
+    await ctrl.$onInit();
+
+    expect(ctrl.pixelConsentDecision).toBe(false);
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+    expect(pixelRule(ctrl).disabled()).toBe(true);
+    // and the submit-time state agrees with what the box shows
+    expect(ctrl.isPixelConsentGranted()).toBe(false);
+  });
+
+  // nothing under the label, so the box renders like the marketing-email
+  // checkbox above it
+  it('carries no description under the label', async () => {
+    const { ctrl } = buildWithConsent();
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).descriptionKey).toBeUndefined();
+  });
+
+  // pixel.history is CNIL audit-trail data, not a UI need
+  it('ignores the audit trail and reads only pixel.value', async () => {
+    const { ctrl } = buildWithConsent({
+      decision: {
+        value: true,
+        history: [{ value: true, timestamp: '2024-03-01T10:00:00Z' }],
+        pixel: {
+          value: false,
+          history: [
+            { value: true, timestamp: '2026-04-10T08:00:00Z' },
+            { value: false, timestamp: '2026-06-01T14:22:00Z' },
+          ],
+        },
+      },
+    });
+
+    await ctrl.$onInit();
+
+    expect(ctrl.pixelConsentDecision).toBe(false);
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+  });
+
+  // fetchRules re-runs on every field change and re-reads the decision, but a
+  // checkbox already on screen is never repainted by it: the rendered state is
+  // the field component's own local copy, set once at its $onInit. So the
+  // loaded state has to be captured once, or a decision that moved in another
+  // tab becomes the submit-time fallback for a box still showing the old one —
+  // writing a consent the customer cannot see on the screen they are saving.
+  it('keeps the state it rendered when the decision moves under it', async () => {
+    const fetchConsentDecision = vi
+      .fn()
+      .mockResolvedValueOnce({ value: true, pixel: { value: false } })
+      // granted in another tab, after this form rendered its unchecked box
+      .mockResolvedValue({ value: true, pixel: { value: true } });
+    const { ctrl, service } = buildWithConsent({ fetchConsentDecision });
+    await ctrl.$onInit();
+
+    // any field change refreshes the rules, and with them the decision
+    await ctrl.updateRules();
+
+    expect(ctrl.pixelConsentDecision).toBe(false);
+    expect(ctrl.isPixelConsentGranted()).toBe(false);
+    expect(pixelRule(ctrl).initialValue).toBe(false);
+
+    // and saving an untouched pixel box cannot grant what it never showed
+    ctrl.model[EMAIL_CONSENT] = true;
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({
+      value: true,
+      pixel: { value: false },
+    });
+  });
+});
+
+describe('the email gate on the pixel checkbox (business rule 9)', () => {
+  it('disables it while marketing email consent is denied', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: false } });
+
+    await ctrl.$onInit();
+
+    expect(pixelRule(ctrl).disabled()).toBe(true);
+  });
+
+  // the trap: the email checkbox's loaded state never reaches the model, so a
+  // naive !this.model.commercialCommunicationsApproval would disable the box
+  // for exactly the customers who are eligible for it
+  it('leaves it enabled for an account that consented and has not touched the box', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: true } });
+
+    await ctrl.$onInit();
+
+    expect(EMAIL_CONSENT in ctrl.model).toBe(false);
+    expect(pixelRule(ctrl).disabled()).toBe(false);
+  });
+
+  it('follows the checkbox rather than the loaded decision once it is clicked', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: true } });
+    await ctrl.$onInit();
+
+    ctrl.model[EMAIL_CONSENT] = false;
+    expect(pixelRule(ctrl).disabled()).toBe(true);
+
+    ctrl.model[EMAIL_CONSENT] = true;
+    expect(pixelRule(ctrl).disabled()).toBe(false);
+  });
+
+  // it is invoked by a one-way binding on every digest pass
+  it('answers without touching the model', async () => {
+    const { ctrl } = buildWithConsent();
+    await ctrl.$onInit();
+    const before = { ...ctrl.model };
+
+    pixelRule(ctrl).disabled();
+    pixelRule(ctrl).disabled();
+
+    expect(ctrl.model).toEqual(before);
+  });
+});
+
+describe('unchecking the marketing email checkbox', () => {
+  it('asks the pixel checkbox to clear itself', async () => {
+    const { ctrl, broadcasts } = buildWithConsent();
+    await ctrl.$onInit();
+
+    await ctrl.onFieldChange({ fieldName: EMAIL_CONSENT }, false);
+
+    expect(broadcastNames(broadcasts)).toContain(
+      'account.pixelTrackingConsent.reset',
+    );
+  });
+
+  // business rule 6: re-enabling is one-directional
+  it('never asks for anything when email consent is granted again', async () => {
+    const { ctrl, broadcasts } = buildWithConsent({
+      decision: { value: false },
+    });
+    await ctrl.$onInit();
+
+    await ctrl.onFieldChange({ fieldName: EMAIL_CONSENT }, true);
+
+    expect(broadcastNames(broadcasts)).not.toContain(
+      'account.pixelTrackingConsent.reset',
+    );
+  });
+
+  // no bundled toggle, no "accept all" side effect
+  it('never auto-checks pixel tracking by granting email consent', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: false } });
+    await ctrl.$onInit();
+
+    await ctrl.onFieldChange({ fieldName: EMAIL_CONSENT }, true);
+
+    expect(PIXEL in ctrl.model).toBe(false);
+    expect(ctrl.isPixelConsentGranted()).toBe(false);
+  });
+
+  it('leaves a previously refused pixel choice refused', async () => {
+    const { ctrl } = buildWithConsent({ decision: { value: false } });
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = false;
+
+    await ctrl.onFieldChange({ fieldName: EMAIL_CONSENT }, true);
+
+    expect(ctrl.model[PIXEL]).toBe(false);
+  });
+
+  it('asks for nothing on an account the checkbox is not offered to', async () => {
+    const { ctrl, broadcasts } = buildWithConsent({ country: 'DE' });
+    await ctrl.$onInit();
+
+    await ctrl.onFieldChange({ fieldName: EMAIL_CONSENT }, false);
+
+    expect(broadcastNames(broadcasts)).not.toContain(
+      'account.pixelTrackingConsent.reset',
+    );
+  });
+});
+
+describe('what saving writes to the consent campaign', () => {
+  it('sends both checkbox states in a single request', async () => {
+    const { ctrl, service } = buildWithConsent({ decision: { value: false } });
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(service.updateConsentDecision).toHaveBeenCalledTimes(1);
+    expect(service.updateConsentDecision).toHaveBeenCalledWith(CAMPAIGN, {
+      value: true,
+      pixel: { value: true },
+    });
+  });
+
+  // a pixel-only change must not send value:false and revoke email consent
+  it('keeps the loaded email consent when only the pixel one changed', async () => {
+    const { ctrl, service } = buildWithConsent({
+      decision: { value: true, pixel: { value: true } },
+    });
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = false;
+
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({
+      value: true,
+      pixel: { value: false },
+    });
+  });
+
+  // the email-keyed guard would have sent nothing at all
+  it('writes when only the pixel checkbox changed', async () => {
+    const { ctrl, service } = buildWithConsent();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(service.updateConsentDecision).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends no pixel key at all for an account out of the country scope', async () => {
+    const { ctrl, service } = buildWithConsent({ country: 'DE' });
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({ value: true });
+    expect('pixel' in consentPayload(service)).toBe(false);
+  });
+
+  // the one combination the API refuses, and it fails the whole request
+  it('can never send pixel consent without email consent', async () => {
+    const { ctrl, service } = buildWithConsent({
+      decision: { value: true, pixel: { value: true } },
+    });
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = false;
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({ value: false });
+  });
+
+  // Revoking email consent sends the bare body the contract documents for it
+  // ("the backend cascades pixel to denied for you"), not the undocumented
+  // { value: false, pixel: { value: false } } — this is the most common save
+  // an FR/IT customer makes, on a validator we do not control.
+  it('sends the documented bare body when email consent is revoked', async () => {
+    const { ctrl, service } = buildWithConsent({
+      decision: { value: true, pixel: { value: true } },
+    });
+    await ctrl.$onInit();
+    // exactly what the cascade leaves behind: both keys false
+    ctrl.model[EMAIL_CONSENT] = false;
+    ctrl.model[PIXEL] = false;
+
+    await ctrl.submit();
+
+    expect(consentPayload(service)).toEqual({ value: false });
+    expect('pixel' in consentPayload(service)).toBe(false);
+  });
+
+  it('writes nothing when neither checkbox was touched', async () => {
+    const { ctrl, service } = buildWithConsent();
+    await ctrl.$onInit();
+
+    await ctrl.submit();
+
+    expect(service.updateConsentDecision).not.toHaveBeenCalled();
+  });
+
+  it('keeps the field out of PUT /me and out of /newAccount/rules', async () => {
+    const { ctrl, service } = buildWithConsent();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+    await ctrl.updateRules();
+
+    expect(PIXEL in service.updateUseraccountInfos.mock.calls[0][0]).toBe(
+      false,
+    );
+    service.postRules.mock.calls.forEach(([params]) => {
+      expect(PIXEL in params).toBe(false);
+    });
+  });
+});
+
+describe('a consent decision the API refuses (the defensive 400)', () => {
+  const refusing = () => {
+    const error = {
+      status: 400,
+      data: {
+        message:
+          'pixel tracking requires marketing email consent to be granted',
+      },
+    };
+    const fetchConsentDecision = vi
+      .fn()
+      .mockResolvedValueOnce({ value: true, pixel: { value: true } })
+      .mockResolvedValue({ value: false, pixel: { value: false } });
+    return buildWithConsent({
+      fetchConsentDecision,
+      updateConsentDecision: vi.fn(() => Promise.reject(error)),
+    });
+  };
+
+  it('re-reads the decision instead of trusting the optimistic state', async () => {
+    const { ctrl, service } = refusing();
+    await ctrl.$onInit();
+    const readsOnLoad = service.fetchConsentDecision.mock.calls.length;
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(service.fetchConsentDecision.mock.calls.length).toBe(
+      readsOnLoad + 1,
+    );
+    expect(ctrl.consentDecision).toBe(false);
+    expect(ctrl.pixelConsentDecision).toBe(false);
+  });
+
+  it('repaints both checkboxes from the fresh answer', async () => {
+    const { ctrl, broadcasts } = refusing();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    const resync = broadcasts.find(
+      ({ name }) => name === 'account.consent.resync',
+    );
+    expect(resync.payload).toEqual({
+      [EMAIL_CONSENT]: false,
+      [PIXEL]: false,
+    });
+  });
+
+  // Set to the fresh answer, NOT deleted: the model has to keep agreeing with
+  // the boxes this handler just repainted, or the retry the error banner
+  // invites builds no consent request at all and reports success having
+  // written nothing.
+  it('puts the server truth back into the model', async () => {
+    const { ctrl } = refusing();
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(ctrl.model[EMAIL_CONSENT]).toBe(false);
+    expect(ctrl.model[PIXEL]).toBe(false);
+  });
+
+  it('still writes on the retry the error banner invites', async () => {
+    const { ctrl, service } = refusing();
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+    ctrl.model[PIXEL] = true;
+    await ctrl.submit();
+    service.updateConsentDecision.mockImplementation(() =>
+      Promise.resolve(null),
+    );
+
+    // the customer presses Save again without re-clicking anything
+    await ctrl.submit();
+
+    expect(service.updateConsentDecision).toHaveBeenCalledTimes(2);
+    // and what it writes is what the repainted boxes show, never the value the
+    // customer was trying to move away from
+    expect(service.updateConsentDecision.mock.calls[1][1]).toEqual({
+      value: false,
+    });
+  });
+
+  // §0: the worldwide marketing-email checkbox is not in this epic's scope, and
+  // out of the country scope the body carries no pixel key, so this route
+  // cannot answer the pixel/email 400 at all
+  it('leaves an out-of-scope account exactly as it was before this feature', async () => {
+    // hoisted, like serverError below: the API rejects with a response object,
+    // and prefer-promise-reject-errors flags the literal at the call site
+    const refusal = { status: 400 };
+    const { ctrl, service, broadcasts } = buildWithConsent({
+      country: 'DE',
+      updateConsentDecision: vi.fn(() => Promise.reject(refusal)),
+    });
+    await ctrl.$onInit();
+    const readsOnLoad = service.fetchConsentDecision.mock.calls.length;
+    ctrl.model[EMAIL_CONSENT] = true;
+
+    await ctrl.submit();
+
+    expect(service.fetchConsentDecision.mock.calls.length).toBe(readsOnLoad);
+    expect(broadcastNames(broadcasts)).not.toContain('account.consent.resync');
+    // the customer's click survives, so pressing Save again retries the write
+    expect(ctrl.model[EMAIL_CONSENT]).toBe(true);
+    expect(ctrl.submitError.status).toBe(400);
+  });
+
+  it('still reports the failure to the customer', async () => {
+    const { ctrl, alerter } = refusing();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(ctrl.submitError.status).toBe(400);
+    expect(alerter.alertFromSWS).toHaveBeenCalled();
+  });
+
+  it('does not re-read on an error that is not a 400', async () => {
+    const serverError = { status: 500 };
+    const { ctrl, service, broadcasts } = buildWithConsent({
+      updateConsentDecision: vi.fn(() => Promise.reject(serverError)),
+    });
+    await ctrl.$onInit();
+    const readsOnLoad = service.fetchConsentDecision.mock.calls.length;
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(service.fetchConsentDecision.mock.calls.length).toBe(readsOnLoad);
+    expect(broadcastNames(broadcasts)).not.toContain('account.consent.resync');
+    expect(ctrl.submitError).toBeTruthy();
+  });
+});
+
+describe('what the pixel checkbox reports to analytics', () => {
+  it('tracks the click as its own consent action', async () => {
+    const { ctrl, atInternet } = buildWithConsent();
+    await ctrl.$onInit();
+
+    await ctrl.onFieldChange({ fieldName: PIXEL }, true);
+
+    expect(atInternet.trackClick).toHaveBeenCalledWith({
+      name: 'accountmodification::product-pixel-consent::enable',
+      type: 'action',
+      chapter1: 'account',
+      chapter2: 'myaccount',
+      chapter3: 'consent',
+    });
+  });
+
+  it('reports the pixel decision on save', async () => {
+    const { ctrl, atInternet } = buildWithConsent();
+    await ctrl.$onInit();
+    ctrl.model[PIXEL] = true;
+
+    await ctrl.submit();
+
+    expect(atInternet.trackPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountEmailConsent: 'opt-in',
+        accountPixelConsent: 'opt-in',
+      }),
+    );
+  });
+
+  it('reports nothing about pixel tracking outside the country scope', async () => {
+    const { ctrl, atInternet } = buildWithConsent({ country: 'DE' });
+    await ctrl.$onInit();
+    ctrl.model[EMAIL_CONSENT] = true;
+
+    await ctrl.submit();
+
+    expect(atInternet.trackPage.mock.calls[0][0]).not.toHaveProperty(
+      'accountPixelConsent',
+    );
+  });
+});

--- a/packages/manager/modules/account/src/user/components/newAccountForm/pixel-tracking-consent.js
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/pixel-tracking-consent.js
@@ -1,0 +1,123 @@
+/**
+ * Pixel-tracking consent — the framework-free part of the feature.
+ *
+ * Nothing here touches AngularJS, `this.model` or the DOM, so the account
+ * edition form (this folder) and the account creation screen
+ * (apps/account-creation, step 2) can both use it as is. Keep it that way: the
+ * rule object, the broadcasts and the field component are the Angular-only
+ * wiring and they live in the files next door.
+ */
+
+/**
+ * Countries the pixel-tracking checkbox is offered in: France and Italy only,
+ * France meaning ALL of its territory — overseas departments, regions and
+ * collectivities included, not just the metropolitan mainland.
+ *
+ * !! THE EXACT CODE LIST IS STILL OPEN (business Open Questions item 10).
+ * !! THIS ARRAY IS THE ONLY THING TO EDIT when it is settled.
+ *
+ * Permanent business scope, not a rollout state: no feature flag guards it,
+ * and the consent API exposes no "is eligible" flag — the registered country
+ * is all it takes.
+ *
+ * The 13 French codes are not invented: they are exactly the codes this form's
+ * own country enum labels group as France (the 13 signup_enum_country_* keys
+ * whose label starts with "France - " in translations/Messages_fr_FR.json).
+ *
+ * Deliberately NOT FR_COUNTRIES (new-account-form-component.constants.js).
+ * That list is the French e-invoicing / SIRET / PPF-directory scope (DROM
+ * only) and omits BL, MF, PM, WF, PF, NC and TF; widening it would switch the
+ * SIRET lookup and the e-invoicing address picker on for New Caledonia and
+ * French Polynesia — a regression in an unrelated, regulated feature. Two
+ * different business rules that merely overlap. Do not "deduplicate" them.
+ */
+export const PIXEL_TRACKING_COUNTRIES = [
+  // France - Métropole
+  'FR',
+  // France - overseas departments and regions
+  'GP', // Guadeloupe
+  'MQ', // Martinique
+  'GF', // French Guiana
+  'RE', // Reunion
+  'YT', // Mayotte
+  // France - overseas collectivities
+  'BL', // Saint-Barthélemy
+  'MF', // Saint-Martin
+  'PM', // Saint-Pierre-et-Miquelon
+  'WF', // Wallis-et-Futuna
+  'PF', // French Polynesia
+  'NC', // New Caledonia
+  'TF', // French Southern Territories
+  // Italy. No territory variant: San Marino and the Vatican are other
+  // countries, even though they bill through the IT subsidiary.
+  'IT',
+];
+
+/**
+ * The whole country decision. Fails closed on purpose — an account with no
+ * country, or with the 'UNKNOWN' placeholder, is not offered the checkbox.
+ * Never express this as a negated exclusion list: that would fail open.
+ * Case is normalised because the creation screen reads the code from another
+ * source than GET /me.
+ */
+export const isPixelTrackingCountry = (country) =>
+  PIXEL_TRACKING_COUNTRIES.includes(String(country || '').toUpperCase());
+
+/**
+ * `pixel.value` of GET /me/consent/<campaign>/decision drives the checkbox.
+ * `pixel.history` is the CNIL audit trail, not a UI need: it is deliberately
+ * never read, here or anywhere else. Optional chaining throughout, so a
+ * backend that has not shipped `pixel` yet reads as denied instead of throwing
+ * inside a GET whose rejection blanks the entire form.
+ *
+ * `&& decision?.value` is not redundant: business rule 9 makes pixel tracking
+ * meaningless without marketing email consent, and a decision that carries
+ * `{ value: false, pixel: { value: true } }` — stale data, or a revocation
+ * applied to the email decision before the backend cascade shipped — must not
+ * be reported as granted. Rendering it verbatim would tick a checkbox that
+ * the email gate simultaneously DISABLES, i.e. a consent the customer cannot
+ * withdraw from this screen (GDPR art. 7(3) requires withdrawal to be as easy
+ * as granting). Reading the pair as denied renders it unchecked instead, and
+ * keeps the one loaded state used by both the checkbox and the submit-time
+ * payload identical.
+ */
+export const readPixelConsent = (decision) =>
+  !!decision?.pixel?.value && !!decision?.value;
+
+/**
+ * Body of PUT /me/consent/<campaign>/decision.
+ *
+ * Both checkbox states travel together in ONE request rather than two
+ * sequential calls: the API applies the email decision first, so a pair sent
+ * together can never be refused, it reads clearer and it saves a round trip.
+ *
+ * `pixel` is omitted entirely — never sent as `false` — in the two cases the
+ * contract has no row for:
+ *
+ *   - an account out of the country scope, which keeps sending exactly the
+ *     `{ value }` body it sends today;
+ *   - a revocation of marketing email consent, `{ value: false }`, which the
+ *     contract documents as "the backend cascades pixel to denied for you".
+ *
+ * That second omission is what keeps every body this function can build to
+ * one of the four rows the contract enumerates. Sending the undocumented
+ * `{ value: false, pixel: { value: false } }` instead would be the single most
+ * common save an FR/IT customer makes when unsubscribing, on a validator we
+ * do not control — and the one refusal the contract does document on this
+ * route fails the WHOLE request, email consent included.
+ *
+ * It also makes the refused pair `{ value: false, pixel: { value: true } }`
+ * unrepresentable rather than merely unreachable: no code path here or in the
+ * creation screen can emit a `pixel` key while `value` is false, whatever
+ * state the caller holds.
+ */
+export const buildConsentDecisionPayload = ({
+  hasEmailConsent,
+  isPixelTrackingAvailable,
+  hasPixelConsent,
+}) => ({
+  value: !!hasEmailConsent,
+  ...(isPixelTrackingAvailable && hasEmailConsent
+    ? { pixel: { value: !!hasPixelConsent } }
+    : {}),
+});

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_de_DE.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_de_DE.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "Sie haben Ihre Kategorie geändert. Bitte aktualisieren Sie die Daten Ihrer {{ category }}, bevor Sie speichern.",
   "signup_legalform_other_switch_company_cta": "Meine Unternehmensdaten aktualisieren",
   "signup_account_info_siret_lookup_hint": "Ihre Unternehmensinformationen sind möglicherweise veraltet.",
-  "signup_account_info_siret_lookup_cta": "Aktualisieren Sie diese mit meiner SIRET-Nummer"
+  "signup_account_info_siret_lookup_cta": "Aktualisieren Sie diese mit meiner SIRET-Nummer",
+  "signup_field_pixelTrackingConsent": "Ich gestatte OVHcloud, Tracking-Pixel in den E-Mails zu verwenden, die an {{ email }} gesendet werden, und zwar auf allen Geräten, die ich zu deren Abruf verwende, um deren Öffnungsrate zu messen, Statistiken zur Verbreitung zu erstellen und bei Bedarf die Häufigkeit dieser Sendungen anzupassen."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_en_GB.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_en_GB.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "You have changed your category. Please update your {{ category }} data before saving.",
   "signup_legalform_other_switch_company_cta": "Update my company data",
   "signup_account_info_siret_lookup_hint": "Your business information may be out of date.",
-  "signup_account_info_siret_lookup_cta": "Update them with my SIRET number"
+  "signup_account_info_siret_lookup_cta": "Update them with my SIRET number",
+  "signup_field_pixelTrackingConsent": "I authorise OVHcloud to use tracking pixels in the emails sent to me at {{ email }}, on all the devices I use to view them, in order to measure their open rate, compile distribution statistics and adapt, if necessary, the frequency of these mailings."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_es_ES.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_es_ES.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "Ha modificado su categoría. Actualice los datos de su {{ category }} antes de guardar.",
   "signup_legalform_other_switch_company_cta": "Actualizar mis datos de empresa",
   "signup_account_info_siret_lookup_hint": "Es posible que la información de vuestra empresa esté obsoleta.",
-  "signup_account_info_siret_lookup_cta": "Actualizadla con mi número de SIRET"
+  "signup_account_info_siret_lookup_cta": "Actualizadla con mi número de SIRET",
+  "signup_field_pixelTrackingConsent": "Autorizo a OVHcloud a utilizar píxeles de seguimiento en los correos electrónicos que se me envían a {{ email }}, en todos los dispositivos que utilizo para consultarlos, con el fin de medir su tasa de apertura, establecer estadísticas de difusión y adaptar, si fuera necesario, la frecuencia de estos envíos."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_CA.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_CA.json
@@ -791,5 +791,6 @@
   "signup_legalform_other_switch_company": "Vous avez modifié votre catégorie. Veuillez mettre à jour les données de votre {{ category }} avant d'enregistrer.",
   "signup_legalform_other_switch_company_cta": "Mettre à jour mes données société",
   "signup_account_info_siret_lookup_hint": "Vos informations d'entreprise sont peut-être obsolètes.",
-  "signup_account_info_siret_lookup_cta": "Les mettre à jour avec mon numéro de SIRET"
+  "signup_account_info_siret_lookup_cta": "Les mettre à jour avec mon numéro de SIRET",
+  "signup_field_pixelTrackingConsent": "J'autorise OVHcloud à utiliser des pixels de suivi dans les e-mails qui me sont adressés à {{ email }}, sur l'ensemble des appareils que j'utilise pour les consulter, afin de mesurer leur taux d'ouverture, d'établir des statistiques de diffusion et d'adapter, si besoin, la fréquence de ces envois."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_FR.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_fr_FR.json
@@ -791,5 +791,6 @@
   "signup_legalform_other_switch_company": "Vous avez modifié votre catégorie. Veuillez mettre à jour les données de votre {{ category }} avant d'enregistrer.",
   "signup_legalform_other_switch_company_cta": "Mettre à jour mes données société",
   "signup_account_info_siret_lookup_hint": "Vos informations d'entreprise sont peut-être obsolètes.",
-  "signup_account_info_siret_lookup_cta": "Les mettre à jour avec mon numéro de SIRET"
+  "signup_account_info_siret_lookup_cta": "Les mettre à jour avec mon numéro de SIRET",
+  "signup_field_pixelTrackingConsent": "J'autorise OVHcloud à utiliser des pixels de suivi dans les e-mails qui me sont adressés à {{ email }}, sur l'ensemble des appareils que j'utilise pour les consulter, afin de mesurer leur taux d'ouverture, d'établir des statistiques de diffusion et d'adapter, si besoin, la fréquence de ces envois."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_it_IT.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_it_IT.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "Hai modificato la tua categoria. Aggiorna i dati della tua {{ category }} prima di salvare.",
   "signup_legalform_other_switch_company_cta": "Aggiorna i miei dati aziendali",
   "signup_account_info_siret_lookup_hint": "Le informazioni sulla tua azienda potrebbero essere obsolete.",
-  "signup_account_info_siret_lookup_cta": "Aggiornale con il mio numero SIRET"
+  "signup_account_info_siret_lookup_cta": "Aggiornale con il mio numero SIRET",
+  "signup_field_pixelTrackingConsent": "Autorizzo OVHcloud a utilizzare pixel di tracciamento nelle e-mail che mi vengono inviate all'indirizzo {{ email }}, su tutti i dispositivi che utilizzo per consultarle, al fine di misurarne il tasso di apertura, elaborare statistiche di diffusione e adattare, se necessario, la frequenza di tali invii."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pl_PL.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pl_PL.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "Zmieniono kategorię. Przed zapisaniem zaktualizuj dane {{ category }}.",
   "signup_legalform_other_switch_company_cta": "Zaktualizuj moje dane firmy",
   "signup_account_info_siret_lookup_hint": "Twoje informacje firmowe mogą być nieaktualne.",
-  "signup_account_info_siret_lookup_cta": "Zaktualizuj je za pomocą mojego numeru SIRET"
+  "signup_account_info_siret_lookup_cta": "Zaktualizuj je za pomocą mojego numeru SIRET",
+  "signup_field_pixelTrackingConsent": "Wyrażam zgodę na wykorzystywanie przez OVHcloud pikseli śledzących w wiadomościach e-mail wysyłanych na adres {{ email }}, na wszystkich urządzeniach, których używam do ich przeglądania, w celu mierzenia wskaźnika ich otwarć, tworzenia statystyk dotyczących wysyłki oraz dostosowywania, w razie potrzeby, częstotliwości tych wysyłek."
 }

--- a/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pt_PT.json
+++ b/packages/manager/modules/account/src/user/components/newAccountForm/translations/Messages_pt_PT.json
@@ -792,5 +792,6 @@
   "signup_legalform_other_switch_company": "Alterou a sua categoria. Queira atualizar os dados da sua {{ category }} antes de guardar.",
   "signup_legalform_other_switch_company_cta": "Atualizar os meus dados de empresa",
   "signup_account_info_siret_lookup_hint": "As suas informações de empresa podem estar obsoletas.",
-  "signup_account_info_siret_lookup_cta": "Atualizá-las com o meu número de SIRET"
+  "signup_account_info_siret_lookup_cta": "Atualizá-las com o meu número de SIRET",
+  "signup_field_pixelTrackingConsent": "Autorizo a OVHcloud a utilizar píxeis de seguimento nos e-mails que me são enviados para {{ email }}, em todos os dispositivos que utilizo para os consultar, a fim de medir a sua taxa de abertura, estabelecer estatísticas de difusão e adaptar, se necessário, a frequência desses envios."
 }

--- a/packages/manager/modules/account/src/user/infos/user-infos.service.js
+++ b/packages/manager/modules/account/src/user/infos/user-infos.service.js
@@ -84,6 +84,8 @@ export default class UserAccountInfosService {
       )
       .then((response) => {
         if (response.status < 300) {
+          // returned verbatim: callers read `value` and, for the marketing
+          // email campaign, the `pixel` object that rides along with it
           return response.data;
         }
 
@@ -91,7 +93,22 @@ export default class UserAccountInfosService {
       });
   }
 
-  updateConsentDecision(campaignName, value) {
+  /**
+   * `decision` is the request body, built by the caller — see
+   * buildConsentDecisionPayload in the account form's
+   * ./components/newAccountForm/pixel-tracking-consent.js. The pixel-tracking
+   * decision rides on this same campaign route and has to be sent together
+   * with the email one, in a single request: the API applies them in a fixed
+   * order (email first) and the whole request is atomic, so a refused pair
+   * writes nothing at all.
+   *
+   * Shapes: { value: true, pixel: { value: true } }  grants both;
+   *         { value: true, pixel: { value: false } } is the normal state;
+   *         { value: false }                         lets the backend cascade
+   *                                                  pixel to denied;
+   *         { value: false, pixel: { value: true } }  is refused with a 400.
+   */
+  updateConsentDecision(campaignName, decision) {
     return this.$http
       .put(
         [
@@ -100,7 +117,7 @@ export default class UserAccountInfosService {
           campaignName,
           'decision',
         ].join('/'),
-        { value },
+        decision,
       )
       .then((response) => {
         if (response.status < 300) {


### PR DESCRIPTION
Add a country-gated pixel-tracking consent checkbox next to the existing marketing-email checkbox on the account edition form. It is offered to France (all of its territory) and Italy accounts only, and never renders anywhere else: outside that scope no rule is built at all.

The checkbox is unchecked by default and stays disabled while marketing-email consent is not granted, since the API refuses that combination outright. Unchecking marketing email clears and disables it in the same UI update, and re-checking marketing email leaves it unchecked: re-subscribing to email never restores pixel tracking, so the customer has to opt back in explicitly.

Both consent states travel together in a single
PUT /me/consent/consent-marketing-email/decision, which the fixed processing order makes safe, and the pixel key is omitted entirely when marketing email is revoked so the backend cascade applies. A refused pair re-fetches the decision and repaints both checkboxes rather than trusting the local state.

The country list, the country predicate, the pixel.value reader and the payload builder live in a framework-free module so the account creation screen can reuse them as is.

ref: #MANAGER-22481

Signed-off-by: Alexis AFONSO <alexis.afonso@ovhcloud.com>